### PR TITLE
blueos: Fix string used for the BlueOS settings sync activation

### DIFF
--- a/src/stores/development.ts
+++ b/src/stores/development.ts
@@ -5,7 +5,7 @@ import { ref } from 'vue'
 import { useBlueOsStorage } from '@/composables/settingsSyncer'
 
 export const systemLoggingEnablingKey = 'cockpit-enable-system-logging'
-export const blueOsSettingsSyncEnablingKey = 'cockpit-enable-system-logging'
+export const blueOsSettingsSyncEnablingKey = 'cockpit-enable-blueos-settings-sync'
 
 export const useDevelopmentStore = defineStore('development', () => {
   const developmentMode = ref(false)


### PR DESCRIPTION
I mistakenly copy-pasted it in the previous PR.