### PR TITLE
widget-manager: Make everything percentage-based

### DIFF
--- a/src/components/EditMenu.vue
+++ b/src/components/EditMenu.vue
@@ -106,10 +106,10 @@ const emit = defineEmits<{
 const availableWidgetTypes = computed(() => Object.values(WidgetType))
 const selectedWidgetType = ref<WidgetType>(availableWidgetTypes.value[0])
 const selectedLayer = ref<Layer>(store.layers[0])
-const initialSize = { width: 600, height: 450 }
+const initialSize = { width: 0.6, height: 0.5 }
 const initialPosition = {
-  x: (window.innerWidth - initialSize.width) / 2,
-  y: (window.innerHeight - initialSize.height) / 2,
+  x: 0.2,
+  y: 0.25,
 }
 
 const availableLayers = computed(() =>

--- a/src/components/SnappingGrid.vue
+++ b/src/components/SnappingGrid.vue
@@ -3,6 +3,7 @@
 </template>
 
 <script setup lang="ts">
+import { useWindowSize } from '@vueuse/core'
 import { computed } from 'vue'
 
 const props = defineProps<{
@@ -12,8 +13,13 @@ const props = defineProps<{
   gridInterval: number
 }>()
 
-const gridIntervalStop = computed(() => `${props.gridInterval}px`)
-const gridIntervalStart = computed(() => `${props.gridInterval - 1}px`)
+const { width: windowWidth, height: windowHeight } = useWindowSize()
+const gridIntervalStyleX = computed(
+  () => `${windowWidth.value * props.gridInterval}px`
+)
+const gridIntervalStyleY = computed(
+  () => `${windowHeight.value * props.gridInterval}px`
+)
 </script>
 
 <style>
@@ -24,18 +30,18 @@ const gridIntervalStart = computed(() => `${props.gridInterval - 1}px`)
   background-image: repeating-linear-gradient(
       0deg,
       transparent,
-      transparent v-bind('gridIntervalStart'),
-      #88f v-bind('gridIntervalStart'),
-      #88f v-bind('gridIntervalStop')
+      transparent calc(v-bind('gridIntervalStyleY') - 1px),
+      #88f calc(v-bind('gridIntervalStyleY') - 1px),
+      #88f v-bind('gridIntervalStyleY')
     ),
     repeating-linear-gradient(
       -90deg,
       transparent,
-      transparent v-bind('gridIntervalStart'),
-      #88f v-bind('gridIntervalStart'),
-      #88f v-bind('gridIntervalStop')
+      transparent calc(v-bind('gridIntervalStyleX') - 1px),
+      #88f calc(v-bind('gridIntervalStyleX') - 1px),
+      #88f v-bind('gridIntervalStyleX')
     );
-  background-size: v-bind('gridIntervalStop') v-bind('gridIntervalStop');
+  background-size: v-bind('gridIntervalStyleX') v-bind('gridIntervalStyleY');
   background-repeat: repeat;
 }
 </style>

--- a/src/stores/widgetManager.ts
+++ b/src/stores/widgetManager.ts
@@ -59,8 +59,8 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
       hash: widgetHash,
       name: widgetHash,
       component: widgetType,
-      position: { x: 10, y: 10 },
-      size: { width: 200, height: 200 },
+      position: { x: 0.05, y: 0.05 },
+      size: { width: 0.2, height: 0.35 },
       options: {},
     })
   }

--- a/src/views/WidgetsView.vue
+++ b/src/views/WidgetsView.vue
@@ -84,7 +84,7 @@ const { x: mouseX } = useMouse()
 const showEditButton = ref(false)
 const editingMode = ref(false)
 const showGrid = ref(false)
-const gridInterval = ref(15)
+const gridInterval = ref(0.01)
 
 const widgetsPresent = computed(() =>
   store.layers.some((layer) => layer.widgets.length != 0)


### PR DESCRIPTION
![percent-cockpit](https://user-images.githubusercontent.com/6551040/192897508-b491a338-06af-4ac9-993b-e85d77f6a17a.gif)

With this, we finally fix #26 

There are usability/aesthetic implications here, specially regarding the size of the edit menu and for how compass sizing works, but those will be addressed in future PRs.