### PR TITLE
Fix video extension

### DIFF
--- a/src/components/VideoLibraryModal.vue
+++ b/src/components/VideoLibraryModal.vue
@@ -99,7 +99,7 @@
                     preload="auto"
                     :poster="!video.isProcessed ? video.thumbnail : undefined"
                   >
-                    <source :src="video.url" type="video/webm" />
+                    <source :src="video.url" />
                   </video>
                   <div
                     v-if="selectedVideos.find((v) => v.fileName === video.fileName) && !isMultipleSelectionMode"
@@ -129,7 +129,7 @@
                   <v-tooltip open-delay="500" activator="parent" location="top">{{
                     video.isProcessed ? 'Processed video' : 'Unprocessed video'
                   }}</v-tooltip>
-                  {{ parseDateFromTitle(video.fileName) ?? 'Cockpit webm' }}
+                  {{ parseDateFromTitle(video.fileName) ?? 'Cockpit video' }}
                   <v-icon
                     size="10"
                     class="ml-1 mt-[3px]"
@@ -203,7 +203,7 @@
                 :poster="selectedVideos[0]?.thumbnail || undefined"
                 class="border-[14px] border-white border-opacity-10 rounded-lg min-h-[382px] aspect-video"
               >
-                <source :src="selectedVideos[0]?.url || undefined" type="video/webm" />
+                <source :src="selectedVideos[0]?.url || undefined" />
               </video>
               <v-btn
                 v-if="
@@ -728,7 +728,8 @@ const selectProcessedVideos = (): void => {
 // Add the log files to the list of files to be downloaded/discarded
 const addLogDataToFileList = (fileNames: string[]): string[] => {
   const filesWithLogData = fileNames.flatMap((fileName) => {
-    const subtitlefileName = fileName.replace('.webm', '.ass')
+    const filenameWithoutExtension = fileName.split('.').slice(0, -1).join('.')
+    const subtitlefileName = `${filenameWithoutExtension}.ass`
     const subtitleExists = availableLogFiles.value.some((video) => video.fileName === subtitlefileName)
     return subtitleExists ? [fileName, subtitlefileName] : [fileName]
   })
@@ -820,7 +821,7 @@ const fetchVideosAndLogData = async (): Promise<void> => {
 
   // Fetch processed videos and logs
   await videoStore.videoStoringDB.iterate((value, key) => {
-    if (key.endsWith('.webm')) {
+    if (videoStore.isVideoFilename(key)) {
       videoFilesOperations.push(
         (async () => {
           const videoBlob = await videoStore.videoStoringDB.getItem<Blob>(key)

--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -5,7 +5,7 @@
     </div>
     <div class="modal-content">
       <video id="video-player" class="w-[100%]" controls autoplay preload="auto">
-        <source :src="videoFileUrl" type="video/webm" />
+        <source :src="videoFileUrl" />
       </video>
     </div>
   </div>

--- a/src/components/mini-widgets/MiniVideoRecorder.vue
+++ b/src/components/mini-widgets/MiniVideoRecorder.vue
@@ -147,7 +147,7 @@ const handleModalUpdate = (newVal: boolean): void => {
 
 // Fetch number of temporary videos on storage
 const fetchNumebrOfTempVideos = async (): Promise<void> => {
-  const nProcessedVideos = (await videoStore.videoStoringDB.keys()).filter((k) => k.endsWith('.webm')).length
+  const nProcessedVideos = (await videoStore.videoStoringDB.keys()).filter((k) => videoStore.isVideoFilename(k)).length
   const nFailedUnprocessedVideos = Object.keys(videoStore.keysFailedUnprocessedVideos).length
   numberOfVideosOnDB.value = nProcessedVideos + nFailedUnprocessedVideos
 }

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -308,7 +308,7 @@ export const useVideoStore = defineStore('video', () => {
         try {
           const videoChunk = await tempVideoChunksDB.getItem(chunkName)
           if (videoChunk) {
-            const firstChunkBlob = new Blob([videoChunk as Blob], { type: 'video/webm;codecs=vp9' })
+            const firstChunkBlob = new Blob([videoChunk as Blob])
             const thumbnail = await extractThumbnailFromVideo(firstChunkBlob)
             updatedInfo.thumbnail = thumbnail
             unprocessedVideos.value = { ...unprocessedVideos.value, ...{ [recordingHash]: updatedInfo } }
@@ -527,7 +527,7 @@ export const useVideoStore = defineStore('video', () => {
       const chunkBlobs = chunks.map((chunk) => chunk.blob)
       debouncedUpdateFileProgress(info.fileName, 50, 'Processing video chunks.')
 
-      const mergedBlob = new Blob([...chunkBlobs], { type: 'video/webm;codecs=vp9' })
+      const mergedBlob = new Blob([...chunkBlobs])
 
       let durFixedBlob: Blob | undefined = undefined
       try {

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -113,3 +113,20 @@ export interface StorageDB {
 }
 
 export type DownloadProgressCallback = (progress: number, total: number) => Promise<void>
+
+export enum VideoExtensionContainer {
+  MKV = 'mkv',
+  MP4 = 'mp4',
+  WEBM = 'webm',
+}
+
+export const getBlobExtensionContainer = (blob: Blob): VideoExtensionContainer | undefined => {
+  if (blob.type.includes('matroska')) {
+    return VideoExtensionContainer.MKV
+  } else if (blob.type.includes('mp4')) {
+    return VideoExtensionContainer.MP4
+  } else if (blob.type.includes('webm')) {
+    return VideoExtensionContainer.WEBM
+  }
+  return undefined
+}


### PR DESCRIPTION
The video files now have the correct extension and all hardcoded mentions to WEBM in the repository are removed.

The `fixWebmDuration` lib is the only exception, as despite the name it fixes the duration for any chunk type.

Fix #999.