### PR TITLE
Bug Fix: Fixing Mode Change Selector Commanding Mode Change Back to Original Mode

### DIFF
--- a/src/components/mini-widgets/ModeSelector.vue
+++ b/src/components/mini-widgets/ModeSelector.vue
@@ -16,8 +16,13 @@ datalogger.registerUsage(DatalogVariable.mode)
 const vehicleStore = useMainVehicleStore()
 const currentMode = ref()
 
-watch(currentMode, () => {
+watch(currentMode, (newVal) => {
   if (currentMode.value === undefined) return
+  // Fetch the current mode directly from the store to ensure it's different
+  if (newVal === vehicleStore.mode) {
+    console.log('New mode is the same as the current one. No mode-change commands will be issued.')
+    return
+  }
   vehicleStore.setFlightMode(currentMode.value)
 })
 


### PR DESCRIPTION
closes #742 

This change fixes an issue where a user selects a new mode to change the vehicle to, but the mode does not change.  This happens because the mode selector is commanding a mode change based on when the variable `currentMode` is changed. This variable is driven off of 2 sources. 

- 1.) the selection from the drop down menu. 
- 2.) the telemetry. 

When a user changes the dropdown menu selection, it triggers the mode change command, but the mode change command doesn't happen fast enough so that the next telemetry update changes the drop down mode back to the original mode which triggers another command to the vehicle to change the mode back to the original state. 

A simple solution to this is to check in the watcher function if the desired mode is already the mode of the vehicle if so, we know that the state change is due to a telemetry update and not from the user. 