### PR TITLE
Move alerts tooltip to the right

### DIFF
--- a/src/components/widgets/Alerter.vue
+++ b/src/components/widgets/Alerter.vue
@@ -16,7 +16,7 @@
       :class="{ 'opacity-0 invisible': !isShowingExpandedAlerts }"
     >
       <div v-for="(alert, i) in sortedAlertsReversed" :key="alert.time_created.toISOString()">
-        <div v-tooltip.bottom="alert.message" class="flex items-center justify-between whitespace-nowrap">
+        <div v-tooltip.right="alert.message" class="flex items-center justify-between whitespace-nowrap">
           <p class="mx-1 overflow-hidden text-lg font-medium leading-none text-ellipsis">{{ alert.message }}</p>
           <div
             class="flex flex-col justify-center mx-1 font-mono text-xs font-semibold leading-3 text-right text-gray-100"


### PR DESCRIPTION
This way, the tooltip doesn't get in the way of the user's mouse, preventing the alerter menu from closing when the mouse hovers the tolltip (thus unhovering the menu itself).

Fix #467 