### PR TITLE
tailwind-css: Fix colors configuration

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,10 +3,11 @@
 module.exports = {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx,vue}'],
   theme: {
-    colors: {
-      critical: '#7F34CF',
+    extend: {
+      colors: {
+        critical: '#7F34CF',
+      },
     },
-    extend: {},
   },
   plugins: [],
 }


### PR DESCRIPTION
Former configuration creates the `critical` color but override the default ones. New configuration extends the default colors, making them also available.