### PR TITLE
Allow logging data from very generic indicator

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -108,27 +108,30 @@
           <div class="bottom-container">
             <SlideToConfirm />
           </div>
-          <Transition name="fade">
-            <div v-if="showBottomBarNow" class="bar bottom-bar">
-              <MiniWidgetContainer
-                :container="widgetStore.currentView.miniWidgetContainers[0]"
-                :allow-editing="widgetStore.editingMode"
-                align="start"
-              />
-              <div />
-              <MiniWidgetContainer
-                :container="widgetStore.currentView.miniWidgetContainers[1]"
-                :allow-editing="widgetStore.editingMode"
-                align="center"
-              />
-              <div />
-              <MiniWidgetContainer
-                :container="widgetStore.currentView.miniWidgetContainers[2]"
-                :allow-editing="widgetStore.editingMode"
-                align="end"
-              />
-            </div>
-          </Transition>
+          <div v-for="(view, index) in widgetStore.viewsToShow" :key="view.name">
+            <Transition name="fade">
+              <!-- #TODO Fix viewsToSHow object reordering on view change. For now, this comparisson works fine, but it's a workaround to be fixed on issue #933 -->
+              <div v-show="index === 2" class="bar bottom-bar">
+                <MiniWidgetContainer
+                  :container="view.miniWidgetContainers[0]"
+                  :allow-editing="widgetStore.editingMode"
+                  align="start"
+                />
+                <div />
+                <MiniWidgetContainer
+                  :container="view.miniWidgetContainers[1]"
+                  :allow-editing="widgetStore.editingMode"
+                  align="center"
+                />
+                <div />
+                <MiniWidgetContainer
+                  :container="view.miniWidgetContainers[2]"
+                  :allow-editing="widgetStore.editingMode"
+                  align="end"
+                />
+              </div>
+            </Transition>
+          </div>
           <router-view />
         </div>
         <EditMenu v-model:edit-mode="widgetStore.editingMode" />

--- a/src/components/MiniWidgetContainer.vue
+++ b/src/components/MiniWidgetContainer.vue
@@ -16,6 +16,7 @@
       <div
         v-for="miniWidget in container.widgets"
         :key="miniWidget.hash"
+        :data-widget-hash="miniWidget.hash"
         class="rounded-md"
         :class="{ 'cursor-grab': allowEditing, 'bg-slate-400': miniWidget.managerVars.highlighted }"
         @mouseover="miniWidget.managerVars.highlighted = allowEditing"
@@ -44,7 +45,7 @@
             :animation="150"
             group="generalGroup"
             class="flex flex-wrap items-center justify-center w-full h-full gap-2"
-            @add="trashList = []"
+            @add="handleDeleteWidget"
           >
             <div v-for="miniWidget in trashList" :key="miniWidget.hash">
               <div class="pointer-events-none select-none">
@@ -64,7 +65,8 @@ import { ref, toRefs } from 'vue'
 import { computed } from 'vue'
 import { VueDraggable } from 'vue-draggable-plus'
 
-import type { MiniWidget, MiniWidgetContainer } from '@/types/miniWidgets'
+import { CurrentlyLoggedVariables } from '@/libs/sensors-logging'
+import type { DraggableEvent, MiniWidget, MiniWidgetContainer } from '@/types/miniWidgets'
 
 import MiniWidgetInstantiator from './MiniWidgetInstantiator.vue'
 
@@ -115,4 +117,13 @@ const refreshWidgetsHashs = (): void => {
 const showWidgetTrashArea = ref(false)
 
 const trashList = ref<MiniWidget[]>([])
+
+const handleDeleteWidget = (event: DraggableEvent): void => {
+  const widgetData = container.value.widgets.find((w) => w.hash === event.item.dataset.widgetHash)
+  if (widgetData) {
+    // Remove miniWidget variableName from Logged variables list
+    CurrentlyLoggedVariables.removeVariable(widgetData.options.displayName)
+  }
+  trashList.value = []
+}
 </script>

--- a/src/components/mini-widgets/VeryGenericIndicator.vue
+++ b/src/components/mini-widgets/VeryGenericIndicator.vue
@@ -224,19 +224,11 @@ const updateLoggedMiniWidgets = (): void => {
 const closeDialog = async (): Promise<void> => {
   const { variableName, displayName } = miniWidget.value.options
   const { managerVars } = miniWidget.value
-  const normalize = (name: string): string => name.toLowerCase().trim()
 
   if (variableName === '' || displayName === '') {
     await Swal.fire({
       text: 'Please select a variable and name it before closing the configuration menu.',
       icon: 'error',
-    })
-    return
-  }
-  if (loggedMiniWidgets.value.some((name) => normalize(name) === normalize(displayName))) {
-    await Swal.fire({
-      text: `This variable name is already being logged. Please rename it on The 'Custom' tab.`,
-      icon: 'info',
     })
     return
   }
@@ -273,7 +265,9 @@ const logCurrentState = (): void => {
 watch(
   finalValue,
   () => {
-    logCurrentState()
+    if (miniWidget.value.managerVars.configMenuOpen === false) {
+      logCurrentState()
+    }
   },
   { immediate: true }
 )
@@ -295,7 +289,8 @@ onMounted(() => {
   updateVariableState()
   updateWidgetName()
   updateGenericVariablesNames()
-  if (miniWidget.value.options.displayName) {
+
+  if (miniWidget.value.options.displayName && widgetStore.editingMode === false) {
     CurrentlyLoggedVariables.addVariable(miniWidget.value.options.displayName)
   }
   lastWidgetName.value = miniWidget.value.options.displayName

--- a/src/libs/sensors-logging.ts
+++ b/src/libs/sensors-logging.ts
@@ -25,6 +25,43 @@ export enum DatalogVariable {
 }
 
 /**
+ * Data for VeryGenericIndicator variables
+ */
+type VeryGenericData = {
+  /**
+   * Display name of the variable
+   */
+  displayName: string
+  /**
+   * Value of the variable
+   */
+  variableValue: string
+  /**
+   * Linux epoch stating when this value was last changed
+   */
+  lastChanged?: number
+  /**
+   * Current view of the variable
+   */
+  currentView?: string
+}
+
+/**
+ * Extended data to also accept VeryGenericIndicator variables
+ */
+/* eslint-disable jsdoc/require-jsdoc  */
+export type ExtendedVariablesData = {
+  /**
+   * Display name of the VeryGenericVariable
+   */
+  [key: string]: {
+    value: string
+    lastChanged: number
+    currentView?: string
+  }
+}
+
+/**
  * State of a variable that can be displayed
  */
 export type VariablesData = {
@@ -58,7 +95,7 @@ export interface CockpitStandardLogPoint {
   /**
    * The actual vehicle data
    */
-  data: VariablesData
+  data: ExtendedVariablesData
 }
 
 /**
@@ -67,12 +104,70 @@ export interface CockpitStandardLogPoint {
 export type CockpitStandardLog = CockpitStandardLogPoint[]
 
 /**
+ * Class to manage the variables that are currently being logged
+ */
+export class CurrentlyLoggedVariables {
+  private static variables: Set<{ name: string; instances: number }> = new Set()
+  private static readonly defaultVariables = new Set<string>(Object.values(DatalogVariable))
+
+  static {
+    this.defaultVariables.forEach((variable) => this.variables.add({ name: variable, instances: 1 }))
+  }
+
+  /**
+   * Adds a new variable to the set if it's not already included, or increments its VGI instances count if it is.
+   * @param {string} name The name of the variable to add or update.
+   */
+  public static addVariable(name: string): void {
+    const existingVariable = Array.from(this.variables).find((variable) => variable.name === name)
+
+    if (existingVariable) {
+      this.variables.delete(existingVariable)
+      this.variables.add({ name: existingVariable.name, instances: existingVariable.instances + 1 })
+    } else {
+      this.variables.add({ name, instances: 1 })
+    }
+  }
+
+  /**
+   * Removes a variable from the set or decrements its VGI instances count if it has more than one.
+   * @param {string} name The name of the variable to remove.
+   */
+  public static removeVariable(name: string): void {
+    if (name) name = name.trim()
+    if (!this.defaultVariables.has(name)) {
+      const existingVariable = Array.from(this.variables).find((variable) => variable.name === name)
+
+      if (existingVariable) {
+        if (existingVariable.instances > 1) {
+          this.variables.delete(existingVariable) // Remove the old entry from the Set.
+          this.variables.add({ name: existingVariable.name, instances: existingVariable.instances - 1 })
+        } else {
+          this.variables.delete(existingVariable)
+        }
+      }
+    } else {
+      console.log(`Attempted to remove default variable: ${name}. Operation not allowed.`)
+    }
+  }
+
+  /**
+   * Retrieves all currently logged variables.
+   * @returns {Set<string>} A set of all variables.
+   */
+  public static getAllVariables(): string[] {
+    return Array.from(this.variables).map((variable) => variable.name)
+  }
+}
+
+/**
  * Manager logging vehicle data and others
  */
 class DataLogger {
   shouldBeLogging = false
   currentCockpitLog: CockpitStandardLog = []
   variablesBeingUsed: DatalogVariable[] = []
+  veryGenericIndicators: VeryGenericData[] = []
   selectedVariablesToShow = useStorage<DatalogVariable[]>('cockpit-datalogger-overlay-variables', [])
   logInterval = useStorage<number>('cockpit-datalogger-log-interval', 1000)
   cockpitLogsDB = localforage.createInstance({
@@ -107,7 +202,7 @@ class DataLogger {
       const timeNowObj = { lastChanged: timeNow.getTime() }
 
       /* eslint-disable vue/max-len, prettier/prettier, max-len */
-      const variablesData = {
+      let variablesData: ExtendedVariablesData = {
         [DatalogVariable.roll]: { value: `${degrees(vehicleStore.attitude.roll)?.toFixed(1)} °`, ...timeNowObj },
         [DatalogVariable.pitch]: { value: `${degrees(vehicleStore.attitude.pitch)?.toFixed(1)} °`, ...timeNowObj },
         [DatalogVariable.heading]: { value: `${degrees(vehicleStore.attitude.yaw)?.toFixed(1)} °`, ...timeNowObj },
@@ -121,12 +216,17 @@ class DataLogger {
         [DatalogVariable.longitude]: { value: `${vehicleStore.coordinates.longitude?.toFixed(6)} °` || 'Unknown', ...timeNowObj },
       }
       /* eslint-enable vue/max-len, prettier/prettier, max-len */
+      const veryGenericData = this.collectVeryGenericData(timeNowObj)
+      variablesData = { ...variablesData, ...veryGenericData }
 
-      this.currentCockpitLog.push({
+      const logPoint: CockpitStandardLogPoint = {
         epoch: timeNow.getTime(),
         seconds: secondsNow,
         data: structuredClone(variablesData),
-      })
+      }
+
+      /* eslint-enable vue/max-len, prettier/prettier, max-len */
+      this.currentCockpitLog.push(logPoint)
 
       await this.cockpitLogsDB.setItem(fileName, this.currentCockpitLog)
 
@@ -136,6 +236,23 @@ class DataLogger {
     }
 
     logRoutine()
+  }
+
+  /**
+   * Collects data from VeryGenericIndicator miniWidgets
+   * @param {VeryGenericData} data
+   * @param {number} data.lastChanged
+   * @returns {ExtendedVariablesData}
+   */
+  collectVeryGenericData(data: { lastChanged: number }): ExtendedVariablesData {
+    const result: ExtendedVariablesData = {}
+    this.veryGenericIndicators.forEach((indicator) => {
+      result[indicator.displayName] = {
+        value: indicator.variableValue,
+        lastChanged: data.lastChanged,
+      }
+    })
+    return result
   }
 
   /**
@@ -192,6 +309,21 @@ class DataLogger {
   registerUsage(variable: DatalogVariable): void {
     if (this.variablesBeingUsed.includes(variable)) return
     this.variablesBeingUsed.push(variable)
+  }
+
+  /**
+   * Register or update a new VeryGenericIndicator
+   * @param {VeryGenericVariableData} data - Data from the VeryGenericIndicator
+   * @returns {void}
+   */
+  registerVeryGenericData(data: VeryGenericData): void {
+    const existingIndicator = this.veryGenericIndicators.find((ind) => ind.displayName === data.displayName)
+
+    if (existingIndicator) {
+      existingIndicator.variableValue = data.variableValue
+    } else {
+      this.veryGenericIndicators.push(data)
+    }
   }
 
   /**

--- a/src/stores/widgetManager.ts
+++ b/src/stores/widgetManager.ts
@@ -16,6 +16,7 @@ import {
   registerActionCallback,
   unregisterActionCallback,
 } from '@/libs/joystick/protocols/cockpit-actions'
+import { CurrentlyLoggedVariables } from '@/libs/sensors-logging'
 import { isEqual, sequentialArray } from '@/libs/utils'
 import type { Point2D, SizeRect2D } from '@/types/general'
 import type { MiniWidget, MiniWidgetContainer } from '@/types/miniWidgets'
@@ -409,7 +410,6 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
     const container: MiniWidgetContainer | undefined = miniWidgetContainersInCurrentView.value.find((cont) => {
       return cont.widgets.includes(miniWidget)
     })
-
     if (container === undefined) {
       Swal.fire({ icon: 'error', text: 'Mini-widget container not found.' })
       return
@@ -417,6 +417,9 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
 
     const index = container.widgets.indexOf(miniWidget)
     container.widgets.splice(index, 1)
+
+    // Remove miniWidget variable from the list of currently logged variables
+    CurrentlyLoggedVariables.removeVariable(miniWidget.options.displayName)
   }
 
   /**

--- a/src/types/miniWidgets.ts
+++ b/src/types/miniWidgets.ts
@@ -75,3 +75,10 @@ export type MiniWidgetProfile = {
    */
   name: string
 }
+
+export type DraggableEvent = {
+  /**
+   * The HTML item that is being dragged
+   */
+  item: HTMLElement
+}

--- a/src/views/ConfigurationLogsView.vue
+++ b/src/views/ConfigurationLogsView.vue
@@ -1,11 +1,14 @@
 <template>
   <BaseConfigurationView>
-    <template #title>Logs configuration</template>
+    <template #title>Logs configuration for {{ currentView }}</template>
     <template #content>
       <h1 class="text-lg font-bold text-slate-600">Variables to be show in the overlay subtitles log:</h1>
+      <span class="text-sm text-slate-400 w-[50%] text-center">
+        Available variables are independant for each view.
+      </span>
       <div class="flex w-[60%] flex-wrap">
         <v-checkbox
-          v-for="variable in DatalogVariable"
+          v-for="variable in loggedVariables.sort()"
           :key="variable"
           v-model="datalogger.selectedVariablesToShow.value"
           :label="variable"
@@ -33,11 +36,24 @@
 
 <script setup lang="ts">
 import { FwbInput, FwbRange } from 'flowbite-vue'
-import { computed, ref, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 
-import { datalogger, DatalogVariable } from '@/libs/sensors-logging'
+import { CurrentlyLoggedVariables, datalogger } from '@/libs/sensors-logging'
+import { useWidgetManagerStore } from '@/stores/widgetManager'
 
 import BaseConfigurationView from './BaseConfigurationView.vue'
+
+const widgetStore = useWidgetManagerStore()
+
+const loggedVariables = ref<string[]>([])
+
+const currentView = ref(widgetStore.currentView.name)
+
+const updateVariables = (): void => {
+  loggedVariables.value = Array.from(CurrentlyLoggedVariables.getAllVariables())
+}
+
+onMounted(updateVariables)
 
 const newFrequency = ref(1000 / datalogger.logInterval.value)
 


### PR DESCRIPTION
- Allow logging of any variable the vehicle offers;
- Custom VeryGenericIndicators now must have a Name and a variable to be accepted;
- Unique Display Name for VeryGenericIndicators from now on. They can monitor the same variable, but with different display names. This is the reference for logging.

Closes #600 