### PR TITLE
edit-menu: Add button to exit edit-mode

### DIFF
--- a/src/components/EditMenu.vue
+++ b/src/components/EditMenu.vue
@@ -94,6 +94,9 @@
           @change="emit('update:showGrid', !showGrid)"
         />
       </v-card-actions>
+      <v-btn flat block @click="emit('update:editMode', false)">
+        Exit edit mode
+      </v-btn>
     </v-card>
   </v-navigation-drawer>
   <teleport to="body">
@@ -155,6 +158,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: 'update:showGrid', showGrid: boolean): void
+  (e: 'update:editMode', editMode: boolean): void
 }>()
 
 const availableWidgetTypes = computed(() => Object.values(WidgetType))


### PR DESCRIPTION
Got some feedback that it is intuitive to go to the edit-menu to exit the edit-mode, which makes sense, since you're using it when you want to exit it.