### PR TITLE
edit-menu: Fix scrollbar appearance when not needed

### DIFF
--- a/src/components/EditMenu.vue
+++ b/src/components/EditMenu.vue
@@ -2,7 +2,7 @@
   <div v-if="editMode" class="w-full h-full pointer-events-none position-absolute editing-mode-overlay" />
   <div
     ref="editMenu"
-    class="flex flex-col items-center justify-between h-full px-2 py-6 m-0 overflow-y-scroll text-white nav-drawer"
+    class="flex flex-col items-center justify-between h-full px-2 py-6 m-0 overflow-y-auto text-white nav-drawer"
   >
     <p class="my-1 text-xl font-semibold">Edit menu</p>
     <div class="w-11/12 h-px my-1 bg-white" />


### PR DESCRIPTION
Before / after:

<img width="492" alt="image" src="https://user-images.githubusercontent.com/6551040/220733656-49d76764-3554-476d-b420-9887d9691618.png">
<img width="452" alt="image" src="https://user-images.githubusercontent.com/6551040/220733717-0713b0c4-4659-47b3-815b-e332493842b6.png">
