### PR TITLE
Use dynamic positioning with respect to bottom bar

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -105,28 +105,28 @@
             </div>
           </div>
           <AltitudeSlider />
+          <div class="bottom-container">
+            <SlideToConfirm />
+          </div>
           <Transition name="fade">
-            <div v-if="showBottomBarNow" class="bottom-container">
-              <SlideToConfirm />
-              <div class="bottom-bar">
-                <MiniWidgetContainer
-                  :container="widgetStore.currentView.miniWidgetContainers[0]"
-                  :allow-editing="widgetStore.editingMode"
-                  align="start"
-                />
-                <div />
-                <MiniWidgetContainer
-                  :container="widgetStore.currentView.miniWidgetContainers[1]"
-                  :allow-editing="widgetStore.editingMode"
-                  align="center"
-                />
-                <div />
-                <MiniWidgetContainer
-                  :container="widgetStore.currentView.miniWidgetContainers[2]"
-                  :allow-editing="widgetStore.editingMode"
-                  align="end"
-                />
-              </div>
+            <div v-if="showBottomBarNow" class="bottom-container bottom-bar">
+              <MiniWidgetContainer
+                :container="widgetStore.currentView.miniWidgetContainers[0]"
+                :allow-editing="widgetStore.editingMode"
+                align="start"
+              />
+              <div />
+              <MiniWidgetContainer
+                :container="widgetStore.currentView.miniWidgetContainers[1]"
+                :allow-editing="widgetStore.editingMode"
+                align="center"
+              />
+              <div />
+              <MiniWidgetContainer
+                :container="widgetStore.currentView.miniWidgetContainers[2]"
+                :allow-editing="widgetStore.editingMode"
+                align="end"
+              />
             </div>
           </Transition>
           <router-view />
@@ -320,7 +320,7 @@ body.hide-cursor {
 }
 .bottom-container {
   position: absolute;
-  bottom: 0;
+  bottom: v-bind('currentBottomBarHeightPixels');
   width: 100%;
   display: flex;
   flex-direction: column;

--- a/src/App.vue
+++ b/src/App.vue
@@ -69,7 +69,7 @@
 
       <div ref="routerSection" class="router-view">
         <div class="main-view" :class="{ 'edit-mode': widgetStore.editingMode }">
-          <div id="mainTopBar" class="z-[60] w-full bg-slate-600/50 absolute flex backdrop-blur-[2px] top-bar">
+          <div id="mainTopBar" class="bar top-bar">
             <button
               class="flex items-center justify-center h-full aspect-square top-bar-hamburger"
               @click="openMainMenu()"
@@ -109,7 +109,7 @@
             <SlideToConfirm />
           </div>
           <Transition name="fade">
-            <div v-if="showBottomBarNow" class="bottom-container bottom-bar">
+            <div v-if="showBottomBarNow" class="bar bottom-bar">
               <MiniWidgetContainer
                 :container="widgetStore.currentView.miniWidgetContainers[0]"
                 :allow-editing="widgetStore.editingMode"
@@ -328,15 +328,23 @@ body.hide-cursor {
   z-index: 60; /* Adjust z-index as needed */
 }
 
-.bottom-bar {
+.bar {
   width: 100%;
   background: rgba(108, 117, 125, 0.5);
   display: flex;
   justify-content: space-between;
+  z-index: 60;
+  position: absolute;
+  @apply backdrop-blur-[2px];
+}
+
+.bottom-bar {
+  bottom: 0;
   height: v-bind('currentBottomBarHeightPixels');
 }
 
 .top-bar {
+  top: 0;
   height: v-bind('currentTopBarHeightPixels');
 }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -69,7 +69,7 @@
 
       <div ref="routerSection" class="router-view">
         <div class="main-view" :class="{ 'edit-mode': widgetStore.editingMode }">
-          <div id="mainTopBar" class="z-[60] w-full h-12 bg-slate-600/50 absolute flex backdrop-blur-[2px]">
+          <div id="mainTopBar" class="z-[60] w-full bg-slate-600/50 absolute flex backdrop-blur-[2px] top-bar">
             <button
               class="flex items-center justify-center h-full aspect-square top-bar-hamburger"
               @click="openMainMenu()"
@@ -108,7 +108,7 @@
           <Transition name="fade">
             <div v-if="showBottomBarNow" class="bottom-container">
               <SlideToConfirm />
-              <div class="bottom-bar h-12">
+              <div class="bottom-bar">
                 <MiniWidgetContainer
                   :container="widgetStore.currentView.miniWidgetContainers[0]"
                   :allow-editing="widgetStore.editingMode"
@@ -271,6 +271,11 @@ onBeforeUnmount(() => unregisterActionCallback(bottomBarToggleCallbackId))
 
 // Start datalogging
 datalogger.startLogging()
+
+// Dynamic styles
+
+const currentTopBarHeightPixels = computed(() => `${widgetStore.currentTopBarHeightPixels}px`)
+const currentBottomBarHeightPixels = computed(() => `${widgetStore.currentBottomBarHeightPixels}px`)
 </script>
 
 <style>
@@ -328,6 +333,11 @@ body.hide-cursor {
   background: rgba(108, 117, 125, 0.5);
   display: flex;
   justify-content: space-between;
+  height: v-bind('currentBottomBarHeightPixels');
+}
+
+.top-bar {
+  height: v-bind('currentTopBarHeightPixels');
 }
 
 .top-bar-hamburger {

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -16,49 +16,37 @@
         <div>coordinates: {{ clickedLocation }}</div>
       </l-tooltip>
     </l-marker>
-    <v-tooltip location="top center" text="Home position is currently undefined" :disabled="Boolean(home)">
-      <template #activator="{ props: tooltipProps }">
-        <v-btn
-          class="absolute left-0 m-3 bottom-12 bg-slate-50"
-          :class="!home ? 'active-events-on-disabled' : ''"
-          :color="followerTarget == WhoToFollow.HOME ? 'red' : ''"
-          elevation="2"
-          style="z-index: 1002; border-radius: 0px"
-          icon="mdi-home-map-marker"
-          size="x-small"
-          v-bind="tooltipProps"
-          :disabled="!home"
-          @click.stop="targetFollower.goToTarget(WhoToFollow.HOME, true)"
-          @dblclick.stop="targetFollower.follow(WhoToFollow.HOME)"
-        />
-      </template>
-    </v-tooltip>
+    <v-btn
+      v-tooltip="Boolean(home) ? undefined : 'Home position is currently undefined'"
+      class="absolute left-0 m-3 bottom-12 bg-slate-50"
+      :class="!home ? 'active-events-on-disabled' : ''"
+      :color="followerTarget == WhoToFollow.HOME ? 'red' : ''"
+      elevation="2"
+      style="z-index: 1002; border-radius: 0px"
+      icon="mdi-home-map-marker"
+      size="x-small"
+      :disabled="!home"
+      @click.stop="targetFollower.goToTarget(WhoToFollow.HOME, true)"
+      @dblclick.stop="targetFollower.follow(WhoToFollow.HOME)"
+    />
     <div v-if="showContextMenu" class="context-menu" :style="{ top: menuPosition.top, left: menuPosition.left }">
       <ul @click.stop="">
         <li @click="onMenuOptionSelect('goto')">GoTo</li>
       </ul>
     </div>
-    <v-tooltip
-      location="top center"
-      text="Vehicle position is currently undefined"
-      :disabled="Boolean(vehiclePosition)"
-    >
-      <template #activator="{ props: tooltipProps }">
-        <v-btn
-          class="absolute m-3 bottom-12 left-10 bg-slate-50"
-          :class="!vehiclePosition ? 'active-events-on-disabled' : ''"
-          :color="followerTarget == WhoToFollow.VEHICLE ? 'red' : ''"
-          elevation="2"
-          style="z-index: 1002; border-radius: 0px"
-          icon="mdi-airplane-marker"
-          size="x-small"
-          v-bind="tooltipProps"
-          :disabled="!vehiclePosition"
-          @click.stop="targetFollower.goToTarget(WhoToFollow.VEHICLE, true)"
-          @dblclick.stop="targetFollower.follow(WhoToFollow.VEHICLE)"
-        />
-      </template>
-    </v-tooltip>
+    <v-btn
+      v-tooltip="Boolean(vehiclePosition) ? undefined : 'Vehicle position is currently undefined'"
+      class="absolute m-3 bottom-12 left-10 bg-slate-50"
+      :class="!vehiclePosition ? 'active-events-on-disabled' : ''"
+      :color="followerTarget == WhoToFollow.VEHICLE ? 'red' : ''"
+      elevation="2"
+      style="z-index: 1002; border-radius: 0px"
+      icon="mdi-airplane-marker"
+      size="x-small"
+      :disabled="!vehiclePosition"
+      @click.stop="targetFollower.goToTarget(WhoToFollow.VEHICLE, true)"
+      @dblclick.stop="targetFollower.follow(WhoToFollow.VEHICLE)"
+    />
     <v-btn
       class="absolute m-3 bottom-12 left-20 bg-slate-50"
       elevation="2"

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -338,7 +338,7 @@ const menuPosition = reactive({ top: '0px', left: '0px' })
 
 // eslint-disable-next-line no-undef
 const onMapClick = (event: L.LeafletMouseEvent): void => {
-  console.log('Map click event:', event) // Log the event object
+  console.debug('Map click event:', event) // Log the event object
 
   // Check if event.latlng is defined and has the required properties
   if (event?.latlng?.lat != null && event?.latlng?.lng != null) {
@@ -358,7 +358,7 @@ const onMapClick = (event: L.LeafletMouseEvent): void => {
 }
 
 const onMenuOptionSelect = (option: string): void => {
-  console.log(`Option selected: ${option}`)
+  console.debug(`Map context menu option selected: ${option}.`)
 
   switch (option) {
     case 'goto':

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -18,7 +18,7 @@
     </l-marker>
     <v-btn
       v-tooltip="Boolean(home) ? undefined : 'Home position is currently undefined'"
-      class="absolute left-0 m-3 bottom-12 bg-slate-50"
+      class="absolute left-0 m-3 bottom-button bg-slate-50"
       :class="!home ? 'active-events-on-disabled' : ''"
       :color="followerTarget == WhoToFollow.HOME ? 'red' : ''"
       elevation="2"
@@ -36,7 +36,7 @@
     </div>
     <v-btn
       v-tooltip="Boolean(vehiclePosition) ? undefined : 'Vehicle position is currently undefined'"
-      class="absolute m-3 bottom-12 left-10 bg-slate-50"
+      class="absolute m-3 bottom-button left-10 bg-slate-50"
       :class="!vehiclePosition ? 'active-events-on-disabled' : ''"
       :color="followerTarget == WhoToFollow.VEHICLE ? 'red' : ''"
       elevation="2"
@@ -48,7 +48,7 @@
       @dblclick.stop="targetFollower.follow(WhoToFollow.VEHICLE)"
     />
     <v-btn
-      class="absolute m-3 bottom-12 left-20 bg-slate-50"
+      class="absolute m-3 bottom-button left-20 bg-slate-50"
       elevation="2"
       style="z-index: 1002; border-radius: 0px"
       icon="mdi-download"
@@ -56,7 +56,7 @@
       @click.stop="downloadMissionFromVehicle"
     />
     <v-btn
-      class="absolute mb-3 ml-1 bottom-12 left-32 bg-slate-50"
+      class="absolute mb-3 ml-1 bottom-button left-32 bg-slate-50"
       elevation="2"
       style="z-index: 1002; border-radius: 0px"
       icon="mdi-play"
@@ -155,6 +155,7 @@ import { degrees } from '@/libs/utils'
 import { TargetFollower, WhoToFollow } from '@/libs/utils-map'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useMissionStore } from '@/stores/mission'
+import { useWidgetManagerStore } from '@/stores/widgetManager'
 import type { WaypointCoordinates } from '@/types/mission'
 import type { Widget } from '@/types/widgets'
 
@@ -393,6 +394,10 @@ const onMenuOptionSelect = (option: string): void => {
   // hide the context menu after an option is selected
   showContextMenu.value = false
 }
+
+// Dynamic styles
+const widgetStore = useWidgetManagerStore()
+const bottomButtonsDisplacement = computed(() => `${widgetStore.widgetBottomClearanceForVisibleArea(widget.value)}px`)
 </script>
 
 <style>
@@ -412,7 +417,7 @@ const onMenuOptionSelect = (option: string): void => {
   justify-content: center;
 }
 .leaflet-control-zoom {
-  transform: translateY(-30px);
+  bottom: v-bind('bottomButtonsDisplacement');
 }
 .context-menu {
   position: absolute;
@@ -442,5 +447,8 @@ const onMenuOptionSelect = (option: string): void => {
 }
 .active-events-on-disabled {
   pointer-events: all;
+}
+.bottom-button {
+  bottom: v-bind('bottomButtonsDisplacement');
 }
 </style>

--- a/src/stores/widgetManager.ts
+++ b/src/stores/widgetManager.ts
@@ -1,6 +1,6 @@
 import '@/libs/cosmos'
 
-import { useDebounceFn, useStorage } from '@vueuse/core'
+import { useDebounceFn, useStorage, useWindowSize } from '@vueuse/core'
 import { saveAs } from 'file-saver'
 import { defineStore } from 'pinia'
 import Swal from 'sweetalert2'
@@ -112,6 +112,18 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
    */
   const isWidgetVisible = (widget: Widget): boolean => {
     return document.visibilityState === 'visible' && viewFromWidget(widget).hash === currentView.value.hash
+  }
+
+  /**
+   * Gets whether or not the widget is on the active view
+   * @returns { number } The bottom clearance, in pixels, a widget should add on it's content to ensure they are not under the bottom bar
+   * @param { Widget } widget - Widget
+   */
+  const widgetBottomClearanceForVisibleArea = (widget: Widget): number => {
+    const { height: windowHeight } = useWindowSize()
+    const bottomEdgeHeightPixels = windowHeight.value * (1 - widget.position.y - widget.size.height)
+    if (bottomEdgeHeightPixels > currentBottomBarHeightPixels.value) return 0
+    return currentBottomBarHeightPixels.value - bottomEdgeHeightPixels
   }
 
   /**
@@ -613,6 +625,7 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
     importProfilesFromVehicle,
     exportProfilesToVehicle,
     isWidgetVisible,
+    widgetBottomClearanceForVisibleArea,
     isRealMiniWidget,
     desiredTopBarHeightPixels,
     desiredBottomBarHeightPixels,

--- a/src/stores/widgetManager.ts
+++ b/src/stores/widgetManager.ts
@@ -34,6 +34,16 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
   const savedProfiles = useStorage<Profile[]>(savedProfilesKey, [])
   const currentViewIndex = useStorage('cockpit-current-view-index', 0)
   const currentProfileIndex = useStorage('cockpit-current-profile-index', 0)
+  const desiredTopBarHeightPixels = ref(48)
+  const desiredBottomBarHeightPixels = ref(48)
+
+  const currentTopBarHeightPixels = computed(() => {
+    return desiredTopBarHeightPixels.value
+  })
+
+  const currentBottomBarHeightPixels = computed(() => {
+    return currentView.value.showBottomBarOnBoot ? desiredBottomBarHeightPixels.value : 0
+  })
 
   const currentView = computed<View>({
     get() {
@@ -604,5 +614,9 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
     exportProfilesToVehicle,
     isWidgetVisible,
     isRealMiniWidget,
+    desiredTopBarHeightPixels,
+    desiredBottomBarHeightPixels,
+    currentTopBarHeightPixels,
+    currentBottomBarHeightPixels,
   }
 })


### PR DESCRIPTION
Now the bottom bar has a dynamic size, that is exposed to everyone. This allows for components like the `SlideToConfirm`, or widgets like the `Map` to use only the visible widgets area (and prevent positioning of buttons under the bar).

The immediate change is that the `Map` widget now does not have its buttons "floating" in the middle of the widget, with a fixed height from the bottom edge. They can now react to the positioning of the widget itself with respect to the bottom bar, never being under it.

Before:
![image](https://github.com/bluerobotics/cockpit/assets/6551040/e3d2553f-afca-4b26-b202-dc18735f88cc)

After:

https://github.com/bluerobotics/cockpit/assets/6551040/424d6f4c-9267-4b7d-a76f-94347c73f97c


