### PR TITLE
widget[multiple]: Use `onBeforeMount` instead of `onMounted`

### DIFF
--- a/src/components/widgets/Indicators.vue
+++ b/src/components/widgets/Indicators.vue
@@ -62,7 +62,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref, toRefs } from 'vue'
+import { onBeforeMount, ref, toRefs } from 'vue'
 
 import { degrees } from '@/libs/utils'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
@@ -79,7 +79,7 @@ const props = defineProps<{
 const widget = toRefs(props).widget
 const showOptionsDialog = ref(false)
 
-onMounted(() => {
+onBeforeMount(() => {
   // Set initial widget options if they don't exist
   if (Object.keys(widget.value.options).length === 0) {
     widget.value.options = {

--- a/src/components/widgets/VideoPlayer.vue
+++ b/src/components/widgets/VideoPlayer.vue
@@ -61,7 +61,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, toRefs, watch } from 'vue'
+import { computed, onBeforeMount, ref, toRefs, watch } from 'vue'
 
 import useWebRtcStream from '@/composables/webRTC'
 import type { RtcPeer } from '@/types/webRTC'
@@ -82,7 +82,7 @@ const videoElement = ref<HTMLVideoElement | undefined>()
 
 const { availablePeers, stream } = useWebRtcStream(selectedPeer)
 
-onMounted(() => {
+onBeforeMount(() => {
   // Set initial widget options if they don't exist
   if (Object.keys(widget.value.options).length === 0) {
     widget.value.options = {


### PR DESCRIPTION
- Changed on VideoPlayer and Indicators widgets
- Guarantee those properties are populated before DOM rendering, preventing undefined state being used

PS: it doesn't solve the problem @patrickelectric is having (high memory usage and others), but is the right thing to do.