### PR TITLE
stores: widgetManager: Add missing cosmos import

### DIFF
--- a/src/stores/widgetManager.ts
+++ b/src/stores/widgetManager.ts
@@ -1,3 +1,5 @@
+import '@/libs/cosmos'
+
 import { useStorage } from '@vueuse/core'
 import { defineStore } from 'pinia'
 import { v4 as uuid4 } from 'uuid'


### PR DESCRIPTION
Got an error related to the `random()` cosmos function not available when trying to add hot component reload. This fix the issue. 