### PR TITLE
sensors-logging: Find log by day prioritizing those from the last day

### DIFF
--- a/src/libs/sensors-logging.ts
+++ b/src/libs/sensors-logging.ts
@@ -24,6 +24,8 @@ export enum DatalogVariable {
   longitude = 'Longitude',
 }
 
+const logDateFormat = 'LLL dd, yyyy'
+
 /**
  * State of a variable that can be displayed
  */
@@ -97,7 +99,7 @@ class DataLogger {
     const vehicleStore = useMainVehicleStore()
 
     const initialTime = new Date()
-    const fileName = `Cockpit (${format(initialTime, 'LLL dd, yyyy - HH꞉mm꞉ss O')}).clog`
+    const fileName = `Cockpit (${format(initialTime, `${logDateFormat} - HH꞉mm꞉ss O`)}).clog`
     this.currentCockpitLog = []
 
     const logRoutine = async (): Promise<void> => {
@@ -201,8 +203,12 @@ class DataLogger {
    */
   async findLogByInitialTime(datetime: Date): Promise<CockpitStandardLog | null> {
     const availableLogsKeys = await this.cockpitLogsDB.keys()
+    const logKeysFromLastDay = availableLogsKeys.filter((key) => {
+      const yesterday = new Date().setDate(new Date().getDate() - 1)
+      return key.includes(format(datetime, logDateFormat)) || key.includes(format(yesterday, logDateFormat))
+    })
 
-    for (const key of availableLogsKeys) {
+    for (const key of [...logKeysFromLastDay, ...availableLogsKeys]) {
       const log = await this.cockpitLogsDB.getItem(key)
 
       // Only consider logs that are actually logs (arrays with at least two elements with an epoch property)


### PR DESCRIPTION
Telemetry logs are taking a lot of time to be processed, and looking more into it, I realized it is because we are accessing each log file individually and checking if it matches our criteria.

This patch fixes it with a quick and dirty solution: iterating first over the logs from the day of the video and the day before, and only them on the rest of the logs (which would be the case only for videos being recorded for more than 24 horus...).

The best solution would be to index the DB by timestamp, sort it and check the logs starting from the most recent one, with a proper cursor, but it is a more complex solution that I need to study more about, while the one here solves the problem already.

Fix #908 