### PR TITLE
widget-view: Show main-menu when hovering main-menu button

### DIFF
--- a/src/views/WidgetsView.vue
+++ b/src/views/WidgetsView.vue
@@ -1,5 +1,5 @@
 <template>
-  <button class="main-menu-button" @click="showMainMenu(!isShowingMainMenu)">
+  <button class="main-menu-button" @click="showMainMenu(true)" @mouseover="showMainMenu(true)">
     <img class="main-menu-button-image" src="@/assets/blue-robotics-logo.svg" />
   </button>
   <div ref="mainMenu" class="main-menu">


### PR DESCRIPTION
With this patch, it takes one click less to reach what you want in the main-menu. It also makes clicking the main-menu button always open the main-menu, to prevent users hovering and miss clicking, closing the menu without intention.

https://user-images.githubusercontent.com/6551040/208500936-49832824-693a-40e8-b834-9d6115baac1b.mov


