### PR TITLE
vite: Force server on `0.0.0.0`

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,4 +35,7 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
   },
+  server: {
+    host: '0.0.0.0',
+  },
 })


### PR DESCRIPTION
This prevents cases where the server is only accessible from the host IP.