### PR TITLE
Add color and opacity controls to the glass interface elements

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,7 +6,10 @@
           v-if="showMainMenu"
           ref="mainMenu"
           class="left-menu slide-in elevation-10"
-          :style="simplifiedMainMenu ? { width: '45px', borderRadius: '0 10px 10px 0' } : mainMenuWidth"
+          :style="[
+            glassMenuStyles,
+            simplifiedMainMenu ? { width: '45px', borderRadius: '0 10px 10px 0' } : mainMenuWidth,
+          ]"
         >
           <v-window v-model="mainMenuStep" class="h-full w-full">
             <v-window-item :value="1" class="h-full">
@@ -524,7 +527,16 @@ onClickOutside(mainMenu, () => {
   if (mainMenuStep.value === 1) {
     closeMainMenu()
   }
+  if (mainMenuStep.value === 2 && currentConfigMenuComponent.value === null) {
+    closeMainMenu()
+  }
 })
+
+const glassMenuStyles = computed(() => ({
+  backgroundColor: interfaceStore.UIGlassEffect.bgColor,
+  color: interfaceStore.UIGlassEffect.fontColor,
+  backdropFilter: `blur(${interfaceStore.UIGlassEffect.blur}px)`,
+}))
 
 const route = useRoute()
 const routerSection = ref()
@@ -607,8 +619,6 @@ body.hide-cursor {
   top: 50%;
   left: 0;
   transform: translateY(-50%);
-  background-color: #4f4f4f33;
-  backdrop-filter: blur(15px);
   box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.3), 0px 8px 12px 6px rgba(0, 0, 0, 0.15);
   z-index: 1000;
 }

--- a/src/components/GlassModal.vue
+++ b/src/components/GlassModal.vue
@@ -4,7 +4,7 @@
     ref="modal"
     class="glass-modal"
     :class="[interfaceStore.isOnSmallScreen ? 'rounded-[10px]' : 'rounded-[20px]', selectedOverflow]"
-    :style="modalPositionStyle"
+    :style="[modalPositionStyle, glassModalStyles]"
   >
     <slot></slot>
   </div>
@@ -49,6 +49,12 @@ const selectedOverflow = ref(props.overflow || 'auto')
 const isPersistent = ref(props.isPersistent || false)
 const modal = ref<HTMLElement | null>(null)
 
+const glassModalStyles = computed(() => ({
+  backgroundColor: interfaceStore.UIGlassEffect.bgColor,
+  color: interfaceStore.UIGlassEffect.fontColor,
+  backdropFilter: `blur(${interfaceStore.UIGlassEffect.blur}px)`,
+}))
+
 const modalPositionStyle = computed(() => {
   switch (modalPosition.value) {
     case 'left':
@@ -92,15 +98,12 @@ watch(
   }
 )
 </script>
-
 <style scoped>
 .glass-modal {
   position: absolute;
   width: auto;
   max-height: 100vh;
   border: 1px solid #cbcbcb33;
-  background-color: #4f4f4f33;
-  backdrop-filter: blur(15px);
   box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.3), 0px 8px 12px 6px rgba(0, 0, 0, 0.15);
   z-index: 100;
 }

--- a/src/components/VideoLibraryModal.vue
+++ b/src/components/VideoLibraryModal.vue
@@ -1,7 +1,7 @@
 <template>
   <v-dialog v-model="isVisible" class="dialog">
     <div class="dialog-frame" :style="dialogStyle">
-      <div class="video-modal">
+      <div class="video-modal" :style="glassModalStyles">
         <div class="modal-content">
           <!-- Left Vertical Menu -->
           <div class="flex flex-col justify-between h-full px-5 py-3 align-center">
@@ -557,6 +557,12 @@ const dialogStyle = computed(() => {
   }
 })
 
+const glassModalStyles = computed(() => ({
+  backgroundColor: interfaceStore.UIGlassEffect.bgColor,
+  color: interfaceStore.UIGlassEffect.fontColor,
+  backdropFilter: `blur(${interfaceStore.UIGlassEffect.blur}px)`,
+}))
+
 const menuButtons = [
   { name: 'Videos', icon: 'mdi-video-outline', selected: true, disabled: false, tooltip: '' },
   { name: 'Pictures', icon: 'mdi-image-outline', selected: false, disabled: true, tooltip: 'Coming soon' },
@@ -1107,8 +1113,6 @@ onBeforeUnmount(() => {
   height: 500px;
   border: 1px solid #cbcbcb33;
   border-radius: 12px;
-  background-color: #4f4f4f33;
-  backdrop-filter: blur(15px);
   box-shadow: 0px 4px 4px 0px #0000004c, 0px 8px 12px 6px #00000026;
   z-index: 100;
 }

--- a/src/stores/appInterface.ts
+++ b/src/stores/appInterface.ts
@@ -9,6 +9,12 @@ export const useAppInterfaceStore = defineStore('responsive', {
     width: windowWidth.value,
     height: windowHeight.value,
     configModalVisibility: false,
+    UIGlassEffect: {
+      opacity: 0.8,
+      bgColor: '#4F4F4F1A',
+      fontColor: '#FFFFFF',
+      blur: 25,
+    },
   }),
   actions: {
     updateWidth() {
@@ -16,6 +22,20 @@ export const useAppInterfaceStore = defineStore('responsive', {
     },
     setConfigModalVisibility(value: boolean) {
       this.configModalVisibility = value
+    },
+    setUIGlassEffect(opacity: number, bgColor: string, fontColor: string, blur: number) {
+      this.UIGlassEffect.opacity = opacity
+      this.UIGlassEffect.bgColor = bgColor
+      this.UIGlassEffect.fontColor = fontColor
+      this.UIGlassEffect.blur = blur
+    },
+    setBgOpacity(opacity: number) {
+      this.UIGlassEffect.opacity = opacity
+      const hex = this.UIGlassEffect.bgColor.replace(/^#/, '').substring(0, 6)
+      const alphaHex = Math.round(opacity * 255)
+        .toString(16)
+        .padStart(2, '0')
+      this.UIGlassEffect.bgColor = `#${hex}${alphaHex}`
     },
   },
   getters: {
@@ -46,6 +66,9 @@ export const useAppInterfaceStore = defineStore('responsive', {
       return 130
     },
     isConfigModalVisible: (state) => state.configModalVisibility,
+    getUIGlassEffect: (state) => {
+      state.UIGlassEffect
+    },
   },
 })
 

--- a/src/views/ConfigurationGeneralView.vue
+++ b/src/views/ConfigurationGeneralView.vue
@@ -243,6 +243,95 @@
             </div>
           </template>
         </ExpansiblePanel>
+        <ExpansiblePanel no-bottom-divider :is-expanded="!interfaceStore.isOnPhoneScreen">
+          <template #title>Interface Configuration</template>
+          <template #content>
+            <div class="flex w-full">
+              <div class="flex flex-col w-full p-4">
+                <div class="flex flex-row justify-start items-center w-full mb-[35px] gap-x-[115px]">
+                  <div class="flex gap-x-[50px]">
+                    <v-menu
+                      :close-on-content-click="false"
+                      location="top start"
+                      origin="top start"
+                      transition="scale-transition"
+                      class="overflow-hidden"
+                    >
+                      <template #activator="{ props }">
+                        <span class="text-start">Glass color</span>
+                        <div
+                          v-bind="props"
+                          class="w-[20px] h-[20px] border-2 border-slate-600 rounded-full cursor-pointer"
+                          :style="{ backgroundColor: interfaceStore.UIGlassEffect.bgColor }"
+                        ></div>
+                      </template>
+                      <v-card class="overflow-hidden"
+                        ><v-color-picker
+                          v-model="interfaceStore.UIGlassEffect.bgColor"
+                          width="400px"
+                          mode="rgba"
+                          theme="dark"
+                      /></v-card>
+                    </v-menu>
+                  </div>
+                  <div class="flex gap-x-[50px] opacity-20">
+                    <v-menu
+                      :close-on-content-click="false"
+                      location="top start"
+                      origin="top start"
+                      transition="scale-transition"
+                      class="overflow-hidden"
+                      disabled
+                    >
+                      <template #activator="{ props }">
+                        <span class="text-start">Font color</span>
+                        <div
+                          v-bind="props"
+                          class="w-[20px] h-[20px] border-2 border-slate-600 rounded-full"
+                          :style="{ backgroundColor: interfaceStore.UIGlassEffect.fontColor }"
+                        ></div>
+                      </template>
+                      <v-card class="overflow-hidden"
+                        ><v-color-picker
+                          v-model="interfaceStore.UIGlassEffect.fontColor"
+                          width="400px"
+                          mode="rgba"
+                          theme="dark"
+                      /></v-card>
+                    </v-menu>
+                  </div>
+                </div>
+                <div class="flex w-full">
+                  <div class="flex w-[33%] mt-[2px]">Opacity</div>
+                  <div class="flex w-[66%]">
+                    <v-slider
+                      :model-value="parseInt(interfaceStore.UIGlassEffect.bgColor.slice(-2), 16) / 255"
+                      color="white"
+                      min="0"
+                      max="1"
+                      step="0.01"
+                      thumb-label
+                      @update:model-value="updateOpacity"
+                    />
+                  </div>
+                </div>
+                <div class="flex w-full">
+                  <div class="flex w-[33%] mt-[2px]">Blur</div>
+                  <div class="flex w-[66%]">
+                    <v-slider
+                      v-model="interfaceStore.UIGlassEffect.blur"
+                      color="white"
+                      min="0"
+                      max="50"
+                      step="1"
+                      thumb-label
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </template>
+        </ExpansiblePanel>
       </div>
     </template>
   </BaseConfigurationView>
@@ -468,6 +557,10 @@ watch(customRtcConfiguration, () => tryToPrettifyRtcConfig())
 onMounted(() => {
   tryToPrettifyRtcConfig()
 })
+
+const updateOpacity = (value: number): void => {
+  interfaceStore.setBgOpacity(value)
+}
 </script>
 <style scoped>
 .uri-input {


### PR DESCRIPTION
* User can now control the glass interface color, blur and opacity via sliders an color pickers on the Configurations-General menu;


https://github.com/user-attachments/assets/e18e5cb3-e52f-4259-a2a2-a0c1bfd34f25


closes #1104 