### PR TITLE
Fix generic indicator size

### DIFF
--- a/src/assets/defaults.ts
+++ b/src/assets/defaults.ts
@@ -94,7 +94,6 @@ export const widgetProfiles: Profile[] = [
                 options: {
                   displayName: 'Pilot Gain',
                   variableName: 'PilotGain',
-                  fractionalDigits: 1,
                   iconName: 'mdi-account-hard-hat',
                   variableUnit: '%',
                   variableMultiplier: 100,
@@ -107,7 +106,6 @@ export const widgetProfiles: Profile[] = [
                 options: {
                   displayName: 'Lights (1)',
                   variableName: 'Lights1',
-                  fractionalDigits: 1,
                   iconName: 'mdi-flashlight',
                   variableUnit: '%',
                   variableMultiplier: 100,
@@ -120,7 +118,6 @@ export const widgetProfiles: Profile[] = [
                 options: {
                   displayName: 'Cam Tilt',
                   variableName: 'CamTilt',
-                  fractionalDigits: 1,
                   iconName: 'mdi-camera-retake',
                   variableUnit: '%',
                   variableMultiplier: 100,
@@ -144,7 +141,6 @@ export const widgetProfiles: Profile[] = [
                 options: {
                   displayName: 'Water Temp',
                   variableName: 'SCALED_PRESSURE2.temperature',
-                  fractionalDigits: 1,
                   iconName: 'mdi-thermometer',
                   variableUnit: '°C',
                   variableMultiplier: '.01',
@@ -267,7 +263,6 @@ export const widgetProfiles: Profile[] = [
                 options: {
                   displayName: 'Pilot Gain',
                   variableName: 'PilotGain',
-                  fractionalDigits: 1,
                   iconName: 'mdi-account-hard-hat',
                   variableUnit: '%',
                   variableMultiplier: 100,
@@ -280,7 +275,6 @@ export const widgetProfiles: Profile[] = [
                 options: {
                   displayName: 'Lights (1)',
                   variableName: 'Lights1',
-                  fractionalDigits: 1,
                   iconName: 'mdi-flashlight',
                   variableUnit: '%',
                   variableMultiplier: 100,
@@ -293,7 +287,6 @@ export const widgetProfiles: Profile[] = [
                 options: {
                   displayName: 'Cam Tilt',
                   variableName: 'CamTilt',
-                  fractionalDigits: 1,
                   iconName: 'mdi-camera-retake',
                   variableUnit: '%',
                   variableMultiplier: 100,
@@ -438,7 +431,6 @@ export const widgetProfiles: Profile[] = [
                 options: {
                   displayName: 'Pilot Gain',
                   variableName: 'PilotGain',
-                  fractionalDigits: 1,
                   iconName: 'mdi-account-hard-hat',
                   variableUnit: '%',
                   variableMultiplier: 100,
@@ -451,7 +443,6 @@ export const widgetProfiles: Profile[] = [
                 options: {
                   displayName: 'Lights (1)',
                   variableName: 'Lights1',
-                  fractionalDigits: 1,
                   iconName: 'mdi-flashlight',
                   variableUnit: '%',
                   variableMultiplier: 100,
@@ -464,7 +455,6 @@ export const widgetProfiles: Profile[] = [
                 options: {
                   displayName: 'Cam Tilt',
                   variableName: 'CamTilt',
-                  fractionalDigits: 1,
                   iconName: 'mdi-camera-retake',
                   variableUnit: '%',
                   variableMultiplier: 100,
@@ -488,7 +478,6 @@ export const widgetProfiles: Profile[] = [
                 options: {
                   displayName: 'Water Temp',
                   variableName: 'SCALED_PRESSURE2.temperature',
-                  fractionalDigits: 1,
                   iconName: 'mdi-thermometer',
                   variableUnit: '°C',
                   variableMultiplier: '.01',

--- a/src/components/mini-widgets/VeryGenericIndicator.vue
+++ b/src/components/mini-widgets/VeryGenericIndicator.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="flex items-center justify-center h-12 py-1 text-white transition-all w-fit">
+  <div class="flex items-center justify-center h-12 py-1 text-white transition-all w-[7rem]">
     <span class="relative w-[2rem] mdi icon-symbol" :class="[miniWidget.options.iconName]"></span>
-    <div class="flex flex-col items-start justify-center mx-1 select-none w-fit min-w-[3rem]">
+    <div class="flex flex-col items-start justify-center ml-1 select-none w-[4.75rem]">
       <div>
         <span class="font-mono text-xl font-semibold leading-6 w-fit">{{ parsedState }}</span>
         <span class="text-xl font-semibold leading-6 w-fit">

--- a/src/components/mini-widgets/VeryGenericIndicator.vue
+++ b/src/components/mini-widgets/VeryGenericIndicator.vue
@@ -41,10 +41,6 @@
           </div>
         </div>
         <div class="flex items-center justify-between w-full my-1">
-          <span class="mr-1 text-slate-100">Fractional digits</span>
-          <input v-model="miniWidget.options.fractionalDigits" class="w-48 px-2 py-1 rounded-md bg-slate-200" />
-        </div>
-        <div class="flex items-center justify-between w-full my-1">
           <span class="mr-1 text-slate-100">Unit</span>
           <input v-model="miniWidget.options.variableUnit" class="w-48 px-2 py-1 rounded-md bg-slate-200" />
         </div>
@@ -140,7 +136,6 @@ onBeforeMount(() => {
     Object.assign(miniWidget.value.options, {
       displayName: '',
       variableName: '',
-      fractionalDigits: 1,
       iconName: 'mdi-help-box',
       variableUnit: '%',
       variableMultiplier: 1,
@@ -155,14 +150,17 @@ onBeforeMount(() => {
 const store = useMainVehicleStore()
 
 const currentState = ref<unknown>(0)
+
+const finalValue = computed(() => Number(miniWidget.value.options.variableMultiplier) * Number(currentState.value))
 const parsedState = computed(() => {
-  if (currentState.value !== undefined) {
-    return round(
-      Number(miniWidget.value.options.variableMultiplier) * Number(currentState.value),
-      miniWidget.value.options.fractionalDigits as number
-    ).toFixed(miniWidget.value.options.fractionalDigits as number)
+  if (currentState.value === undefined) {
+    return '--'
   }
-  return '--'
+  const value = finalValue.value
+  if (value < 1) return value.toFixed(2)
+  if (value >= 1 && value < 100) return value.toFixed(1)
+  if (value >= 10000) return `${(value / 10000).toFixed(0)}k`
+  return value.toFixed(0)
 })
 
 const updateVariableState = (): void => {

--- a/src/types/genericIndicator.ts
+++ b/src/types/genericIndicator.ts
@@ -19,10 +19,6 @@ export interface VeryGenericIndicatorPreset {
    */
   variableUnit: string
   /**
-   * Number of digits to be displayed after the decimal separator (usually dot)
-   */
-  fractionalDigits: number
-  /**
    * Value that multiplies the original value to bring it to a representative unit system
    */
   variableMultiplier: number
@@ -34,7 +30,6 @@ export const veryGenericIndicatorPresets: VeryGenericIndicatorPreset[] = [
     variableName: 'CamTilt',
     iconName: 'mdi-camera-retake',
     variableUnit: '%',
-    fractionalDigits: 0,
     variableMultiplier: 100,
   },
   {
@@ -42,7 +37,6 @@ export const veryGenericIndicatorPresets: VeryGenericIndicatorPreset[] = [
     variableName: 'CamPan',
     iconName: 'mdi-camera-retake',
     variableUnit: '%',
-    fractionalDigits: 0,
     variableMultiplier: 100,
   },
   {
@@ -50,7 +44,6 @@ export const veryGenericIndicatorPresets: VeryGenericIndicatorPreset[] = [
     variableName: 'TetherTrn',
     iconName: 'mdi-horizontal-rotate-clockwise',
     variableUnit: 'x',
-    fractionalDigits: 0,
     variableMultiplier: 100,
   },
   {
@@ -58,7 +51,6 @@ export const veryGenericIndicatorPresets: VeryGenericIndicatorPreset[] = [
     variableName: 'Lights1',
     iconName: 'mdi-flashlight',
     variableUnit: '%',
-    fractionalDigits: 0,
     variableMultiplier: 100,
   },
   {
@@ -66,7 +58,6 @@ export const veryGenericIndicatorPresets: VeryGenericIndicatorPreset[] = [
     variableName: 'Lights2',
     iconName: 'mdi-flashlight',
     variableUnit: '%',
-    fractionalDigits: 0,
     variableMultiplier: 100,
   },
   {
@@ -74,7 +65,6 @@ export const veryGenericIndicatorPresets: VeryGenericIndicatorPreset[] = [
     variableName: 'PilotGain',
     iconName: 'mdi-account-hard-hat',
     variableUnit: '%',
-    fractionalDigits: 0,
     variableMultiplier: 100,
   },
   {
@@ -82,7 +72,6 @@ export const veryGenericIndicatorPresets: VeryGenericIndicatorPreset[] = [
     variableName: 'InputHold',
     iconName: 'mdi-gesture-tap-hold',
     variableUnit: '',
-    fractionalDigits: 0,
     variableMultiplier: 1,
   },
   {
@@ -90,7 +79,6 @@ export const veryGenericIndicatorPresets: VeryGenericIndicatorPreset[] = [
     variableName: 'RollPitch',
     iconName: 'mdi-controller',
     variableUnit: '',
-    fractionalDigits: 0,
     variableMultiplier: 1,
   },
 ]


### PR DESCRIPTION
This problem was happening for smaller screens.

Before:

<img width="433" alt="Screenshot 2023-11-28 at 17 51 24" src="https://github.com/bluerobotics/cockpit/assets/6551040/225ea1c0-33e3-4409-9aa4-a78cd053042e">

After:

<img width="433" alt="Screenshot 2023-11-28 at 17 52 01" src="https://github.com/bluerobotics/cockpit/assets/6551040/4e84dfbc-8d09-43da-b517-885cef4fff15">
