### PR TITLE
widgets[video-player]: Change menu button styling

### DIFF
--- a/src/components/widgets/VideoPlayer.vue
+++ b/src/components/widgets/VideoPlayer.vue
@@ -205,6 +205,8 @@ video {
   margin: 5px;
   top: 0;
   right: 0;
+  color: white;
+  filter: drop-shadow(2px 2px black);
 }
 .video-widget:hover .options-btn {
   display: block;


### PR DESCRIPTION
Change color and adds shadow. This way, it gets easier to see it under both dark and light colors.

Fix #207 