### PR TITLE
Disarming the vehicle using the warning modal when opening menu with armed vehicle is generating dead state #833

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -187,18 +187,22 @@ const openMainMenu = (): void => {
   requestDisarmConfirmationPopup = true
   Swal.fire({
     title: 'Be careful',
-    text: 'Vehicle is currently armed, its not recommended to open the main menu.',
+    text: 'The vehicle is currently armed, it is not recommended to open the main menu.',
     icon: 'warning',
     showCancelButton: true,
     showConfirmButton: true,
     cancelButtonText: 'Continue anyway',
     confirmButtonText: 'Disarm vehicle',
   }).then((result) => {
+    // Opens the main menu only after disarming by the slider is confirmed
     if (result.isConfirmed && vehicleStore.isArmed) {
-      vehicleStore.disarm()
+      vehicleStore.disarm().then(() => {
+        showMainMenu.value = true
+      })
+    } else if (result.dismiss === Swal.DismissReason.cancel) {
+      showMainMenu.value = true
     }
     requestDisarmConfirmationPopup = false
-    showMainMenu.value = true
   })
 }
 


### PR DESCRIPTION
Main menu and disarm slider will not coexist on the screen while opening the menu through the vehicle's 'disarm before opening menu' alert popover.