### PR TITLE
Allow changing the RTC configuration

### DIFF
--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -65,7 +65,7 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
   const cpuLoad = ref<number>()
   const globalAddress = useStorage('cockpit-vehicle-address', defaultGlobalAddress)
 
-  const defaultMainConnectionURI = ref<string>(`${ws_protocol}://${globalAddress.value}:6040/ws/mavlink`)
+  const defaultMainConnectionURI = ref<string>(`${ws_protocol}://${globalAddress.value}/mavlink2rest/ws/mavlink`)
   const defaultWebRTCSignallingURI = ref<string>(`${ws_protocol}://${globalAddress.value}:6021/`)
   const customMainConnectionURI = useStorage('cockpit-vehicle-custom-main-connection-uri', {
     data: defaultMainConnectionURI.value,
@@ -319,6 +319,7 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
 
   ConnectionManager.onMainConnection.add(() => {
     const newMainConnection = ConnectionManager.mainConnection()
+    console.log('Main connection changed:', newMainConnection?.uri().toString())
     if (newMainConnection !== undefined) {
       customMainConnectionURI.value.data = newMainConnection.uri().toString()
     }

--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -75,7 +75,7 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     data: defaultWebRTCSignallingURI.value,
     enabled: false,
   } as CustomParameter<string>)
-  const rtcConfiguration = useStorage('cockpit-rtc-config', defaultRtcConfiguration)
+  const customWebRTCConfiguration = useStorage('cockpit-rtc-config', defaultRtcConfiguration)
 
   const lastHeartbeat = ref<Date>()
   const firmwareType = ref<MavAutopilot>()
@@ -123,6 +123,21 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
    */
   const isVehicleOnline = computed(() => {
     return lastHeartbeat.value !== undefined && new Date(timeNow.value).getTime() - lastHeartbeat.value.getTime() < 5000
+  })
+
+  const rtcConfiguration = computed(() => {
+    const queryWebRtcConfiguration = new URLSearchParams(window.location.search).get('webRTCConfiguration')
+    if (queryWebRtcConfiguration) {
+      console.log('Using WebRTC configuration from query parameter')
+      console.log(queryWebRtcConfiguration)
+      try {
+        return JSON.parse(queryWebRtcConfiguration)
+      } catch (error) {
+        console.error('Failed to parse WebRTC configuration from query parameter.', error)
+      }
+    }
+    console.log('Using WebRTC configuration from storage.')
+    return customWebRTCConfiguration.value
   })
 
   /**
@@ -509,6 +524,7 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     icon,
     configurationPages,
     rtcConfiguration,
+    customWebRTCConfiguration,
     genericVariables,
     availableGenericVariables,
     registerUsageOfGenericVariable,

--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -101,21 +101,17 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const modes = ref<Map<string, any>>()
 
-  const mainConnectionURI = computed(
-    () =>
-      new Connection.URI(
-        customMainConnectionURI.value.enabled ? customMainConnectionURI.value.data : defaultMainConnectionURI.value
-      )
-  )
+  const mainConnectionURI = computed(() => {
+    const queryURI = new URLSearchParams(window.location.search).get('mainConnectionURI')
+    const customURI = customMainConnectionURI.value.enabled ? customMainConnectionURI.value.data : undefined
+    return new Connection.URI(queryURI ?? customURI ?? defaultMainConnectionURI.value)
+  })
 
-  const webRTCSignallingURI = computed(
-    () =>
-      new Connection.URI(
-        customWebRTCSignallingURI.value.enabled
-          ? customWebRTCSignallingURI.value.data
-          : defaultWebRTCSignallingURI.value
-      )
-  )
+  const webRTCSignallingURI = computed(() => {
+    const queryWebRTCSignallingURI = new URLSearchParams(window.location.search).get('webRTCSignallingURI')
+    const customURI = customWebRTCSignallingURI.value.enabled ? customWebRTCSignallingURI.value.data : undefined
+    return new Connection.URI(queryWebRTCSignallingURI ?? customURI ?? defaultWebRTCSignallingURI.value)
+  })
 
   /**
    * Check if vehicle is online (no more than 5 seconds passed since last heartbeat)

--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -52,6 +52,11 @@ interface CustomParameter<T> {
   enabled: boolean
 }
 
+const defaultRtcConfiguration = {
+  bundlePolicy: 'max-bundle',
+  iceServers: [],
+} as RTCConfiguration
+
 export const useMainVehicleStore = defineStore('main-vehicle', () => {
   const controllerStore = useControllerStore()
   const widgetStore = useWidgetManagerStore()
@@ -70,6 +75,7 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     data: defaultWebRTCSignallingURI.value,
     enabled: false,
   } as CustomParameter<string>)
+  const rtcConfiguration = useStorage('cockpit-rtc-config', defaultRtcConfiguration)
 
   const lastHeartbeat = ref<Date>()
   const firmwareType = ref<MavAutopilot>()
@@ -461,11 +467,6 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
       cockpitActionsManager.sendCockpitActions()
     }
   }, 10)
-
-  const rtcConfiguration = {
-    bundlePolicy: 'max-bundle',
-    iceServers: [],
-  } as RTCConfiguration
 
   return {
     arm,

--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -75,7 +75,10 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     data: defaultWebRTCSignallingURI.value,
     enabled: false,
   } as CustomParameter<string>)
-  const customWebRTCConfiguration = useStorage('cockpit-rtc-config', defaultRtcConfiguration)
+  const customWebRTCConfiguration = useStorage('cockpit-custom-rtc-config', {
+    data: defaultRtcConfiguration,
+    enabled: false,
+  })
 
   const lastHeartbeat = ref<Date>()
   const firmwareType = ref<MavAutopilot>()
@@ -133,7 +136,7 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
       }
     }
     console.log('Using WebRTC configuration from storage.')
-    return customWebRTCConfiguration.value
+    return customWebRTCConfiguration.value.enabled ? customWebRTCConfiguration.value.data : defaultRtcConfiguration
   })
 
   /**

--- a/src/views/ConfigurationGeneralView.vue
+++ b/src/views/ConfigurationGeneralView.vue
@@ -348,11 +348,11 @@ const isValidSocketConnectionURI = (value: string): boolean | string => {
   return true
 }
 
-const customRtcConfiguration = ref<string>(JSON.stringify(mainVehicleStore.rtcConfiguration, null, 4))
+const customRtcConfiguration = ref<string>(JSON.stringify(mainVehicleStore.customWebRTCConfiguration, null, 4))
 const updateWebRtcConfiguration = (): void => {
   try {
     const newConfig = JSON.parse(customRtcConfiguration.value)
-    mainVehicleStore.rtcConfiguration = newConfig
+    mainVehicleStore.customWebRTCConfiguration = newConfig
     location.reload()
   } catch (error) {
     alert(`Could not update WebRTC configuration. ${error}.`)

--- a/src/views/ConfigurationGeneralView.vue
+++ b/src/views/ConfigurationGeneralView.vue
@@ -137,13 +137,38 @@
           />
         </v-form>
         <span>Current address: {{ mainVehicleStore.webRTCSignallingURI.toString() }} </span><br />
+        <div class="my-4 ml-2">
+          <span class="text-lg">Custom RTC configuration:</span>
+          <div class="mx-2">
+            <div class="flex">
+              <v-textarea
+                id="rtcConfigTextInput"
+                v-model="customRtcConfiguration"
+                variant="underlined"
+                label="Custom WebRTC Configuration"
+                clearable
+                :rows="8"
+                hint="e.g.: { iceServers: [{ urls: 'stun:stun.l.google.com:19302' }] }"
+                class="uri-input"
+              />
+              <v-btn
+                v-tooltip.bottom="'Save'"
+                icon="mdi-check"
+                class="mx-1 mb-5 pa-0"
+                rounded="lg"
+                flat
+                @click="updateWebRtcConfiguration"
+              />
+            </div>
+          </div>
+        </div>
       </v-card>
     </template>
   </BaseConfigurationView>
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { onMounted, ref, watch } from 'vue'
 
 import { defaultGlobalAddress } from '@/assets/defaults'
 import * as Connection from '@/libs/connection/connection'
@@ -322,6 +347,36 @@ const isValidSocketConnectionURI = (value: string): boolean | string => {
   }
   return true
 }
+
+const customRtcConfiguration = ref<string>(JSON.stringify(mainVehicleStore.rtcConfiguration, null, 4))
+const updateWebRtcConfiguration = (): void => {
+  try {
+    const newConfig = JSON.parse(customRtcConfiguration.value)
+    mainVehicleStore.rtcConfiguration = newConfig
+    location.reload()
+  } catch (error) {
+    alert(`Could not update WebRTC configuration. ${error}.`)
+  }
+}
+
+const tryToPrettifyRtcConfig = (): void => {
+  try {
+    const ugly = customRtcConfiguration.value
+    const obj = JSON.parse(ugly)
+    const pretty = JSON.stringify(obj, null, 4)
+    if (ugly !== pretty) {
+      customRtcConfiguration.value = pretty
+    }
+  } catch (error) {
+    // Do nothing if the JSON is invalid
+  }
+}
+
+watch(customRtcConfiguration, () => tryToPrettifyRtcConfig())
+
+onMounted(() => {
+  tryToPrettifyRtcConfig()
+})
 </script>
 
 <style scoped>

--- a/src/views/ConfigurationGeneralView.vue
+++ b/src/views/ConfigurationGeneralView.vue
@@ -137,13 +137,21 @@
           />
         </v-form>
         <span>Current address: {{ mainVehicleStore.webRTCSignallingURI.toString() }} </span><br />
-        <div class="my-4 ml-2">
+        <div class="my-4">
           <span class="text-lg">Custom RTC configuration:</span>
-          <div class="mx-2">
+          <div class="mt-2">
             <div class="flex">
+              <v-checkbox
+                v-model="mainVehicleStore.customWebRTCConfiguration.enabled"
+                v-tooltip.bottom="'Enable custom'"
+                class="mx-1 mb-5 pa-0"
+                rounded="lg"
+                hide-details
+              />
               <v-textarea
                 id="rtcConfigTextInput"
                 v-model="customRtcConfiguration"
+                :disabled="!mainVehicleStore.customWebRTCConfiguration.enabled"
                 variant="underlined"
                 label="Custom WebRTC Configuration"
                 clearable
@@ -348,11 +356,11 @@ const isValidSocketConnectionURI = (value: string): boolean | string => {
   return true
 }
 
-const customRtcConfiguration = ref<string>(JSON.stringify(mainVehicleStore.customWebRTCConfiguration, null, 4))
+const customRtcConfiguration = ref<string>(JSON.stringify(mainVehicleStore.customWebRTCConfiguration.data, null, 4))
 const updateWebRtcConfiguration = (): void => {
   try {
     const newConfig = JSON.parse(customRtcConfiguration.value)
-    mainVehicleStore.customWebRTCConfiguration = newConfig
+    mainVehicleStore.customWebRTCConfiguration.data = newConfig
     location.reload()
   } catch (error) {
     alert(`Could not update WebRTC configuration. ${error}.`)


### PR DESCRIPTION
This patch allows a persistent configuration of the WebRTC configurations. This allow the usage of Cockpit with BlueSim.

To test it, open a BlueSim instance and access the following address:

`http://localhost:5173/?webRTCConfiguration={"iceServers":[{"urls":"stun:stun.l.google.com:19302"}]}&webRTCSignallingURI=ws://BLUE-SIM-IP:6041`

You can also remove the "webRTCConfiguration" from the query parameters and set it directly in the general configuration menu. The "webRTCSignallingURI" parameter is needed since setting it in the menu is broken until #938 is merged.

<img width="602" alt="image" src="https://github.com/bluerobotics/cockpit/assets/6551040/e16ea08b-c94e-47e8-88ab-a3b7b048d559">


Fix #925 