### PR TITLE
Improve video recording management

### DIFF
--- a/src/components/mini-widgets/MiniVideoRecorder.vue
+++ b/src/components/mini-widgets/MiniVideoRecorder.vue
@@ -41,7 +41,7 @@
         <button
           class="flex items-center p-3 mx-2 font-medium transition-all rounded-md shadow-md w-fit text-uppercase hover:bg-slate-100"
           :class="{ 'bg-slate-200 opacity-30 pointer-events-none': isLoadingStream }"
-          @click=";[startRecording(), (isStreamSelectDialogOpen = false)]"
+          @click="startRecording"
         >
           <span>Record</span>
           <v-icon v-if="isLoadingStream" class="m-2 animate-spin">mdi-loading</v-icon>
@@ -54,21 +54,16 @@
 
 <script setup lang="ts">
 import { useMouseInElement, useTimestamp } from '@vueuse/core'
-import { format, intervalToDuration } from 'date-fns'
-import { saveAs } from 'file-saver'
-import fixWebmDuration from 'fix-webm-duration'
+import { intervalToDuration } from 'date-fns'
 import { storeToRefs } from 'pinia'
 import Swal, { type SweetAlertResult } from 'sweetalert2'
 import { computed, onBeforeMount, onBeforeUnmount, ref, toRefs, watch } from 'vue'
 
-import { datalogger } from '@/libs/sensors-logging'
 import { isEqual } from '@/libs/utils'
-import { useMissionStore } from '@/stores/mission'
 import { useVideoStore } from '@/stores/video'
 import type { MiniWidget } from '@/types/miniWidgets'
 
 const videoStore = useVideoStore()
-const { missionName } = useMissionStore()
 
 const props = defineProps<{
   /**
@@ -80,18 +75,12 @@ const miniWidget = toRefs(props).miniWidget
 
 const nameSelectedStream = ref<string | undefined>()
 const { namesAvailableStreams } = storeToRefs(videoStore)
-const mediaRecorder = ref<MediaRecorder>()
 const recorderWidget = ref()
 const { isOutside } = useMouseInElement(recorderWidget)
 const isStreamSelectDialogOpen = ref(false)
 const isLoadingStream = ref(false)
-const timeRecordingStart = ref(new Date())
 const timeNow = useTimestamp({ interval: 100 })
 const mediaStream = ref<MediaStream | undefined>()
-
-const isRecording = computed(() => {
-  return mediaRecorder.value !== undefined && mediaRecorder.value.state === 'recording'
-})
 
 onBeforeMount(async () => {
   // Set initial widget options if they don't exist
@@ -109,69 +98,38 @@ watch(nameSelectedStream, () => {
 })
 
 const toggleRecording = async (): Promise<void> => {
+  if (nameSelectedStream.value === undefined) {
+    Swal.fire({ text: 'No stream selected. Please choose one before continuing.', icon: 'error' })
+    return
+  }
   if (isRecording.value) {
-    stopRecording()
+    videoStore.stopRecording(nameSelectedStream.value)
     return
   }
   // Open dialog so user can choose the stream which will be recorded
   isStreamSelectDialogOpen.value = true
 }
 
-const startRecording = async (): Promise<SweetAlertResult | void> => {
-  if (namesAvailableStreams.value.isEmpty()) {
-    return Swal.fire({ text: 'No streams available.', icon: 'error' })
-  }
+const startRecording = (): void => {
   if (nameSelectedStream.value === undefined) {
-    if (namesAvailableStreams.value.length === 1) {
-      await updateCurrentStream(namesAvailableStreams.value[0])
-    } else {
-      return Swal.fire({ text: 'No stream selected. Please choose one before continuing.', icon: 'error' })
-    }
+    Swal.fire({ text: 'No stream selected.', icon: 'error' })
+    return
   }
-  if (mediaStream.value === undefined) {
-    return Swal.fire({ text: 'Media stream not defined.', icon: 'error' })
-  }
-  if (!mediaStream.value.active) {
-    return Swal.fire({ text: 'Media stream not yet active. Wait a second and try again.', icon: 'error' })
-  }
-
-  timeRecordingStart.value = new Date()
-  const fileName = `${missionName || 'Cockpit'} (${format(timeRecordingStart.value, 'LLL dd, yyyy - HH꞉mm꞉ss O')})`
-  mediaRecorder.value = new MediaRecorder(mediaStream.value)
-  if (!datalogger.logging()) {
-    datalogger.startLogging()
-  }
-  const videoTrack = mediaStream.value.getVideoTracks()[0]
-  const vWidth = videoTrack.getSettings().width || 1920
-  const vHeight = videoTrack.getSettings().height || 1080
-  mediaRecorder.value.start(1000)
-  let chunks: Blob[] = []
-  mediaRecorder.value.ondataavailable = async (e) => {
-    chunks.push(e.data)
-    await videoStore.videoRecoveryDB.setItem(fileName, chunks)
-  }
-
-  mediaRecorder.value.onstop = () => {
-    const blob = new Blob(chunks, { type: 'video/webm' })
-    const videoTelemetryLog = datalogger.getSlice(datalogger.currentCockpitLog, timeRecordingStart.value, new Date())
-    const assLog = datalogger.toAssOverlay(videoTelemetryLog, vWidth, vHeight, timeRecordingStart.value.getTime())
-    var logBlob = new Blob([assLog], { type: 'text/plain' })
-    fixWebmDuration(blob, Date.now() - timeRecordingStart.value.getTime()).then((fixedBlob) => {
-      saveAs(fixedBlob, `${fileName}.webm`)
-      saveAs(logBlob, `${fileName}.ass`)
-      videoStore.videoRecoveryDB.removeItem(fileName)
-    })
-    chunks = []
-    mediaRecorder.value = undefined
-  }
+  videoStore.startRecording(nameSelectedStream.value)
+  isStreamSelectDialogOpen.value = false
 }
 
-const stopRecording = (): void => {
-  mediaRecorder.value?.stop()
-}
+const isRecording = computed(() => {
+  if (nameSelectedStream.value === undefined) return false
+  return videoStore.isRecording(nameSelectedStream.value)
+})
 
 const timePassedString = computed(() => {
-  const duration = intervalToDuration({ start: timeRecordingStart.value, end: timeNow.value })
+  if (nameSelectedStream.value === undefined) return '00:00:00'
+  const timeRecordingStart = videoStore.getStreamData(nameSelectedStream.value)?.timeRecordingStart
+  if (timeRecordingStart === undefined) return '00:00:00'
+
+  const duration = intervalToDuration({ start: timeRecordingStart, end: timeNow.value })
   const durationHours = duration.hours?.toFixed(0).length === 1 ? `0${duration.hours}` : duration.hours
   const durationMinutes = duration.minutes?.toFixed(0).length === 1 ? `0${duration.minutes}` : duration.minutes
   const durationSeconds = duration.seconds?.toFixed(0).length === 1 ? `0${duration.seconds}` : duration.seconds
@@ -196,16 +154,10 @@ const updateCurrentStream = async (streamName: string | undefined): Promise<Swee
       return Swal.fire({ text: 'Could not load media stream.', icon: 'error' })
     }
   }
-  miniWidget.value.options.streamName = nameSelectedStream.value
+  miniWidget.value.options.streamName = streamName
 }
 
 const streamConnectionRoutine = setInterval(() => {
-  // If the video player widget is cold booted, assign the first stream to it
-  if (miniWidget.value.options.streamName === undefined && !namesAvailableStreams.value.isEmpty()) {
-    miniWidget.value.options.streamName = namesAvailableStreams.value[0]
-    nameSelectedStream.value = miniWidget.value.options.streamName
-  }
-
   const updatedMediaStream = videoStore.getMediaStream(miniWidget.value.options.streamName)
   // If the widget is not connected to the MediaStream, try to connect it
   if (!isEqual(updatedMediaStream, mediaStream.value)) {

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -70,7 +70,7 @@ export const useVideoStore = defineStore('video', () => {
   }
 
   /**
-   * bandwith or stress the stream provider more than we need to.
+   * Get the MediaStream object related to a given stream, if available
    * @param {string} streamName - Name of the stream
    * @returns {MediaStream | undefined} MediaStream that is running, if available
    */

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -47,8 +47,7 @@ export const useVideoStore = defineStore('video', () => {
       console.log(`New stream for '${streamName}':`)
       console.log(JSON.stringify(updatedStream, null, 2))
       activateStream(streamName)
-      // @ts-ignore
-      activeStreams.value[streamName].stream = updatedStream
+      activeStreams.value[streamName]!.stream = updatedStream
     })
   }, 300)
 
@@ -63,8 +62,10 @@ export const useVideoStore = defineStore('video', () => {
     const webRtcManager = new WebRTCManager(webRTCSignallingURI.val, rtcConfiguration)
     const { mediaStream } = webRtcManager.startStream(stream, allowedIceIps)
     activeStreams.value[streamName] = {
+      // @ts-ignore: This is actually not reactive
       stream: stream,
       webRtcManager: webRtcManager,
+      // @ts-ignore: This is actually not reactive
       mediaStream: mediaStream,
     }
   }
@@ -78,8 +79,7 @@ export const useVideoStore = defineStore('video', () => {
     if (activeStreams.value[streamName] === undefined) {
       activateStream(streamName)
     }
-    // @ts-ignore
-    return activeStreams.value[streamName].mediaStream
+    return activeStreams.value[streamName]!.mediaStream
   }
 
   // Offer download of backuped videos

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -1,5 +1,3 @@
-import type { Ref } from 'vue'
-
 import { WebRTCManager } from '@/composables/webRTC'
 import type { Stream } from '@/libs/webrtc/signalling_protocol'
 
@@ -10,7 +8,7 @@ export interface StreamData {
   /**
    * The actual WebRTC stream
    */
-  stream: Ref<Stream | undefined>
+  stream: Stream | undefined
   /**
    * The responsible for its management
    */
@@ -18,5 +16,5 @@ export interface StreamData {
   /**
    * MediaStream object, if WebRTC stream is chosen
    */
-  mediaStream: Ref<MediaStream | undefined>
+  mediaStream: MediaStream | undefined
 }

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -17,4 +17,12 @@ export interface StreamData {
    * MediaStream object, if WebRTC stream is chosen
    */
   mediaStream: MediaStream | undefined
+  /**
+   * MediaRecorder object for that stream
+   */
+  mediaRecorder: MediaRecorder | undefined
+  /**
+   * Date object with info on when a recording was started, if so
+   */
+  timeRecordingStart: Date | undefined
 }


### PR DESCRIPTION
Put the video store in charge of managing the video recordings, so recording information gets stored with the stream data. There are two main benefits on this:
- The lifecycle of a widget (e.g.: a view being changed and a recording widget being unmounted) does not affect the state of a recording
- Multiple recordings, from different streams, can be done simultaneously

Fix #624 
Fix #633

~To be merged after #654.~