### PR TITLE
ci: Wrap tag releases with zip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: macos-latest
+        - os: macos-13
           suffix: macos
           extension: dmg
 


### PR DESCRIPTION
macos-14 has some problems when generating the artifact

Fix #1062 