### PR TITLE
Map follows vehicle by default

### DIFF
--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -29,7 +29,7 @@
       class="absolute m-3 bottom-12 left-10 bg-slate-50"
       elevation="2"
       style="z-index: 1002; border-radius: 0px"
-      icon="mdi-image-filter-center-focus-strong"
+      icon="mdi-airplane-marker"
       size="x-small"
       @click="whoToFollow = WhoToFollow.VEHICLE"
     />

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -96,7 +96,7 @@
     />
     <v-btn
       class="absolute m-3 rounded-sm shadow-sm bottom-14 left-56 bg-slate-50"
-      icon="mdi-image-filter-center-focus-strong"
+      icon="mdi-airplane-marker"
       size="x-small"
       @click="whoToFollow = WhoToFollow.VEHICLE"
     />


### PR DESCRIPTION
Map follows the vehicle by default.
Auto-center on the home when clicking the home icon. Same for vehicle.
Changes the vehicle-follow icon.
All changes implemented for both Map widget and mission planning view.

Fix #386.