### PR TITLE
Add RTP receiver jitter buffer target configuration

### DIFF
--- a/src/libs/webrtc/session.ts
+++ b/src/libs/webrtc/session.ts
@@ -130,6 +130,47 @@ export class Session {
   }
 
   /**
+   * Sets jitterBufferTarget (milliseconds)
+   * @param {number | null} jitterBufferTarget - Target RTP receiver jitter buffer time in milliseconds
+   */
+  public setJitterBufferTarget(jitterBufferTarget: number | null): void {
+    this.peerConnection.getReceivers().forEach((receiver: RTCRtpReceiver) => {
+      if (receiver.track.kind !== 'video') {
+        return
+      }
+
+      let playoutDelayHint = null
+      if (jitterBufferTarget) {
+        if (jitterBufferTarget > 4000) {
+          jitterBufferTarget = 4000
+        } else if (jitterBufferTarget < 0) {
+          jitterBufferTarget = 0
+        }
+
+        playoutDelayHint = jitterBufferTarget / 1000 // in seconds, legacy Chrome API
+      }
+
+      console.debug(
+        `RTCRtpReceiver jitterBufferTarget attribute set from ${
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (receiver as any).jitterBufferTarget
+        } to ${jitterBufferTarget}`
+      )
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(receiver as any).jitterBufferTarget = jitterBufferTarget // in milliseconds (DOMHighResTimeStamp)
+
+      console.debug(
+        `RTCRtpReceiver playoutDelayHint attribute set from ${
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (receiver as any).playoutDelayHint
+        } to ${playoutDelayHint}`
+      )
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(receiver as any).playoutDelayHint = playoutDelayHint
+    })
+  }
+
+  /**
    * Defines the behavior for when a remote SDP is received from the signalling server
    * @param {RTCSessionDescription} description - The SDP received from the signalling server
    */

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -31,6 +31,7 @@ export const useVideoStore = defineStore('video', () => {
 
   const allowedIceIps = useStorage<string[]>('cockpit-allowed-stream-ips', [])
   const allowedIceProtocols = useStorage<string[]>('cockpit-allowed-stream-protocols', [])
+  const jitterBufferTarget = useStorage<number | null>('cockpit-jitter-buffer-target', 0)
   const activeStreams = ref<{ [key in string]: StreamData | undefined }>({})
   const mainWebRTCManager = new WebRTCManager(webRTCSignallingURI.val, rtcConfiguration)
   const availableIceIps = ref<string[]>([])
@@ -76,7 +77,12 @@ export const useVideoStore = defineStore('video', () => {
   const activateStream = (streamName: string): void => {
     const stream = ref()
     const webRtcManager = new WebRTCManager(webRTCSignallingURI.val, rtcConfiguration)
-    const { mediaStream, connected } = webRtcManager.startStream(stream, allowedIceIps, allowedIceProtocols)
+    const { mediaStream, connected } = webRtcManager.startStream(
+      stream,
+      allowedIceIps,
+      allowedIceProtocols,
+      jitterBufferTarget
+    )
     activeStreams.value[streamName] = {
       // @ts-ignore: This is actually not reactive
       stream: stream,
@@ -707,6 +713,7 @@ export const useVideoStore = defineStore('video', () => {
     availableIceIps,
     allowedIceIps,
     allowedIceProtocols,
+    jitterBufferTarget,
     namesAvailableStreams,
     videoStoringDB,
     tempVideoChunksDB,

--- a/src/views/ConfigurationVideoView.vue
+++ b/src/views/ConfigurationVideoView.vue
@@ -51,6 +51,29 @@
           />
         </div>
       </div>
+
+      <p class="text-sm font-bold text-grey-darken-1 bg-grey-lighten-5">RTP Jitter Buffer (Target) duration:</p>
+      <div
+        class="flex flex-col items-center px-5 py-3 m-5 font-medium text-center border rounded-md text-grey-darken-1 bg-grey-lighten-5 w-[40%]"
+      >
+        <p>Increasing this will result in increased video latency, but it can help compensate the network jitter.</p>
+        <br />
+        <p>Cockpit's default is zero milliseconds, but you can leave it empty to use the browser's default.</p>
+      </div>
+      <div class="flex items-center justify-start">
+        <v-text-field
+          v-model.number="jitterBufferTarget"
+          placeholder="auto"
+          type="number"
+          style="width: 100px"
+          class="text-sm"
+          max="4000"
+          min="0"
+          :rules="jitterBufferTargetRules"
+          @input="handleJitterBufferTargetInput"
+        />
+        <a class="pl-1">ms</a>
+      </div>
     </template>
   </BaseConfigurationView>
 </template>
@@ -77,5 +100,20 @@ onMounted(() => {
   }
 })
 
-const { allowedIceIps, allowedIceProtocols, availableIceIps } = storeToRefs(videoStore)
+/**
+ * Handles the input for setting the jitter buffer target
+ * @param {string} input - The input value to be processed
+ */
+function handleJitterBufferTargetInput(input: InputEvent): void {
+  if (input.data === null) {
+    jitterBufferTarget.value = null
+  }
+}
+
+const jitterBufferTargetRules = [
+  (value: number | '') => value === '' || value >= 0 || 'Must be >= 0',
+  (value: number | '') => value === '' || value <= 4000 || 'Must be <= 4000',
+]
+
+const { allowedIceIps, allowedIceProtocols, availableIceIps, jitterBufferTarget } = storeToRefs(videoStore)
 </script>


### PR DESCRIPTION
This patch allows us to control the [RTP receiver target jitter buffer](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpReceiver/jitterBufferTarget).

The default value is set to zero, which gives us the minimum possible latency for the stream. 

From my tests, setting it to zero improved latency compared to the browser's default (unbeknownst to me).

![image](https://github.com/bluerobotics/cockpit/assets/5920286/7a170862-63e9-4300-b6fb-2fe0b2921b2d)
