### PR TITLE
eslintrc: Disable param and return description

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -38,6 +38,8 @@ module.exports = {
         ],
       },
     ],
+    'jsdoc/require-param-description': 0,
+    'jsdoc/require-returns-description': 0,
     'max-len': ['error', { code: 120 }],
     'no-alert': 'off',
     'no-console': 'off',


### PR DESCRIPTION
The function name already can provide information of the return,
and the parameter name with the function description can also inform what it does.

We can write the description when necessary.

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>