### PR TITLE
Move widgets away from bars

### DIFF
--- a/src/components/WidgetHugger.vue
+++ b/src/components/WidgetHugger.vue
@@ -66,7 +66,7 @@ const props = withDefaults(defineProps<Props>(), {
   hideOverflow: false,
 })
 
-const widget = toRefs(props).widget
+const { size, position, managerVars } = toRefs(props.widget)
 const allowMoving = toRefs(props).allowMoving
 const allowResizing = toRefs(props).allowResizing
 const outerWidgetRef = ref<HTMLElement | undefined>()
@@ -85,7 +85,7 @@ const hoveringWidgetOrOverlay = computed(() => hoveringOverlay.value || hovering
 
 // Put the widget into highlighted state when in edit-mode and hovering over it
 watch([hoveringWidgetOrOverlay, allowMoving], () => {
-  widget.value.managerVars.highlighted = hoveringWidgetOrOverlay.value && allowMoving.value
+  managerVars.value.highlighted = hoveringWidgetOrOverlay.value && allowMoving.value
 })
 
 const draggingWidget = ref(false)
@@ -103,7 +103,7 @@ const handleDragStart = (event: MouseEvent): void => {
   if (!allowMoving.value || isResizing.value || !outerWidgetRef.value) return
   draggingWidget.value = true
   initialMousePos.value = { x: event.clientX, y: event.clientY }
-  initialWidgetPos.value = widget.value.position
+  initialWidgetPos.value = position.value
   outerWidgetRef.value.style.cursor = 'grabbing'
   event.stopPropagation()
   event.preventDefault()
@@ -114,8 +114,8 @@ const handleResizeStart = (event: MouseEvent): void => {
   isResizing.value = true
   resizeHandle.value = event.target
   initialMousePos.value = { x: event.clientX, y: event.clientY }
-  initialWidgetPos.value = widget.value.position
-  initialWidgetSize.value = widget.value.size
+  initialWidgetPos.value = position.value
+  initialWidgetSize.value = size.value
   event.stopPropagation()
   event.preventDefault()
 }
@@ -126,9 +126,9 @@ const handleDrag = (event: MouseEvent): void => {
   const dx = (event.clientX - initialMousePos.value.x) / viewSize.value.width
   const dy = (event.clientY - initialMousePos.value.y) / viewSize.value.height
 
-  widget.value.position = {
-    x: constrain(initialWidgetPos.value.x + dx, 0, 1 - widget.value.size.width),
-    y: constrain(initialWidgetPos.value.y + dy, 0, 1 - widget.value.size.height),
+  position.value = {
+    x: constrain(initialWidgetPos.value.x + dx, 0, 1 - size.value.width),
+    y: constrain(initialWidgetPos.value.y + dy, 0, 1 - size.value.height),
   }
 }
 
@@ -171,11 +171,11 @@ const handleResize = (event: MouseEvent): void => {
     newHeight += dy
   }
 
-  widget.value.position = {
-    x: constrain(newLeft, 0, 1 - widget.value.size.width),
-    y: constrain(newTop, 0, 1 - widget.value.size.height),
+  position.value = {
+    x: constrain(newLeft, 0, 1 - size.value.width),
+    y: constrain(newTop, 0, 1 - size.value.height),
   }
-  widget.value.size = {
+  size.value = {
     width: constrain(newWidth, 0.01, 1),
     height: constrain(newHeight, 0.01, 1),
   }
@@ -197,11 +197,11 @@ const resizeWidgetToMinimalSize = (): void => {
   if (innerWidgetRef.value === undefined) return
   const { clientHeight, clientWidth, scrollWidth, scrollHeight } = innerWidgetRef.value
   if (scrollWidth > 1.05 * clientWidth) {
-    widget.value.size.width = (1.1 * scrollWidth) / windowWidth.value
+    size.value.width = (1.1 * scrollWidth) / windowWidth.value
     stillAutoResizing = true
   }
   if (scrollHeight > 1.05 * clientHeight) {
-    widget.value.size.height = (1.1 * scrollHeight) / windowHeight.value
+    size.value.height = (1.1 * scrollHeight) / windowHeight.value
     stillAutoResizing = true
   }
 
@@ -209,11 +209,11 @@ const resizeWidgetToMinimalSize = (): void => {
 }
 
 onMounted(async () => {
-  if (widget.value.managerVars.timesMounted === 0) {
+  if (managerVars.value.timesMounted === 0) {
     resizeWidgetToMinimalSize()
   }
   makeWidgetRespectWalls()
-  widget.value.managerVars.timesMounted += 1
+  managerVars.value.timesMounted += 1
 
   if (widgetResizeHandles.value) {
     for (let i = 0; i < widgetResizeHandles.value.length; i++) {
@@ -248,24 +248,24 @@ const outerBounds = useElementBounding(outerWidgetRef)
 const makeWidgetRespectWalls = (): void => {
   for (const bound of [outerBounds.left.value, outerBounds.right.value]) {
     if (bound < 0 || bound > windowWidth.value) {
-      widget.value.position.x = 1 - widget.value.size.width
+      position.value.x = 1 - size.value.width
     }
   }
   for (const bound of [outerBounds.top.value, outerBounds.bottom.value]) {
     if (bound < 0 || bound > windowHeight.value) {
-      widget.value.position.y = 1 - widget.value.size.height
+      position.value.y = 1 - size.value.height
     }
   }
 }
 
 const sizeStyle = computed(() => ({
-  width: `${100 * widget.value.size.width}%`,
-  height: `${100 * widget.value.size.height}%`,
+  width: `${100 * size.value.width}%`,
+  height: `${100 * size.value.height}%`,
 }))
 
 const positionStyle = computed(() => ({
-  left: `${100 * widget.value.position.x}%`,
-  top: `${100 * widget.value.position.y}%`,
+  left: `${100 * position.value.x}%`,
+  top: `${100 * position.value.y}%`,
 }))
 
 const overlayDisplayStyle = computed(() => {
@@ -288,7 +288,7 @@ const cursorStyle = computed(() => {
 
 const devInfoBlurLevel = computed(() => `${devStore.widgetDevInfoBlurLevel}px`)
 
-const highlighted = computed(() => widget.value.managerVars.highlighted)
+const highlighted = computed(() => managerVars.value.highlighted)
 </script>
 
 <style>

--- a/src/components/WidgetHugger.vue
+++ b/src/components/WidgetHugger.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script setup lang="ts">
-import { useElementBounding, useElementHover, useWindowSize } from '@vueuse/core'
+import { useElementHover, useWindowSize } from '@vueuse/core'
 import { computed, nextTick, onMounted, ref, toRefs, watch } from 'vue'
 
 import { constrain, round } from '@/libs/utils'
@@ -212,7 +212,6 @@ onMounted(async () => {
   if (managerVars.value.timesMounted === 0) {
     resizeWidgetToMinimalSize()
   }
-  makeWidgetRespectWalls()
   managerVars.value.timesMounted += 1
 
   if (widgetResizeHandles.value) {
@@ -242,21 +241,6 @@ watch(allowMoving, (isAllowing, wasAllowing) => {
     outerWidgetRef.value?.style.setProperty('cursor', 'grab')
   }
 })
-
-const outerBounds = useElementBounding(outerWidgetRef)
-
-const makeWidgetRespectWalls = (): void => {
-  for (const bound of [outerBounds.left.value, outerBounds.right.value]) {
-    if (bound < 0 || bound > windowWidth.value) {
-      position.value.x = 1 - size.value.width
-    }
-  }
-  for (const bound of [outerBounds.top.value, outerBounds.bottom.value]) {
-    if (bound < 0 || bound > windowHeight.value) {
-      position.value.y = 1 - size.value.height
-    }
-  }
-}
 
 const sizeStyle = computed(() => ({
   width: `${100 * size.value.width}%`,

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -503,7 +503,9 @@ const executeMissionOnVehicle = (): void => {
 
 // Set dynamic styles for correct displacement of the bottom buttons when the widget is below the bottom bar
 const widgetStore = useWidgetManagerStore()
-const bottomButtonsDisplacement = computed(() => `${widgetStore.widgetBottomClearanceForVisibleArea(widget.value)}px`)
+const bottomButtonsDisplacement = computed(() => {
+  return `${Math.max(-widgetStore.widgetClearanceForVisibleArea(widget.value).bottom, 0)}px`
+})
 </script>
 
 <style>

--- a/src/stores/widgetManager.ts
+++ b/src/stores/widgetManager.ts
@@ -122,14 +122,24 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
 
   /**
    * Gets whether or not the widget is on the active view
-   * @returns { number } The bottom clearance, in pixels, a widget should add on it's content to ensure they are not under the bottom bar
+   * @returns { { top: number, bottom: number } } The top and bottom clearances, in pixels, a widget should add on it's content to ensure they are not under the top/bottom bar.
+   * Positive clearances mean the widget is already under the bar, while negative clearances mean the widget is that amount away from the bar.
    * @param { Widget } widget - Widget
    */
-  const widgetBottomClearanceForVisibleArea = (widget: Widget): number => {
+  // eslint-disable-next-line jsdoc/require-jsdoc
+  const widgetClearanceForVisibleArea = (widget: Widget): { top: number; bottom: number } => {
+    const clearances = { top: 0, bottom: 0 }
     const { height: windowHeight } = useWindowSize()
-    const bottomEdgeHeightPixels = windowHeight.value * (1 - widget.position.y - widget.size.height)
-    if (bottomEdgeHeightPixels > currentBottomBarHeightPixels.value) return 0
-    return currentBottomBarHeightPixels.value - bottomEdgeHeightPixels
+
+    const widgetTopEdgePixels = windowHeight.value * widget.position.y
+    const topBarStartPixels = currentTopBarHeightPixels.value
+    clearances.top = widgetTopEdgePixels - topBarStartPixels
+
+    const widgetBottomEdgePixels = windowHeight.value * (widget.position.y + widget.size.height)
+    const bottomBarStartPixels = windowHeight.value - currentBottomBarHeightPixels.value
+    clearances.bottom = bottomBarStartPixels - widgetBottomEdgePixels
+
+    return clearances
   }
 
   /**
@@ -651,7 +661,7 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
     exportProfilesToVehicle,
     loadDefaultProfileForVehicle,
     isWidgetVisible,
-    widgetBottomClearanceForVisibleArea,
+    widgetClearanceForVisibleArea,
     isRealMiniWidget,
     desiredTopBarHeightPixels,
     desiredBottomBarHeightPixels,

--- a/src/stores/widgetManager.ts
+++ b/src/stores/widgetManager.ts
@@ -38,6 +38,7 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
   const currentProfileIndex = useStorage('cockpit-current-profile-index', 0)
   const desiredTopBarHeightPixels = ref(48)
   const desiredBottomBarHeightPixels = ref(48)
+  const visibleAreaMinClearancePixels = ref(20)
   const vehicleTypeProfileCorrespondency = useStorage<typeof defaultProfileVehicleCorrespondency>(
     'cockpit-default-vehicle-type-profiles',
     defaultProfileVehicleCorrespondency
@@ -665,6 +666,7 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
     isRealMiniWidget,
     desiredTopBarHeightPixels,
     desiredBottomBarHeightPixels,
+    visibleAreaMinClearancePixels,
     currentTopBarHeightPixels,
     currentBottomBarHeightPixels,
   }


### PR DESCRIPTION
With this patch, widgets will not go under the top/bottom bar when the window is resized, nor the user will be able to move a widget to under the bars, with the exception being full-screened widgets.

I will keep this as draft for now to make sure I'm happy with the solution, and I've tested for all edge-cases.

Fix #634 

Before:

https://github.com/bluerobotics/cockpit/assets/6551040/9fca0261-f944-418a-82a2-60eef3b4d7d0



After:

https://github.com/bluerobotics/cockpit/assets/6551040/f7228c3c-023e-4fd9-a6df-e2b86a0dfe75



https://github.com/bluerobotics/cockpit/assets/6551040/43be5008-494c-4a1f-949c-c86230a19796

