### PR TITLE
electron: Take 100% of the screen size

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow } from 'electron'
+import { app, BrowserWindow, screen } from 'electron'
 import { join } from 'path'
 
 export const ROOT_PATH = {
@@ -14,12 +14,15 @@ let mainWindow: BrowserWindow | null
  * Create electron window
  */
 function createWindow(): void {
+  const { width, height } = screen.getPrimaryDisplay().workAreaSize
   mainWindow = new BrowserWindow({
     icon: join(ROOT_PATH.public, 'favicon.ico'),
     webPreferences: {
       contextIsolation: false,
       nodeIntegration: false,
     },
+    width,
+    height,
   })
 
   // Test active push message to Renderer-process.


### PR DESCRIPTION
As this is a ground station, the user probably wants to use the whole screen. At the same time, putting the application on fullscreen by default can be somewhat intrusive. This also improves the user experience, since previous to this patch the default value (800, 600px) would be used and for a large number of screens, this will be very small and seem like a broken UI.