### PR TITLE
mini-video-recorder: Stop reconnecting stream that is already connected

### DIFF
--- a/src/components/mini-widgets/MiniVideoRecorder.vue
+++ b/src/components/mini-widgets/MiniVideoRecorder.vue
@@ -139,7 +139,6 @@ const toggleRecording = async (): Promise<void> => {
   }
 
   // If there's a stream selected already, try to use it without requiring further user interaction
-  await updateCurrentStream(nameSelectedStream.value)
   startRecording()
 }
 


### PR DESCRIPTION
The problem of one being able to start multiple recordings with the same widget was being originated by the fact that whenever the user clicked to start a recording, even if the widget was already connected, it tried to connect again.

Without this step, that was being awaited for, the user simply can't start two recordings simultaneously, fixing also the other problems that raised from this.

As a bonus, now clicking to start a recording starts it instantaneously.

Fix #804 