### PR TITLE
widget[power-bar]: Improve structure so it has a natural minimum size

### DIFF
--- a/src/components/widgets/PowerBar.vue
+++ b/src/components/widgets/PowerBar.vue
@@ -9,10 +9,11 @@
     <v-switch
       v-model="armSwitch"
       :disabled="!vehicleStore.isVehicleOnline()"
-      class="v-input--horizontal"
+      class="v-input--horizontal mx-1"
       color="red-darken-3"
       :label="`${armSwitch ? 'Armed' : 'Disarmed'}`"
       :loading="vehicleStore.isArmed !== armSwitch ? 'warning' : undefined"
+      hide-details
     />
 
     <v-select
@@ -23,6 +24,7 @@
       variant="outlined"
       no-data-text="Waiting for available modes."
       hide-details
+      class="mx-1"
       :loading="vehicleStore.mode !== flightMode"
     />
 


### PR DESCRIPTION
Minimal size before and after:
<img width="147" alt="image" src="https://user-images.githubusercontent.com/6551040/203149043-0054cf19-50e3-4275-8567-a8a533199165.png"> <img width="368" alt="image" src="https://user-images.githubusercontent.com/6551040/203148748-ba2f63f5-d4d4-46d8-bd0f-e17299816ea6.png">

