### PR TITLE
Allow recovering unprocessed videos

### DIFF
--- a/src/libs/sensors-logging.ts
+++ b/src/libs/sensors-logging.ts
@@ -75,6 +75,13 @@ class DataLogger {
   variablesBeingUsed: DatalogVariable[] = []
   selectedVariablesToShow = useStorage<DatalogVariable[]>('cockpit-datalogger-overlay-variables', [])
   logInterval = useStorage<number>('cockpit-datalogger-log-interval', 1000)
+  cockpitLogsDB = localforage.createInstance({
+    driver: localforage.INDEXEDDB,
+    name: 'Cockpit - Sensor Logs',
+    storeName: 'cockpit-sensor-logs-db',
+    version: 1.0,
+    description: 'Local backups of Cockpit sensor logs, to be retrieved in case of failure.',
+  })
 
   /**
    * Start an intervaled logging
@@ -88,13 +95,6 @@ class DataLogger {
     this.shouldBeLogging = true
 
     const vehicleStore = useMainVehicleStore()
-    const cockpitLogsDB = localforage.createInstance({
-      driver: localforage.INDEXEDDB,
-      name: 'Cockpit - Sensor Logs',
-      storeName: 'cockpit-sensor-logs-db',
-      version: 1.0,
-      description: 'Local backups of Cockpit sensor logs, to be retrieved in case of failure.',
-    })
 
     const initialTime = new Date()
     const fileName = `Cockpit (${format(initialTime, 'LLL dd, yyyy - HH꞉mm꞉ss O')}).clog`
@@ -128,7 +128,7 @@ class DataLogger {
         data: structuredClone(variablesData),
       })
 
-      await cockpitLogsDB.setItem(fileName, this.currentCockpitLog)
+      await this.cockpitLogsDB.setItem(fileName, this.currentCockpitLog)
 
       if (this.shouldBeLogging) {
         setTimeout(logRoutine, this.logInterval.value)

--- a/src/libs/sensors-logging.ts
+++ b/src/libs/sensors-logging.ts
@@ -195,6 +195,32 @@ class DataLogger {
   }
 
   /**
+   * Returns a log that encompasses the given time
+   * @param { Date } datetime - A timestamp that is between the initial and final time of the log
+   * @returns { CockpitStandardLog | null }
+   */
+  async findLogByInitialTime(datetime: Date): Promise<CockpitStandardLog | null> {
+    const availableLogsKeys = await this.cockpitLogsDB.keys()
+
+    for (const key of availableLogsKeys) {
+      const log = await this.cockpitLogsDB.getItem(key)
+
+      // Only consider logs that are actually logs (arrays with at least two elements with an epoch property)
+      if (!Array.isArray(log) || log.length < 2) continue
+      if (log[0].epoch === undefined || log[log.length - 1].epoch === undefined) continue
+
+      const logInitialTime = new Date(log[0].epoch)
+      const logFinalTime = new Date(log[log.length - 1].epoch)
+
+      if (datetime >= logInitialTime && datetime <= logFinalTime) {
+        return log
+      }
+    }
+
+    return null
+  }
+
+  /**
    * Get desired part of a log based on timestamp
    * @param {CockpitStandardLog} completeLog The log from which the slice should be taken from
    * @param {Date} initialTime The timestamp from which the log should be started from

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -444,6 +444,22 @@ export const useVideoStore = defineStore('video', () => {
     }
   }
 
+  // Discard all data related to videos that were not processed
+  const discardAllUnprocessedVideos = async (): Promise<void> => {
+    console.log('Discarding unprocessed videos.')
+
+    const keysUnprocessedVideos = keysAllUnprocessedVideos.value
+    const currentChunks = await tempVideoChunksDB.keys()
+    const chunksUnprocessedVideos = currentChunks.filter((chunkName) => {
+      return keysUnprocessedVideos.some((key) => chunkName.includes(key))
+    })
+
+    unprocessedVideos.value = {}
+    for (const chunk of chunksUnprocessedVideos) {
+      tempVideoChunksDB.removeItem(chunk)
+    }
+  }
+
   // Warn user about videos that were not processed but are available to be processed
   if (keysAllUnprocessedVideos.value.length > 0) {
     const nUnprocVideos = keysAllUnprocessedVideos.value.length
@@ -572,6 +588,7 @@ export const useVideoStore = defineStore('video', () => {
     keysAllUnprocessedVideos,
     keysFailedUnprocessedVideos,
     processUnprocessedVideos,
+    discardAllUnprocessedVideos,
     temporaryVideoDBSize,
     videoStorageFileSize,
     getMediaStream,

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -394,6 +394,18 @@ export const useVideoStore = defineStore('video', () => {
     }
   }
 
+  // Warn user about videos that were not processed but are available to be processed
+  if (unprocessedVideosKeys.value.length > 0) {
+    const nUnprocVideos = unprocessedVideosKeys.value.length
+    Swal.fire({
+      title: 'Unprocessed videos detected',
+      text: `You have ${nUnprocVideos} ${nUnprocVideos === 1 ? 'video that was' : 'videos that were'} not processed.
+        This can happen if the app was closed while the video was being recorded, or if the app run out of memory
+        during the processing. Please go to the video page, in the configuration menu, to process or discard those.`,
+      icon: 'warning',
+    })
+  }
+
   // Routine to make sure the user has chosen the allowed ICE candidate IPs, so the stream works as expected
   let warningTimeout: NodeJS.Timeout | undefined = undefined
   const iceIpCheckInterval = setInterval(async (): Promise<void> => {

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -158,6 +158,10 @@ export const useVideoStore = defineStore('video', () => {
       return
     }
 
+    if (!datalogger.logging()) {
+      datalogger.startLogging()
+    }
+
     activeStreams.value[streamName]!.timeRecordingStart = new Date()
     const streamData = activeStreams.value[streamName] as StreamData
 
@@ -172,9 +176,7 @@ export const useVideoStore = defineStore('video', () => {
     const timeRecordingStartString = format(streamData.timeRecordingStart!, 'LLL dd, yyyy - HH꞉mm꞉ss O')
     const fileName = `${missionStore.missionName || 'Cockpit'} (${timeRecordingStartString}) #${recordingHash}`
     activeStreams.value[streamName]!.mediaRecorder = new MediaRecorder(streamData.mediaStream!)
-    if (!datalogger.logging()) {
-      datalogger.startLogging()
-    }
+
     const videoTrack = streamData.mediaStream!.getVideoTracks()[0]
     const vWidth = videoTrack.getSettings().width || 1920
     const vHeight = videoTrack.getSettings().height || 1080

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -374,6 +374,26 @@ export const useVideoStore = defineStore('video', () => {
     videoStoringDB.setItem(`${info.fileName}.ass`, logBlob)
   }
 
+  const unprocessedVideosKeys = computed(() => Object.keys(unprocessedVideos.value))
+
+  // Process videos that were being recorded when the app was closed
+  const processUnprocessedVideos = async (): Promise<void> => {
+    if (Object.keys(unprocessedVideos.value).isEmpty()) return
+    console.log(`Processing unprocessed videos: ${Object.keys(unprocessedVideos.value).join(', ')}`)
+
+    const chunks = await tempVideoChunksDB.keys()
+    if (chunks.length === 0) {
+      console.log('No video recording data found.')
+      return
+    }
+
+    for (const [recordingHash, info] of Object.entries(unprocessedVideos.value)) {
+      console.log(`Processing unprocessed video: ${info.fileName}`)
+      await processVideoChunksAndTelemetry(recordingHash, info)
+      delete unprocessedVideos.value[recordingHash]
+    }
+  }
+
   // Routine to make sure the user has chosen the allowed ICE candidate IPs, so the stream works as expected
   let warningTimeout: NodeJS.Timeout | undefined = undefined
   const iceIpCheckInterval = setInterval(async (): Promise<void> => {
@@ -487,6 +507,8 @@ export const useVideoStore = defineStore('video', () => {
     downloadFilesFromVideoDB,
     clearTemporaryVideoDB,
     downloadTempVideoDB,
+    unprocessedVideosKeys,
+    processUnprocessedVideos,
     temporaryVideoDBSize,
     videoStorageFileSize,
     getMediaStream,

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -33,10 +33,22 @@ export type UnprocessedVideoInfo = {
    */
   dateStart: Date
   /**
-   * The date the recording finished
-   * This is updated as the recording goes.
+   * The last date in which the recording was updated.
+   * This is updated as the recording goes on. If there's no update for a long time, it's an indication that the recording finished or failed.
    */
-  dateFinish: Date
+  dateLastRecordingUpdate: Date
+  /**
+   * This date is explicitly set when the recording finishes.
+   * This is undefined while the recording is ongoing.
+   * If there's no update on the 'dateLastRecordingUpdate' for a long time, and this is undefined, it's an indication that the recording failed.
+   */
+  dateFinish: Date | undefined
+  /**
+   * The last date in which the processing was updated.
+   * This is updated as the processing goes on. If there's no update for a long time and the processing didn't finish, it's an indication that the processing failed.
+   * This is undefined when the processing didn't start yet.
+   */
+  dateLastProcessignUpdate: Date | undefined
   /**
    * The name of the file
    */

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -26,3 +26,27 @@ export interface StreamData {
    */
   timeRecordingStart: Date | undefined
 }
+
+export type UnprocessedVideoInfo = {
+  /**
+   * The date the recording started
+   */
+  dateStart: Date
+  /**
+   * The date the recording finished
+   * This is updated as the recording goes.
+   */
+  dateFinish: Date
+  /**
+   * The name of the file
+   */
+  fileName: string
+  /**
+   *  The width of the video
+   */
+  vWidth: number
+  /**
+   *  The height of the video
+   */
+  vHeight: number
+}

--- a/src/views/ConfigurationVideoView.vue
+++ b/src/views/ConfigurationVideoView.vue
@@ -34,14 +34,20 @@
 
       <div
         v-if="nUnprocVideos > 0"
-        class="flex flex-col items-center justify-center max-w-sm px-6 py-4 m-4 text-center transition-all rounded-md cursor-pointer bg-slate-600 text-slate-50 hover:bg-slate-500/80"
-        @click="processUnprocessedVideos()"
+        class="flex flex-col items-center px-5 py-3 m-5 font-medium text-center border rounded-md text-grey-darken-1 bg-grey-lighten-5 w-[40%]"
       >
-        <span class="mb-3 text-lg font-medium">Unprocessed videos detected</span>
-        <span class="text-sm text-slate-300/90">
+        <span class="m-2 text-lg font-bold">Unprocessed videos detected</span>
+        <span class="text-sm text-slate-500/90">
           You have {{ nUnprocVideos }} {{ nUnprocVideos === 1 ? 'video that was' : 'videos that were' }} not processed.
         </span>
-        <span class="text-sm text-slate-300/90">Click here to process {{ nUnprocVideos === 1 ? 'it' : 'them' }}.</span>
+        <div class="flex justify-center m-6 align-center">
+          <Button class="mx-2 w-fit" size="large" :disabled="nUnprocVideos === 0" @click="processUnprocessedVideos()">
+            Process
+          </Button>
+          <Button class="mx-2 w-fit" :disabled="nUnprocVideos === 0" @click="discardAllUnprocessedVideos()">
+            Discard
+          </Button>
+        </div>
       </div>
 
       <div v-if="availableVideosAndLogs.isEmpty()" class="max-w-[50%] bg-slate-100 rounded-md p-6 border">
@@ -125,6 +131,7 @@ import { storeToRefs } from 'pinia'
 import Swal from 'sweetalert2'
 import { computed, onMounted, ref } from 'vue'
 
+import Button from '@/components/Button.vue'
 import { formatBytes } from '@/libs/utils'
 import { useVideoStore } from '@/stores/video'
 
@@ -215,6 +222,19 @@ const processUnprocessedVideos = async (): Promise<void> => {
     icon: 'success',
     title: 'Videos processed',
     text: 'All unprocessed videos were successfully processed and are now available for download.',
+    showConfirmButton: false,
+    timer: 5000,
+  })
+}
+
+const discardAllUnprocessedVideos = async (): Promise<void> => {
+  await videoStore.discardAllUnprocessedVideos()
+  await fetchVideoAndLogsData()
+  selectedFilesNames.value = []
+  Swal.fire({
+    icon: 'success',
+    title: 'Videos discarded',
+    text: 'All unprocessed videos were successfully discarded.',
     showConfirmButton: false,
     timer: 5000,
   })

--- a/src/views/ConfigurationVideoView.vue
+++ b/src/views/ConfigurationVideoView.vue
@@ -183,6 +183,26 @@ const downloadAndUpdateDB = async (filenames: string[]): Promise<void> => {
 }
 
 const clearTemporaryVideoFiles = async (): Promise<void> => {
+  const videosBeingRecorded = videoStore.keysAllUnprocessedVideos.length > videoStore.keysFailedUnprocessedVideos.length
+
+  if (videosBeingRecorded) {
+    Swal.fire({
+      icon: 'error',
+      title: 'Video(s) being recorded',
+      text: 'You must stop all ongoing video recordings before clearing the temporary storage.',
+    })
+    return
+  }
+
+  if (videoStore.keysAllUnprocessedVideos.length > 0) {
+    Swal.fire({
+      icon: 'error',
+      title: 'Unprocessed videos detected',
+      text: 'You must process or discard all unprocessed videos before clearing the temporary storage.',
+    })
+    return
+  }
+
   await videoStore.clearTemporaryVideoDB()
   await fetchTemporaryDbSize()
 }
@@ -200,5 +220,5 @@ const processUnprocessedVideos = async (): Promise<void> => {
   })
 }
 
-const nUnprocVideos = computed(() => videoStore.unprocessedVideosKeys.length)
+const nUnprocVideos = computed(() => videoStore.keysFailedUnprocessedVideos.length)
 </script>

--- a/src/views/ConfigurationVideoView.vue
+++ b/src/views/ConfigurationVideoView.vue
@@ -32,6 +32,18 @@
         />
       </div>
 
+      <div
+        v-if="nUnprocVideos > 0"
+        class="flex flex-col items-center justify-center max-w-sm px-6 py-4 m-4 text-center transition-all rounded-md cursor-pointer bg-slate-600 text-slate-50 hover:bg-slate-500/80"
+        @click="processUnprocessedVideos()"
+      >
+        <span class="mb-3 text-lg font-medium">Unprocessed videos detected</span>
+        <span class="text-sm text-slate-300/90">
+          You have {{ nUnprocVideos }} {{ nUnprocVideos === 1 ? 'video that was' : 'videos that were' }} not processed.
+        </span>
+        <span class="text-sm text-slate-300/90">Click here to process {{ nUnprocVideos === 1 ? 'it' : 'them' }}.</span>
+      </div>
+
       <div v-if="availableVideosAndLogs.isEmpty()" class="max-w-[50%] bg-slate-100 rounded-md p-6 border">
         <p class="mb-4 text-2xl font-semibold text-center text-slate-500">No videos available.</p>
         <p class="text-center text-slate-400">
@@ -110,8 +122,8 @@
 <script setup lang="ts">
 import { FwbTable, FwbTableBody, FwbTableCell, FwbTableHead, FwbTableHeadCell, FwbTableRow } from 'flowbite-vue'
 import { storeToRefs } from 'pinia'
-import { ref } from 'vue'
-import { onMounted } from 'vue'
+import Swal from 'sweetalert2'
+import { computed, onMounted, ref } from 'vue'
 
 import { formatBytes } from '@/libs/utils'
 import { useVideoStore } from '@/stores/video'
@@ -174,4 +186,19 @@ const clearTemporaryVideoFiles = async (): Promise<void> => {
   await videoStore.clearTemporaryVideoDB()
   await fetchTemporaryDbSize()
 }
+
+const processUnprocessedVideos = async (): Promise<void> => {
+  await videoStore.processUnprocessedVideos()
+  await fetchVideoAndLogsData()
+  selectedFilesNames.value = []
+  Swal.fire({
+    icon: 'success',
+    title: 'Videos processed',
+    text: 'All unprocessed videos were successfully processed and are now available for download.',
+    showConfirmButton: false,
+    timer: 5000,
+  })
+}
+
+const nUnprocVideos = computed(() => videoStore.unprocessedVideosKeys.length)
 </script>


### PR DESCRIPTION
This patch gets back the functionality of recovering videos when Cockpit was interrupted during a recording (tab closing, shut down, lid closed, etc).

On top of that, it also allows for a recovery on situations where for some reason a processing (triggered by the stop button) failed.

To be merged after #788.
Fix #777.