### PR TITLE
widget-hugger: Don't close widget edit menu if hovering it

### DIFF
--- a/src/components/WidgetHugger.vue
+++ b/src/components/WidgetHugger.vue
@@ -13,7 +13,7 @@
       class="resizer"
       :class="{ draggingResizer, hoveringResizer, allowResizing }"
     />
-    <div v-if="hoveringOverlay" class="editing-buttons">
+    <div v-if="hoveringOverlay || !notHoveringEditMenu" class="editing-buttons">
       <v-menu
         v-if="allowResizing || allowOrdering || allowDeleting"
         location="top"
@@ -21,7 +21,7 @@
         <template #activator="{ props: menuProps }">
           <v-btn v-bind="menuProps" size="x-small" icon="mdi-pencil" />
         </template>
-        <v-list>
+        <v-list ref="widgetEditMenu">
           <v-btn
             v-if="allowOrdering"
             class="ma-1"
@@ -157,6 +157,9 @@ const lastNonFullScreenSize = ref(props.size)
 const widgetOverlay = ref()
 const { isOutside: notHoveringOverlay } = useMouseInElement(widgetOverlay)
 const hoveringOverlay = computed(() => !notHoveringOverlay.value)
+
+const widgetEditMenu = ref()
+const { isOutside: notHoveringEditMenu } = useMouseInElement(widgetEditMenu)
 
 const { position: widgetRawPosition, dragging: draggingWidget } =
   useDragInElement(


### PR DESCRIPTION
Previously, if the widget was smaller than it's edit-menu, when hovering outside the widget, even if still hovering the menu, the menu closed.

Before/after:

https://user-images.githubusercontent.com/6551040/203123886-0958ae9b-dfe6-47c6-9a60-4b1d74883d33.mov


https://user-images.githubusercontent.com/6551040/203123978-ff1c1820-bdf8-4c24-bd8a-d941040ca334.mov



