### PR TITLE
views: WidgetsView: Fix main button behaviour when always visible

### DIFF
--- a/src/views/WidgetsView.vue
+++ b/src/views/WidgetsView.vue
@@ -5,7 +5,7 @@
         v-bind="menuProps"
         class="edit-mode-btn"
         icon="mdi-menu"
-        :disabled="!activateMainMenuButton"
+        :disabled="!(activateMainMenuButton || showMainMenuButton)"
       />
     </template>
     <v-card class="pa-2 ma-2">


### PR DESCRIPTION
Fix style once "always visible" is enabled.
The button appears with "disable" once the mouse goes outside the "active area" when "always visible" is on, the PR fix this behaviour

old:
![Peek 02-11-2022 11-25-old](https://user-images.githubusercontent.com/1215497/199515445-0a8ce064-ac6e-4a0a-a14e-b20e51bd99eb.gif)

new:
![Peek 02-11-2022 11-25](https://user-images.githubusercontent.com/1215497/199515491-987ac530-e99e-45f7-a083-479a1841ff48.gif)


Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>