### PR TITLE
More improvements on joystick UX

### DIFF
--- a/src/views/ConfigurationJoystickView.vue
+++ b/src/views/ConfigurationJoystickView.vue
@@ -11,12 +11,33 @@
         <p class="text-base text-center">Make sure that a joystick is connected.</p>
         <p class="text-base text-center">You can hit any key to test the joystick connection.</p>
       </div>
-      <div
-        v-else-if="buttonFunctions.length === 0"
-        class="flex flex-col items-center px-5 py-3 m-5 font-bold border rounded-md text-blue-grey-darken-1 bg-blue-lighten-5 w-fit"
-      >
-        <p>Could not stablish communication with the vehicle.</p>
-        <p>Button functions will appear as numbers. If connection is restablished, function names will appear.</p>
+      <div v-else>
+        <div
+          class="flex flex-col items-center px-5 py-3 m-5 font-medium text-center border rounded-md text-grey-darken-1 bg-grey-lighten-5 w-fit"
+        >
+          <p class="font-bold">
+            This is the joystick configuration page. Here you can calibrate your joystick and map its buttons to
+            functions in your drone.
+          </p>
+          <br />
+          <p>
+            Click the buttons in your physical controller and see them being activated here. If any button does not
+            light up in this virtual joystick or is switched with another, click in it here and follow the instructions
+            to remap it.
+          </p>
+          <br />
+          <p>
+            By clicking the virtual buttons and axis you are also able to choose the function in your drone that this
+            button controls, as whel as set axis limits.
+          </p>
+        </div>
+        <div
+          v-if="buttonFunctions.length === 0"
+          class="flex flex-col items-center px-5 py-3 m-5 font-bold border rounded-md text-blue-grey-darken-1 bg-blue-lighten-5 w-fit"
+        >
+          <p>Could not stablish communication with the vehicle.</p>
+          <p>Button functions will appear as numbers. If connection is restablished, function names will appear.</p>
+        </div>
       </div>
       <div
         v-for="[key, joystick] in controllerStore.joysticks"


### PR DESCRIPTION
- Style "no-joystick" banner
- Add instructions for remapping

<img width="843" alt="image" src="https://user-images.githubusercontent.com/6551040/225930764-792e3f60-f968-4e43-a5e2-b3b781ae4321.png">

<img width="844" alt="image" src="https://user-images.githubusercontent.com/6551040/225931854-7aca15f5-e115-43dd-911e-9ec45583a876.png">

@patrickelectric I would recommend creating a new version of Cockpit so the BlueOS extension get this update, as it can help a lot with the user's understanding of the mapping experience.