### PR TITLE
Re-style edit menu

### DIFF
--- a/src/components/EditMenu.vue
+++ b/src/components/EditMenu.vue
@@ -19,7 +19,11 @@
             :key="view.hash"
             class="flex items-center justify-between w-full my-1"
           >
-            <Button class="flex items-center justify-center w-full h-8 overflow-auto" @click="store.selectView(view)">
+            <Button
+              class="flex items-center justify-center w-full h-8 overflow-auto"
+              :class="{ 'selected-view': view === store.currentView }"
+              @click="store.selectView(view)"
+            >
               <p class="overflow-hidden text-sm text-ellipsis ml-7 whitespace-nowrap">{{ view.name }}</p>
               <div class="grow" />
               <div class="icon-btn mdi mdi-cog" @click="renameView(view)" />
@@ -364,5 +368,9 @@ const { pressed: mousePressed } = useMousePressed()
 }
 .icon-btn:hover {
   @apply bg-slate-500;
+}
+
+.selected-view {
+  @apply bg-slate-400;
 }
 </style>


### PR DESCRIPTION
This is part of the profile-management reintegration.

With this change, the left-side menu gets way less bloated, the widget names don't get overflown, and we open space for the profile-management section.

Before / after:

![image](https://github.com/bluerobotics/cockpit/assets/6551040/15f11d33-0902-4ccb-b42f-66dfecb2b0ca)

![image](https://github.com/bluerobotics/cockpit/assets/6551040/b68d278c-9478-4fcc-b5c2-3c106c44996f)

To be merged after #489.