### PR TITLE
interaction-dialog: Make all variables optional

### DIFF
--- a/src/components/InteractionDialog.vue
+++ b/src/components/InteractionDialog.vue
@@ -135,11 +135,11 @@ interface Props {
   /**
    * The variant of the dialog, determining the icon and color.
    */
-  variant: 'info' | 'success' | 'error' | 'warning' | 'text-only'
+  variant?: 'info' | 'success' | 'error' | 'warning' | 'text-only'
   /**
    * Message to display in the dialog. If an array, elements will be displayed as an item list.
    */
-  message: string | string[]
+  message?: string | string[]
   /**
    * Persistent dialogs can't be closed with 'esc' or a backdrop click.
    */


### PR DESCRIPTION
Since there are already use cases where everything is optional, including `variant` and `message`, and we already have defaults for those, we make everything optional and remove the unnecessary warnings that we currently have.