### PR TITLE
Add support for non-default (1) vehicle ID (SYSID_THISMAV)

### DIFF
--- a/src/libs/vehicle/ardupilot/arducopter.ts
+++ b/src/libs/vehicle/ardupilot/arducopter.ts
@@ -76,9 +76,10 @@ export class ArduCopter extends ArduPilotVehicle<CustomMode> {
 
   /**
    * Create ArduCopter vehicle
+   * @param {number} system_id
    */
-  constructor() {
-    super(Vehicle.Type.Copter)
+  constructor(system_id: number) {
+    super(Vehicle.Type.Copter, system_id)
   }
 
   /**
@@ -108,11 +109,6 @@ export class ArduCopter extends ArduPilotVehicle<CustomMode> {
    * @param {Package} mavlink
    */
   onMAVLinkPackage(mavlink: Package): void {
-    const { system_id, component_id } = mavlink.header
-    if (system_id != 1 || component_id !== 1) {
-      return
-    }
-
     switch (mavlink.message.type) {
       case MAVLinkType.HEARTBEAT: {
         const heartbeat = mavlink.message as Message.Heartbeat

--- a/src/libs/vehicle/ardupilot/arduplane.ts
+++ b/src/libs/vehicle/ardupilot/arduplane.ts
@@ -49,9 +49,10 @@ export class ArduPlane extends ArduPilotVehicle<CustomMode> {
 
   /**
    * Create ArduPlane vehicle
+   * @param {number} system_id
    */
-  constructor() {
-    super(Vehicle.Type.Plane)
+  constructor(system_id: number) {
+    super(Vehicle.Type.Plane, system_id)
   }
 
   /**
@@ -81,11 +82,6 @@ export class ArduPlane extends ArduPilotVehicle<CustomMode> {
    * @param {Package} mavlink
    */
   onMAVLinkPackage(mavlink: Package): void {
-    const { system_id, component_id } = mavlink.header
-    if (system_id != 1 || component_id !== 1) {
-      return
-    }
-
     switch (mavlink.message.type) {
       case MAVLinkType.HEARTBEAT: {
         const heartbeat = mavlink.message as Message.Heartbeat

--- a/src/libs/vehicle/ardupilot/ardurover.ts
+++ b/src/libs/vehicle/ardupilot/ardurover.ts
@@ -37,9 +37,10 @@ export class ArduRover extends ArduPilotVehicle<CustomMode> {
 
   /**
    * Create ArduRover vehicle
+   * @param {number} system_id
    */
-  constructor() {
-    super(Vehicle.Type.Rover)
+  constructor(system_id: number) {
+    super(Vehicle.Type.Rover, system_id)
   }
 
   /**
@@ -69,11 +70,6 @@ export class ArduRover extends ArduPilotVehicle<CustomMode> {
    * @param {Package} mavlink
    */
   onMAVLinkPackage(mavlink: Package): void {
-    const { system_id, component_id } = mavlink.header
-    if (system_id != 1 || component_id !== 1) {
-      return
-    }
-
     switch (mavlink.message.type) {
       case MAVLinkType.HEARTBEAT: {
         const heartbeat = mavlink.message as Message.Heartbeat

--- a/src/libs/vehicle/ardupilot/ardusub.ts
+++ b/src/libs/vehicle/ardupilot/ardusub.ts
@@ -43,9 +43,10 @@ export class ArduSub extends ArduPilotVehicle<CustomMode> {
 
   /**
    * Create ArduSub vehicle
+   * @param {number} system_id
    */
-  constructor() {
-    super(Vehicle.Type.Sub)
+  constructor(system_id: number) {
+    super(Vehicle.Type.Sub, system_id)
   }
 
   /**
@@ -75,11 +76,6 @@ export class ArduSub extends ArduPilotVehicle<CustomMode> {
    * @param {Package} mavlink
    */
   onMAVLinkPackage(mavlink: Package): void {
-    const { system_id, component_id } = mavlink.header
-    if (system_id != 1 || component_id !== 1) {
-      return
-    }
-
     switch (mavlink.message.type) {
       case MAVLinkType.HEARTBEAT: {
         const heartbeat = mavlink.message as Message.Heartbeat

--- a/src/libs/vehicle/ardupilot/types.ts
+++ b/src/libs/vehicle/ardupilot/types.ts
@@ -31,10 +31,13 @@ const cockpitAltRefFromMavlinkFrame = (mavframe: MavFrame): AltitudeReferenceTyp
   return correspondency === undefined ? undefined : correspondency[1]
 }
 
-export const convertCockpitWaypointsToMavlink = (cockpitWaypoints: Waypoint[]): Message.MissionItemInt[] => {
+export const convertCockpitWaypointsToMavlink = (
+  cockpitWaypoints: Waypoint[],
+  system_id: number
+): Message.MissionItemInt[] => {
   return cockpitWaypoints.map((cockpitWaypoint, i) => {
     return {
-      target_system: 1,
+      target_system: system_id,
       target_component: 1,
       type: MAVLinkType.MISSION_ITEM_INT,
       seq: i,

--- a/src/libs/vehicle/vehicle-factory.ts
+++ b/src/libs/vehicle/vehicle-factory.ts
@@ -23,14 +23,19 @@ export class VehicleFactory {
    * Create vehicle based on the firmware and vehicle type
    * @param {Vehicle.Firmware} firmware
    * @param {Vehicle.Type} type
+   * @param {number} system_id - The system ID for the vehicle
    * @returns {Vehicle.Abstract | undefined}
    */
-  static createVehicle(firmware: Vehicle.Firmware, type: Vehicle.Type): Vehicle.Abstract | undefined {
+  static createVehicle(
+    firmware: Vehicle.Firmware,
+    type: Vehicle.Type,
+    system_id: number
+  ): Vehicle.Abstract | undefined {
     let vehicle: undefined | Vehicle.Abstract = undefined
 
     switch (firmware) {
       case Vehicle.Firmware.ArduPilot:
-        vehicle = VehicleFactory.createArduPilotVehicle(type)
+        vehicle = VehicleFactory.createArduPilotVehicle(type, system_id)
         break
     }
 
@@ -50,18 +55,19 @@ export class VehicleFactory {
   /**
    * Create ArduPilot vehicle based on the category
    * @param  {Vehicle.Type} type
+   * @param  {number} system_id
    * @returns {Vehicle.Abstract | undefined}
    */
-  static createArduPilotVehicle(type: Vehicle.Type): Vehicle.Abstract | undefined {
+  static createArduPilotVehicle(type: Vehicle.Type, system_id: number): Vehicle.Abstract | undefined {
     switch (type) {
       case Vehicle.Type.Copter:
-        return new ArduCopter()
+        return new ArduCopter(system_id)
       case Vehicle.Type.Plane:
-        return new ArduPlane()
+        return new ArduPlane(system_id)
       case Vehicle.Type.Rover:
-        return new ArduRover()
+        return new ArduRover(system_id)
       case Vehicle.Type.Sub:
-        return new ArduSub()
+        return new ArduSub(system_id)
       default:
         unimplemented('Firmware not supported')
     }
@@ -105,18 +111,18 @@ function createVehicleFromMessage(message: Uint8Array): void {
 
   switch (heartbeat.mavtype.type) {
     case MavType.MAV_TYPE_SUBMARINE:
-      VehicleFactory.createVehicle(Vehicle.Firmware.ArduPilot, Vehicle.Type.Sub)
+      VehicleFactory.createVehicle(Vehicle.Firmware.ArduPilot, Vehicle.Type.Sub, system_id)
       break
     case MavType.MAV_TYPE_GROUND_ROVER:
     case MavType.MAV_TYPE_SURFACE_BOAT:
-      VehicleFactory.createVehicle(Vehicle.Firmware.ArduPilot, Vehicle.Type.Rover)
+      VehicleFactory.createVehicle(Vehicle.Firmware.ArduPilot, Vehicle.Type.Rover, system_id)
       break
     case MavType.MAV_TYPE_FLAPPING_WING:
     case MavType.MAV_TYPE_VTOL_TILTROTOR:
     case MavType.MAV_TYPE_VTOL_QUADROTOR:
     case MavType.MAV_TYPE_VTOL_DUOROTOR:
     case MavType.MAV_TYPE_FIXED_WING:
-      VehicleFactory.createVehicle(Vehicle.Firmware.ArduPilot, Vehicle.Type.Plane)
+      VehicleFactory.createVehicle(Vehicle.Firmware.ArduPilot, Vehicle.Type.Plane, system_id)
       break
     case MavType.MAV_TYPE_TRICOPTER:
     case MavType.MAV_TYPE_COAXIAL:
@@ -125,7 +131,7 @@ function createVehicleFromMessage(message: Uint8Array): void {
     case MavType.MAV_TYPE_OCTOROTOR:
     case MavType.MAV_TYPE_DODECAROTOR:
     case MavType.MAV_TYPE_QUADROTOR:
-      VehicleFactory.createVehicle(Vehicle.Firmware.ArduPilot, Vehicle.Type.Copter)
+      VehicleFactory.createVehicle(Vehicle.Firmware.ArduPilot, Vehicle.Type.Copter, system_id)
       break
     default:
       console.warn(`Vehicle type not supported: ${system_id}/${component_id}: ${heartbeat.mavtype.type}`)

--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -363,7 +363,7 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
       Object.assign(genericVariables, newGenericVariablesState)
     })
     mainVehicle.value.onMAVLinkMessage.add(MAVLinkType.HEARTBEAT, (pack: Package) => {
-      if (pack.header.system_id != 1 || pack.header.component_id != 1) {
+      if (pack.header.component_id != 1) {
         return
       }
 


### PR DESCRIPTION
**Motivation:**
Adds the possibility to use cockpit in multivehicle environments, where people may be using multiple tools to monitor/track different robots and be connected to several mavlink sessions.

I personally use 20+ robots, where I need to gather and track information from multiple at the same time, and our setup and system is built around identifying robots by their ID. It will also allow us to use cockpit to start testing more smoothly without having to tear down entire existing system.

**Changes:**
* Add detection, storage, and handling of system_id
  * Ardupilot has protected/export where we store the ID for later use
  * Updated all functions I could find where I believe it to be required
* Remove/adapt code that excludes all vehicles except for 1
* Update the VehicleFactory class to account for system_id, and use it when creating vehicles
* Updated all vehicles to be created with the system_id detected

**Devices tested:**
* Tested on SITL with our custom firmware, using mavlink router
* Tested on physical pi4 running custom rover variant firmware

**Tests:**
* Arm/Disarm with a vehicle id of 200
* Mode changes back and forth
* Messages, data/info/mavlink packets get displayed