### PR TITLE
Make PWA app installation icon appear on browsers

### DIFF
--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -16,6 +16,6 @@
     ],
     "theme_color": "#ffffff",
     "background_color": "#ffffff",
-    "display": "standalone",
+    "display": "fullscreen",
     "orientation": "landscape"
 }

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -17,5 +17,6 @@
     "theme_color": "#ffffff",
     "background_color": "#ffffff",
     "display": "fullscreen",
-    "orientation": "landscape"
+    "orientation": "landscape",
+    "start_url": "/"
 }


### PR DESCRIPTION
Without it, the user has to open the browser menu and use the hidden "install this site as app" option.

<img width="871" alt="image" src="https://github.com/bluerobotics/cockpit/assets/6551040/c366cbc9-4a34-4d25-bcff-5b246bd8e6ab">
