### PR TITLE
Try to prevent user from closing Cockpit during video record

### DIFF
--- a/src/components/mini-widgets/MiniVideoRecorder.vue
+++ b/src/components/mini-widgets/MiniVideoRecorder.vue
@@ -249,6 +249,22 @@ watch(externalStreams, () => {
     updateCurrentStream(savedStream)
   }
 })
+
+// Try to prevent user from closing Cockpit when a stream is being recorded
+watch(isRecording, () => {
+  if (!isRecording.value) {
+    window.onbeforeunload = null
+    return
+  }
+  window.onbeforeunload = () => {
+    const alertMsg = `
+      You have a video recording ongoing.
+      Remember to stop it before closing Cockpit, or the record will be lost.
+    `
+    Swal.fire({ text: alertMsg, icon: 'warning' })
+    return 'I hope the user does not click on the leave button.'
+  }
+})
 </script>
 
 <style scoped>


### PR DESCRIPTION
This is the best we can do for now. Chrome (as most other browsers) do not allow us anymore to set a custom message on the tab-closing alert.

With this patch, it's very unlikely that the user will make the same mistake twice.

A better solution for the future would be to save the recording direct to the user's drive, instead of the memory. I don't know if that's possible or not.

https://github.com/bluerobotics/cockpit/assets/6551040/0ce2557b-b847-456b-a384-2c800b14da77

Fix #518 