### PR TITLE
Allow blocking IPs from transmitting WebRTC video

### DIFF
--- a/src/components/mini-widgets/MiniVideoRecorder.vue
+++ b/src/components/mini-widgets/MiniVideoRecorder.vue
@@ -244,7 +244,7 @@ watch(externalStreams, () => {
   // Retrieve stream from the saved stream name, otherwise choose the first available stream as a fallback
   const savedStream = savedStreamName ? availableStreams.value.find((s) => s.name === savedStreamName) : undefined
 
-  if (savedStream !== undefined && savedStream !== selectedStream.value && selectedStream.value === undefined) {
+  if (savedStream !== undefined && savedStream.id !== selectedStream.value?.id && selectedStream.value === undefined) {
     console.debug!('[WebRTC] trying to set stream...')
     updateCurrentStream(savedStream)
   }

--- a/src/components/mini-widgets/MiniVideoRecorder.vue
+++ b/src/components/mini-widgets/MiniVideoRecorder.vue
@@ -57,6 +57,7 @@ import { useMouseInElement, useTimestamp } from '@vueuse/core'
 import { format, intervalToDuration } from 'date-fns'
 import { saveAs } from 'file-saver'
 import fixWebmDuration from 'fix-webm-duration'
+import { storeToRefs } from 'pinia'
 import Swal, { type SweetAlertResult } from 'sweetalert2'
 import { computed, onBeforeMount, onBeforeUnmount, ref, toRefs, watch } from 'vue'
 import adapter from 'webrtc-adapter'
@@ -65,7 +66,11 @@ import { WebRTCManager } from '@/composables/webRTC'
 import type { Stream } from '@/libs/webrtc/signalling_protocol'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useMissionStore } from '@/stores/mission'
+import { useVideoStore } from '@/stores/video'
 import type { MiniWidget } from '@/types/miniWidgets'
+
+const videoStore = useVideoStore()
+const { allowedIceIps } = storeToRefs(videoStore)
 
 const { rtcConfiguration, webRTCSignallingURI } = useMainVehicleStore()
 const { missionName } = useMissionStore()
@@ -82,7 +87,7 @@ const miniWidget = toRefs(props).miniWidget
 
 const selectedStream = ref<Stream | undefined>()
 const webRTCManager = new WebRTCManager(webRTCSignallingURI.val, rtcConfiguration)
-const { availableStreams: externalStreams, mediaStream } = webRTCManager.startStream(selectedStream, ref(undefined))
+const { availableStreams: externalStreams, mediaStream } = webRTCManager.startStream(selectedStream, allowedIceIps)
 const mediaRecorder = ref<MediaRecorder>()
 const recorderWidget = ref()
 const { isOutside } = useMouseInElement(recorderWidget)

--- a/src/components/mini-widgets/MiniVideoRecorder.vue
+++ b/src/components/mini-widgets/MiniVideoRecorder.vue
@@ -82,7 +82,7 @@ const miniWidget = toRefs(props).miniWidget
 
 const selectedStream = ref<Stream | undefined>()
 const webRTCManager = new WebRTCManager(webRTCSignallingURI.val, rtcConfiguration)
-const { availableStreams: externalStreams, mediaStream } = webRTCManager.startStream(selectedStream)
+const { availableStreams: externalStreams, mediaStream } = webRTCManager.startStream(selectedStream, ref(undefined))
 const mediaRecorder = ref<MediaRecorder>()
 const recorderWidget = ref()
 const { isOutside } = useMouseInElement(recorderWidget)

--- a/src/components/widgets/VideoPlayer.vue
+++ b/src/components/widgets/VideoPlayer.vue
@@ -133,7 +133,7 @@ watch(availableStreams, () => {
       ? availableStreams.value.find((s) => s.name === savedStreamName)
       : availableStreams.value.first()
 
-  if (savedStream !== undefined && savedStream !== selectedStream.value) {
+  if (savedStream !== undefined && savedStream.id !== selectedStream.value?.id) {
     console.debug!('[WebRTC] trying to set stream...')
     selectedStream.value = savedStream
   }

--- a/src/components/widgets/VideoPlayer.vue
+++ b/src/components/widgets/VideoPlayer.vue
@@ -38,7 +38,7 @@
         <v-combobox
           v-model="selectedICEIPsField"
           multiple
-          :items="availableICEIPsBuffer"
+          :items="videoStore.availableIceIps"
           label="Allowed WebRTC remote IP Addresses"
           class="w-full my-3 uri-input"
           variant="outlined"
@@ -76,7 +76,10 @@ import { WebRTCManager } from '@/composables/webRTC'
 import { isValidNetworkAddress } from '@/libs/utils'
 import type { Stream } from '@/libs/webrtc/signalling_protocol'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
+import { useVideoStore } from '@/stores/video'
 import type { Widget } from '@/types/widgets'
+
+const videoStore = useVideoStore()
 
 const isValidHostAddress = (value: string): boolean | string => {
   return isValidNetworkAddress(value) ?? 'Invalid host address. Should be an IP address or a hostname'
@@ -95,7 +98,6 @@ const props = defineProps<{
 
 const widget = toRefs(props).widget
 
-const availableICEIPsBuffer = ref<string[]>([])
 const selectedICEIPsField = ref<string[]>([])
 const selectedICEIPs = ref<string[] | undefined>()
 const selectedStream = ref<Stream | undefined>()
@@ -147,8 +149,9 @@ watch(selectedICEIPsField, () => {
 })
 
 setInterval(() => {
-  const combinedArray = [...availableICEIPsBuffer.value, ...availableICEIPs.value]
-  availableICEIPsBuffer.value = combinedArray.filter((value, index, array) => array.indexOf(value) === index)
+  const combinedIps = [...videoStore.availableIceIps, ...availableICEIPs.value]
+  const uniqueIps = combinedIps.filter((value, index, array) => array.indexOf(value) === index)
+  videoStore.availableIceIps = uniqueIps
 }, 1000)
 
 watch(selectedStream, () => (widget.value.options.streamName = selectedStream.value?.name))

--- a/src/components/widgets/VideoPlayer.vue
+++ b/src/components/widgets/VideoPlayer.vue
@@ -69,6 +69,7 @@
 </template>
 
 <script setup lang="ts">
+import { storeToRefs } from 'pinia'
 import { computed, onBeforeMount, onBeforeUnmount, ref, toRefs, watch } from 'vue'
 import adapter from 'webrtc-adapter'
 
@@ -80,6 +81,7 @@ import { useVideoStore } from '@/stores/video'
 import type { Widget } from '@/types/widgets'
 
 const videoStore = useVideoStore()
+const { allowedIceIps } = storeToRefs(videoStore)
 
 const isValidHostAddress = (value: string): boolean | string => {
   return isValidNetworkAddress(value) ?? 'Invalid host address. Should be an IP address or a hostname'
@@ -98,14 +100,13 @@ const props = defineProps<{
 
 const widget = toRefs(props).widget
 
-const selectedICEIPsField = ref<string[]>([])
-const selectedICEIPs = ref<string[] | undefined>()
+const selectedICEIPsField = ref<string[]>(allowedIceIps.value)
 const selectedStream = ref<Stream | undefined>()
 const videoElement = ref<HTMLVideoElement | undefined>()
 const webRTCManager = new WebRTCManager(webRTCSignallingURI.val, rtcConfiguration)
 const { availableStreams, availableICEIPs, mediaStream, signallerStatus, streamStatus } = webRTCManager.startStream(
   selectedStream,
-  selectedICEIPs
+  allowedIceIps
 )
 
 onBeforeMount(() => {
@@ -145,7 +146,7 @@ watch(mediaStream, async (newStream, oldStream) => {
 
 watch(selectedICEIPsField, () => {
   const validSelectedIPs = selectedICEIPsField.value.filter((address) => isValidHostAddress(address))
-  selectedICEIPs.value = validSelectedIPs
+  allowedIceIps.value = validSelectedIPs
 })
 
 setInterval(() => {

--- a/src/composables/webRTC.ts
+++ b/src/composables/webRTC.ts
@@ -46,7 +46,7 @@ export class WebRTCManager {
   private streamName: string | undefined
   private session: Session | undefined
   private rtcConfiguration: RTCConfiguration
-  private selectedICEIPs: string[] | undefined
+  private selectedICEIPs: string[] = []
 
   private hasEnded = false
   private signaller: Signaller
@@ -87,10 +87,9 @@ export class WebRTCManager {
    * @param { Ref<string[]> } selectedICEIPs
    * @returns { startStreamReturn }
    */
-  public startStream(
-    selectedStream: Ref<Stream | undefined>,
-    selectedICEIPs: Ref<string[] | undefined>
-  ): startStreamReturn {
+  public startStream(selectedStream: Ref<Stream | undefined>, selectedICEIPs: Ref<string[]>): startStreamReturn {
+    this.selectedICEIPs = selectedICEIPs.value
+
     watch(selectedStream, (newStream, oldStream) => {
       if (newStream?.id === oldStream?.id) {
         return
@@ -125,9 +124,6 @@ export class WebRTCManager {
         this.startSession()
       }
     })
-
-    // FIXME: I want to assign this.selectedICEIPs when startStream is first called
-    // this.selectedICEIPs = selectedICEIPs.value
 
     return {
       availableStreams: this.availableStreams,

--- a/src/composables/webRTC.ts
+++ b/src/composables/webRTC.ts
@@ -16,6 +16,10 @@ interface startStreamReturn {
    */
   availableStreams: Ref<Array<Stream>>
   /**
+   * A list of IPs from WebRTC candidates that are available
+   */
+  availableICEIPs: Ref<Array<string>>
+  /**
    * MediaStream object, if WebRTC stream is chosen
    */
   mediaStream: Ref<MediaStream | undefined>
@@ -34,6 +38,7 @@ interface startStreamReturn {
  */
 export class WebRTCManager {
   private availableStreams: Ref<Array<Stream>> = ref(new Array<Stream>())
+  private availableICEIPs: Ref<Array<string>> = ref(new Array<string>())
   private mediaStream: Ref<MediaStream | undefined> = ref()
   private signallerStatus: Ref<string> = ref('waiting...')
   private streamStatus: Ref<string> = ref('waiting...')
@@ -126,6 +131,7 @@ export class WebRTCManager {
 
     return {
       availableStreams: this.availableStreams,
+      availableICEIPs: this.availableICEIPs,
       mediaStream: this.mediaStream,
       signallerStatus: this.signallerStatus,
       streamStatus: this.streamStatus,
@@ -335,6 +341,7 @@ export class WebRTCManager {
       this.rtcConfiguration,
       selectedICEIPs,
       (event: RTCTrackEvent): void => this.onTrackAdded(event),
+      (availableICEIPs: string[]) => (this.availableICEIPs.value = availableICEIPs),
       (_sessionId, reason) => this.onSessionClosed(reason)
     )
 

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -59,3 +59,22 @@ export const resetCanvas = (context: CanvasRenderingContext2D): void => {
   context.clearRect(0, 0, context.canvas.width, context.canvas.height)
   context.globalCompositeOperation = 'source-over'
 }
+
+export const isValidNetworkAddress = (maybeAddress: string): boolean => {
+  if (maybeAddress && maybeAddress.length >= 255) {
+    return false
+  }
+
+  // Regexes from https://stackoverflow.com/a/106223/3850957
+  const ipRegex = new RegExp(
+    '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$'
+  )
+  const hostnameRegex = new RegExp(
+    '^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$'
+  )
+
+  if (ipRegex.test(maybeAddress) || hostnameRegex.test(maybeAddress)) {
+    return true
+  }
+  return false
+}

--- a/src/libs/webrtc/session.ts
+++ b/src/libs/webrtc/session.ts
@@ -170,7 +170,12 @@ export class Session {
    */
   public onIncomingICE(candidate: RTCIceCandidateInit): void {
     // Ignores unwanted routes, useful, for example, to prevent WebRTC to chose the wrong route, like when the OS default is WiFi but you want to receive the video via tether because of reliability
-    if (candidate.candidate && !this.selectedICEIPs.some((address) => candidate.candidate!.includes(address))) {
+    if (
+      candidate.candidate &&
+      Array.isArray(this.selectedICEIPs) &&
+      !this.selectedICEIPs.isEmpty() &&
+      !this.selectedICEIPs.some((address) => candidate.candidate!.includes(address))
+    ) {
       console.debug(`[WebRTC] [Session] ICE candidate ignored: ${JSON.stringify(candidate, null, 4)}`)
       return
     }

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -1,8 +1,10 @@
+import { useStorage } from '@vueuse/core'
 import { defineStore } from 'pinia'
 import { reactive } from 'vue'
 
 export const useVideoStore = defineStore('video', () => {
   const availableIceIps = reactive<string[]>([])
+  const allowedIceIps = useStorage<string[]>('cockpit-allowed-stream-ips', [])
 
-  return { availableIceIps }
+  return { availableIceIps, allowedIceIps }
 })

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -1,0 +1,8 @@
+import { defineStore } from 'pinia'
+import { reactive } from 'vue'
+
+export const useVideoStore = defineStore('video', () => {
+  const availableIceIps = reactive<string[]>([])
+
+  return { availableIceIps }
+})

--- a/src/views/ConfigurationGeneralView.vue
+++ b/src/views/ConfigurationGeneralView.vue
@@ -138,6 +138,7 @@ import { ref, watch } from 'vue'
 import { defaultGlobalAddress } from '@/assets/defaults'
 import * as Connection from '@/libs/connection/connection'
 import { ConnectionManager } from '@/libs/connection/connection-manager'
+import { isValidNetworkAddress } from '@/libs/utils'
 import * as Protocol from '@/libs/vehicle/protocol/protocol'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 
@@ -164,23 +165,7 @@ watch(
 )
 
 const isValidHostAddress = (value: string): boolean | string => {
-  if (value.length >= 255) {
-    return 'Address is too long'
-  }
-
-  // Regexes from https://stackoverflow.com/a/106223/3850957
-  const ipRegex = new RegExp(
-    '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$'
-  )
-  const hostnameRegex = new RegExp(
-    '^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$'
-  )
-
-  if (ipRegex.test(value) || hostnameRegex.test(value)) {
-    return true
-  }
-
-  return 'Invalid host address. Should be an IP address or a hostname'
+  return isValidNetworkAddress(value) ?? 'Invalid host address. Should be an IP address or a hostname'
 }
 
 const isValidSocketConnectionURI = (value: string): boolean | string => {

--- a/src/views/ConfigurationGeneralView.vue
+++ b/src/views/ConfigurationGeneralView.vue
@@ -2,13 +2,13 @@
   <BaseConfigurationView>
     <template #title>General configuration</template>
     <template #content>
-      <v-card class="pa-5 pb-2 ma-4" max-width="600px">
+      <v-card class="pb-2 pa-5 ma-4" max-width="600px">
         <v-icon :icon="'mdi-earth'" class="mr-3" />
         <span class="text-h6">Global vehicle address</span>
         <v-form
           ref="globalAddressForm"
           v-model="globalAddressFormValid"
-          class="d-flex justify-center align-center"
+          class="justify-center d-flex align-center"
           @submit.prevent="setGlobalAddress"
         >
           <v-text-field
@@ -20,13 +20,13 @@
             :rules="[isValidHostAddress]"
           />
 
-          <v-btn v-tooltip.bottom="'Set'" icon="mdi-check" class="pa-0 mx-1 mb-5" rounded="lg" flat type="submit" />
+          <v-btn v-tooltip.bottom="'Set'" icon="mdi-check" class="mx-1 mb-5 pa-0" rounded="lg" flat type="submit" />
           <v-template>
             <v-btn
               v-tooltip.bottom="'Reset to default'"
               :disabled="newGlobalAddress === defaultGlobalAddress"
               icon="mdi-refresh"
-              class="pa-0 mx-1 mb-5"
+              class="mx-1 mb-5 pa-0"
               rounded="lg"
               flat
               @click="resetGlobalAddress"
@@ -35,20 +35,20 @@
         </v-form>
         <span>Current address: {{ mainVehicleStore.globalAddress }} </span><br />
       </v-card>
-      <v-card class="pa-5 pb-2 ma-4" max-width="600px">
+      <v-card class="pb-2 pa-5 ma-4" max-width="600px">
         <v-progress-circular v-if="vehicleConnected === undefined" indeterminate size="24" class="mr-3" />
         <v-icon v-else :icon="vehicleConnected ? 'mdi-lan-connect' : 'mdi-lan-disconnect'" class="mr-3" />
         <span class="text-h6">Mavlink2Rest connection</span>
         <v-form
           ref="connectionForm"
           v-model="connectionFormValid"
-          class="d-flex justify-center align-center"
+          class="justify-center d-flex align-center"
           @submit.prevent="addNewVehicleConnection"
         >
           <v-checkbox
             v-model="connectionURI.isCustom"
             v-tooltip.bottom="'Enable custom'"
-            class="pa-0 mx-1 mb-5"
+            class="mx-1 mb-5 pa-0"
             rounded="lg"
             hide-details
           />
@@ -64,13 +64,13 @@
             :rules="[isValidSocketConnectionURI]"
           />
 
-          <v-btn v-tooltip.bottom="'Set'" icon="mdi-check" class="pa-0 mx-1 mb-5" rounded="lg" flat type="submit" />
+          <v-btn v-tooltip.bottom="'Set'" icon="mdi-check" class="mx-1 mb-5 pa-0" rounded="lg" flat type="submit" />
           <v-template>
             <v-btn
               v-tooltip.bottom="'Reset to default'"
               :disabled="connectionURI.toString() === connectionURI.defaultValue.toString()"
               icon="mdi-refresh"
-              class="pa-0 mx-1 mb-5"
+              class="mx-1 mb-5 pa-0"
               rounded="lg"
               flat
               @click="resetVehicleConnection"
@@ -85,19 +85,19 @@
           }}</span
         >
       </v-card>
-      <v-card class="pa-5 pb-2 ma-4" max-width="600px">
+      <v-card class="pb-2 pa-5 ma-4" max-width="600px">
         <v-icon :icon="'mdi-lan-pending'" class="mr-3" />
         <span class="text-h6">WebRTC connection</span>
         <v-form
           ref="webRTCSignallingForm"
           v-model="webRTCSignallingFormValid"
-          class="d-flex justify-center align-center"
+          class="justify-center d-flex align-center"
           @submit.prevent="setWebRTCSignallingURI"
         >
           <v-checkbox
             v-model="webRTCSignallingURI.isCustom"
             v-tooltip.bottom="'Enable custom'"
-            class="pa-0 mx-1 mb-5"
+            class="mx-1 mb-5 pa-0"
             rounded="lg"
             hide-details
           />
@@ -113,13 +113,13 @@
             :rules="[isValidSocketConnectionURI]"
           />
 
-          <v-btn v-tooltip.bottom="'Set'" icon="mdi-check" class="pa-0 mx-1 mb-5" rounded="lg" flat type="submit" />
+          <v-btn v-tooltip.bottom="'Set'" icon="mdi-check" class="mx-1 mb-5 pa-0" rounded="lg" flat type="submit" />
           <v-template>
             <v-btn
               v-tooltip.bottom="'Reset to default'"
               :disabled="webRTCSignallingURI.val.toString() === webRTCSignallingURI.defaultValue.toString()"
               icon="mdi-refresh"
-              class="pa-0 mx-1 mb-5"
+              class="mx-1 mb-5 pa-0"
               rounded="lg"
               flat
               @click="resetWebRTCSignallingURI"


### PR DESCRIPTION
This patch allows the user to select which IPs should be allowed to transmit WebRTC video streams.
The selection is persistent between boots.
The only thing missing now is a popup saying to the user that he should define those (when they are undefined).

The solution was developed by @joaoantoniocardoso at #564. I kept his commits and polished the solution from there.

Fix #526 

https://github.com/bluerobotics/cockpit/assets/6551040/86124b93-37ef-48db-b0a6-8954ea2ef74a

