### PR TITLE
blueos: Allow monitoring BlueOS CPU temperature with the VeryGenericIndicator

### DIFF
--- a/src/libs/blueos.ts
+++ b/src/libs/blueos.ts
@@ -115,3 +115,26 @@ export const getArdupilotVersion = async (vehicleAddress: string): Promise<strin
     throw new Error(`Could not get Ardupilot firmware version. ${error}`)
   }
 }
+
+export const getStatus = async (vehicleAddress: string): Promise<boolean> => {
+  try {
+    const url = `http://${vehicleAddress}/status`
+    const result = await ky.get(url, { timeout: defaultTimeout })
+    return result.ok
+  } catch (error) {
+    throw new Error(`Could not get BlueOS status. ${error}`)
+  }
+}
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+type RawCpuTempInfo = { name: string; temperature: number; maximum_temperature: number; critical_temperature: number }
+
+export const getCpuTempCelsius = async (vehicleAddress: string): Promise<number> => {
+  try {
+    const url = `http://${vehicleAddress}/system-information/system/temperature`
+    const cpuTempRawInfo: RawCpuTempInfo[] = await ky.get(url, { timeout: defaultTimeout }).json()
+    return cpuTempRawInfo[0].temperature
+  } catch (error) {
+    throw new Error(`Could not get temperature of the BlueOS CPU. ${error}`)
+  }
+}


### PR DESCRIPTION
Apart from solving the problem, this implementation exposes how coupled things are right now regarding the vehicle store and the data used by the widgets (like the `VeryGenericIndicator`). We should improve the discussion around how to better accomplish that so that it's more natural to add this kind of feature.

<img width="448" alt="image" src="https://github.com/bluerobotics/cockpit/assets/6551040/76f1d1ce-93a8-4ea7-995c-986d96e04c72">


Fix #956 