### PR TITLE
vehicle-alerter: Remove pitch range alert

### DIFF
--- a/src/stores/vehicleAlerter.ts
+++ b/src/stores/vehicleAlerter.ts
@@ -1,7 +1,6 @@
 import { defineStore } from 'pinia'
-import { ref, watch } from 'vue'
+import { watch } from 'vue'
 
-import { degrees } from '@/libs/utils'
 import { useAlertStore } from '@/stores/alert'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { Alert, AlertLevel } from '@/types/alert'
@@ -9,8 +8,6 @@ import { Alert, AlertLevel } from '@/types/alert'
 export const useVehicleAlerterStore = defineStore('vehicle-alerter', () => {
   const vehicleStore = useMainVehicleStore()
   const alertStore = useAlertStore()
-
-  const pitchDegreeLimit = ref(30)
 
   watch(vehicleStore.statusText, () => {
     alertStore.pushAlert(new Alert(vehicleStore.statusText.severity, `Status: ${vehicleStore.statusText.text}`))
@@ -28,19 +25,4 @@ export const useVehicleAlerterStore = defineStore('vehicle-alerter', () => {
       alertStore.pushAlert(new Alert(AlertLevel.Info, `Vehicle ${state}`))
     }
   )
-
-  let lastPitch = 0
-  watch(vehicleStore.attitude, (newAttitude) => {
-    if (degrees(Math.abs(newAttitude.pitch - lastPitch)) < 0.1) return
-    lastPitch = newAttitude.pitch
-
-    const pitchDegrees = degrees(newAttitude.pitch)
-    const parsedPitch = pitchDegrees.toFixed(2)
-    if (pitchDegrees < -pitchDegreeLimit.value) {
-      alertStore.pushAlert(new Alert(AlertLevel.Critical, `Pitch too low (${parsedPitch})`))
-    }
-    if (pitchDegrees > pitchDegreeLimit.value) {
-      alertStore.pushAlert(new Alert(AlertLevel.Critical, `Pitch too high (${parsedPitch})`))
-    }
-  })
 })


### PR DESCRIPTION
This alert was developed to test initial alerts integration.

Right now this alert does not help much, since boats and ROVs do not have much problem with high/low pitches, and it is alerting a lot unnecessarily.

I'm removing it for now, and for the future I propose we have a generic alert configuration where the user can choose a variable and set a alert-range for it, completelly custom for his setup.