### PR TITLE
github: ci: Do not run yarn install update on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Run yarn
         run: |
-          yarn install
+          yarn install --frozen-lockfile
           yarn lint
           yarn typecheck
           yarn build


### PR DESCRIPTION
With frozen-lockfile we have reproducible dependencies, where the same version as the lockfile is used. 

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>