### PR TITLE
Optimize parsing of generic messages data

### DIFF
--- a/src/components/mini-widgets/VeryGenericIndicator.vue
+++ b/src/components/mini-widgets/VeryGenericIndicator.vue
@@ -246,7 +246,7 @@ const updateWidgetName = (): void => {
   miniWidget.value.name = miniWidget.value.options.displayName || miniWidget.value.options.variableName
 }
 const updateGenericVariablesNames = (): void => {
-  allVariablesNames.value = Object.keys(store.genericVariables)
+  allVariablesNames.value = store.availableGenericVariables
 }
 
 const logData = computed(() => ({
@@ -272,10 +272,8 @@ watch(
   { immediate: true }
 )
 
-watch(store.genericVariables, () => {
-  updateVariableState()
-  updateGenericVariablesNames()
-})
+watch(store.genericVariables, () => updateVariableState())
+watch(store.availableGenericVariables, () => updateGenericVariablesNames())
 watch(
   miniWidget,
   () => {
@@ -293,6 +291,11 @@ onMounted(() => {
   if (miniWidget.value.options.displayName && widgetStore.editingMode === false) {
     CurrentlyLoggedVariables.addVariable(miniWidget.value.options.displayName)
   }
+
+  if (miniWidget.value.options.variableName) {
+    store.registerUsageOfGenericVariable(miniWidget.value.options.variableName)
+  }
+
   lastWidgetName.value = miniWidget.value.options.displayName
 })
 
@@ -339,6 +342,7 @@ const chooseVariable = (variable: string): void => {
   miniWidget.value.options.variableName = variable
   variableNameSearchString.value = ''
   showVariableChooseModal.value = false
+  store.registerUsageOfGenericVariable(variable)
 }
 
 const chooseIcon = (iconName: string): void => {

--- a/src/components/mini-widgets/VeryGenericIndicator.vue
+++ b/src/components/mini-widgets/VeryGenericIndicator.vue
@@ -16,7 +16,7 @@
     persistent
     class="w-[100vw] flex justify-center items-center"
   >
-    <v-card class="configModal p-8">
+    <v-card class="p-8 configModal">
       <div class="close-icon mdi mdi-close" @click.stop="closeDialog"></div>
       <v-card-title class="text-white">
         <div class="flex items-center mb-3 mt-[-5px] justify-evenly">
@@ -141,7 +141,7 @@
         <div
           v-for="(template, i) in veryGenericIndicatorPresets"
           :key="i"
-          class="flex items-center m-2 rounded-md px-2 text-white justify-center cursor-pointer hover:bg-slate-100/20 transition-all"
+          class="flex items-center justify-center px-2 m-2 text-white transition-all rounded-md cursor-pointer hover:bg-slate-100/20"
           @click="setIndicatorFromTemplate(template)"
         >
           <span class="relative w-[2rem] mdi icon-symbol text-[34px] mx-2" :class="[template.iconName]"></span>
@@ -284,6 +284,12 @@ watch(
   { deep: true }
 )
 onMounted(() => {
+  // Update old variables naming to new pattern
+  // TODO: Remove this before 1.0.0 release
+  if (miniWidget.value.options.variableName) {
+    miniWidget.value.options.variableName = miniWidget.value.options.variableName.replaceAll('.', '/')
+  }
+
   updateVariableState()
   updateWidgetName()
   updateGenericVariablesNames()

--- a/src/libs/vehicle/ardupilot/ardupilot.ts
+++ b/src/libs/vehicle/ardupilot/ardupilot.ts
@@ -223,7 +223,7 @@ export abstract class ArduPilotVehicle<Modes> extends Vehicle.AbstractVehicle<Mo
   }
 
   registerUsageOfMessageType = (messagePath: string): void => {
-    const pathKeys = messagePath.split('.')
+    const pathKeys = messagePath.split('/')
 
     if (!this._usedGenericVariablesdMessagePaths[pathKeys[0]]) {
       this._usedGenericVariablesdMessagePaths[pathKeys[0]] = []
@@ -300,13 +300,13 @@ export abstract class ArduPilotVehicle<Modes> extends Vehicle.AbstractVehicle<Mo
           if (identifier === undefined) {
             getDeepVariables(v as Record<string, unknown>, acc, k)
           } else {
-            getDeepVariables(v as Record<string, unknown>, acc, `${k}.ID${v[identifier]}`)
+            getDeepVariables(v as Record<string, unknown>, acc, `${k}/ID${v[identifier]}`)
           }
         } else {
           if (baseKey === undefined) {
             acc.push(k)
           } else {
-            acc.push(`${baseKey}.${k}`)
+            acc.push(`${baseKey}/${k}`)
           }
         }
       })
@@ -323,7 +323,7 @@ export abstract class ArduPilotVehicle<Modes> extends Vehicle.AbstractVehicle<Mo
 
     if (Object.keys(this._usedGenericVariablesdMessagePaths).includes(mavlink_message.message.type)) {
       this._usedGenericVariablesdMessagePaths[mavlink_message.message.type].forEach((path) => {
-        const pathKeys = path.split('.')
+        const pathKeys = path.split('/')
 
         let parentValue = mavlink_message.message
         for (let i = 1; i < pathKeys.length; i++) {


### PR DESCRIPTION
This patch makes:
- searching for available generic variables happens only every 5 seconds (instead of with each received message)
- retrieve data only for the messages/variables being used (and happens with direct access instead of search)

#937 