### PR TITLE
Use ‘Cockpit’ in video file names if mission name is not set

### DIFF
--- a/src/components/mini-widgets/MiniVideoRecorder.vue
+++ b/src/components/mini-widgets/MiniVideoRecorder.vue
@@ -186,7 +186,8 @@ const startRecording = async (): Promise<SweetAlertResult | void> => {
   mediaRecorder.value.onstop = () => {
     const blob = new Blob(chunks, { type: 'video/webm' })
     fixWebmDuration(blob, Date.now() - timeRecordingStart.value.getTime()).then((fixedBlob) => {
-      saveAs(fixedBlob, `${missionName} (${format(timeRecordingStart.value, 'LLL dd, yyyy - HH꞉mm꞉ss O')})`)
+      const fileName = `${missionName || 'Cockpit'} (${format(timeRecordingStart.value, 'LLL dd, yyyy - HH꞉mm꞉ss O')})`
+      saveAs(fixedBlob, fileName)
     })
     chunks = []
     mediaRecorder.value = undefined


### PR DESCRIPTION
Fix #534