### PR TITLE
Warn user when video recording starts to fail

### DIFF
--- a/src/components/InteractionDialog.vue
+++ b/src/components/InteractionDialog.vue
@@ -73,26 +73,25 @@ interface Action {
   action: () => void
 }
 
-const props = withDefaults(
-  defineProps<{
-    showDialog: boolean
-    title: string
-    contentComponent: string
-    maxWidth: number
-    actions: Action[]
-    variant: string
-    message: string
-  }>(),
-  {
-    showDialog: false,
-    title: '',
-    contentComponent: '',
-    maxWidth: 600,
-    actions: () => [],
-    variant: '',
-    message: '',
-  }
-)
+interface Props {
+  showDialog?: boolean
+  title?: string
+  contentComponent?: string
+  maxWidth?: number
+  actions?: Action[]
+  variant?: string
+  message?: string
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  showDialog: false,
+  title: '',
+  contentComponent: '',
+  maxWidth: 600,
+  actions: () => [],
+  variant: '',
+  message: '',
+})
 
 const emit = defineEmits(['update:showDialog'])
 

--- a/src/components/VideoLibraryModal.vue
+++ b/src/components/VideoLibraryModal.vue
@@ -630,11 +630,9 @@ const processVideos = async (): Promise<void> => {
     isMultipleSelectionMode.value = false
     await fetchVideosAndLogData()
   } catch (error) {
-    if (error instanceof Error) {
-      console.error('Video processing failed:', error.message)
-    } else {
-      console.error('Processing failed with non-Error type:', error)
-    }
+    const errorMsg = `Video processing failed: ${(error as Error).message ?? error!.toString()}`
+    console.error(errorMsg)
+    snackbarMessage.value = errorMsg
     openSnackbar.value = true
     errorProcessingVideos.value = true
   }
@@ -771,7 +769,7 @@ const openDownloadInfoDialog = (): void => {
       ? 'You are downloading both processed and unprocessed videos'
       : 'You are downloading unprocessed video chunks',
     message: hasProcessedVideos
-      ? `One of the .zip files contains unprocessed video chunks, which are not playable. 
+      ? `One of the .zip files contains unprocessed video chunks, which are not playable.
       For a playable video, you need to process it first.`
       : 'For a playable video, you need to process it first.',
     variant: 'info',

--- a/src/components/VideoLibraryModal.vue
+++ b/src/components/VideoLibraryModal.vue
@@ -325,11 +325,7 @@
                       transition="slide-x-reverse-transition"
                     >
                       <template #activator="{ props: buttonProps, isActive }">
-                        <div
-                          class="flex items-center justify-center w-full h-full"
-                          v-bind="buttonProps"
-                          v-on="isActive"
-                        >
+                        <div class="flex items-center justify-center w-full h-full" v-bind="buttonProps">
                           <v-icon
                             :size="button.size"
                             :class="{ 'rotate-[-45deg]': isActive, 'outline outline-6 outline-[#ffffff55]': isActive }"


### PR DESCRIPTION
With this patch we start to warn the user if a chunk fails to be written to disk, as well as if the chunk recording takes more than 5 seconds. The warning says that the system is having trouble saving the record, that parts of the video can be lost, and therefore it's suggested to start a new recording.

The warning is emitted at most once per recording.

This patch also allows the video processing to proceed when the duration-fix fails, delivering a video without the duration fixed.

Fix #977
Fix #993 