### PR TITLE
components: ConfigurationMenu: Use more space for content

### DIFF
--- a/src/components/ConfigurationMenu.vue
+++ b/src/components/ConfigurationMenu.vue
@@ -1,8 +1,9 @@
 <template>
   <v-card class="pa-2" width="100%" height="100%">
-    <v-card-title>Configuration menu</v-card-title>
     <v-layout>
-      <v-navigation-drawer permanent>
+      <v-navigation-drawer>
+        <v-card-title>Configuration menu</v-card-title>
+        <v-divider/>
         <v-list v-model:selected="currentMenuComponent">
           <v-list-item
             v-for="(menu, i) in menus"


### PR DESCRIPTION
Move title to be inside drawer to have more space vertically

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>