### PR TITLE
package: Add `productName` tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: cockpit-${{ matrix.suffix }}
-          path: dist/cockpit*.${{ matrix.extension }}
+          path: dist/Cockpit*.${{ matrix.extension }}
           if-no-files-found: error
 
       - name: Upload Release
@@ -105,7 +105,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/') && success()
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: dist/cockpit*.${{ matrix.extension }}
+          file: dist/Cockpit*.${{ matrix.extension }}
           tag: ${{ github.ref }}
           overwrite: true
           prerelease: true
@@ -142,7 +142,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: cockpit-flatpak
-          path: dist/cockpit*.flatpak
+          path: dist/Cockpit*.flatpak
           if-no-files-found: error
 
       - name: Upload Release
@@ -150,7 +150,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/') && success()
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: dist/cockpit*.flatpak
+          file: dist/Cockpit*.flatpak
           tag: ${{ github.ref }}
           overwrite: true
           prerelease: true

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
       "dist"
     ],
     "appId": "org.bluerobotics.cockpit",
+    "productName": "Cockpit",
     "mac": {
       "category": "public.app-category.utilities",
       "icon": "public/pwa-512x512.png"


### PR DESCRIPTION
This is the name that goes to the application on the OS executable/shortcut.

As of now it's using the "name" tag by default, which enforces camelCase.