### PR TITLE
widget-manager: Check if widget type exists before placing it

### DIFF
--- a/src/views/WidgetsView.vue
+++ b/src/views/WidgetsView.vue
@@ -40,6 +40,7 @@
     >
       <template v-for="widget in layer.widgets.slice().reverse()" :key="widget">
         <WidgetHugger
+          v-if="Object.values(WidgetType).includes(widget.component)"
           :position="widget.position"
           :size="widget.size"
           :allow-moving="editingMode"


### PR DESCRIPTION
Prevents inexistent widget types from breaking the UI. This usually happens while developing new widgets, for example.