### PR TITLE
mini-video-recorder: Fix starting records of unconfigured widgets

### DIFF
--- a/src/components/mini-widgets/MiniVideoRecorder.vue
+++ b/src/components/mini-widgets/MiniVideoRecorder.vue
@@ -98,12 +98,10 @@ watch(nameSelectedStream, () => {
 })
 
 const toggleRecording = async (): Promise<void> => {
-  if (nameSelectedStream.value === undefined) {
-    Swal.fire({ text: 'No stream selected. Please choose one before continuing.', icon: 'error' })
-    return
-  }
   if (isRecording.value) {
-    videoStore.stopRecording(nameSelectedStream.value)
+    if (nameSelectedStream.value !== undefined) {
+      videoStore.stopRecording(nameSelectedStream.value)
+    }
     return
   }
   // Open dialog so user can choose the stream which will be recorded


### PR DESCRIPTION
In case a video recorder widget was never configured for some stream, it would throw an error instead of allowing selecting one.

Fix #690 