### PR TITLE
Add `SURFTRAK` mode support for ArduSub

### DIFF
--- a/src/libs/joystick/protocols/mavlink-manual-control.ts
+++ b/src/libs/joystick/protocols/mavlink-manual-control.ts
@@ -39,6 +39,7 @@ export enum MAVLinkButtonFunction {
     mode_circle = 'Mode circle', // 10
     mode_guided = 'Mode guided', // 11
     mode_acro = 'Mode acro', // 12
+    mode_surftrak = 'Mode surftrak', // 13
     mount_center = 'Mount center', // 21
     mount_tilt_up = 'Mount tilt up', // 22
     mount_tilt_down = 'Mount tilt down', // 23
@@ -235,6 +236,7 @@ const mavlinkManualControlButtonFunctions: { [key in MAVLinkButtonFunction]: MAV
   [MAVLinkButtonFunction.mode_circle]: new MAVLinkManualControlButtonAction(MAVLinkButtonFunction.mode_circle, 'Mode circle'),
   [MAVLinkButtonFunction.mode_guided]: new MAVLinkManualControlButtonAction(MAVLinkButtonFunction.mode_guided, 'Mode guided'),
   [MAVLinkButtonFunction.mode_acro]: new MAVLinkManualControlButtonAction(MAVLinkButtonFunction.mode_acro, 'Mode acro'),
+  [MAVLinkButtonFunction.mode_surftrak]: new MAVLinkManualControlButtonAction(MAVLinkButtonFunction.mode_surftrak, 'Mode surftrak'),
   [MAVLinkButtonFunction.mount_center]: new MAVLinkManualControlButtonAction(MAVLinkButtonFunction.mount_center, 'Mount center'),
   [MAVLinkButtonFunction.mount_tilt_up]: new MAVLinkManualControlButtonAction(MAVLinkButtonFunction.mount_tilt_up, 'Mount tilt up'),
   [MAVLinkButtonFunction.mount_tilt_down]: new MAVLinkManualControlButtonAction(MAVLinkButtonFunction.mount_tilt_down, 'Mount tilt down'),

--- a/src/libs/vehicle/ardupilot/ardusub.ts
+++ b/src/libs/vehicle/ardupilot/ardusub.ts
@@ -32,6 +32,8 @@ export enum CustomMode {
   MANUAL = 19,
   // Automatically detect motors orientation
   MOTOR_DETECT = 20,
+  // Manual angle with automatic depth/throttle (from rangefinder altitude)
+  SURFTRAK = 21,
 }
 
 /**


### PR DESCRIPTION
Fixes #786.

⚠️ **UNTESTED** - I just figured I'd get the code started, and hopefully someone can comment if there's something obvious I'm missing.

If possible it would be nice to have the mode and joystick button disabled for firmwares that don't support them (e.g. for non-ArduSub vehicles, and ArduSub <4.5), or at least provide an obvious warning when trying to switch to it (this may already happen if the vehicle rejects the mode change - not sure), but I'm not sure how to do either of those things.

@clydemcqueen may have some input as well.

---

@rafaellehmkuhl as a small comment, it seems weird to me to have to put the same information in twice in the `mavlink-manual-control.ts` file - could the button function actions not be added dynamically using the `MAVLinkButtonFunction` enum?