### PR TITLE
Supress invalid global address

### DIFF
--- a/src/views/ConfigurationGeneralView.vue
+++ b/src/views/ConfigurationGeneralView.vue
@@ -17,7 +17,7 @@
             type="input"
             hint="Address of the Vehicle. E.g: blueos.local"
             class="uri-input"
-            :rules="[isValidHostAddress]"
+            :rules="[isValidHostAddress, isValidConnectionURI]"
           />
 
           <v-btn v-tooltip.bottom="'Set'" icon="mdi-check" class="mx-1 mb-5 pa-0" rounded="lg" flat type="submit" />
@@ -168,6 +168,15 @@ const isValidHostAddress = (value: string): boolean | string => {
   return isValidNetworkAddress(value) ?? 'Invalid host address. Should be an IP address or a hostname'
 }
 
+const isValidConnectionURI = (value: string): boolean | string => {
+  try {
+    new Connection.URI(`ws://${value}:6040/`)
+  } catch (error) {
+    return `Invalid connection URI. ${error}.`
+  }
+  return true
+}
+
 const isValidSocketConnectionURI = (value: string): boolean | string => {
   try {
     const conn = new Connection.URI(value)
@@ -213,6 +222,13 @@ const addNewVehicleConnection = async (): Promise<void> => {
 
 const setGlobalAddress = async (): Promise<void> => {
   await globalAddressForm.value.validate()
+
+  const validation = isValidConnectionURI(newGlobalAddress.value)
+  if (validation !== true) {
+    alert(validation)
+    return
+  }
+
   mainVehicleStore.globalAddress = newGlobalAddress.value
 
   // Temporary solution to actually set the address and connect the vehicle, since this is non-reactive today.

--- a/src/views/ConfigurationGeneralView.vue
+++ b/src/views/ConfigurationGeneralView.vue
@@ -169,6 +169,11 @@ const isValidHostAddress = (value: string): boolean | string => {
 }
 
 const isValidConnectionURI = (value: string): boolean | string => {
+  const forbiddenStartStrings = ['http://', 'https://', 'ws://', 'wss://']
+  if (forbiddenStartStrings.some((protocol) => value.startsWith(protocol))) {
+    return 'Address should not include protocol (e.g.: "http://", "wss://").'
+  }
+
   try {
     new Connection.URI(`ws://${value}:6040/`)
   } catch (error) {


### PR DESCRIPTION
This patch prevents the user from using bad global addresses, that will for sure not work or can break Cockpit.

Fix #893 