### PR TITLE
ci: Run `apt update` before flatpak installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,7 @@ jobs:
 
       - name: Install flatpak
         run: |
+          sudo apt update
           sudo apt install -y --fix-missing flatpak flatpak-builder
           sudo flatpak remote-add --system flathub https://flathub.org/repo/flathub.flatpakrepo
           flatpak remote-add --user flathub https://flathub.org/repo/flathub.flatpakrepo || true


### PR DESCRIPTION
The fix on #853 strangely worked only on the PR itself. This fix is working on other PRs (tested on #855).