### PR TITLE
edit-menu: Move new-layer/profile button to the side of their selectors

### DIFF
--- a/src/components/EditMenu.vue
+++ b/src/components/EditMenu.vue
@@ -75,8 +75,15 @@
         return-object
         @update:model-value="loadProfile"
       />
+      <v-btn
+        class="ml-2"
+        icon="mdi-plus"
+        size="small"
+        variant="outlined"
+        rounded="lg"
+        @click="profileCreationDialog.reveal"
+      />
     </div>
-    <v-btn class="m-1 text-white" @click="profileCreationDialog.reveal"> Create new profile </v-btn>
     <v-btn class="m-1 text-white" @click="profileResetDialog.reveal"> Reset profiles </v-btn>
     <v-switch
       class="flex items-center justify-center m-1 max-h-8"


### PR DESCRIPTION
Before and after:

![image](https://user-images.githubusercontent.com/6551040/232119641-e28f044a-5add-47b6-9c6c-9ac9848cebe1.png) ![image](https://user-images.githubusercontent.com/6551040/232119568-22177736-dd83-4629-8366-27d8b00086a2.png)

![image](https://user-images.githubusercontent.com/6551040/232120273-6ca804c6-36be-4793-ba4c-9e33c99654c3.png) ![image](https://user-images.githubusercontent.com/6551040/232120078-95060ced-df88-4628-aeb7-22caa289e9a4.png)

