### PR TITLE
Tie vehicles to joystick profiles

### DIFF
--- a/src/assets/joystick-profiles.ts
+++ b/src/assets/joystick-profiles.ts
@@ -1,3 +1,4 @@
+import { MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import { JoystickModel } from '@/libs/joystick/manager'
 import { availableCockpitActions } from '@/libs/joystick/protocols/cockpit-actions'
 import {
@@ -16,6 +17,12 @@ import {
 export const defaultRovMappingHash = '10b0075a-27a7-4800-ba95-f35fd722d1df'
 export const defaultBoatMappingHash = 'd3427f20-ba28-4cf7-ae24-ec740dd6dce0'
 export const defaultMavMappingHash = 'dd654387-18fc-4674-89a6-4dc4d0bc8240'
+
+export const defaultProtocolMappingVehicleCorrespondency = {
+  [MavType.MAV_TYPE_SUBMARINE]: defaultRovMappingHash,
+  [MavType.MAV_TYPE_SURFACE_BOAT]: defaultBoatMappingHash,
+  [MavType.MAV_TYPE_QUADROTOR]: defaultMavMappingHash,
+}
 
 // TODO: Adjust mapping for PS5 controller
 export const cockpitStandardToProtocols: JoystickProtocolActionsMapping[] = [

--- a/src/assets/joystick-profiles.ts
+++ b/src/assets/joystick-profiles.ts
@@ -13,10 +13,15 @@ import {
   JoystickButton,
 } from '@/types/joystick'
 
+export const defaultRovMappingHash = '10b0075a-27a7-4800-ba95-f35fd722d1df'
+export const defaultBoatMappingHash = 'd3427f20-ba28-4cf7-ae24-ec740dd6dce0'
+export const defaultMavMappingHash = 'dd654387-18fc-4674-89a6-4dc4d0bc8240'
+
 // TODO: Adjust mapping for PS5 controller
 export const cockpitStandardToProtocols: JoystickProtocolActionsMapping[] = [
   {
     name: 'ROV functions mapping',
+    hash: defaultRovMappingHash,
     axesCorrespondencies: {
       [JoystickAxis.A0]: { action: mavlinkManualControlAxes.axis_y, min: -1000, max: +1000 },
       [JoystickAxis.A1]: { action: mavlinkManualControlAxes.axis_x, min: +1000, max: -1000 },
@@ -68,6 +73,7 @@ export const cockpitStandardToProtocols: JoystickProtocolActionsMapping[] = [
   },
   {
     name: 'Boat functions mapping',
+    hash: defaultBoatMappingHash,
     axesCorrespondencies: {
       [JoystickAxis.A0]: { action: mavlinkManualControlAxes.axis_y, min: -1000, max: +1000 },
       [JoystickAxis.A1]: { action: mavlinkManualControlAxes.axis_x, min: +1000, max: -1000 },
@@ -119,6 +125,7 @@ export const cockpitStandardToProtocols: JoystickProtocolActionsMapping[] = [
   },
   {
     name: 'MAV functions mapping',
+    hash: defaultMavMappingHash,
     axesCorrespondencies: {
       [JoystickAxis.A0]: { action: mavlinkManualControlAxes.axis_r, min: -1000, max: +1000 },
       [JoystickAxis.A1]: { action: mavlinkManualControlAxes.axis_z, min: +1000, max: 0 },

--- a/src/stores/controller.ts
+++ b/src/stores/controller.ts
@@ -11,6 +11,7 @@ import {
   defaultProtocolMappingVehicleCorrespondency,
 } from '@/assets/joystick-profiles'
 import { getKeyDataFromCockpitVehicleStorage, setKeyDataOnCockpitVehicleStorage } from '@/libs/blueos'
+import { MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import { type JoystickEvent, EventType, joystickManager, JoystickModel } from '@/libs/joystick/manager'
 import { allAvailableAxes, allAvailableButtons } from '@/libs/joystick/protocols'
 import { modifierKeyActions, otherAvailableActions } from '@/libs/joystick/protocols/other'
@@ -340,6 +341,17 @@ export const useControllerStore = defineStore('controller', () => {
     mapping.hash = correspondentDefault?.hash ?? uuid4()
   })
 
+  const loadDefaultProtocolMappingForVehicle = (vehicleType: MavType): void => {
+    // @ts-ignore: We know that the value is a string
+    const defaultMappingHash = vehicleTypeProtocolMappingCorrespondency.value[vehicleType]
+    const defaultProtocolMapping = cockpitStandardToProtocols.find((mapping) => mapping.hash === defaultMappingHash)
+    if (!defaultProtocolMapping) {
+      throw new Error('Could not find default mapping for this vehicle.')
+    }
+
+    loadProtocolMapping(defaultProtocolMapping)
+  }
+
   return {
     registerControllerUpdateCallback,
     enableForwarding,
@@ -360,5 +372,6 @@ export const useControllerStore = defineStore('controller', () => {
     importFunctionsMapping,
     exportFunctionsMappingToVehicle,
     importFunctionsMappingFromVehicle,
+    loadDefaultProtocolMappingForVehicle,
   }
 })

--- a/src/stores/controller.ts
+++ b/src/stores/controller.ts
@@ -5,7 +5,11 @@ import Swal from 'sweetalert2'
 import { v4 as uuid4 } from 'uuid'
 import { computed, ref, toRaw, watch } from 'vue'
 
-import { availableGamepadToCockpitMaps, cockpitStandardToProtocols } from '@/assets/joystick-profiles'
+import {
+  availableGamepadToCockpitMaps,
+  cockpitStandardToProtocols,
+  defaultProtocolMappingVehicleCorrespondency,
+} from '@/assets/joystick-profiles'
 import { getKeyDataFromCockpitVehicleStorage, setKeyDataOnCockpitVehicleStorage } from '@/libs/blueos'
 import { type JoystickEvent, EventType, joystickManager, JoystickModel } from '@/libs/joystick/manager'
 import { allAvailableAxes, allAvailableButtons } from '@/libs/joystick/protocols'
@@ -42,6 +46,10 @@ export const useControllerStore = defineStore('controller', () => {
   const availableButtonActions = allAvailableButtons
   const enableForwarding = ref(true)
   const holdLastInputWhenWindowHidden = useStorage('cockpit-hold-last-joystick-input-when-window-hidden', false)
+  const vehicleTypeProtocolMappingCorrespondency = useStorage<typeof defaultProtocolMappingVehicleCorrespondency>(
+    'cockpit-default-vehicle-type-protocol-mappings',
+    defaultProtocolMappingVehicleCorrespondency
+  )
 
   const protocolMapping = computed<JoystickProtocolActionsMapping>({
     get() {
@@ -342,6 +350,7 @@ export const useControllerStore = defineStore('controller', () => {
     cockpitStdMappings,
     availableAxesActions,
     availableButtonActions,
+    vehicleTypeProtocolMappingCorrespondency,
     loadProtocolMapping,
     exportJoystickMapping,
     importJoystickMapping,

--- a/src/types/joystick.ts
+++ b/src/types/joystick.ts
@@ -134,6 +134,10 @@ export interface JoystickProtocolActionsMapping {
    */
   name: string
   /**
+   * Unique identifier for the mapping
+   */
+  hash: string
+  /**
    * Correspondency from Gamepad API to protocol axis.
    * Corresponds to which Axis in the protocol should the Nth axis be mapped to.
    */


### PR DESCRIPTION
- Allows assigning different vehicle types to a joystick mapping
- Auto-set joystick mapping on boot based on vehicle type

Fix #858 
Fix #859 