### PR TITLE
widgets[video-recorder]: Move recording stop logic to `onstop` callback

### DIFF
--- a/src/components/widgets/VideoRecorder.vue
+++ b/src/components/widgets/VideoRecorder.vue
@@ -154,17 +154,16 @@ const startRecording = async (): Promise<SweetAlertResult | void> => {
     const blob = new Blob(chunks, { type: 'video/webm' })
     chunks = []
     saveAs(blob, 'video')
+    mediaRecorder.value = undefined
+    if (selectedStream.value?.id === 'screenStream' && mediaStream.value !== undefined) {
+      // If recording the screen stream, stop the tracks also, so the browser removes the recording warning.
+      mediaStream.value.getTracks().forEach((track: MediaStreamTrack) => track.stop())
+    }
   }
 }
 
 const stopRecording = (): void => {
-  if (mediaRecorder.value === undefined || !isRecording.value) return
-  mediaRecorder.value.stop()
-  mediaRecorder.value = undefined
-  // If recording the screen stream, stop the tracks also, so the browser removes the recording warning.
-  if (selectedStream.value?.id === 'screenStream' && mediaStream.value !== undefined) {
-    mediaStream.value.getTracks().forEach((track: MediaStreamTrack) => track.stop())
-  }
+  mediaRecorder.value?.stop()
 }
 
 const updateCurrentStream = async (stream: Stream | undefined): Promise<SweetAlertResult | void> => {


### PR DESCRIPTION
When the user stops sharing the screen instead of clicking the stop button, the `onstop` callback is called and so the UI state resets weren't performed.

The stop-sharing-button is very showy, so probably users will end up using it.

<img width="473" alt="image" src="https://user-images.githubusercontent.com/6551040/228849187-53f2d60f-c477-4edd-be05-fc32c06ecd48.png">
