### PR TITLE
system-logging: Make system logger print/log more than the first call argument

### DIFF
--- a/src/libs/system-logging.ts
+++ b/src/libs/system-logging.ts
@@ -45,38 +45,98 @@ const saveLogEventInDB = (event: LogEvent): void => {
 const enableSystemLogging = localStorage.getItem(systemLoggingEnablingKey)
 if (enableSystemLogging === 'true') {
   const oldConsoleError = window.console.error
-  window.console.error = (o) => {
-    oldConsoleError(o)
-    saveLogEventInDB({ epoch: new Date().getTime(), level: 'error', msg: o })
+  window.console.error = (...o: any[]) => {
+    oldConsoleError(...o)
+    o.forEach((m) => {
+      let msg = m
+      try {
+        msg = m.toString()
+      } catch {
+        msg = ''
+      }
+      if (msg !== '') {
+        saveLogEventInDB({ epoch: new Date().getTime(), level: 'error', msg: msg })
+      }
+    })
   }
 
   const oldConsoleWarn = window.console.warn
-  window.console.warn = (o) => {
-    oldConsoleWarn(o)
-    saveLogEventInDB({ epoch: new Date().getTime(), level: 'warn', msg: o })
+  window.console.warn = (...o: any[]) => {
+    oldConsoleWarn(...o)
+    o.forEach((m) => {
+      let msg = m
+      try {
+        msg = m.toString()
+      } catch {
+        msg = ''
+      }
+      if (msg !== '') {
+        saveLogEventInDB({ epoch: new Date().getTime(), level: 'warn', msg: msg })
+      }
+    })
   }
 
   const oldConsoleInfo = window.console.info
-  window.console.info = (o) => {
-    oldConsoleInfo(o)
-    saveLogEventInDB({ epoch: new Date().getTime(), level: 'info', msg: o })
+  window.console.info = (...o: any[]) => {
+    oldConsoleInfo(...o)
+    o.forEach((m) => {
+      let msg = m
+      try {
+        msg = m.toString()
+      } catch {
+        msg = ''
+      }
+      if (msg !== '') {
+        saveLogEventInDB({ epoch: new Date().getTime(), level: 'info', msg: msg })
+      }
+    })
   }
 
   const oldConsoleDebug = window.console.debug
-  window.console.debug = (o) => {
-    oldConsoleDebug(o)
-    saveLogEventInDB({ epoch: new Date().getTime(), level: 'debug', msg: o })
+  window.console.debug = (...o: any[]) => {
+    oldConsoleDebug(...o)
+    o.forEach((m) => {
+      let msg = m
+      try {
+        msg = m.toString()
+      } catch {
+        msg = ''
+      }
+      if (msg !== '') {
+        saveLogEventInDB({ epoch: new Date().getTime(), level: 'debug', msg: msg })
+      }
+    })
   }
 
   const oldConsoleTrace = window.console.trace
-  window.console.trace = (o) => {
-    oldConsoleTrace(o)
-    saveLogEventInDB({ epoch: new Date().getTime(), level: 'trace', msg: o })
+  window.console.trace = (...o: any[]) => {
+    oldConsoleTrace(...o)
+    o.forEach((m) => {
+      let msg = m
+      try {
+        msg = m.toString()
+      } catch {
+        msg = ''
+      }
+      if (msg !== '') {
+        saveLogEventInDB({ epoch: new Date().getTime(), level: 'trace', msg: msg })
+      }
+    })
   }
 
   const oldConsoleLog = window.console.log
-  window.console.log = (o) => {
-    oldConsoleLog(o)
-    saveLogEventInDB({ epoch: new Date().getTime(), level: 'Log', msg: o })
+  window.console.log = (...o: any[]) => {
+    oldConsoleLog(...o)
+    o.forEach((m) => {
+      let msg = m
+      try {
+        msg = m.toString()
+      } catch {
+        msg = ''
+      }
+      if (msg !== '') {
+        saveLogEventInDB({ epoch: new Date().getTime(), level: 'Log', msg: msg })
+      }
+    })
   }
 }

--- a/src/libs/system-logging.ts
+++ b/src/libs/system-logging.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-empty */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { format } from 'date-fns'
 import localforage from 'localforage'
@@ -44,99 +43,29 @@ const saveLogEventInDB = (event: LogEvent): void => {
 
 const enableSystemLogging = localStorage.getItem(systemLoggingEnablingKey)
 if (enableSystemLogging === 'true') {
-  const oldConsoleError = window.console.error
-  window.console.error = (...o: any[]) => {
-    oldConsoleError(...o)
-    o.forEach((m) => {
-      let msg = m
-      try {
-        msg = m.toString()
-      } catch {
-        msg = ''
-      }
-      if (msg !== '') {
-        saveLogEventInDB({ epoch: new Date().getTime(), level: 'error', msg: msg })
-      }
-    })
+  const oldConsoleFunction = {
+    error: console.error,
+    warn: console.warn,
+    info: console.info,
+    debug: console.debug,
+    trace: console.trace,
+    log: console.log,
   }
-
-  const oldConsoleWarn = window.console.warn
-  window.console.warn = (...o: any[]) => {
-    oldConsoleWarn(...o)
-    o.forEach((m) => {
-      let msg = m
-      try {
-        msg = m.toString()
-      } catch {
-        msg = ''
-      }
-      if (msg !== '') {
-        saveLogEventInDB({ epoch: new Date().getTime(), level: 'warn', msg: msg })
-      }
-    })
-  }
-
-  const oldConsoleInfo = window.console.info
-  window.console.info = (...o: any[]) => {
-    oldConsoleInfo(...o)
-    o.forEach((m) => {
-      let msg = m
-      try {
-        msg = m.toString()
-      } catch {
-        msg = ''
-      }
-      if (msg !== '') {
-        saveLogEventInDB({ epoch: new Date().getTime(), level: 'info', msg: msg })
-      }
-    })
-  }
-
-  const oldConsoleDebug = window.console.debug
-  window.console.debug = (...o: any[]) => {
-    oldConsoleDebug(...o)
-    o.forEach((m) => {
-      let msg = m
-      try {
-        msg = m.toString()
-      } catch {
-        msg = ''
-      }
-      if (msg !== '') {
-        saveLogEventInDB({ epoch: new Date().getTime(), level: 'debug', msg: msg })
-      }
-    })
-  }
-
-  const oldConsoleTrace = window.console.trace
-  window.console.trace = (...o: any[]) => {
-    oldConsoleTrace(...o)
-    o.forEach((m) => {
-      let msg = m
-      try {
-        msg = m.toString()
-      } catch {
-        msg = ''
-      }
-      if (msg !== '') {
-        saveLogEventInDB({ epoch: new Date().getTime(), level: 'trace', msg: msg })
-      }
-    })
-  }
-
-  const oldConsoleLog = window.console.log
-  window.console.log = (...o: any[]) => {
-    oldConsoleLog(...o)
-    o.forEach((m) => {
-      let msg = m
-      try {
-        msg = m.toString()
-      } catch {
-        msg = ''
-      }
-      if (msg !== '') {
-        saveLogEventInDB({ epoch: new Date().getTime(), level: 'Log', msg: msg })
-      }
-    })
-  }
+  Object.entries(oldConsoleFunction).forEach(([level, fn]) => {
+    // @ts-ignore
+    window.console[level] = (...o: any[]) => {
+      fn(...o)
+      o.forEach((m) => {
+        let msg = m
+        try {
+          msg = m.toString()
+        } catch {
+          msg = ''
+        }
+        if (msg !== '') {
+          saveLogEventInDB({ epoch: new Date().getTime(), level: level, msg: msg })
+        }
+      })
+    }
+  })
 }

--- a/src/libs/system-logging.ts
+++ b/src/libs/system-logging.ts
@@ -55,6 +55,7 @@ if (enableSystemLogging === 'true') {
     // @ts-ignore
     window.console[level] = (...o: any[]) => {
       fn(...o)
+      let wholeMessage = ''
       o.forEach((m) => {
         let msg = m
         try {
@@ -63,9 +64,11 @@ if (enableSystemLogging === 'true') {
           msg = ''
         }
         if (msg !== '') {
-          saveLogEventInDB({ epoch: new Date().getTime(), level: level, msg: msg })
+          wholeMessage += ' '
+          wholeMessage += msg
         }
       })
+      saveLogEventInDB({ epoch: new Date().getTime(), level: level, msg: wholeMessage })
     }
   })
 }

--- a/src/libs/system-logging.ts
+++ b/src/libs/system-logging.ts
@@ -1,5 +1,9 @@
+/* eslint-disable no-empty */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { format } from 'date-fns'
 import localforage from 'localforage'
+
+import { systemLoggingEnablingKey } from '@/stores/development'
 
 export const cockpitSytemLogsDB = localforage.createInstance({
   driver: localforage.INDEXEDDB,
@@ -38,38 +42,41 @@ const saveLogEventInDB = (event: LogEvent): void => {
   cockpitSytemLogsDB.setItem(fileName, currentSystemLog)
 }
 
-const oldConsoleError = window.console.error
-window.console.error = (o) => {
-  oldConsoleError(o)
-  saveLogEventInDB({ epoch: new Date().getTime(), level: 'error', msg: o })
-}
+const enableSystemLogging = localStorage.getItem(systemLoggingEnablingKey)
+if (enableSystemLogging === 'true') {
+  const oldConsoleError = window.console.error
+  window.console.error = (o) => {
+    oldConsoleError(o)
+    saveLogEventInDB({ epoch: new Date().getTime(), level: 'error', msg: o })
+  }
 
-const oldConsoleWarn = window.console.warn
-window.console.warn = (o) => {
-  oldConsoleWarn(o)
-  saveLogEventInDB({ epoch: new Date().getTime(), level: 'warn', msg: o })
-}
+  const oldConsoleWarn = window.console.warn
+  window.console.warn = (o) => {
+    oldConsoleWarn(o)
+    saveLogEventInDB({ epoch: new Date().getTime(), level: 'warn', msg: o })
+  }
 
-const oldConsoleInfo = window.console.info
-window.console.info = (o) => {
-  oldConsoleInfo(o)
-  saveLogEventInDB({ epoch: new Date().getTime(), level: 'info', msg: o })
-}
+  const oldConsoleInfo = window.console.info
+  window.console.info = (o) => {
+    oldConsoleInfo(o)
+    saveLogEventInDB({ epoch: new Date().getTime(), level: 'info', msg: o })
+  }
 
-const oldConsoleDebug = window.console.debug
-window.console.debug = (o) => {
-  oldConsoleDebug(o)
-  saveLogEventInDB({ epoch: new Date().getTime(), level: 'debug', msg: o })
-}
+  const oldConsoleDebug = window.console.debug
+  window.console.debug = (o) => {
+    oldConsoleDebug(o)
+    saveLogEventInDB({ epoch: new Date().getTime(), level: 'debug', msg: o })
+  }
 
-const oldConsoleTrace = window.console.trace
-window.console.trace = (o) => {
-  oldConsoleTrace(o)
-  saveLogEventInDB({ epoch: new Date().getTime(), level: 'trace', msg: o })
-}
+  const oldConsoleTrace = window.console.trace
+  window.console.trace = (o) => {
+    oldConsoleTrace(o)
+    saveLogEventInDB({ epoch: new Date().getTime(), level: 'trace', msg: o })
+  }
 
-const oldConsoleLog = window.console.log
-window.console.log = (o) => {
-  oldConsoleLog(o)
-  saveLogEventInDB({ epoch: new Date().getTime(), level: 'Log', msg: o })
+  const oldConsoleLog = window.console.log
+  window.console.log = (o) => {
+    oldConsoleLog(o)
+    saveLogEventInDB({ epoch: new Date().getTime(), level: 'Log', msg: o })
+  }
 }

--- a/src/stores/development.ts
+++ b/src/stores/development.ts
@@ -1,9 +1,12 @@
+import { useStorage } from '@vueuse/core'
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
+export const systemLoggingEnablingKey = 'cockpit-enable-system-logging'
 export const useDevelopmentStore = defineStore('development', () => {
   const developmentMode = ref(false)
   const widgetDevInfoBlurLevel = ref(3)
+  const enableSystemLogging = useStorage(systemLoggingEnablingKey, true)
 
-  return { developmentMode, widgetDevInfoBlurLevel }
+  return { developmentMode, widgetDevInfoBlurLevel, enableSystemLogging }
 })

--- a/src/views/ConfigurationDevelopmentView.vue
+++ b/src/views/ConfigurationDevelopmentView.vue
@@ -3,6 +3,13 @@
     <template #title>Development configuration</template>
     <template #content>
       <v-switch v-model="devStore.developmentMode" label="Development mode" class="ma-2" color="rgb(0, 20, 80)" />
+      <v-switch
+        v-model="devStore.enableSystemLogging"
+        label="Enable system logging"
+        class="m-2"
+        color="rgb(0, 20, 80)"
+        @update:model-value="reloadCockpit"
+      />
       <v-slider
         v-model="devStore.widgetDevInfoBlurLevel"
         label="Dev info blur level"
@@ -72,4 +79,6 @@ const downloadLog = async (logName: string): Promise<void> => {
   const logBlob = new Blob([logParts], { type: 'application/json' })
   saveAs(logBlob, logName)
 }
+
+const reloadCockpit = (): void => location.reload()
 </script>


### PR DESCRIPTION
It is still not saving objects correctly to the system logs. For some reason, stringifying them is causing a serious performance overhead, so I just kept them not being logged for now. As this already allows them to be printed by the console and extra console arguments to be printed as well, it's already a win.

Fix #685 