### PR TITLE
Make Alerter take 25% of the bar size at most

### DIFF
--- a/src/components/widgets/Alerter.vue
+++ b/src/components/widgets/Alerter.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="relative flex-grow mx-1 my-1.5">
+  <div class="relative flex-grow mx-1 my-1.5 max-w-[25%]">
     <div
       ref="currentAlertBar"
       class="flex items-center justify-between p-1 overflow-hidden rounded cursor-pointer select-none whitespace-nowrap bg-slate-800/75"


### PR DESCRIPTION
Sometimes we receive huge mavlink messages that make the alerter take the entire top bar.