### PR TITLE
Parse vehicle parameter table once

### DIFF
--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -345,15 +345,17 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
         metadata = ardurover_metadata
       }
 
+      const updatedParameterTable = {}
       for (const category of Object.values(metadata)) {
         for (const [name, parameter] of Object.entries(category)) {
           if (!isNaN(Number(parameter))) {
             continue
           }
           const newParameterTable = { ...parametersTable, ...{ [name]: parameter } }
-          Object.assign(parametersTable, newParameterTable)
+          Object.assign(updatedParameterTable, newParameterTable)
         }
       }
+      Object.assign(parametersTable, updatedParameterTable)
     }
     requestParametersList()
   })


### PR DESCRIPTION
With the previous implementation, the reactive property of the store was updated hundreds of times on the initial parsing, leading to a performance bottleneck.

The new implementation parse the entire metadata and then assign it to the reactive property, so it prevents unnecessary reactive calculations.

Fix #362.

Parsing went from 1.2 seconds to 12 milliseconds.