### PR TITLE
Fixing Incorrect Xbox One S PID

### DIFF
--- a/src/assets/joystick-profiles.ts
+++ b/src/assets/joystick-profiles.ts
@@ -161,6 +161,11 @@ export const availableGamepadToCockpitMaps: { [key in JoystickModel]: GamepadToC
     axes: [0, 1, 2, 3],
     buttons: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17],
   },
+  [JoystickModel.XboxOne_Wireless]: {
+    name: 'Xbox One S',
+    axes: [0, 1, 2, 3],
+    buttons: [0, 1, 2, 3, 4, 11, 6, 7, 8, 9, 5, 11, 12, 13, 14, 15, 16, 17],
+  },
   [JoystickModel.XboxOneS_Bluetooth]: {
     name: 'Xbox One S',
     axes: [0, 1, 2, 3],

--- a/src/libs/joystick/manager.ts
+++ b/src/libs/joystick/manager.ts
@@ -18,6 +18,7 @@ export enum EventType {
 export enum JoystickModel {
   DualSense = 'DualSense (PS5)',
   DualShock4 = 'DualShock (PS4)',
+  XboxOne_Wireless = 'Xbox One Wireless Controller',
   XboxOneS_Bluetooth = 'Xbox One S (bluetooth)',
   XboxController_Bluetooth = 'Xbox controller (bluetooth)',
   XboxController_Wired = 'Xbox controller (wired)',
@@ -31,7 +32,8 @@ const JoystickMapVidPid: Map<string, JoystickModel> = new Map([
   // Sony
   ['054c:0ce6', JoystickModel.DualSense],
   ['054c:09cc', JoystickModel.DualShock4],
-  ['045e:02e0', JoystickModel.XboxOneS_Bluetooth],
+  ['045e:02e0', JoystickModel.XboxOne_Wireless],
+  ['045e:02fd', JoystickModel.XboxOneS_Bluetooth],
   ['045e:0b13', JoystickModel.XboxController_Bluetooth],
   ['045e:0b12', JoystickModel.XboxController_Wired],
   ['28de:11ff', JoystickModel.XboxController_360],


### PR DESCRIPTION
The code had previously had the  "Xbox One Wireless Controller" as the "Xbox One S Controller [Bluetooth]"
"Xbox One Wireless Controller" :  https://devicehunt.com/view/type/usb/vendor/045E/device/02E0
"Xbox One S Controller [Bluetooth]" : https://devicehunt.com/view/type/usb/vendor/045E/device/02FD

Discovered from draft PR https://github.com/bluerobotics/cockpit/pull/799