### PR TITLE
alerts: Disable alerts with `Info` level by default

### DIFF
--- a/src/stores/alert.ts
+++ b/src/stores/alert.ts
@@ -13,7 +13,7 @@ export const useAlertStore = defineStore('alert', () => {
   const enabledAlertLevels = useStorage('cockpit-enabled-alert-levels', [
     { level: AlertLevel.Success, enabled: true },
     { level: AlertLevel.Error, enabled: true },
-    { level: AlertLevel.Info, enabled: true },
+    { level: AlertLevel.Info, enabled: false },
     { level: AlertLevel.Warning, enabled: true },
     { level: AlertLevel.Critical, enabled: true },
   ])


### PR DESCRIPTION
They are annoying and usually not important.

Fix #378 