### PR TITLE
app: Hide overflow also on `body`

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,7 +7,8 @@
 </template>
 
 <style>
-html {
+html,
+body {
   /* Removes the scrollbar */
   overflow: hidden !important;
 }


### PR DESCRIPTION
This fixes the problem of getting blank space in the right and bottom of the screen when something gets bigger than the window.