### PR TITLE
widgets: Close widgets/mini-widgets configuration menus on boot

### DIFF
--- a/src/stores/widgetManager.ts
+++ b/src/stores/widgetManager.ts
@@ -502,6 +502,10 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
       p.views.forEach((v) => {
         v.showBottomBarOnBoot = v.showBottomBarOnBoot ?? true
         v.visible = v.visible ?? true
+
+        // If there's any configuration menu open, close it
+        v.widgets.forEach((w) => (w.managerVars.configMenuOpen = false))
+        v.miniWidgetContainers.forEach((c) => c.widgets.forEach((w) => (w.managerVars.configMenuOpen = false)))
       })
     )
   })


### PR DESCRIPTION
This prevents erratic behaviors, like the menu not opening because Cockpit was closed with it open.

Fix #723 