### PR TITLE
iframe: Persist position on DOM so it doesn't reload on view change

### DIFF
--- a/src/components/widgets/IFrame.vue
+++ b/src/components/widgets/IFrame.vue
@@ -1,14 +1,14 @@
 <template>
-  <div class="w-full h-full relative">
-    <iframe
-      v-show="iframe_loaded"
-      :src="widget.options.source"
-      :style="iframeStyle"
-      frameborder="0"
-      height="100%"
-      width="100%"
-      @load="loadFinished"
-    />
+  <div class="w-full h-full">
+    <teleport to=".widgets-view">
+      <iframe
+        v-show="iframe_loaded"
+        :src="widget.options.source"
+        :style="iframeStyle"
+        frameborder="0"
+        @load="loadFinished"
+      />
+    </teleport>
     <v-dialog v-model="widget.managerVars.configMenuOpen" min-width="400" max-width="35%">
       <v-card class="pa-2">
         <v-card-title>Settings</v-card-title>
@@ -34,6 +34,7 @@
 </template>
 
 <script setup lang="ts">
+import { useWindowSize } from '@vueuse/core'
 import { computed, defineProps, onBeforeMount, ref, toRefs } from 'vue'
 
 import { useWidgetManagerStore } from '@/stores/widgetManager'
@@ -62,11 +63,26 @@ onBeforeMount(() => {
   }
 })
 
+const { width: windowWidth, height: windowHeight } = useWindowSize()
+
 const iframeStyle = computed<string>(() => {
+  let newStyle = ''
+
+  newStyle = newStyle.concat(' ', 'position: absolute;')
+  newStyle = newStyle.concat(' ', `left: ${widget.value.position.x * windowWidth.value}px;`)
+  newStyle = newStyle.concat(' ', `top: ${widget.value.position.y * windowHeight.value}px;`)
+  newStyle = newStyle.concat(' ', `width: ${widget.value.size.width * windowWidth.value}px;`)
+  newStyle = newStyle.concat(' ', `height: ${widget.value.size.height * windowHeight.value}px;`)
+
   if (widgetManagerStore.editingMode) {
-    return 'pointer-events:none; border:0;'
+    newStyle = newStyle.concat(' ', 'pointer-events:none; border:0;')
   }
-  return ''
+
+  if (!widgetManagerStore.isWidgetVisible(widget.value)) {
+    newStyle = newStyle.concat(' ', 'display: none;')
+  }
+
+  return newStyle
 })
 
 const iframeOpacity = computed<number>(() => {


### PR DESCRIPTION
Right now I'm positioning the actual iFrame element. 

~I will try to do that with the iFrame widget, so it doesn't add extra position/size logic and supports native widget features (like the toolbar repositioning).~ I think we can leave with that for now, so I've opened #1043 to track future improvements on that.

https://github.com/bluerobotics/cockpit/assets/6551040/56d144df-721c-4320-915a-08cb6ea140ea


Fix #731 