### PR TITLE
Dockerfile: Add missing readme label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,10 @@ LABEL authors='[\
     {\
         "name": "Patrick José Pereira",\
         "email": "patrick@bluerobotics.com"\
+    },\
+    {\
+        "name": "Arturo Manzoli",\
+        "email": "arturo@bluerobotics.com"\
     }\
 ]'
 LABEL company='{\

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,8 @@ LABEL tags='[\
 LABEL links='{\
         "support": "https://discuss.bluerobotics.com/c/bluerobotics-software"\
     }'
+LABEL readme="https://raw.githubusercontent.com/bluerobotics/cockpit/master/README.md"
+
 
 COPY ./dist /cockpit
 ENTRYPOINT ["simple-http-server", "--index", "cockpit"]


### PR DESCRIPTION
Cockpit README is not showing in BlueOS