### PR TITLE
Refresh page after setting new global address

### DIFF
--- a/src/views/ConfigurationGeneralView.vue
+++ b/src/views/ConfigurationGeneralView.vue
@@ -229,6 +229,10 @@ const addNewVehicleConnection = async (): Promise<void> => {
 const setGlobalAddress = async (): Promise<void> => {
   await globalAddressForm.value.validate()
   mainVehicleStore.globalAddress = newGlobalAddress.value
+
+  // Temporary solution to actually set the address and connect the vehicle, since this is non-reactive today.
+  // TODO: Modify the store variables to be reactive.
+  location.reload()
 }
 
 const setWebRTCSignallingURI = async (): Promise<void> => {


### PR DESCRIPTION
This is a temporary fix for the problem of setting a new global address and the configuration not being done.