### PR TITLE
Fix `DepthIndicator` for smaller (<10cm) and residual (<1cm) values

### DIFF
--- a/src/components/mini-widgets/DepthIndicator.vue
+++ b/src/components/mini-widgets/DepthIndicator.vue
@@ -3,7 +3,7 @@
     <img src="@/assets/depth-icon.svg" class="h-full" :draggable="false" />
     <div class="flex flex-col items-start justify-center ml-1 min-w-[4rem] max-w-[6rem] select-none">
       <div>
-        <span class="font-mono text-xl font-semibold leading-6 w-fit">{{ averageDepth.toPrecision(precision) }}</span>
+        <span class="font-mono text-xl font-semibold leading-6 w-fit">{{ finalDepth.toPrecision(precision) }}</span>
         <span class="text-xl font-semibold leading-6 w-fit"> m</span>
       </div>
       <span class="w-full text-sm font-semibold leading-4 whitespace-nowrap">Depth</span>
@@ -28,11 +28,13 @@ const depth = ref(0)
 watch(store.altitude, () => (depth.value = -store.altitude.msl))
 const { history: depthHistory } = useRefHistory(depth, { capacity: 50 })
 const averageDepth = useAverage(() => depthHistory.value.map((depthHistoryValue) => depthHistoryValue.snapshot))
+const finalDepth = computed(() => (averageDepth.value < 0.01 ? 0 : averageDepth.value))
 const precision = computed(() => {
-  const avDepth = averageDepth.value
-  if (avDepth < 1) return 2
-  if (avDepth >= 1 && avDepth < 100) return 3
-  if (avDepth >= 10000) return 5
+  const fDepth = finalDepth.value
+  if (fDepth < 0.1) return 1
+  if (fDepth < 1) return 2
+  if (fDepth >= 1 && fDepth < 100) return 3
+  if (fDepth >= 10000) return 5
   return 4
 })
 </script>


### PR DESCRIPTION
This kind of problem was happening for really small values:

![photo_5129721321742248927_x](https://github.com/bluerobotics/cockpit/assets/6551040/d3448f52-82f7-45d0-b1d4-d1b6e7e91c2c)

We now support only values of 1cm or more.

Thanks @joaoantoniocardoso for quickly reporting this one.
