### PR TITLE
Make video download faster (and give proper feedback)

### DIFF
--- a/src/components/VideoLibraryModal.vue
+++ b/src/components/VideoLibraryModal.vue
@@ -796,7 +796,7 @@ const discardVideosAndUpdateDB = async (): Promise<void> => {
   snackbarMessage.value = `${selectedVideoArraySize} video(s) discarded.`
   openSnackbar.value = true
   await fetchVideosAndLogData()
-  availableVideos.value.length > 0 ? (selectedVideos.value = [availableVideos.value[0]]) : (selectedVideos.value = [])
+  selectedVideos.value = availableVideos.value.length > 0 ? [availableVideos.value[0]] : []
   if (availableVideos.value.length === 1) isMultipleSelectionMode.value = false
   deleteButtonLoading.value = false
 }
@@ -847,18 +847,7 @@ const fetchVideosAndLogData = async (): Promise<void> => {
   // Fetch unprocessed videos
   const unprocessedVideos = await videoStore.unprocessedVideos
   const unprocessedVideoOperations = Object.entries(unprocessedVideos).map(async ([hash, videoInfo]) => {
-    return {
-      dateStart: videoInfo.dateStart,
-      dateLastRecordingUpdate: videoInfo.dateLastRecordingUpdate,
-      dateFinish: videoInfo.dateFinish,
-      fileName: videoInfo.fileName,
-      vWidth: videoInfo.vWidth,
-      vHeight: videoInfo.vHeight,
-      hash: hash,
-      thumbnail: videoInfo.thumbnail,
-      url: '',
-      isProcessed: false,
-    }
+    return { ...videoInfo, ...{ hash: hash, url: '', isProcessed: false } }
   })
 
   const videos = await Promise.all(videoFilesOperations)

--- a/src/components/VideoLibraryModal.vue
+++ b/src/components/VideoLibraryModal.vue
@@ -736,7 +736,18 @@ const addLogDataToFileList = (fileNames: string[]): string[] => {
 }
 
 const downloadVideoAndTelemetryFiles = async (): Promise<void> => {
+  let initialMessageShown = false
+
+  const fillProgressData = async (progress: number, total: number): Promise<void> => {
+    const progressPercentage = ((100 * progress) / total).toFixed(1)
+    if (!initialMessageShown) return
+    snackbarMessage.value = `Preparing download: ${progressPercentage}%.`
+    openSnackbar.value = true
+  }
+
   snackbarMessage.value = 'Getting your download ready...'
+  setTimeout(() => (initialMessageShown = true), 1500)
+
   let tempProcessedVideos: string[] = []
   let tempUnprocessedVideos: string[] = []
 
@@ -748,11 +759,11 @@ const downloadVideoAndTelemetryFiles = async (): Promise<void> => {
   if (tempProcessedVideos.length > 0) {
     const dataLogFilesAdded = addLogDataToFileList(tempProcessedVideos)
 
-    await videoStore.downloadFilesFromVideoDB(dataLogFilesAdded)
+    await videoStore.downloadFilesFromVideoDB(dataLogFilesAdded, fillProgressData)
   }
   if (tempUnprocessedVideos.length > 0) {
     openDownloadInfoDialog()
-    await videoStore.downloadTempVideo(tempUnprocessedVideos)
+    await videoStore.downloadTempVideo(tempUnprocessedVideos, fillProgressData)
   }
 }
 

--- a/src/components/VideoLibraryModal.vue
+++ b/src/components/VideoLibraryModal.vue
@@ -853,8 +853,11 @@ const fetchVideosAndLogData = async (): Promise<void> => {
   const videos = await Promise.all(videoFilesOperations)
   const logFiles = await Promise.all(logFileOperations)
   const unprocessedVideosData = await Promise.all(unprocessedVideoOperations)
-  // Filter videos that are currently being recorded
-  const validUnprocessedVideos = unprocessedVideosData.filter((video) => video.dateFinish)
+
+  // Filter out videos that are currently being recorded
+  const validUnprocessedVideos = unprocessedVideosData.filter((video) => {
+    return video.dateFinish || videoStore.keysFailedUnprocessedVideos.includes(video.hash)
+  })
 
   availableVideos.value = [...videos, ...validUnprocessedVideos]
   availableLogFiles.value = logFiles

--- a/src/components/mini-widgets/MiniVideoRecorder.vue
+++ b/src/components/mini-widgets/MiniVideoRecorder.vue
@@ -147,12 +147,9 @@ const handleModalUpdate = (newVal: boolean): void => {
 
 // Fetch number of temporary videos on storage
 const fetchNumebrOfTempVideos = async (): Promise<void> => {
-  let numberOfVideos = 0
-  await videoStore.videoStoringDB.iterate((value, key) => {
-    key.endsWith('.webm') && numberOfVideos++
-  })
-  Object.values(videoStore.keysFailedUnprocessedVideos).forEach(() => numberOfVideos++)
-  numberOfVideosOnDB.value = numberOfVideos
+  const nProcessedVideos = (await videoStore.videoStoringDB.keys()).filter((k) => k.endsWith('.webm')).length
+  const nFailedUnprocessedVideos = Object.keys(videoStore.keysFailedUnprocessedVideos).length
+  numberOfVideosOnDB.value = nProcessedVideos + nFailedUnprocessedVideos
 }
 
 // eslint-disable-next-line jsdoc/require-jsdoc

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -346,9 +346,8 @@ export const useVideoStore = defineStore('video', () => {
 
   const createZipAndDownload = async (files: FileDescriptor[], zipFilename: string): Promise<void> => {
     const zipWriter = new ZipWriter(new BlobWriter('application/zip'))
-    for (const { filename, blob } of files) {
-      await zipWriter.add(filename, new BlobReader(blob))
-    }
+    const zipAddingPromises = files.map(({ filename, blob }) => zipWriter.add(filename, new BlobReader(blob)))
+    Promise.all(zipAddingPromises)
     const blob = await zipWriter.close()
     saveAs(blob, zipFilename)
   }

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -345,7 +345,7 @@ export const useVideoStore = defineStore('video', () => {
   }
 
   const createZipAndDownload = async (files: FileDescriptor[], zipFilename: string): Promise<void> => {
-    const zipWriter = new ZipWriter(new BlobWriter('application/zip'))
+    const zipWriter = new ZipWriter(new BlobWriter('application/zip'), { level: 0 })
     const zipAddingPromises = files.map(({ filename, blob }) => zipWriter.add(filename, new BlobReader(blob)))
     Promise.all(zipAddingPromises)
     const blob = await zipWriter.close()

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -111,3 +111,5 @@ export interface FileDescriptor {
 export interface StorageDB {
   getItem: (key: string) => Promise<Blob | null | undefined>
 }
+
+export type DownloadProgressCallback = (progress: number, total: number) => Promise<void>


### PR DESCRIPTION
This patch reduces in about 70% the time to download a video.
Videos with 22 minutes (1.1GB) that were taking around 36 seconds to be downloaded, now take around 10 seconds. To reduce this time, I configured the file compressor to level zero, which makes it not compress the video at all, and only write it to the zip file. This does not affect the file size since the `.webm` video is already compressed.

Despite that, considering that even 10 seconds is a lot of time for the user, considering that they don't know if the download is going to proceed or not, I've added a progress feedback, which tells the user how far he is from having his video downloaded.

https://github.com/bluerobotics/cockpit/assets/6551040/fa382769-94bc-4c33-bf0e-2a860471a3d1

Now, even if the download takes a little more, the user knows that it is indeed going to happen, and know how much to wait.

Fix #929.
To be merged after #996.