### PR TITLE
Video store rules all

### DIFF
--- a/src/components/ConfigurationMenu.vue
+++ b/src/components/ConfigurationMenu.vue
@@ -42,6 +42,7 @@ import ConfigurationDevelopmentView from '../views/ConfigurationDevelopmentView.
 import ConfigurationGeneralView from '../views/ConfigurationGeneralView.vue'
 import ConfigurationJoystickView from '../views/ConfigurationJoystickView.vue'
 import ConfigurationLogsView from '../views/ConfigurationLogsView.vue'
+import ConfigurationVideoView from '../views/ConfigurationVideoView.vue'
 
 const store = useMainVehicleStore()
 
@@ -58,6 +59,11 @@ const menus = [
     icon: 'mdi-controller',
     title: 'Joystick',
     component: ConfigurationJoystickView,
+  },
+  {
+    icon: 'mdi-video',
+    title: 'Video',
+    component: ConfigurationVideoView,
   },
   {
     icon: 'mdi-script',

--- a/src/composables/webRTC.ts
+++ b/src/composables/webRTC.ts
@@ -38,7 +38,7 @@ interface startStreamReturn {
  */
 export class WebRTCManager {
   private availableStreams: Ref<Array<Stream>> = ref(new Array<Stream>())
-  private availableICEIPs: Ref<Array<string>> = ref(new Array<string>())
+  public availableICEIPs: Ref<Array<string>> = ref(new Array<string>())
   private mediaStream: Ref<MediaStream | undefined> = ref()
   private signallerStatus: Ref<string> = ref('waiting...')
   private streamStatus: Ref<string> = ref('waiting...')

--- a/src/libs/sensors-logging.ts
+++ b/src/libs/sensors-logging.ts
@@ -231,9 +231,6 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text`
         }
       })
 
-      console.log(videoWidth, videoHeight)
-      console.log(0.1*videoWidth, 0.05*videoHeight)
-
       assFile = assFile.concat(`\nDialogue: 0,0:0:${secondsStart}.00,0:0:${secondsFinish}.00,Default,,${0.1*videoWidth},0,${0.05*videoHeight},,${subtitleDataString1}`)
       assFile = assFile.concat(`\nDialogue: 0,0:0:${secondsStart}.00,0:0:${secondsFinish}.00,Default,,${0.4*videoWidth},0,${0.05*videoHeight},,${subtitleDataString2}`)
       assFile = assFile.concat(`\nDialogue: 0,0:0:${secondsStart}.00,0:0:${secondsFinish}.00,Default,,${0.7*videoWidth},0,${0.05*videoHeight},,${subtitleDataString3}`)

--- a/src/libs/webrtc/signaller.ts
+++ b/src/libs/webrtc/signaller.ts
@@ -42,7 +42,11 @@ export class Signaller {
     console.debug('[WebRTC] [Signaller] ' + status)
     this.onStatusChange?.(status)
 
-    this.ws = this.connect()
+    try {
+      this.ws = this.connect()
+    } catch (error) {
+      console.error(`Could not establish initial connection. ${error}`)
+    }
   }
 
   /**
@@ -609,7 +613,11 @@ export class Signaller {
     oldWs.onmessage = null
     oldWs.onerror = null
 
-    this.ws = this.connect()
+    try {
+      this.ws = this.connect()
+    } catch (error) {
+      console.error(`[WebRTC] [Signaller] Could not reconnect. ${error}`)
+    }
   }
 
   /**

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -136,7 +136,7 @@ export const useVideoStore = defineStore('video', () => {
           </br>
           <p>To prevent issues and achieve an optimal streaming experience, please:</p>
           <ol>
-            <li>1. Open the configuration of one of your video widgets (in Edit Mode).</li>
+            <li>1. Open the video configuration page (Main-menu > Configuration > Video).</li>
             <li>2. Select the IP address that should be used for the video streaming.</li>
           </ol>
         `,

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -1,0 +1,22 @@
+import type { Ref } from 'vue'
+
+import { WebRTCManager } from '@/composables/webRTC'
+import type { Stream } from '@/libs/webrtc/signalling_protocol'
+
+/**
+ * Everything needed for every stream
+ */
+export interface StreamData {
+  /**
+   * The actual WebRTC stream
+   */
+  stream: Ref<Stream | undefined>
+  /**
+   * The responsible for its management
+   */
+  webRtcManager: WebRTCManager
+  /**
+   * MediaStream object, if WebRTC stream is chosen
+   */
+  mediaStream: Ref<MediaStream | undefined>
+}

--- a/src/views/ConfigurationVideoView.vue
+++ b/src/views/ConfigurationVideoView.vue
@@ -1,0 +1,46 @@
+<template>
+  <BaseConfigurationView>
+    <template #title>Video configuration</template>
+    <template #content>
+      <div
+        class="flex flex-col items-center px-5 py-3 m-5 font-medium text-center border rounded-md text-grey-darken-1 bg-grey-lighten-5 w-[40%]"
+      >
+        <p class="font-bold">
+          This is the video configuration page. Here you can configure the behavior of your video streams.
+        </p>
+        <br />
+        <p>
+          First of all, it's important that you select the IP (or IPs) that should be allowed to route video streams.
+          Those will usually be the ones for your wired connections. This configuration allows Cockpit to block other
+          available IPs, like those from WiFi and Hotspot connections, preventing lag and stuttering in your video
+          streams.
+        </p>
+      </div>
+
+      <div class="flex w-[30rem] flex-wrap">
+        <v-combobox
+          v-model="allowedIceIps"
+          multiple
+          :items="availableIceIps"
+          label="Allowed WebRTC remote IP Addresses"
+          class="w-full my-3 uri-input"
+          variant="outlined"
+          chips
+          clearable
+          hint="IP Addresses of the Vehicle allowed to be used for the WebRTC ICE Routing. Usually, the IP of the tether/cabled interface. Blank means any route. E.g: 192.168.2.2"
+        />
+      </div>
+    </template>
+  </BaseConfigurationView>
+</template>
+
+<script setup lang="ts">
+import { storeToRefs } from 'pinia'
+
+import { useVideoStore } from '@/stores/video'
+
+import BaseConfigurationView from './BaseConfigurationView.vue'
+
+const videoStore = useVideoStore()
+const { allowedIceIps, availableIceIps } = storeToRefs(videoStore)
+</script>


### PR DESCRIPTION
With this patch, the video store begins being responsible for internally routing available video streams.

https://github.com/bluerobotics/cockpit/assets/6551040/be61243d-39dc-4de6-8e53-915247cabdf7

Instead of having each video stream consumer (e.g.: VideoPlayer, MiniVideoRecorder) taking full control of the stream it is consuming, we delegate that to the video store, with the widget solely requesting (to the store) the stream it needs. The video store them checks if the requested stream is already being consumed, and if so, routes the same stream, instead of opening a new one with the WebRTC server, which was causing unnecessary usage of both bandwidth and computer resources, to the point of causing system failures or video stuttering.

In resume, with this patch one can add as many widgets as it wants for a same stream and only one connecting will be made to consume it.

I explicitly followed a non-reactive interval-based approach, as I'm not fully confident on the reactive behavior of the WebRTC composable yet. I think we still have an opportunity in the future to improve this code, making it completely reactive, but as it is the performance footprint is very small, and we benefit from having this patch sooner, fixing a critical problem being experienced by our beta testers.

Fix #360
Fix #602
Helps #633.

PS: 