### PR TITLE
Remove button-like behavior from `VeryGenericIndicator`

### DIFF
--- a/src/components/mini-widgets/VeryGenericIndicator.vue
+++ b/src/components/mini-widgets/VeryGenericIndicator.vue
@@ -1,7 +1,5 @@
 <template>
-  <div
-    class="flex items-center justify-center h-12 py-1 text-white transition-all cursor-pointer w-fit hover:bg-slate-100/20"
-  >
+  <div class="flex items-center justify-center h-12 py-1 text-white transition-all w-fit">
     <span class="relative w-[2rem] mdi icon-symbol" :class="[miniWidget.options.iconName]"></span>
     <div class="flex flex-col items-start justify-center mx-1 select-none w-fit min-w-[3rem]">
       <div>


### PR DESCRIPTION
This is a deprecated code from when this mini-widget was configured by clicking in it.