### PR TITLE
CI: Set a timeout when installing packages to avoid failing with unstable network

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Run yarn
         run: |
-          yarn install --frozen-lockfile
+          yarn install --frozen-lockfile --network-timeout 300000
           yarn lint
           yarn typecheck
           yarn build
@@ -62,7 +62,7 @@ jobs:
       - name: Build electron
         run: |
           npm install --global yarn
-          yarn install --frozen-lockfile
+          yarn install --frozen-lockfile --network-timeout 300000
           yarn build
           yarn deploy:electron
 


### PR DESCRIPTION
Ref:
https://github.com/bluerobotics/cockpit/actions/runs/4450756711/jobs/7816631177
https://github.com/bluerobotics/cockpit/actions/runs/4450728556