### PR TITLE
widgets[image-viewer]: Disallow image drag

### DIFF
--- a/src/components/widgets/ImageView.vue
+++ b/src/components/widgets/ImageView.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <img :src="src" />
+    <img :src="src" draggable="false" />
     <v-btn
       class="options-btn"
       icon="mdi-dots-vertical"


### PR DESCRIPTION
To prevent unwanted visual behavior.