### PR TITLE
interaction-dialog: Don't share the resolve/reject state between different instances

### DIFF
--- a/src/composables/interactionDialog.ts
+++ b/src/composables/interactionDialog.ts
@@ -55,9 +55,6 @@ interface DialogResult {
   isConfirmed: boolean
 }
 
-let resolveFn: (value: DialogResult | PromiseLike<DialogResult>) => void
-let rejectFn: (reason?: DialogResult) => void
-
 /**
  * Provides methods to control the interaction dialog.
  * @returns {object} - An object containing the showDialog and closeDialog methods.
@@ -94,6 +91,8 @@ export function useInteractionDialog(): {
   })
 
   let dialogApp: App<Element> | null = null
+  let resolveFn: (value: DialogResult | PromiseLike<DialogResult>) => void
+  let rejectFn: (reason?: DialogResult) => void
 
   const mountDialog = (): void => {
     const mountPoint = document.createElement('div')


### PR DESCRIPTION
I love when those issues where we spend hours debugging and the solution was in one line of code. 

Happy to have solved this one. Was driving me crazy.

Fix #1054 