### PR TITLE
A few more tweaks to the video recorder

### DIFF
--- a/src/components/widgets/VideoRecorder.vue
+++ b/src/components/widgets/VideoRecorder.vue
@@ -24,7 +24,7 @@
       />
       <div class="flex items-center">
         <button
-          class="w-auto p-3 mx-2 font-medium transition-all rounded-md shadow-md text-uppercase hover:bg-slate-100"
+          class="w-auto p-3 m-2 font-medium transition-all rounded-md shadow-md text-uppercase hover:bg-slate-100"
           @click="isStreamSelectDialogOpen = false"
         >
           Cancel


### PR DESCRIPTION
I did some more extensive tests today and could get those cases. 
The most important one is certainly the blocking when the stream is not loaded, since the user can't know, after selecting the stream, how much time will it take to load it.

https://user-images.githubusercontent.com/6551040/228657945-186dae17-98c9-49c5-9cbe-c8dd1bc90ce8.mov

- Block recording when media stream not yet loaded
- Save stream name on stream change
- Only load saved streams when none is selected

