### PR TITLE
widget[indicators]: Prevent widget to be resized till text wraps

### DIFF
--- a/src/components/widgets/Indicators.vue
+++ b/src/components/widgets/Indicators.vue
@@ -118,6 +118,7 @@ onBeforeMount(() => {
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  white-space: nowrap;
 }
 .options-btn {
   display: none;


### PR DESCRIPTION
Minimal size before and after:

<img width="145" alt="image" src="https://user-images.githubusercontent.com/6551040/203147154-045bbae3-fc7a-4781-9b57-0ece84339707.png"> <img width="207" alt="image" src="https://user-images.githubusercontent.com/6551040/203147256-c9e78366-7dda-4884-8b38-f38f7b5b80cc.png">
