### PR TITLE
Use dashes instead of 0 when no data is available on the GenericIndicator widget

### DIFF
--- a/src/components/mini-widgets/GenericIndicator.vue
+++ b/src/components/mini-widgets/GenericIndicator.vue
@@ -106,7 +106,12 @@ onBeforeMount(() => {
 const store = useMainVehicleStore()
 
 const currentState = ref<unknown>(0)
-const parsedState = computed(() => round(Number(options.variableMultiplier) * Number(currentState.value)))
+const parsedState = computed(() => {
+  if (currentState.value) {
+    return round(Number(options.variableMultiplier) * Number(currentState.value)).toString()
+  }
+  return '--'
+})
 
 const updateVariableState = (): void => {
   currentState.value = store.genericVariables[options.variableName as string]


### PR DESCRIPTION
![image](https://github.com/bluerobotics/cockpit/assets/6551040/2e1fe558-d12a-4192-9247-c3129e83f9f7)

Fix #421 