### PR TITLE
Fix widgets selection bar (on the edit-menu) removing multiple simultaneously scroll events

### DIFF
--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -90,3 +90,12 @@ export const formatBytes = (bytes: number, decimals = 2): string => {
 
   return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`
 }
+
+/**
+ * Check if the wheel event is associated with a horizontal scroll
+ * @param {WheelEvent} e The wheel event
+ * @returns {boolean} Whether or not the wheel event is associated with a horizontal scroll
+ */
+export const isHorizontalScroll = (e: WheelEvent): boolean => {
+  return e.shiftKey
+}


### PR DESCRIPTION
Add check for TrackPad and horizontal scroll to avoid multiple wheel and scroll events to interact simultaneously.
Fixes #753 