### PR TITLE
Further performance improvements

### DIFF
--- a/src/components/widgets/Attitude.vue
+++ b/src/components/widgets/Attitude.vue
@@ -67,7 +67,10 @@ import { computed, nextTick, onBeforeMount, onMounted, reactive, ref, toRefs, wa
 import { datalogger, DatalogVariable } from '@/libs/sensors-logging'
 import { constrain, degrees, radians, resetCanvas, round } from '@/libs/utils'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
+import { useWidgetManagerStore } from '@/stores/widgetManager'
 import type { Widget } from '@/types/widgets'
+
+const widgetStore = useWidgetManagerStore()
 
 datalogger.registerUsage(DatalogVariable.roll)
 datalogger.registerUsage(DatalogVariable.pitch)
@@ -287,6 +290,7 @@ watch(rollAngleDeg, () => {
 
 // Update canvas whenever reference variables changes
 watch([renderVars, canvasSize, widget.value.options], () => {
+  if (!widgetStore.isWidgetVisible(widget.value)) return
   nextTick(() => renderCanvas())
 })
 </script>

--- a/src/components/widgets/Compass.vue
+++ b/src/components/widgets/Compass.vue
@@ -29,7 +29,10 @@ import Dropdown from '@/components/Dropdown.vue'
 import { datalogger, DatalogVariable } from '@/libs/sensors-logging'
 import { degrees, radians, resetCanvas, sequentialArray } from '@/libs/utils'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
+import { useWidgetManagerStore } from '@/stores/widgetManager'
 import type { Widget } from '@/types/widgets'
+
+const widgetStore = useWidgetManagerStore()
 
 datalogger.registerUsage(DatalogVariable.heading)
 const store = useMainVehicleStore()
@@ -216,6 +219,7 @@ watch(yaw, () => {
 
 // Update canvas whenever reference variables changes
 watch(renderVariables, () => {
+  if (!widgetStore.isWidgetVisible(widget.value)) return
   nextTick(() => renderCanvas())
 })
 </script>

--- a/src/components/widgets/CompassHUD.vue
+++ b/src/components/widgets/CompassHUD.vue
@@ -44,7 +44,10 @@ import { computed, nextTick, onBeforeMount, onMounted, reactive, ref, toRefs, wa
 import { datalogger, DatalogVariable } from '@/libs/sensors-logging'
 import { degrees, radians, resetCanvas } from '@/libs/utils'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
+import { useWidgetManagerStore } from '@/stores/widgetManager'
 import type { Widget } from '@/types/widgets'
+
+const widgetStore = useWidgetManagerStore()
 
 datalogger.registerUsage(DatalogVariable.heading)
 const store = useMainVehicleStore()
@@ -241,6 +244,7 @@ watch(yaw, () => {
 
 // Update canvas whenever reference variables changes
 watch([renderVars, canvasSize, widget.value.options], () => {
+  if (!widgetStore.isWidgetVisible(widget.value)) return
   nextTick(() => renderCanvas())
 })
 </script>

--- a/src/components/widgets/DepthHUD.vue
+++ b/src/components/widgets/DepthHUD.vue
@@ -36,7 +36,10 @@ import { computed, nextTick, onBeforeMount, onMounted, reactive, ref, toRefs, wa
 import { datalogger, DatalogVariable } from '@/libs/sensors-logging'
 import { constrain, range, resetCanvas, round } from '@/libs/utils'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
+import { useWidgetManagerStore } from '@/stores/widgetManager'
 import type { Widget } from '@/types/widgets'
+
+const widgetStore = useWidgetManagerStore()
 
 datalogger.registerUsage(DatalogVariable.depth)
 const store = useMainVehicleStore()
@@ -217,6 +220,7 @@ watch(depth, () => {
 
 // Update canvas whenever reference variables changes
 watch([renderVars, canvasSize, widget.value.options], () => {
+  if (!widgetStore.isWidgetVisible(widget.value)) return
   nextTick(() => renderCanvas())
 })
 </script>

--- a/src/components/widgets/VirtualHorizon.vue
+++ b/src/components/widgets/VirtualHorizon.vue
@@ -12,11 +12,23 @@
 <script setup lang="ts">
 import { useElementSize } from '@vueuse/core'
 import gsap from 'gsap'
-import { computed, nextTick, reactive, ref, watch } from 'vue'
+import { computed, nextTick, reactive, ref, toRefs, watch } from 'vue'
 
 import { datalogger, DatalogVariable } from '@/libs/sensors-logging'
 import { degrees, radians, resetCanvas } from '@/libs/utils'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
+import { useWidgetManagerStore } from '@/stores/widgetManager'
+import type { Widget } from '@/types/widgets'
+
+const widgetStore = useWidgetManagerStore()
+
+const props = defineProps<{
+  /**
+   * Widget reference
+   */
+  widget: Widget
+}>()
+const widget = toRefs(props).widget
 
 datalogger.registerUsage(DatalogVariable.roll)
 datalogger.registerUsage(DatalogVariable.pitch)
@@ -230,6 +242,7 @@ watch(rollAngleDeg, () => {
 
 // Update canvas whenever reference variables changes
 watch(renderVariables, () => {
+  if (!widgetStore.isWidgetVisible(widget.value)) return
   nextTick(() => renderCanvas())
 })
 </script>

--- a/src/stores/widgetManager.ts
+++ b/src/stores/widgetManager.ts
@@ -95,6 +95,15 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
   }
 
   /**
+   * Gets whether or not the widget is on the active view
+   * @returns { boolean }
+   * @param { Widget } widget - Widget
+   */
+  const isWidgetVisible = (widget: Widget): boolean => {
+    return viewFromWidget(widget).hash === currentView.value.hash
+  }
+
+  /**
    * Adds new profile to the store
    * @param { Profile } profile - The profile to be saved
    * @returns { Profile } The profile object just created
@@ -528,5 +537,6 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
     isFullScreen,
     importProfilesFromVehicle,
     exportProfilesToVehicle,
+    isWidgetVisible,
   }
 })

--- a/src/stores/widgetManager.ts
+++ b/src/stores/widgetManager.ts
@@ -100,7 +100,7 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
    * @param { Widget } widget - Widget
    */
   const isWidgetVisible = (widget: Widget): boolean => {
-    return viewFromWidget(widget).hash === currentView.value.hash
+    return document.visibilityState === 'visible' && viewFromWidget(widget).hash === currentView.value.hash
   }
 
   /**


### PR DESCRIPTION
This patch leads to a huge improvement in Cockpit's performance, as it forces resource-intensive widgets that are not visible to not re-render.

I tried using the [checkVisibility](https://developer.mozilla.org/en-US/docs/Web/API/Element/checkVisibility) property, but it does not work on our case since the elements are in the DOM, just not on top.

On my computer, it reduced the CPU usage of the Cockpit tab in about 30%. It also prevented crashes that were happening when I left Cockpit open in the background.