### PR TITLE
Improve reactivity on panel opening triggers during screen width changes 

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -264,7 +264,7 @@
 </template>
 
 <script setup lang="ts">
-import { onClickOutside, useDebounceFn, useFullscreen, useTimestamp } from '@vueuse/core'
+import { onClickOutside, useDebounceFn, useFullscreen, useTimestamp, useWindowSize } from '@vueuse/core'
 import { format } from 'date-fns'
 import Swal from 'sweetalert2'
 import { computed, DefineComponent, markRaw, onBeforeUnmount, onMounted, ref, watch } from 'vue'
@@ -299,6 +299,7 @@ import ConfigurationMissionView from './views/ConfigurationMissionView.vue'
 import ConfigurationVideoView from './views/ConfigurationVideoView.vue'
 
 const { showDialog, closeDialog } = useInteractionDialog()
+const { width: windowWidth, height: windowHeight } = useWindowSize()
 
 const widgetStore = useWidgetManagerStore()
 const vehicleStore = useMainVehicleStore()
@@ -314,7 +315,6 @@ const isMenuOpen = ref(false)
 const isSlidingOut = ref(false)
 const mainMenuStep = ref(1)
 const simplifiedMainMenu = ref(false)
-const windowHeight = ref(window.innerHeight)
 
 const configMenu = [
   {
@@ -378,30 +378,32 @@ watch(isConfigModalVisible, (newVal) => {
 })
 
 watch(
-  () => windowHeight.value < 450,
+  () => windowWidth.value < 450,
   (isSmall: boolean) => {
     simplifiedMainMenu.value = isSmall
   }
 )
 
-const updateWindowHeight = (): void => {
-  windowHeight.value = window.innerHeight
+const updateWindowWidth = (): void => {
+  windowWidth.value = window.innerWidth
 }
 
 onMounted(() => {
-  window.addEventListener('resize', updateWindowHeight)
-  if (windowHeight.value < 450) {
+  window.addEventListener('resize', updateWindowWidth)
+  if (windowWidth.value < 450) {
     simplifiedMainMenu.value = true
   }
 })
 
 onBeforeUnmount(() => {
-  window.removeEventListener('resize', updateWindowHeight)
+  window.removeEventListener('resize', updateWindowWidth)
 })
 
 const mainMenuWidth = computed(() => {
   const width =
-    interfaceStore.isOnSmallScreen && mainMenuStep.value === 2 ? '60px' : `${interfaceStore.mainMenuWidth}px`
+    interfaceStore.isOnSmallScreen && mainMenuStep.value === 2 && !simplifiedMainMenu.value
+      ? '60px'
+      : `${interfaceStore.mainMenuWidth}px`
   return { width }
 })
 

--- a/src/components/ExpansiblePanel.vue
+++ b/src/components/ExpansiblePanel.vue
@@ -175,6 +175,13 @@ const toggleWarning = (): void => {
   isWarningOpen.value = !isWarningOpen.value
 }
 
+watch(
+  () => props.isExpanded,
+  (newValue) => {
+    isPanelExpanded.value = newValue ?? false
+  }
+)
+
 watch(isPanelExpanded, (newValue) => {
   if (content.value) {
     if (newValue) {

--- a/src/components/GlassModal.vue
+++ b/src/components/GlassModal.vue
@@ -61,7 +61,7 @@ const modalPositionStyle = computed(() => {
       return {
         top: '50%',
         left: interfaceStore.isOnSmallScreen
-          ? `${interfaceStore.mainMenuWidth - 20}px`
+          ? `${interfaceStore.mainMenuWidth}px`
           : `${interfaceStore.mainMenuWidth + 30}px`,
         transform: 'translateY(-50%)',
       }

--- a/src/stores/appInterface.ts
+++ b/src/stores/appInterface.ts
@@ -2,11 +2,12 @@ import { useWindowSize } from '@vueuse/core'
 import { defineStore } from 'pinia'
 import { watch } from 'vue'
 
-const { width: windowWidth } = useWindowSize()
+const { width: windowWidth, height: windowHeight } = useWindowSize()
 
 export const useAppInterfaceStore = defineStore('responsive', {
   state: () => ({
     width: windowWidth.value,
+    height: windowHeight.value,
     configModalVisibility: false,
   }),
   actions: {
@@ -32,7 +33,7 @@ export const useAppInterfaceStore = defineStore('responsive', {
       if (state.width >= 1600 && state.width < 1920) return 'xl'
       if (state.width >= 1920) return '2xl'
     },
-    currentWindowSize: (state) => `${state.width} x ${window.innerHeight}`,
+    currentWindowSize: (state) => `${state.width} x ${state.height}`,
     isOnSmallScreen: (state) => state.width < 1280,
     isOnPhoneScreen: (state) => state.width < 600,
     mainMenuWidth: (state) => {
@@ -47,7 +48,7 @@ export const useAppInterfaceStore = defineStore('responsive', {
   },
 })
 
-watch(windowWidth, (newWidth) => {
+watch(windowWidth, () => {
   const store = useAppInterfaceStore()
-  store.width = newWidth
+  store.updateWidth()
 })

--- a/src/stores/appInterface.ts
+++ b/src/stores/appInterface.ts
@@ -34,10 +34,10 @@ export const useAppInterfaceStore = defineStore('responsive', {
     },
     currentWindowSize: (state) => `${state.width} x ${window.innerHeight}`,
     isOnSmallScreen: (state) => state.width < 1280,
-    isOnPhoneScreen: () => window.innerHeight < 600,
+    isOnPhoneScreen: (state) => state.width < 600,
     mainMenuWidth: (state) => {
       if (state.width < 720) return 78
-      if (state.width >= 720 && state.width < 980) return 78
+      if (state.width >= 720 && state.width < 980) return 95
       if (state.width >= 980 && state.width < 1280) return 95
       if (state.width >= 1280 && state.width < 1600) return 102
       if (state.width >= 1600 && state.width < 1920) return 121

--- a/src/views/ConfigurationAlertsView.vue
+++ b/src/views/ConfigurationAlertsView.vue
@@ -2,7 +2,7 @@
   <BaseConfigurationView>
     <template #title>Alerts configuration</template>
     <template #content>
-      <div class="flex flex-col justify-around align-start ml-5">
+      <div class="flex flex-col justify-around align-start ml-5 max-w-[85vw]">
         <v-switch
           v-model="alertStore.enableVoiceAlerts"
           label="Enable voice alerts"

--- a/src/views/ConfigurationDevelopmentView.vue
+++ b/src/views/ConfigurationDevelopmentView.vue
@@ -2,7 +2,7 @@
   <BaseConfigurationView>
     <template #title>Development configuration</template>
     <template #content>
-      <div class="max-w-[87vw] max-h-[80vh] overflow-y-auto -mr-4">
+      <div class="max-w-[85vw] max-h-[80vh] overflow-y-auto -mr-4">
         <div
           class="flex flex-col justify-between items-center w-full"
           :class="interfaceStore.isOnPhoneScreen ? 'scale-[80%] mt-0 -mb-3' : 'scale-100 mt-4'"
@@ -33,7 +33,7 @@
             thumb-label="hover"
           />
         </div>
-        <ExpansiblePanel :is-expanded="!interfaceStore.isOnSmallScreen">
+        <ExpansiblePanel :is-expanded="!interfaceStore.isOnPhoneScreen">
           <template #title>System logs</template>
           <template #content>
             <v-data-table

--- a/src/views/ConfigurationGeneralView.vue
+++ b/src/views/ConfigurationGeneralView.vue
@@ -2,8 +2,8 @@
   <BaseConfigurationView>
     <template #title>General configuration</template>
     <template #content>
-      <div class="flex-col h-full w-[540px] max-h-[90vh] overflow-y-auto ml-[10px] pr-3 -mr-[10px]">
-        <ExpansiblePanel no-top-divider :is-expanded="!interfaceStore.isOnSmallScreen">
+      <div class="flex-col h-full max-w-[85vw] max-h-[90vh] overflow-y-auto ml-[10px] pr-3 -mr-[10px]">
+        <ExpansiblePanel no-top-divider :is-expanded="!interfaceStore.isOnPhoneScreen">
           <template #title>Global vehicle address</template>
           <template #subtitle>Current address: {{ mainVehicleStore.globalAddress }}</template>
           <template #info
@@ -47,7 +47,7 @@
             </v-form>
           </template>
         </ExpansiblePanel>
-        <ExpansiblePanel no-top-divider :is-expanded="!interfaceStore.isOnSmallScreen">
+        <ExpansiblePanel no-top-divider :is-expanded="!interfaceStore.isOnPhoneScreen">
           <template #info>
             <strong>Mavlink2Rest Connection:</strong> Configures MAVLink over HTTP/WS. Toggle to enable/disable and
             apply settings to take effect.
@@ -121,7 +121,7 @@
             </v-form>
           </template>
         </ExpansiblePanel>
-        <ExpansiblePanel no-top-divider no-bottom-divider :is-expanded="!interfaceStore.isOnSmallScreen">
+        <ExpansiblePanel no-top-divider no-bottom-divider :is-expanded="!interfaceStore.isOnPhoneScreen">
           <template #info>
             <strong>WebRTC connection:</strong> Establishes real-time communication over the web. Set the signaling
             server URI and toggle to activate.
@@ -188,7 +188,7 @@
             </v-form>
           </template>
         </ExpansiblePanel>
-        <ExpansiblePanel no-bottom-divider :is-expanded="!interfaceStore.isOnSmallScreen">
+        <ExpansiblePanel no-bottom-divider :is-expanded="!interfaceStore.isOnPhoneScreen">
           <template #title>Custom RTC Configuration</template>
           <template #content>
             <div class="flex justify-between mt-2 w-full">

--- a/src/views/ConfigurationLogsView.vue
+++ b/src/views/ConfigurationLogsView.vue
@@ -17,7 +17,9 @@
       <template #content>
         <div
           class="flex justify-start align-start mb-2"
-          :class="interfaceStore.isOnSmallScreen ? 'h-[80vh] w-[88vw] gap-x-0 mt-2' : 'h-[50vh] w-[60vw] gap-x-1 mt-4'"
+          :class="
+            interfaceStore.isOnSmallScreen ? 'h-[80vh] max-w-[85vw] gap-x-0 mt-2' : 'h-[50vh] max-w-[60vw] gap-x-1 mt-4'
+          "
         >
           <div
             class="overflow-y-auto overflow-x-hidden"

--- a/src/views/ConfigurationMissionView.vue
+++ b/src/views/ConfigurationMissionView.vue
@@ -2,7 +2,7 @@
   <BaseConfigurationView>
     <template #title>Mission configuration</template>
     <template #content>
-      <div class="flex flex-col justify-between items-start ml-[1vw] max-w-[700px]">
+      <div class="flex flex-col justify-between items-start ml-[1vw] max-w-[85vw]">
         <v-switch
           v-model="missionStore.slideEventsEnabled"
           label="Enable slide to confirm"
@@ -10,7 +10,7 @@
           class="mt-2 -mb-2 ml-3"
         />
 
-        <ExpansiblePanel no-bottom-divider is-expanded>
+        <ExpansiblePanel no-bottom-divider :is-expanded="!interfaceStore.isOnPhoneScreen">
           <template #title>Enable confirmation on specific categories:</template>
           <template #info>
             Add an extra confirmation step for UI elements that can trigger mission critical actions.

--- a/src/views/ConfigurationVideoView.vue
+++ b/src/views/ConfigurationVideoView.vue
@@ -3,7 +3,7 @@
     <template #help-icon> </template>
     <template #title>Video configuration</template>
     <template #content>
-      <div class="flex-col h-full ml-[1vw] w-[540px]">
+      <div class="flex-col h-full ml-[1vw] max-w-[85vw]">
         <ExpansiblePanel no-top-divider :is-expanded="!interfaceStore.isOnPhoneScreen">
           <template #title>Allowed WebRTC remote IP Addresses</template>
           <template #info


### PR DESCRIPTION
Relates to #1073, where configuration submodule's expansible panes were inert during screen width changes;

https://github.com/bluerobotics/cockpit/assets/14910201/25ee3c9d-87c3-4421-a90f-aa652c41eea0



closes #1073 