### PR TITLE
widgets[DepthHUD]: Don't allow indicator to pass above 0 meters

### DIFF
--- a/src/components/widgets/DepthHUD.vue
+++ b/src/components/widgets/DepthHUD.vue
@@ -177,7 +177,7 @@ const renderCanvas = (): void => {
     ctx.stroke()
   }
 
-  const indicatorY = renderVars.indicatorY
+  const indicatorY = Math.max(renderVars.indicatorY, 0)
 
   ctx.strokeStyle = widget.value.options.hudColor
   ctx.fillStyle = widget.value.options.hudColor


### PR DESCRIPTION
This path is a visual improvement. With it, any depth value above 0 (out of water) is shown in the 0 level. Previously, it looked broken.

Before and after:

![image](https://github.com/bluerobotics/cockpit/assets/6551040/e88774d3-5f52-42eb-973b-b334512f5d04)

![image](https://github.com/bluerobotics/cockpit/assets/6551040/bb9a7513-fc06-4f37-9821-7716fb8ffd8e)
