### PR TITLE
Implement new main menu and responsivity logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy:electron:dir": "electron-builder --dir",
     "deploy:electron": "electron-builder --publish=never",
     "deploy:flatpak": "electron-builder --x64 --linux flatpak",
-    "dev": "vite",
+    "dev": "vite --host",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --ignore-path .gitignore --max-warnings=0",
     "preview": "vite preview --port 5050",
     "serve": "vite preview",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,52 +1,179 @@
 <template>
   <v-app>
     <v-main>
-      <Dialog v-model:show="showMainMenu">
-        <div class="flex flex-col items-center justify-around">
-          <v-btn
-            v-if="route.name === 'widgets-view'"
-            prepend-icon="mdi-pencil"
-            class="w-full m-1 text-white action-button bg-slate-500 hover:bg-slate-400"
-            @click="widgetStore.editingMode = !widgetStore.editingMode"
-          >
-            Edit mode
-          </v-btn>
-          <v-btn
-            v-if="route.name !== 'widgets-view'"
-            prepend-icon="mdi-send"
-            class="w-full m-1 text-white action-button bg-slate-500 hover:bg-slate-400"
-            to="/"
-          >
-            Flight
-          </v-btn>
-          <v-btn
-            v-if="route.name !== 'Mission planning'"
-            prepend-icon="mdi-map-marker-radius"
-            class="w-full m-1 text-white action-button bg-slate-500 hover:bg-slate-400"
-            to="/mission-planning"
-          >
-            Mission planning
-          </v-btn>
-          <v-btn
-            prepend-icon="mdi-cog"
-            class="w-full m-1 text-white action-button bg-slate-500 hover:bg-slate-400"
-            @click="showConfigurationMenu = true"
-          >
-            Configuration
-          </v-btn>
-          <v-btn
-            :prepend-icon="fullScreenToggleIcon"
-            class="w-full m-1 text-white action-button bg-slate-500 hover:bg-slate-400"
-            @click="toggleFullscreen"
-          >
-            {{ isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen' }}
-          </v-btn>
+      <transition name="slide-in-left">
+        <div v-if="showMainMenu" ref="mainMenu" class="left-menu slide-in">
+          <v-window v-model="mainMenuStep" class="h-full w-full">
+            <v-window-item :value="1" class="h-full">
+              <div class="flex flex-col pt-5 pb-6 h-full justify-between align-center gap-y-10">
+                <GlassButton
+                  v-if="route.name === 'widgets-view'"
+                  label="Edit Mode"
+                  :selected="widgetStore.editingMode"
+                  :label-class="menuLabelSize"
+                  variant="round"
+                  :width="buttonSize"
+                  icon="mdi-pencil"
+                  :disabled="false"
+                  @click="
+                    () => {
+                      widgetStore.editingMode = !widgetStore.editingMode
+                      closeMainMenu()
+                    }
+                  "
+                />
+                <GlassButton
+                  v-if="route.name !== 'widgets-view'"
+                  label="Flight"
+                  :label-class="menuLabelSize"
+                  variant="round"
+                  :width="buttonSize"
+                  icon="mdi-send"
+                  :disabled="false"
+                  :selected="$route.name === 'Flight'"
+                  @click="
+                    () => {
+                      $router.push('/')
+                      closeMainMenu()
+                    }
+                  "
+                />
+                <GlassButton
+                  v-if="route.name !== 'Mission planning'"
+                  label="Mission Planning"
+                  :label-class="menuLabelSize"
+                  variant="round"
+                  icon="mdi-map-marker-radius"
+                  :width="buttonSize"
+                  :disabled="false"
+                  :selected="$route.name === 'Mission planning'"
+                  @click="
+                    () => {
+                      $router.push('/mission-planning')
+                      closeMainMenu()
+                    }
+                  "
+                />
+                <GlassButton
+                  label="Configuration"
+                  :label-class="menuLabelSize"
+                  icon="mdi-cog"
+                  variant="round"
+                  button-class="-mt-1"
+                  :width="buttonSize"
+                  :disabled="false"
+                  :selected="showConfigurationMenu"
+                  @click="mainMenuStep = 2"
+                />
+                <GlassButton
+                  :label="isFullscreen ? 'Exit Fullscreen' : 'Enter Fullscreen'"
+                  :label-class="menuLabelSize"
+                  :icon="fullScreenToggleIcon"
+                  variant="round"
+                  :width="buttonSize"
+                  :disabled="false"
+                  :selected="false"
+                  @click="
+                    () => {
+                      toggleFullscreen()
+                      closeMainMenu()
+                    }
+                  "
+                />
+              </div>
+            </v-window-item>
+            <v-window-item :value="2" class="h-full w-full">
+              <div class="flex flex-col pt-1 pb-2 w-full h-full justify-between gap-y-1">
+                <GlassButton
+                  label="General"
+                  :label-class="menuLabelSize"
+                  icon="mdi-view-dashboard-variant"
+                  variant="uncontained"
+                  no-glass
+                  :height="buttonSize * 0.5"
+                  :icon-size="buttonSize * 0.6"
+                  :disabled="false"
+                />
+                <GlassButton
+                  label="Joystick"
+                  :label-class="menuLabelSize"
+                  icon="mdi-controller"
+                  variant="uncontained"
+                  no-glass
+                  :height="buttonSize * 0.5"
+                  :icon-size="buttonSize * 0.6"
+                  :disabled="false"
+                />
+                <GlassButton
+                  label="Video"
+                  :label-class="menuLabelSize"
+                  icon="mdi-video"
+                  variant="uncontained"
+                  no-glass
+                  :height="buttonSize * 0.5"
+                  :icon-size="buttonSize * 0.6"
+                  :disabled="false"
+                />
+                <GlassButton
+                  label="Telemetry"
+                  :label-class="menuLabelSize"
+                  icon="mdi-subtitles-outline"
+                  variant="uncontained"
+                  no-glass
+                  :height="buttonSize * 0.5"
+                  :icon-size="buttonSize * 0.6"
+                  :disabled="false"
+                />
+                <GlassButton
+                  label="Alerts"
+                  :label-class="menuLabelSize"
+                  icon="mdi-alert-rhombus-outline"
+                  variant="uncontained"
+                  no-glass
+                  :height="buttonSize * 0.5"
+                  :icon-size="buttonSize * 0.6"
+                  :disabled="false"
+                />
+                <GlassButton
+                  label="Dev"
+                  :label-class="menuLabelSize"
+                  icon="mdi-dev-to"
+                  variant="uncontained"
+                  no-glass
+                  :height="buttonSize * 0.5"
+                  :icon-size="buttonSize * 0.6"
+                  :disabled="false"
+                />
+                <GlassButton
+                  label="Mission"
+                  :label-class="menuLabelSize"
+                  icon="mdi-map-marker-path"
+                  variant="uncontained"
+                  no-glass
+                  :height="buttonSize * 0.5"
+                  :icon-size="buttonSize * 0.6"
+                  :disabled="false"
+                />
+                <div class="flex flex-col justify-center align-center">
+                  <v-divider width="70%" class="mb-4" />
+                  <GlassButton
+                    :label-class="menuLabelSize"
+                    icon="mdi-arrow-left"
+                    variant="round"
+                    :width="buttonSize / 2.4"
+                    :disabled="false"
+                    :selected="false"
+                    @click="mainMenuStep = 1"
+                  />
+                </div>
+              </div>
+            </v-window-item>
+          </v-window>
         </div>
-      </Dialog>
+      </transition>
+
       <teleport to="body">
-        <v-dialog v-model="showConfigurationMenu" transition="dialog-bottom-transition" width="100%" height="100%">
-          <ConfigurationMenu />
-        </v-dialog>
+        <GlassModal :is-visible="showConfigurationMenu"><ConfigurationGeneralView /></GlassModal>
       </teleport>
 
       <teleport to="body">
@@ -72,7 +199,7 @@
           <div id="mainTopBar" class="bar top-bar">
             <button
               class="flex items-center justify-center h-full aspect-square top-bar-hamburger"
-              @click="openMainMenu()"
+              @click="toggleMainMenu"
             >
               <span class="text-3xl transition-all mdi mdi-menu text-slate-300 hover:text-slate-50" />
             </button>
@@ -143,17 +270,10 @@
 import { onClickOutside, useDebounceFn, useFullscreen, useTimestamp } from '@vueuse/core'
 import { format } from 'date-fns'
 import Swal from 'sweetalert2'
-import {
-  // type AsyncComponentLoader,
-  computed,
-  onBeforeUnmount,
-  // defineAsyncComponent,
-  ref,
-  watch,
-} from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 
-import ConfigurationMenu from '@/components/ConfigurationMenu.vue'
+import { useInteractionDialog } from '@/composables/interactionDialog'
 import { coolMissionNames } from '@/libs/funny-name/words'
 import {
   availableCockpitActions,
@@ -163,53 +283,131 @@ import {
 import { useMissionStore } from '@/stores/mission'
 
 import AltitudeSlider from './components/AltitudeSlider.vue'
-import Dialog from './components/Dialog.vue'
 import EditMenu from './components/EditMenu.vue'
+import GlassButton from './components/GlassButton.vue'
 import MiniWidgetContainer from './components/MiniWidgetContainer.vue'
 import SlideToConfirm from './components/SlideToConfirm.vue'
 import Alerter from './components/widgets/Alerter.vue'
 import { datalogger } from './libs/sensors-logging'
+import { useAppInterfaceStore } from './stores/appInterface'
 import { useMainVehicleStore } from './stores/mainVehicle'
 import { useWidgetManagerStore } from './stores/widgetManager'
+const { showDialog, closeDialog } = useInteractionDialog()
 
 const widgetStore = useWidgetManagerStore()
 const vehicleStore = useMainVehicleStore()
+const responsiveStore = useAppInterfaceStore()
 
 const showConfigurationMenu = ref(false)
 
 // Main menu
 const showMainMenu = ref(false)
+const isMenuOpen = ref(false)
+const isSlidingOut = ref(false)
+const mainMenuStep = ref(1)
+
+let requestDisarmConfirmationPopup = false
+
+const toggleMainMenu = (): void => {
+  if (isMenuOpen.value === true) {
+    closeMainMenu()
+  } else {
+    openMainMenu()
+  }
+}
 
 // When a isVehicleArmed change its value a watcher call Swal.close, this flag is
 // used to avoid closing others Swal instances instead of the one intended
-let requestDisarmConfirmationPopup = false
 const openMainMenu = (): void => {
-  if (!vehicleStore.isArmed) {
-    showMainMenu.value = true
-    return
-  }
-
-  requestDisarmConfirmationPopup = true
-  Swal.fire({
-    title: 'Be careful',
-    text: 'The vehicle is currently armed, it is not recommended to open the main menu.',
-    icon: 'warning',
-    showCancelButton: true,
-    showConfirmButton: true,
-    cancelButtonText: 'Continue anyway',
-    confirmButtonText: 'Disarm vehicle',
-  }).then((result) => {
-    // Opens the main menu only after disarming by the slider is confirmed
-    if (result.isConfirmed && vehicleStore.isArmed) {
-      vehicleStore.disarm().then(() => {
+  if (vehicleStore.isArmed) {
+    showDialog({
+      title: 'Be careful',
+      maxWidth: 650,
+      message: 'The vehicle is currently armed and it is not recommended to open the main menu.',
+      actions: [
+        {
+          text: 'Continue anyway',
+          action: () => {
+            showMainMenu.value = true
+            isMenuOpen.value = true
+            closeDialog()
+          },
+        },
+        {
+          text: 'Disarm vehicle',
+          action: () => {
+            disarmVehicle()
+          },
+        },
+      ],
+      variant: 'warning',
+    }).then((result) => {
+      if (result.isConfirmed && vehicleStore.isArmed) {
+        vehicleStore.disarm().then(() => {
+          showMainMenu.value = true
+          isMenuOpen.value = true
+        })
+      } else {
         showMainMenu.value = true
-      })
-    } else if (result.dismiss === Swal.DismissReason.cancel) {
-      showMainMenu.value = true
-    }
-    requestDisarmConfirmationPopup = false
-  })
+        isMenuOpen.value = true
+      }
+      requestDisarmConfirmationPopup = false
+    })
+  } else {
+    showMainMenu.value = true
+    isMenuOpen.value = true
+  }
 }
+
+// Close Main Menu Logic
+const closeMainMenu = (): void => {
+  isSlidingOut.value = true
+  setTimeout(() => {
+    showMainMenu.value = false
+    isSlidingOut.value = false
+    isMenuOpen.value = false
+    mainMenuStep.value = 1
+  }, 20)
+}
+
+const disarmVehicle = (): void => {
+  vehicleStore.disarm().then(() => {
+    showMainMenu.value = true
+  })
+  closeDialog()
+}
+
+const handleEscKey = (event: KeyboardEvent): void => {
+  if (event.key === 'Escape' && showMainMenu.value) {
+    closeMainMenu()
+  }
+}
+
+onMounted(() => {
+  window.addEventListener('keydown', handleEscKey)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', handleEscKey)
+})
+
+const buttonSize = computed(() => {
+  if (responsiveStore.is2xl) return 60
+  if (responsiveStore.isXl) return 55
+  if (responsiveStore.isLg) return 50
+  if (responsiveStore.isMd) return 45
+  if (responsiveStore.isSm) return 30
+  return 25
+})
+
+const menuLabelSize = computed(() => {
+  if (responsiveStore.is2xl) return 'text-[16px]'
+  if (responsiveStore.isXl) return 'text-[15px]'
+  if (responsiveStore.isLg) return 'text-[13px]'
+  if (responsiveStore.isMd) return 'text-[12px]'
+  if (responsiveStore.isSm) return 'text-[10px]'
+  return 'text-[10px]'
+})
 
 const isVehicleArmed = computed(() => vehicleStore.isArmed)
 watch(isVehicleArmed, (isArmed) => {
@@ -219,7 +417,9 @@ watch(isVehicleArmed, (isArmed) => {
 })
 
 const mainMenu = ref()
-onClickOutside(mainMenu, () => (showMainMenu.value = false))
+onClickOutside(mainMenu, () => {
+  closeMainMenu()
+})
 
 const route = useRoute()
 const routerSection = ref()
@@ -276,7 +476,6 @@ onBeforeUnmount(() => unregisterActionCallback(bottomBarToggleCallbackId))
 datalogger.startLogging()
 
 // Dynamic styles
-
 const currentTopBarHeightPixels = computed(() => `${widgetStore.currentTopBarHeightPixels}px`)
 const currentBottomBarHeightPixels = computed(() => `${widgetStore.currentBottomBarHeightPixels}px`)
 </script>
@@ -287,14 +486,62 @@ body {
   /* Removes the scrollbar */
   overflow: hidden !important;
 }
+
 body.hide-cursor {
   cursor: none;
 }
+
+.left-menu {
+  position: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  @apply 2xl:w-[130px] 2xl:h-auto xl:w-[121px] xl:h-auto lg:w-[102px] lg:h-auto md:w-[95px] md:h-auto sm:w-[78px] sm:h-auto;
+  padding-top: 5px;
+  border-radius: 0 20px 20px 0;
+  border: 1px #cbcbcb33 solid;
+  border-left: none;
+  top: 50%;
+  left: 0;
+  transform: translateY(-50%);
+  background-color: #4f4f4f33;
+  backdrop-filter: blur(15px);
+  box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.3);
+  z-index: 1000;
+}
+
+@keyframes slideInLeft {
+  from {
+    transform: translateX(-100%) translateY(-50%);
+  }
+  to {
+    transform: translateX(0) translateY(-50%);
+  }
+}
+
+@keyframes slideOutLeft {
+  from {
+    transform: translateX(0) translateY(-50%);
+  }
+  to {
+    transform: translateX(-100%) translateY(-50%);
+  }
+}
+
+.slide-in-left-enter-active {
+  animation: slideInLeft 300ms ease forwards;
+}
+
+.slide-in-left-leave-active {
+  animation: slideOutLeft 300ms ease forwards;
+}
+
 .router-view {
   width: 100%;
   height: 100%;
   position: relative;
 }
+
 .main-view {
   transition: all 0.2s;
   width: 100%;
@@ -303,11 +550,13 @@ body.hide-cursor {
   right: 0%;
   top: 0%;
 }
+
 .main-view.edit-mode {
   transform: scale(0.8);
   right: -10%;
   top: -10%;
 }
+
 .swal2-container {
   z-index: 10000;
 }
@@ -316,11 +565,13 @@ body.hide-cursor {
 .fade-leave-active {
   transition: all 0.3s cubic-bezier(0.55, 0, 0.1, 1);
 }
+
 .fade-enter-from,
 .fade-leave-to {
   opacity: 0;
   transform: translate(0, 100px);
 }
+
 .bottom-container {
   position: absolute;
   bottom: v-bind('currentBottomBarHeightPixels');
@@ -328,7 +579,7 @@ body.hide-cursor {
   display: flex;
   flex-direction: column;
   align-items: center;
-  z-index: 60; /* Adjust z-index as needed */
+  z-index: 60;
 }
 
 .bar {

--- a/src/components/GlassButton.vue
+++ b/src/components/GlassButton.vue
@@ -1,0 +1,156 @@
+<template>
+  <div
+    class="flex flex-col items-center 2xl:gap-y-1 xl: gap-y-1 cursor-pointer"
+    :class="isUncontained ? 'mark-on-hover py-2 ' : undefined"
+  >
+    <button
+      :disabled="disabled"
+      class="flex items-center justify-center"
+      :class="[
+        isUncontained ? 'no-glass' : 'frosted-button',
+        selected ? 'frosted-button-selected' : '',
+        { 'frosted-button-disabled': disabled, 'rounded-full': isRound },
+        buttonClass,
+      ]"
+      :style="{ width: buttonStyle.width!.toString() + 'px', height: buttonStyle.height!.toString() + 'px' }"
+    >
+      <template v-if="tooltip">
+        <v-tooltip open-delay="600" activator="parent" location="top">
+          {{ tooltip }}
+        </v-tooltip>
+      </template>
+      <v-icon v-if="isRound || isUncontained" :size="iconSize" :class="iconClass" class="ml-[4%] mt-[2%]">
+        {{ icon }}
+      </v-icon>
+      <div v-else class="flex items-center justify-center w-full h-full">
+        <v-icon :size="iconSize" class="mr-2" :class="iconClass">
+          {{ icon }}
+        </v-icon>
+        <div class="text-white ml-2" :class="labelClass">
+          {{ label }}
+        </div>
+      </div>
+    </button>
+    <div
+      v-if="isRound || isUncontained"
+      class="flex justify-center align-center text-center text-white px-4 font-semibold 2xl:mt-2 xl:mt-1 lg:mt-0 md:mt-0 sm:-mt-1 mt-1"
+      :class="labelClass"
+    >
+      {{ label }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{
+  /**
+   * The text label displayed on the button (rectangular variant) or under the button (round).
+   */
+  label?: string
+  /**
+   * Additional Tailwind classes for the label.
+   */
+  labelClass?: string
+  /**
+   * The icon to display in the button (prepend on rectangular, centered on round).
+   */
+  icon?: string
+  /**
+   * Additional Tailwind classes for the icon.
+   */
+  iconClass?: string
+  /**
+   * The size of the icon.
+   */
+  iconSize?: number
+  /**
+   * Additional Tailwind classes for the button.
+   */
+  buttonClass?: string
+  /**
+   * Whether the button is disabled.
+   */
+  disabled?: boolean
+  /**
+   * The tooltip text displayed on hover.
+   */
+  tooltip?: string
+  /**
+   * Visual feedback for the button when toggled selected.
+   */
+  selected?: boolean
+  /**
+   * The shape of the button.
+   */
+  variant?: 'round' | 'rectangular' | 'uncontained'
+  /**
+   * The width of the button (when round, this is the only size nedded).
+   */
+  width?: number
+  /**
+   * The height of the button.
+   */
+  height?: number
+}>()
+
+const label = computed(() => props.label)
+const icon = computed(() => props.icon)
+const disabled = computed(() => props.disabled)
+const tooltip = computed(() => props.tooltip)
+const selected = computed(() => props.selected)
+const isRound = computed(() => props.variant === 'round')
+const isUncontained = computed(() => props.variant === 'uncontained')
+const iconSize = computed(() => (isRound.value ? (props.width || 26) * 0.6 : props.iconSize))
+
+const buttonStyle = computed(() => ({
+  width: props.width || 40,
+  height: isRound.value ? props.width : props.height || 40,
+}))
+</script>
+
+<style scoped>
+.frosted-button {
+  background-color: rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  color: white;
+  transition: all 0.3s;
+}
+.frosted-button:hover {
+  background-color: rgba(255, 255, 255, 0.35);
+}
+.frosted-button-selected {
+  background-color: rgba(255, 255, 255, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.25);
+}
+.frosted-button-disabled {
+  background-color: rgba(255, 255, 255, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: none;
+  color: rgba(255, 255, 255, 0.5);
+}
+.no-glass {
+  background-color: transparent;
+  border: none;
+  box-shadow: none;
+  color: white;
+}
+.mark-on-hover:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+.icon-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+}
+.divider {
+  width: 1px;
+  height: 75%;
+  background-color: rgba(255, 255, 255, 0.2);
+}
+</style>

--- a/src/components/InteractionDialog.vue
+++ b/src/components/InteractionDialog.vue
@@ -3,7 +3,7 @@
     <v-card :max-width="maxWidth || 600" class="main-dialog px-2 rounded-lg">
       <v-card-title>
         <div
-          class="flex justify-center test-center pt-2 mb-2 text-[20px] font-bold text-nowrap text-ellipsis overflow-x-hidden"
+          class="flex justify-center test-center pt-2 mb-1 text-[20px] font-bold text-nowrap text-ellipsis overflow-x-hidden"
           :class="`w-[${maxWidth}px]`"
         >
           {{ title }}
@@ -11,11 +11,11 @@
       </v-card-title>
       <v-card-text class="pb-5">
         <div class="flex justify-center align-center w-full mb-3">
-          <v-icon v-if="variant" size="38" color="white" class="mr-8">{{
+          <v-icon v-if="variant" size="46" :color="variant === 'success' ? 'green' : 'yellow'" class="mr-8 ml-2">{{
             variant === 'info'
               ? 'mdi-information'
               : variant === 'warning'
-              ? 'mdi-alert'
+              ? 'mdi-alert-rhombus'
               : variant === 'error'
               ? 'mdi-alert-circle'
               : 'mdi-check-circle'
@@ -43,13 +43,13 @@
             :color="button.color || undefined"
             :class="button.class || undefined"
             :disabled="button.disabled || false"
-            @click="button.action"
+            @click="handleAction(button.action)"
           >
             {{ button.text }}
           </v-btn>
         </div>
         <div v-else class="flex w-full px-1 py-2 justify-end">
-          <v-btn size="small" variant="text" @click="internalShowDialog = false">Close</v-btn>
+          <v-btn size="small" variant="text" @click="handleAction(() => (internalShowDialog = false))">Close</v-btn>
         </div>
       </v-card-actions>
     </v-card>
@@ -63,24 +63,65 @@ import { useInteractionDialog } from '@/composables/interactionDialog'
 
 const { closeDialog } = useInteractionDialog()
 
-/* eslint-disable jsdoc/require-jsdoc */
+/**
+ *
+ */
 interface Action {
+  /**
+   *
+   */
   text: string
+  /**
+   *
+   */
   size?: string
+  /**
+   *
+   */
   color?: string
+  /**
+   *
+   */
   class?: string
+  /**
+   *
+   */
   disabled?: boolean
+  /**
+   *
+   */
   action: () => void
 }
 
 const props = withDefaults(
   defineProps<{
+    /**
+     *
+     */
     showDialog: boolean
+    /**
+     *
+     */
     title: string
+    /**
+     *
+     */
     contentComponent: string
+    /**
+     *
+     */
     maxWidth: number
+    /**
+     *
+     */
     actions: Action[]
+    /**
+     *
+     */
     variant: string
+    /**
+     *
+     */
     message: string
   }>(),
   {
@@ -94,7 +135,7 @@ const props = withDefaults(
   }
 )
 
-const emit = defineEmits(['update:showDialog'])
+const emit = defineEmits(['update:showDialog', 'confirmed', 'dismissed'])
 
 const internalShowDialog = ref(props.showDialog)
 
@@ -109,15 +150,21 @@ watch(internalShowDialog, (newVal) => {
   if (!newVal) {
     closeDialog()
     emit('update:showDialog', newVal)
+    emit('dismissed')
   }
 })
+
+const handleAction = (action: () => void): void => {
+  action()
+  emit('confirmed')
+}
 </script>
 
 <style scoped>
 .main-dialog {
   color: white;
-  border: 1px solid #fafafa44;
-  background-color: #aaaaaa99;
+  border: 1px solid #fafafa33;
+  background-color: #aaaaaa44;
   backdrop-filter: blur(30px);
   box-shadow: 0px 4px 4px 0px #0000004c, 0px 8px 12px 6px #00000026;
 }

--- a/src/stores/appInterface.ts
+++ b/src/stores/appInterface.ts
@@ -1,0 +1,29 @@
+import { defineStore } from 'pinia'
+
+export const useAppInterfaceStore = defineStore('responsive', {
+  state: () => ({
+    width: window.innerWidth,
+  }),
+  actions: {
+    updateWidth() {
+      this.width = window.innerWidth
+    },
+  },
+  getters: {
+    isXs: (state) => state.width < 720, // Extra small devices (5-6" mobile screens in landscape)
+    isSm: (state) => state.width >= 720 && state.width < 980, // Small devices (6-7" mobile screens in landscape)
+    isMd: (state) => state.width >= 980 && state.width < 1280, // Medium devices (7-10" tablets in landscape)
+    isLg: (state) => state.width >= 1280 && state.width < 1600, // Large devices (HD in landscape)
+    isXl: (state) => state.width >= 1600 && state.width < 1920, // Extra large devices (HD+ desktop/laptop screens in landscape)
+    is2xl: (state) => state.width >= 1920, // FullHD and above - Extra extra large devices
+    currentWindowBreakpoint: (state) => {
+      if (state.width < 720) return 'xs'
+      if (state.width >= 720 && state.width < 980) return 'sm'
+      if (state.width >= 980 && state.width < 1280) return 'md'
+      if (state.width >= 1280 && state.width < 1600) return 'lg'
+      if (state.width >= 1600 && state.width < 1920) return 'xl'
+      if (state.width >= 1920) return '2xl'
+    },
+    currentWindowSize: (state) => `${state.width} x ${window.innerHeight}`,
+  },
+})

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,14 @@ module.exports = {
       colors: {
         critical: '#7F34CF',
       },
+      screens: {
+        'xs': { max: '719px' }, // Extra small devices (5-6" mobile screens in landscape)
+        'sm': { min: '720px', max: '979px' }, // Small devices (6-7" mobile screens in landscape)
+        'md': { min: '980px', max: '1279px' }, // Medium devices (7-10" tablets in landscape)
+        'lg': { min: '1280px', max: '1599px' }, // Large devices (HD in landscape)
+        'xl': { min: '1600px', max: '1919px' }, // Extra large devices (HD+ desktop/laptop screens in landscape)
+        '2xl': { min: '1920px' }, // FullHD and above - Extra extra large devices
+      },
     },
   },
   plugins: [require('tailwind-scrollbar-hide'), require('flowbite/plugin')],


### PR DESCRIPTION
* Main menu, glass version - already with the modifications from cockpit meeting in 06/03/24;
* Responsivity logic using Tailwind breakpoints and Pinia store;
* Configuration menu items added;

Running on different device screen resolutions:
![image](https://github.com/bluerobotics/cockpit/assets/14910201/3150d316-a155-45ae-b571-ea41612f68b7)
![image](https://github.com/bluerobotics/cockpit/assets/14910201/ff31af5a-dd6f-4657-9017-eca57c846b8b)

![image](https://github.com/bluerobotics/cockpit/assets/14910201/9bb7c79a-78e4-4f23-94ca-1fc76f42f2df)
![image](https://github.com/bluerobotics/cockpit/assets/14910201/05aeed24-30ac-4ab4-b85b-6332a3ebef10)

Closes #968 