### PR TITLE
Force rendering of `Compass` and `VirtualHorizon` on widget resizing

### DIFF
--- a/src/components/widgets/Compass.vue
+++ b/src/components/widgets/Compass.vue
@@ -234,7 +234,7 @@ const adjustLinesX = (): void => {
 watch(yaw, () => adjustLinesX())
 
 // Update canvas whenever reference variables changes
-watch(renderVariables, () => {
+watch([renderVariables, width, height], () => {
   if (!widgetStore.isWidgetVisible(widget.value)) return
   nextTick(() => renderCanvas())
 })

--- a/src/components/widgets/VirtualHorizon.vue
+++ b/src/components/widgets/VirtualHorizon.vue
@@ -249,7 +249,7 @@ watch(rollAngleDeg, () => {
 })
 
 // Update canvas whenever reference variables changes
-watch(renderVariables, () => {
+watch([renderVariables, width, height], () => {
   if (!widgetStore.isWidgetVisible(widget.value)) return
   nextTick(() => renderCanvas())
 })


### PR DESCRIPTION
The canvas itself is being resized with the resizing of the widget (which happens when the user resized the window or the widget on edit-mode), which causes the canvas to be cleared. We solve this by forcing the render when the size changes.

Fix #909 