### PR TITLE
Always teleport the `Dialog` component to the body tag

### DIFF
--- a/src/components/Dialog.vue
+++ b/src/components/Dialog.vue
@@ -1,9 +1,11 @@
 <template>
-  <dialog ref="dialogRef" class="modal">
-    <div ref="dialogContentRef" class="flex flex-col items-center justify-center w-full h-full p-5 backdrop-blur-sm">
-      <slot></slot>
-    </div>
-  </dialog>
+  <teleport to="body">
+    <dialog ref="dialogRef" class="modal">
+      <div ref="dialogContentRef" class="flex flex-col items-center justify-center w-full h-full p-5 backdrop-blur-sm">
+        <slot></slot>
+      </div>
+    </dialog>
+  </teleport>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
Fix #487 