### PR TITLE
workflow: create docs-check

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,20 @@
+name: Docs Check
+
+ on:
+   pull_request:
+     branches:
+       - master
+     types:
+       - opened
+       - labeled
+       - unlabeled
+
+ jobs:
+   fail-if-docs-needed:
+     if: contains(github.event.pull_request.labels.*.name, 'docs-needed')
+     runs-on: ubuntu-latest
+     steps:
+       - name: Fail if PR needs accompanying docs to be written
+         run: |
+           echo "This change needs to be documented. Please get the docs approved, and change 'docs-needed' to 'docs-complete'."
+           exit 1


### PR DESCRIPTION
Provides a fail indicator for PRs with the "docs-needed" label.

Process found at https://stackoverflow.com/a/71504928/15326510

DO NOT MERGE until base cockpit docs have been written and published.