### PR TITLE
video: Do not skip videos that  do not started processing when searching for failed ones

### DIFF
--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -445,10 +445,10 @@ export const useVideoStore = defineStore('video', () => {
   }
 
   // Discard all data related to videos that were not processed
-  const discardAllUnprocessedVideos = async (): Promise<void> => {
+  const discardUnprocessedVideos = async (includeNotFailed = false): Promise<void> => {
     console.log('Discarding unprocessed videos.')
 
-    const keysUnprocessedVideos = keysAllUnprocessedVideos.value
+    const keysUnprocessedVideos = includeNotFailed ? keysAllUnprocessedVideos.value : keysFailedUnprocessedVideos.value
     const currentChunks = await tempVideoChunksDB.keys()
     const chunksUnprocessedVideos = currentChunks.filter((chunkName) => {
       return keysUnprocessedVideos.some((key) => chunkName.includes(key))
@@ -588,7 +588,7 @@ export const useVideoStore = defineStore('video', () => {
     keysAllUnprocessedVideos,
     keysFailedUnprocessedVideos,
     processUnprocessedVideos,
-    discardAllUnprocessedVideos,
+    discardUnprocessedVideos,
     temporaryVideoDBSize,
     videoStorageFileSize,
     getMediaStream,

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -413,12 +413,12 @@ export const useVideoStore = defineStore('video', () => {
 
     return keysAllUnprocessedVideos.value.filter((recordingHash) => {
       const info = unprocessedVideos.value[recordingHash]
-      if (info === undefined || info.dateLastProcessignUpdate === undefined) return false
 
       const secondsSinceLastRecordingUpdate = differenceInSeconds(dateNow, new Date(info.dateLastRecordingUpdate))
       const recording = info.dateFinish === undefined && secondsSinceLastRecordingUpdate < 10
 
-      const secondsSinceLastProcessingUpdate = differenceInSeconds(dateNow, new Date(info.dateLastProcessignUpdate))
+      const dateLastProcessingUpdate = new Date(info.dateLastProcessignUpdate ?? 0)
+      const secondsSinceLastProcessingUpdate = differenceInSeconds(dateNow, dateLastProcessingUpdate)
       const processing = info.dateFinish !== undefined && secondsSinceLastProcessingUpdate < 10
 
       return !recording && !processing

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -349,7 +349,7 @@ export const useVideoStore = defineStore('video', () => {
 
   const processVideoChunksAndTelemetry = async (recordingHash: string, info: UnprocessedVideoInfo): Promise<void> => {
     if (info.dateFinish === undefined) {
-      throw new Error('Trying to process video that was not finished. Aborting.')
+      info.dateFinish = info.dateLastRecordingUpdate
     }
 
     // eslint-disable-next-line jsdoc/require-jsdoc

--- a/src/views/ConfigurationVideoView.vue
+++ b/src/views/ConfigurationVideoView.vue
@@ -215,16 +215,25 @@ const clearTemporaryVideoFiles = async (): Promise<void> => {
 }
 
 const processUnprocessedVideos = async (): Promise<void> => {
-  await videoStore.processUnprocessedVideos()
-  await fetchVideoAndLogsData()
-  selectedFilesNames.value = []
-  Swal.fire({
-    icon: 'success',
-    title: 'Videos processed',
-    text: 'All unprocessed videos were successfully processed and are now available for download.',
-    showConfirmButton: false,
-    timer: 5000,
-  })
+  try {
+    await videoStore.processUnprocessedVideos()
+    Swal.fire({
+      icon: 'success',
+      title: 'Videos processed',
+      text: 'All unprocessed videos were successfully processed and are now available for download.',
+      showConfirmButton: false,
+      timer: 5000,
+    })
+  } catch (error) {
+    Swal.fire({
+      icon: 'error',
+      title: 'Error processing videos',
+      text: `Some of the videos could not be processed. ${error}`,
+    })
+  } finally {
+    await fetchVideoAndLogsData()
+    selectedFilesNames.value = []
+  }
 }
 
 const discardFailedUnprocessedVideos = async (): Promise<void> => {

--- a/src/views/ConfigurationVideoView.vue
+++ b/src/views/ConfigurationVideoView.vue
@@ -44,7 +44,7 @@
           <Button class="mx-2 w-fit" size="large" :disabled="nUnprocVideos === 0" @click="processUnprocessedVideos()">
             Process
           </Button>
-          <Button class="mx-2 w-fit" :disabled="nUnprocVideos === 0" @click="discardAllUnprocessedVideos()">
+          <Button class="mx-2 w-fit" :disabled="nUnprocVideos === 0" @click="discardFailedUnprocessedVideos()">
             Discard
           </Button>
         </div>
@@ -227,8 +227,8 @@ const processUnprocessedVideos = async (): Promise<void> => {
   })
 }
 
-const discardAllUnprocessedVideos = async (): Promise<void> => {
-  await videoStore.discardAllUnprocessedVideos()
+const discardFailedUnprocessedVideos = async (): Promise<void> => {
+  await videoStore.discardUnprocessedVideos()
   await fetchVideoAndLogsData()
   selectedFilesNames.value = []
   Swal.fire({


### PR DESCRIPTION
This is one of the cases where the user reloads the page or is too fast reloading after stopping, and the video didn't start to process. It was mistakenly removed from the failed check.

@JoaoMario109 this is the one I mentioned before. With this patch I couln't find failed cases anymore (besides the ones you raised on #804, which were there before the recovery PR).