### PR TITLE
Use 0-360 range on the `CompassHUD`

### DIFF
--- a/src/components/widgets/CompassHUD.vue
+++ b/src/components/widgets/CompassHUD.vue
@@ -203,7 +203,7 @@ const renderCanvas = (): void => {
     if (!widget.value.options.useNegativeRange) {
       finalAngle = finalAngle < 0 ? finalAngle + 360 : finalAngle
     }
-    ctx.fillText(`${finalAngle.toFixed(2)}°`, halfCanvasWidth, refFontSize)
+    ctx.fillText(`${finalAngle.toFixed(1)}°`, halfCanvasWidth, refFontSize)
   }
 
   // Draw reference triangle


### PR DESCRIPTION
![image](https://github.com/bluerobotics/cockpit/assets/6551040/24e01711-4052-4d58-9500-9b25b80705a1)

Also allows using the -180/+180 range if desired, and reduce the number of digits after the decimal place to 1.

Fix #265 
Fix #499 