### PR TITLE
widgets[map]: Add vehicle position, heading and path

### DIFF
--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -40,7 +40,7 @@
         </svg>
       </l-icon>
     </l-marker>
-    <l-marker :lat-lng="vehiclePosition" name="Vehicle">
+    <l-marker :lat-lng="vehiclePosition ?? [0, 0]" name="Vehicle">
       <l-icon :icon-anchor="[50, 50]">
         <svg
           version="1.1"
@@ -108,11 +108,15 @@ const bounds = ref(null)
 const center = ref([-27.5935, -48.55854])
 const home = ref(center.value)
 const vehiclePosition = computed(() =>
-  vehicleStore.coordinates.latitude ? [vehicleStore.coordinates.latitude, vehicleStore.coordinates.longitude] : [0, 0]
+  vehicleStore.coordinates.latitude
+    ? [vehicleStore.coordinates.latitude, vehicleStore.coordinates.longitude]
+    : undefined
 )
 const vehicleHeading = computed(() => (vehicleStore.attitude.yaw ? degrees(vehicleStore.attitude?.yaw).toFixed(2) : 0))
 const { history: vehiclePositionHistory } = useRefHistory(vehiclePosition)
-const vehicleLatLongHistory = computed(() => vehiclePositionHistory.value.map((posHis) => posHis.snapshot))
+const vehicleLatLongHistory = computed(() =>
+  vehiclePositionHistory.value.filter((posHis) => posHis.snapshot !== undefined).map((posHis) => posHis.snapshot)
+)
 const map: Ref<null | any> = ref(null) // eslint-disable-line @typescript-eslint/no-explicit-any
 const leafletObject = ref<null | Map>(null)
 


### PR DESCRIPTION
Adds position and heading.

<img width="771" alt="image" src="https://user-images.githubusercontent.com/6551040/231541953-0213aeae-e1de-4410-9658-acd09ae3c868.png">

Fix #297
Fix #298 
Improves #84 
