### PR TITLE
ardupilot: Do not duplicate path of available generic variables

### DIFF
--- a/src/libs/vehicle/ardupilot/ardupilot.ts
+++ b/src/libs/vehicle/ardupilot/ardupilot.ts
@@ -280,10 +280,9 @@ export abstract class ArduPilotVehicle<Modes> extends Vehicle.AbstractVehicle<Mo
             getDeepVariables(v as Record<string, unknown>, acc, `${k}/${identifier}=${v[identifier]}`)
           }
         } else {
-          if (baseKey === undefined) {
-            acc.push(k)
-          } else {
-            acc.push(`${baseKey}/${k}`)
+          const path = baseKey === undefined ? k : `${baseKey}/${k}`
+          if (!acc.includes(path)) {
+            acc.push(path)
           }
         }
       })


### PR DESCRIPTION
Left Cockpit running for an hour an it didn't reach 200MB (without a camera connected).

Before:

https://github.com/bluerobotics/cockpit/assets/6551040/b8348dc5-8eb4-4128-b687-112480a17b4b

After:

https://github.com/bluerobotics/cockpit/assets/6551040/e5204aa3-9c5d-4d71-9190-f57f5c80c01e

Fix #1027 
Fix #1047