### PR TITLE
Adjust `DepthIndicator` precision based on it's value (and fix it's width)

### DIFF
--- a/src/components/mini-widgets/DepthIndicator.vue
+++ b/src/components/mini-widgets/DepthIndicator.vue
@@ -3,7 +3,7 @@
     <img src="@/assets/depth-icon.svg" class="h-full" :draggable="false" />
     <div class="flex flex-col items-start justify-center ml-1 min-w-[4rem] max-w-[6rem] select-none">
       <div>
-        <span class="font-mono text-xl font-semibold leading-6 w-fit">{{ round(averageDepth, 2).toFixed(2) }}</span>
+        <span class="font-mono text-xl font-semibold leading-6 w-fit">{{ averageDepth.toPrecision(precision) }}</span>
         <span class="text-xl font-semibold leading-6 w-fit"> m</span>
       </div>
       <span class="w-full text-sm font-semibold leading-4 whitespace-nowrap">Depth</span>
@@ -15,8 +15,8 @@
 import { useRefHistory } from '@vueuse/core'
 import { useAverage } from '@vueuse/math'
 import { ref, watch } from 'vue'
+import { computed } from 'vue'
 
-import { round } from '@/libs/utils'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 
 const store = useMainVehicleStore()
@@ -26,4 +26,11 @@ const depth = ref(0)
 watch(store.altitude, () => (depth.value = -store.altitude.msl))
 const { history: depthHistory } = useRefHistory(depth, { capacity: 50 })
 const averageDepth = useAverage(() => depthHistory.value.map((depthHistoryValue) => depthHistoryValue.snapshot))
+const precision = computed(() => {
+  const avDepth = averageDepth.value
+  if (avDepth < 1) return 2
+  if (avDepth >= 1 && avDepth < 100) return 3
+  if (avDepth >= 10000) return 5
+  return 4
+})
 </script>

--- a/src/components/mini-widgets/DepthIndicator.vue
+++ b/src/components/mini-widgets/DepthIndicator.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex items-center w-fit min-w-[8rem] max-w-[9rem] h-12 p-1 text-white justify-center">
+  <div class="flex items-center w-[8.25rem] h-12 p-1 text-white justify-center">
     <img src="@/assets/depth-icon.svg" class="h-full" :draggable="false" />
     <div class="flex flex-col items-start justify-center ml-1 min-w-[4rem] max-w-[6rem] select-none">
       <div>


### PR DESCRIPTION


https://github.com/bluerobotics/cockpit/assets/6551040/71e9ffc8-27aa-4509-a185-367ccb711a90



This way it provides the indication in a sane matter, without extra unnecessary precision and without breaking the UI.

(Actually) fix #376 