### PR TITLE
generic-variables: Fix watcher for newly tracked generic variables

### DIFF
--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -309,7 +309,7 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     usedGenericVariables.value.push(variable)
   }
 
-  watchThrottled(usedGenericVariables, () => registerGenericVariablesUsageOnVehicle(), { throttle: 1000 })
+  watchThrottled(usedGenericVariables, () => registerGenericVariablesUsageOnVehicle(), { throttle: 1000, deep: true })
 
   const registerGenericVariablesUsageOnVehicle = (): void => {
     if (!mainVehicle.value) return


### PR DESCRIPTION
Fix #1028 