### PR TITLE
widgets[video-player]: Change saved stream when selected changes

### DIFF
--- a/src/components/widgets/VideoPlayer.vue
+++ b/src/components/widgets/VideoPlayer.vue
@@ -116,7 +116,6 @@ watch(mediaStream, async (newStream, oldStream) => {
     return
   }
 
-  widget.value.options.streamName = selectedStream.value?.name
   videoElement.value.srcObject = newStream
   videoElement.value
     .play()
@@ -129,6 +128,8 @@ watch(mediaStream, async (newStream, oldStream) => {
       streamStatus.value = msg
     })
 })
+
+watch(selectedStream, () => (widget.value.options.streamName = selectedStream.value?.name))
 
 watch(availableStreams, () => {
   const savedStreamName: string | undefined = widget.value.options.streamName


### PR DESCRIPTION
This prevents the undesired behavior we were having where the user selects a different stream, but the selector goes back to the original one. You can notice that in the following recording, where I try to select the "stream ball" but the selector goes back to the original stream.

https://user-images.githubusercontent.com/6551040/228661573-604ed993-5a07-4ea2-8991-54047823dde2.mov

This was happening because the saved was updated only when `mediaStream` was updated, which happened at the same time as the new `availableStreams` were updated, creating a race-condition.