### PR TITLE
joystick-config: Use relative path for joystick SVG file

### DIFF
--- a/src/components/joysticks/JoystickPS.vue
+++ b/src/components/joysticks/JoystickPS.vue
@@ -173,7 +173,7 @@ watch(
 )
 
 const joystick_svg_path = computed(() => {
-  return `/images/${joystickSvgModel.value}.svg`
+  return `./images/${joystickSvgModel.value}.svg`
 })
 
 watch(


### PR DESCRIPTION
This way the standalone Electron app can also load it.

<img width="1804" alt="image" src="https://github.com/bluerobotics/cockpit/assets/6551040/fcea94b7-f84e-4d8f-a13f-685eef4abd7e">

Fix #882 