### PR TITLE
Fixing Bug with Wrong simple-http-server Architecture Being Installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Build frontend
 FROM --platform=$BUILDPLATFORM oven/bun:1.0.3-slim AS frontendBuilder
 
+ARG TARGETARCH
+
 RUN mkdir /frontend && ls /frontend
 COPY . /frontend
 RUN bun install --cwd /frontend
@@ -8,10 +10,19 @@ RUN bun run --cwd /frontend build
 
 FROM alpine:3.14
 
+ARG TARGETARCH
 # Install simple http server
 RUN apk add --no-cache wget
-RUN wget https://github.com/TheWaWaR/simple-http-server/releases/download/v0.6.6/armv7-unknown-linux-musleabihf-simple-http-server \
-    -O /usr/bin/simple-http-server
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        wget https://github.com/TheWaWaR/simple-http-server/releases/download/v0.6.6/x86_64-unknown-linux-musl-simple-http-server -O /usr/bin/simple-http-server; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+        wget https://github.com/TheWaWaR/simple-http-server/releases/download/v0.6.6/aarch64-unknown-linux-musl-simple-http-server -O /usr/bin/simple-http-server; \
+    elif [ "$TARGETARCH" = "arm" ]; then \
+        wget https://github.com/TheWaWaR/simple-http-server/releases/download/v0.6.6/armv7-unknown-linux-musleabihf-simple-http-server -O /usr/bin/simple-http-server; \
+    else \
+        echo "Unsupported architecture: $TARGETARCH"; exit 1; \
+    fi
+
 RUN chmod +x /usr/bin/simple-http-server
 
 LABEL authors='[\


### PR DESCRIPTION
I noticed when trying to install cockpit as an extension using blueOS on x86 the container was failing to run do to `exec /usr/bin/simple-http-server: exec format error`

I noticed there was no logic to wget the correct server architecture in the Dockerfile