### PR TITLE
Treat edge-cases on the VideoPlayer and MiniVideoRecorder

### DIFF
--- a/src/components/mini-widgets/MiniVideoRecorder.vue
+++ b/src/components/mini-widgets/MiniVideoRecorder.vue
@@ -189,6 +189,19 @@ const updateCurrentStream = async (streamName: string | undefined): Promise<void
 }
 
 const streamConnectionRoutine = setInterval(() => {
+  // If the video recording widget is cold booted, assign the first stream to it
+  if (miniWidget.value.options.streamName === undefined && !namesAvailableStreams.value.isEmpty()) {
+    miniWidget.value.options.streamName = namesAvailableStreams.value[0]
+    nameSelectedStream.value = miniWidget.value.options.streamName
+
+    // If there are multiple streams available, warn user that we chose one automatically and they should change if wanted
+    if (namesAvailableStreams.value.length > 1) {
+      const text = `You have multiple streams available, so we chose one randomly to start with.
+        If you want to change it, please open the widget configuration.`
+      Swal.fire({ title: 'Multiple streams detected', text: text, icon: 'info', confirmButtonText: 'OK' })
+    }
+  }
+
   const updatedMediaStream = videoStore.getMediaStream(miniWidget.value.options.streamName)
   // If the widget is not connected to the MediaStream, try to connect it
   if (!isEqual(updatedMediaStream, mediaStream.value)) {

--- a/src/components/mini-widgets/MiniVideoRecorder.vue
+++ b/src/components/mini-widgets/MiniVideoRecorder.vue
@@ -111,14 +111,16 @@ const toggleRecording = async (): Promise<void> => {
     }
     return
   }
-  // If there's a stream selected already, try to use it without requiring further user interaction
-  if (nameSelectedStream.value !== undefined) {
-    await updateCurrentStream(nameSelectedStream.value)
-    startRecording()
+
+  // If there's no stream selected, open the configuration dialog so user can choose the stream which will be recorded
+  if (nameSelectedStream.value === undefined) {
+    isStreamSelectDialogOpen.value = true
     return
   }
-  // Open dialog so user can choose the stream which will be recorded
-  isStreamSelectDialogOpen.value = true
+
+  // If there's a stream selected already, try to use it without requiring further user interaction
+  await updateCurrentStream(nameSelectedStream.value)
+  startRecording()
 }
 
 const startRecording = (): void => {

--- a/src/components/widgets/VideoPlayer.vue
+++ b/src/components/widgets/VideoPlayer.vue
@@ -61,6 +61,7 @@
 
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
+import Swal from 'sweetalert2'
 import { computed, onBeforeMount, onBeforeUnmount, ref, toRefs, watch } from 'vue'
 
 import { isEqual } from '@/libs/utils'
@@ -101,6 +102,13 @@ const streamConnectionRoutine = setInterval(() => {
   if (widget.value.options.streamName === undefined && !namesAvailableStreams.value.isEmpty()) {
     widget.value.options.streamName = namesAvailableStreams.value[0]
     nameSelectedStream.value = widget.value.options.streamName
+
+    // If there are multiple streams available, warn user that we chose one automatically and he should change if wanted
+    if (namesAvailableStreams.value.length > 1) {
+      const text = `You have multiple streams available, so we chose one randomly to start with.
+        If you want to change it, please open the widget configuration on the edit-menu.`
+      Swal.fire({ title: 'Multiple streams detected', text: text, icon: 'info', confirmButtonText: 'OK' })
+    }
   }
 
   const updatedMediaStream = videoStore.getMediaStream(widget.value.options.streamName)

--- a/src/components/widgets/VideoPlayer.vue
+++ b/src/components/widgets/VideoPlayer.vue
@@ -3,6 +3,13 @@
     <div v-if="nameSelectedStream === undefined" class="no-video-alert">
       <span>No video stream selected.</span>
     </div>
+    <div v-else-if="!namesAvailableStreams.includes(nameSelectedStream)" class="no-video-alert">
+      <p>The selected stream is not available.</p>
+      <p>Please check its source or select another stream.</p>
+    </div>
+    <div v-else-if="mediaStream === undefined" class="no-video-alert">
+      <span>Loading stream...</span>
+    </div>
     <video ref="videoElement" muted autoplay playsinline disablePictureInPicture>
       Your browser does not support the video tag.
     </video>
@@ -116,6 +123,10 @@ const streamConnectionRoutine = setInterval(() => {
   if (!isEqual(updatedMediaStream, mediaStream.value)) {
     mediaStream.value = updatedMediaStream
   }
+
+  console.log('nameSelectedStream.value', nameSelectedStream.value)
+  console.log('mediaStream.value', mediaStream.value)
+  console.log('------------------')
 }, 1000)
 onBeforeUnmount(() => clearInterval(streamConnectionRoutine))
 


### PR DESCRIPTION
- Assert video is available before start recording
- Auto-assign stream (only if there's only one stream available)
- Let the user know if the selected stream is loading or not available

<img width="647" alt="image" src="https://github.com/bluerobotics/cockpit/assets/6551040/21869554-aba7-4bdf-bc4a-987432ea5377">

<img width="799" alt="image" src="https://github.com/bluerobotics/cockpit/assets/6551040/fce25417-11d1-46e4-9da8-61d7ddff944a">

Fix #773 
Fix #270 
Fix #763 
Fix #764 
