### PR TITLE
main: Segregate Vue app creation from plugin connecting and mounting

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -9,4 +9,6 @@ import router from './router'
 
 loadFonts()
 
-createApp(App).use(router).use(vuetify).use(VueKonva).use(createPinia()).mount('#app')
+const app = createApp(App)
+app.use(router).use(vuetify).use(VueKonva).use(createPinia())
+app.mount('#app')


### PR DESCRIPTION
This is necessary to make VueDevTools detect and allow usage of plugin debug tools (e.g.: Pinia, Router, etc)