### PR TITLE
widgets: Make manager vars non-persistent

### DIFF
--- a/src/assets/defaults.ts
+++ b/src/assets/defaults.ts
@@ -1,6 +1,13 @@
 import { MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import { OverlayGrid } from '@/libs/sensors-logging'
-import { type MiniWidgetProfile, type Profile, MiniWidgetType, WidgetType } from '@/types/widgets'
+import {
+  type MiniWidgetProfile,
+  type Profile,
+  MiniWidgetManagerVars,
+  MiniWidgetType,
+  WidgetManagerVars,
+  WidgetType,
+} from '@/types/widgets'
 
 export const defaultRovProfileHash = 'c2bcf04d-048f-496f-9d78-fc4002608028'
 export const defaultBoatProfileHash = 'adb7d856-f2e5-4980-aaeb-c39c1fa3562b'
@@ -12,7 +19,7 @@ export const defaultProfileVehicleCorrespondency = {
   [MavType.MAV_TYPE_QUADROTOR]: defaultMavProfileHash,
 }
 
-export const defaultWidgetManagerVars = {
+export const defaultWidgetManagerVars: WidgetManagerVars = {
   everMounted: false,
   configMenuOpen: false,
   allowMoving: false,
@@ -23,7 +30,7 @@ export const defaultWidgetManagerVars = {
   highlighted: false,
 }
 
-export const defaultMiniWidgetManagerVars = {
+export const defaultMiniWidgetManagerVars: MiniWidgetManagerVars = {
   everMounted: false,
   configMenuOpen: false,
   highlighted: false,
@@ -56,7 +63,6 @@ export const widgetProfiles: Profile[] = [
               height: 0.118,
             },
             options: {},
-            managerVars: defaultWidgetManagerVars,
           },
           {
             hash: '0a786865-0eff-408c-bc1d-a2b710222418',
@@ -73,7 +79,6 @@ export const widgetProfiles: Profile[] = [
             options: {
               headingStyle: 'North Up',
             },
-            managerVars: defaultWidgetManagerVars,
           },
           {
             hash: '6439e791-3031-4928-aff2-8bd9af713798',
@@ -87,7 +92,6 @@ export const widgetProfiles: Profile[] = [
               width: 1,
               height: 1,
             },
-            managerVars: defaultWidgetManagerVars,
             options: {
               videoFitStyle: 'cover',
               flipHorizontally: false,
@@ -103,7 +107,6 @@ export const widgetProfiles: Profile[] = [
                 hash: '59517f70-4221-491a-8f10-c877c05c22b5',
                 component: MiniWidgetType.ViewSelector,
                 name: 'ViewSelector',
-                managerVars: defaultMiniWidgetManagerVars,
                 options: {},
               },
               {
@@ -117,7 +120,6 @@ export const widgetProfiles: Profile[] = [
                   variableMultiplier: 100,
                 },
                 hash: '2f720389-4037-4523-9b98-249cf9640289',
-                managerVars: defaultMiniWidgetManagerVars,
               },
               {
                 component: MiniWidgetType.VeryGenericIndicator,
@@ -130,7 +132,6 @@ export const widgetProfiles: Profile[] = [
                   variableMultiplier: 100,
                 },
                 hash: 'e43916ab-7f41-4c41-810d-96b5f651c6da',
-                managerVars: defaultMiniWidgetManagerVars,
               },
               {
                 component: MiniWidgetType.VeryGenericIndicator,
@@ -143,7 +144,6 @@ export const widgetProfiles: Profile[] = [
                   variableMultiplier: 100,
                 },
                 hash: '31cc564a-a01e-456a-b181-f04ba512486a',
-                managerVars: defaultMiniWidgetManagerVars,
               },
             ],
           },
@@ -154,7 +154,6 @@ export const widgetProfiles: Profile[] = [
                 hash: '7e1dd699-b336-4026-ad7d-f214aee5e4b7',
                 component: MiniWidgetType.DepthIndicator,
                 name: 'DepthIndicator',
-                managerVars: defaultMiniWidgetManagerVars,
                 options: {},
               },
               {
@@ -168,7 +167,6 @@ export const widgetProfiles: Profile[] = [
                   variableMultiplier: '.01',
                 },
                 hash: '9ee52751-e828-4947-a7ce-0b2f3c2bc42f',
-                managerVars: defaultMiniWidgetManagerVars,
               },
             ],
           },
@@ -179,21 +177,18 @@ export const widgetProfiles: Profile[] = [
                 hash: '837a6722-1e54-4ace-9a92-d9c5af059d16',
                 component: MiniWidgetType.ArmerButton,
                 name: 'ArmerButton',
-                managerVars: defaultMiniWidgetManagerVars,
                 options: {},
               },
               {
                 hash: 'c6301929-cdfc-48af-9fdd-c87ce65d7395',
                 component: MiniWidgetType.ModeSelector,
                 name: 'ModeSelector',
-                managerVars: defaultMiniWidgetManagerVars,
                 options: {},
               },
               {
                 hash: 'a4d0d6ce-9978-40f2-89ab-958f91137177',
                 component: MiniWidgetType.MiniVideoRecorder,
                 name: 'MiniVideoRecorder',
-                managerVars: defaultMiniWidgetManagerVars,
                 options: {},
               },
             ],
@@ -217,7 +212,6 @@ export const widgetProfiles: Profile[] = [
               height: 0.118,
             },
             options: {},
-            managerVars: defaultWidgetManagerVars,
           },
           {
             hash: '0a786865-0eff-408c-bc1d-a2b710222418',
@@ -234,7 +228,6 @@ export const widgetProfiles: Profile[] = [
             options: {
               headingStyle: 'North Up',
             },
-            managerVars: defaultWidgetManagerVars,
           },
           {
             hash: '0dd57510-2b14-4c94-82b9-f1c3baad01f0',
@@ -253,7 +246,6 @@ export const widgetProfiles: Profile[] = [
               flipHorizontally: false,
               flipVertically: false,
             },
-            managerVars: defaultWidgetManagerVars,
           },
           {
             hash: '8a5c6fe7-9d8e-4f7b-a187-e6a29292bc5a',
@@ -270,7 +262,6 @@ export const widgetProfiles: Profile[] = [
             options: {
               showVehiclePath: true,
             },
-            managerVars: defaultWidgetManagerVars,
           },
         ],
         miniWidgetContainers: [
@@ -282,7 +273,6 @@ export const widgetProfiles: Profile[] = [
                 name: 'ViewSelector',
                 options: {},
                 hash: '0759321f-edd0-4f12-bce1-6a4ff0469a7a',
-                managerVars: defaultMiniWidgetManagerVars,
               },
               {
                 component: MiniWidgetType.VeryGenericIndicator,
@@ -295,7 +285,6 @@ export const widgetProfiles: Profile[] = [
                   variableMultiplier: 100,
                 },
                 hash: '6e3df171-7caa-457f-9dbe-a3e9b7184be1',
-                managerVars: defaultMiniWidgetManagerVars,
               },
               {
                 component: MiniWidgetType.VeryGenericIndicator,
@@ -308,7 +297,6 @@ export const widgetProfiles: Profile[] = [
                   variableMultiplier: 100,
                 },
                 hash: '5676835a-1c22-457d-9349-2bad920512fd',
-                managerVars: defaultMiniWidgetManagerVars,
               },
               {
                 component: MiniWidgetType.VeryGenericIndicator,
@@ -321,7 +309,6 @@ export const widgetProfiles: Profile[] = [
                   variableMultiplier: 100,
                 },
                 hash: '1bab7dc9-72fe-4ade-868b-20a5a4d27741',
-                managerVars: defaultMiniWidgetManagerVars,
               },
             ],
           },
@@ -333,14 +320,12 @@ export const widgetProfiles: Profile[] = [
                 name: 'DepthIndicator',
                 options: {},
                 hash: 'afd47470-d7e8-41ba-ba7b-a00dab76f510',
-                managerVars: defaultMiniWidgetManagerVars,
               },
               {
                 component: MiniWidgetType.SatelliteIndicator,
                 name: 'SatelliteIndicator',
                 options: {},
                 hash: '11cfd5aa-f71c-4f65-a8dc-fa475bbce1ec',
-                managerVars: defaultMiniWidgetManagerVars,
               },
             ],
           },
@@ -352,14 +337,12 @@ export const widgetProfiles: Profile[] = [
                 name: 'ArmerButton',
                 options: {},
                 hash: '30e66f52-04ab-45b7-afaf-c03ebc4be108',
-                managerVars: defaultMiniWidgetManagerVars,
               },
               {
                 component: MiniWidgetType.ModeSelector,
                 name: 'ModeSelector',
                 options: {},
                 hash: 'acee316f-dab1-44b0-aa1d-e7d75cdbecab',
-                managerVars: defaultMiniWidgetManagerVars,
               },
             ],
           },
@@ -388,7 +371,6 @@ export const widgetProfiles: Profile[] = [
               hudColor: '#FFFFFF',
               useNegativeRange: false,
             },
-            managerVars: defaultWidgetManagerVars,
           },
           {
             hash: '98e255e7-6ad4-4214-b8f9-5ddeec57f869',
@@ -406,7 +388,6 @@ export const widgetProfiles: Profile[] = [
               showDepthValue: true,
               hudColor: '#FFFFFF',
             },
-            managerVars: defaultWidgetManagerVars,
           },
           {
             hash: '85c0bf8a-b729-43c9-89cb-0f36b8248a08',
@@ -428,7 +409,6 @@ export const widgetProfiles: Profile[] = [
               pitchHeightFactor: 300,
               hudColor: '#FFFFFF',
             },
-            managerVars: defaultWidgetManagerVars,
           },
           {
             hash: '57de5cb2-d7b2-4651-a8de-5dbbc5730aee',
@@ -447,7 +427,6 @@ export const widgetProfiles: Profile[] = [
               flipHorizontally: false,
               flipVertically: false,
             },
-            managerVars: defaultWidgetManagerVars,
           },
         ],
         miniWidgetContainers: [
@@ -459,7 +438,6 @@ export const widgetProfiles: Profile[] = [
                 name: 'ViewSelector',
                 options: {},
                 hash: 'd180e07f-156c-4025-a823-697318c04906',
-                managerVars: defaultMiniWidgetManagerVars,
               },
               {
                 component: MiniWidgetType.VeryGenericIndicator,
@@ -472,7 +450,6 @@ export const widgetProfiles: Profile[] = [
                   variableMultiplier: 100,
                 },
                 hash: 'b6004238-0e1c-4012-b570-2ecee57f75a3',
-                managerVars: defaultMiniWidgetManagerVars,
               },
               {
                 component: MiniWidgetType.VeryGenericIndicator,
@@ -485,7 +462,6 @@ export const widgetProfiles: Profile[] = [
                   variableMultiplier: 100,
                 },
                 hash: '164ac246-291b-4a1d-bb2d-fdfdf88b1de9',
-                managerVars: defaultMiniWidgetManagerVars,
               },
               {
                 component: MiniWidgetType.VeryGenericIndicator,
@@ -498,7 +474,6 @@ export const widgetProfiles: Profile[] = [
                   variableMultiplier: 100,
                 },
                 hash: '23fc4b2b-0922-4225-b9cc-1dc87fb77b84',
-                managerVars: defaultMiniWidgetManagerVars,
               },
             ],
           },
@@ -510,7 +485,6 @@ export const widgetProfiles: Profile[] = [
                 name: 'DepthIndicator',
                 options: {},
                 hash: 'b3572cc4-f9a0-427a-90a1-1756e0694af5',
-                managerVars: defaultMiniWidgetManagerVars,
               },
               {
                 component: MiniWidgetType.VeryGenericIndicator,
@@ -523,7 +497,6 @@ export const widgetProfiles: Profile[] = [
                   variableMultiplier: '.01',
                 },
                 hash: 'ba554289-246e-44a8-b4b2-dfdb6672ea00',
-                managerVars: defaultMiniWidgetManagerVars,
               },
             ],
           },
@@ -535,21 +508,18 @@ export const widgetProfiles: Profile[] = [
                 name: 'ArmerButton',
                 options: {},
                 hash: '0a85fc48-d8b2-4e8c-bb24-c326ffc0d2ed',
-                managerVars: defaultMiniWidgetManagerVars,
               },
               {
                 component: MiniWidgetType.ModeSelector,
                 name: 'ModeSelector',
                 options: {},
                 hash: 'ec66aedd-6cce-4533-bfa9-8e3c36906688',
-                managerVars: defaultMiniWidgetManagerVars,
               },
               {
                 component: MiniWidgetType.MiniVideoRecorder,
                 name: 'MiniVideoRecorder',
                 options: {},
                 hash: '111563f5-78cf-45b4-bc98-a81d1defed66',
-                managerVars: defaultMiniWidgetManagerVars,
               },
             ],
           },
@@ -575,7 +545,6 @@ export const widgetProfiles: Profile[] = [
             component: WidgetType.Map,
             position: { x: 0, y: 0 },
             size: { width: 1, height: 1 },
-            managerVars: defaultWidgetManagerVars,
             options: {},
           },
         ],
@@ -587,7 +556,6 @@ export const widgetProfiles: Profile[] = [
                 hash: 'c6eb406b-8e3c-4ab9-a348-4ad5058352be',
                 component: MiniWidgetType.ViewSelector,
                 name: 'ViewSelector',
-                managerVars: defaultMiniWidgetManagerVars,
                 options: {},
               },
             ],
@@ -621,7 +589,6 @@ export const widgetProfiles: Profile[] = [
               height: 0.118,
             },
             options: {},
-            managerVars: defaultWidgetManagerVars,
           },
           {
             hash: '0a786865-0eff-408c-bc1d-a2b710222418',
@@ -638,7 +605,6 @@ export const widgetProfiles: Profile[] = [
             options: {
               headingStyle: 'North Up',
             },
-            managerVars: defaultWidgetManagerVars,
           },
           {
             hash: '61412ae7-efb2-4a23-ad1e-2b58bbf0e5fc',
@@ -655,7 +621,6 @@ export const widgetProfiles: Profile[] = [
             options: {
               showVehiclePath: true,
             },
-            managerVars: defaultWidgetManagerVars,
           },
         ],
         miniWidgetContainers: [
@@ -667,7 +632,6 @@ export const widgetProfiles: Profile[] = [
                 component: MiniWidgetType.TakeoffLandCommander,
                 options: {},
                 hash: '0fec5430-8e49-43f0-9d7f-f3bec5f2c17e',
-                managerVars: defaultMiniWidgetManagerVars,
               },
             ],
           },
@@ -679,7 +643,6 @@ export const widgetProfiles: Profile[] = [
                 component: MiniWidgetType.RelativeAltitudeIndicator,
                 options: {},
                 hash: '11952b31-5123-44cd-8730-735caab2ec57',
-                managerVars: defaultMiniWidgetManagerVars,
               },
             ],
           },
@@ -691,14 +654,12 @@ export const widgetProfiles: Profile[] = [
                 component: MiniWidgetType.ModeSelector,
                 options: {},
                 hash: 'd9dc79e3-dd8a-473c-ba60-dbb83e41412a',
-                managerVars: defaultMiniWidgetManagerVars,
               },
               {
                 name: 'Armer Button',
                 component: MiniWidgetType.ArmerButton,
                 options: {},
                 hash: 'fe8cd3c0-f542-4343-bfb2-b6369d1522fe',
-                managerVars: defaultMiniWidgetManagerVars,
               },
             ],
           },
@@ -720,21 +681,18 @@ export const miniWidgetsProfiles: MiniWidgetProfile[] = [
             hash: '5b21cf5b-5849-413a-8bee-f1c4b42522f8',
             component: MiniWidgetType.BaseCommIndicator,
             name: 'BaseCommIndicator',
-            managerVars: defaultMiniWidgetManagerVars,
             options: {},
           },
           {
             hash: '41354445-2057-4574-80f5-bdc6d394dfe7',
             component: MiniWidgetType.JoystickCommIndicator,
             name: 'JoystickCommIndicator',
-            managerVars: defaultMiniWidgetManagerVars,
             options: {},
           },
           {
             hash: '7b31c4c4-e273-4f75-b0b7-d56263c4177d',
             component: MiniWidgetType.BatteryIndicator,
             name: 'BatteryIndicator',
-            managerVars: defaultMiniWidgetManagerVars,
             options: {},
           },
         ],

--- a/src/components/EditMenu.vue
+++ b/src/components/EditMenu.vue
@@ -131,9 +131,9 @@
           >
             <Button
               class="flex items-center justify-center w-full h-8 pl-3 overflow-auto cursor-grab active:cursor-grabbing"
-              :class="{ '!bg-slate-400': widget.managerVars.highlighted }"
-              @mouseover="widget.managerVars.highlighted = true"
-              @mouseleave="widget.managerVars.highlighted = false"
+              :class="{ '!bg-slate-400': store.widgetManagerVars(widget.hash).highlighted }"
+              @mouseover="store.widgetManagerVars(widget.hash).highlighted = true"
+              @mouseleave="store.widgetManagerVars(widget.hash).highlighted = false"
             >
               <span class="mr-3 text-base text-slate-700">⠿</span>
               <p class="overflow-hidden text-sm text-ellipsis whitespace-nowrap">{{ widget.name }}</p>
@@ -143,7 +143,7 @@
                 :class="{ 'mdi-fullscreen-exit': store.isFullScreen(widget) }"
                 @click="store.toggleFullScreen(widget)"
               />
-              <div class="icon-btn mdi mdi-cog" @click="store.openWidgetConfigMenu(widget)" />
+              <div class="icon-btn mdi mdi-cog" @click="store.widgetManagerVars(widget.hash).configMenuOpen = true" />
               <div class="icon-btn mdi mdi-trash-can" @click="store.deleteWidget(widget)" />
             </Button>
           </div>
@@ -172,16 +172,19 @@
               v-for="widget in miniWidgetContainer.widgets"
               :key="widget.hash"
               class="flex items-center justify-between w-full h-10 px-2 py-1 my-1 rounded-md"
-              :class="{ 'bg-slate-400': widget.managerVars.highlighted }"
-              @mouseover="widget.managerVars.highlighted = true"
-              @mouseleave="widget.managerVars.highlighted = false"
+              :class="{ 'bg-slate-400': store.miniWidgetManagerVars(widget.hash).highlighted }"
+              @mouseover="store.miniWidgetManagerVars(widget.hash).highlighted = true"
+              @mouseleave="store.miniWidgetManagerVars(widget.hash).highlighted = false"
             >
               <div class="flex items-center justify-start w-full overflow-auto">
                 <p class="overflow-hidden select-none text-ellipsis whitespace-nowrap">
                   {{ widget.name || widget.component }}
                 </p>
               </div>
-              <div class="icon-btn mdi mdi-cog" @click="widget.managerVars.configMenuOpen = true" />
+              <div
+                class="icon-btn mdi mdi-cog"
+                @click="store.miniWidgetManagerVars(widget.hash).configMenuOpen = true"
+              />
               <div class="icon-btn mdi mdi-trash-can" @click="store.deleteMiniWidget(widget)" />
             </div>
           </TransitionGroup>

--- a/src/components/MiniWidgetContainer.vue
+++ b/src/components/MiniWidgetContainer.vue
@@ -18,9 +18,12 @@
         :key="miniWidget.hash"
         :data-widget-hash="miniWidget.hash"
         class="rounded-md"
-        :class="{ 'cursor-grab': allowEditing, 'bg-slate-400': miniWidget.managerVars.highlighted }"
-        @mouseover="miniWidget.managerVars.highlighted = allowEditing"
-        @mouseleave="miniWidget.managerVars.highlighted = false"
+        :class="{
+          'cursor-grab': allowEditing,
+          'bg-slate-400': widgetStore.miniWidgetManagerVars(miniWidget.hash).highlighted,
+        }"
+        @mouseover="widgetStore.miniWidgetManagerVars(miniWidget.hash).highlighted = allowEditing"
+        @mouseleave="widgetStore.miniWidgetManagerVars(miniWidget.hash).highlighted = false"
       >
         <div :class="{ 'select-none pointer-events-none': allowEditing }">
           <MiniWidgetInstantiator :mini-widget="miniWidget" />
@@ -66,9 +69,12 @@ import { computed } from 'vue'
 import { VueDraggable } from 'vue-draggable-plus'
 
 import { CurrentlyLoggedVariables } from '@/libs/sensors-logging'
+import { useWidgetManagerStore } from '@/stores/widgetManager'
 import type { DraggableEvent, MiniWidget, MiniWidgetContainer } from '@/types/widgets'
 
 import MiniWidgetInstantiator from './MiniWidgetInstantiator.vue'
+
+const widgetStore = useWidgetManagerStore()
 
 const emit = defineEmits<{
   (e: 'chooseMiniWidget', value: unknown): void

--- a/src/components/WidgetHugger.vue
+++ b/src/components/WidgetHugger.vue
@@ -68,7 +68,7 @@ const props = withDefaults(defineProps<Props>(), {
 })
 
 const widget = toRefs(props).widget
-const { size, position, managerVars } = toRefs(props.widget)
+const { size, position } = toRefs(props.widget)
 const allowMoving = toRefs(props).allowMoving
 const allowResizing = toRefs(props).allowResizing
 const outerWidgetRef = ref<HTMLElement | undefined>()
@@ -87,7 +87,7 @@ const hoveringWidgetOrOverlay = computed(() => hoveringOverlay.value || hovering
 
 // Put the widget into highlighted state when in edit-mode and hovering over it
 watch([hoveringWidgetOrOverlay, allowMoving], () => {
-  managerVars.value.highlighted = hoveringWidgetOrOverlay.value && allowMoving.value
+  widgetStore.widgetManagerVars(widget.value.hash).highlighted = hoveringWidgetOrOverlay.value && allowMoving.value
 })
 
 const draggingWidget = ref(false)
@@ -211,10 +211,10 @@ const resizeWidgetToMinimalSize = (): void => {
 }
 
 onMounted(async () => {
-  if (managerVars.value.everMounted === false) {
+  if (widgetStore.miniWidgetManagerVars(widget.value.hash).everMounted === false) {
     resizeWidgetToMinimalSize()
   }
-  managerVars.value.everMounted = true
+  widgetStore.miniWidgetManagerVars(widget.value.hash).everMounted = true
 
   if (widgetResizeHandles.value) {
     for (let i = 0; i < widgetResizeHandles.value.length; i++) {
@@ -301,7 +301,7 @@ const cursorStyle = computed(() => {
 
 const devInfoBlurLevel = computed(() => `${devStore.widgetDevInfoBlurLevel}px`)
 
-const highlighted = computed(() => managerVars.value.highlighted)
+const highlighted = computed(() => widgetStore.miniWidgetManagerVars(widget.value.hash).highlighted)
 </script>
 
 <style>

--- a/src/components/mini-widgets/MiniVideoRecorder.vue
+++ b/src/components/mini-widgets/MiniVideoRecorder.vue
@@ -20,7 +20,7 @@
       <div
         v-if="nameSelectedStream"
         class="flex flex-col max-w-[50%] scroll-container transition-all border-blur cursor-pointer"
-        @click="miniWidget.managerVars.configMenuOpen = true"
+        @click="widgetStore.miniWidgetManagerVars(miniWidget.hash).configMenuOpen = true"
       >
         <div class="text-xs text-white select-none scroll-text">{{ nameSelectedStream }}</div>
       </div>
@@ -47,7 +47,7 @@
       >
     </div>
   </div>
-  <v-dialog v-model="miniWidget.managerVars.configMenuOpen" width="auto">
+  <v-dialog v-model="widgetStore.miniWidgetManagerVars(miniWidget.hash).configMenuOpen" width="auto">
     <div class="p-6 m-5 bg-white rounded-md">
       <p class="text-xl font-semibold">Choose a stream to record</p>
       <div class="w-auto h-px my-2 bg-grey-lighten-3" />
@@ -66,7 +66,7 @@
       <div class="flex items-center">
         <button
           class="w-auto p-3 m-2 font-medium transition-all rounded-md shadow-md text-uppercase hover:bg-slate-100"
-          @click="miniWidget.managerVars.configMenuOpen = false"
+          @click="widgetStore.miniWidgetManagerVars(miniWidget.hash).configMenuOpen = false"
         >
           Cancel
         </button>
@@ -179,7 +179,7 @@ const toggleRecording = async (): Promise<void> => {
 
   // If there's no stream selected, open the configuration dialog so user can choose the stream which will be recorded
   if (nameSelectedStream.value === undefined) {
-    miniWidget.value.managerVars.configMenuOpen = true
+    widgetStore.miniWidgetManagerVars(miniWidget.value.hash).configMenuOpen = true
     return
   }
 
@@ -194,7 +194,7 @@ const startRecording = (): void => {
   }
   assertStreamIsSelectedAndAvailable(nameSelectedStream.value)
   videoStore.startRecording(nameSelectedStream.value)
-  miniWidget.value.managerVars.configMenuOpen = false
+  widgetStore.miniWidgetManagerVars(miniWidget.value.hash).configMenuOpen = false
 }
 
 const isRecording = computed(() => {

--- a/src/components/mini-widgets/VeryGenericIndicator.vue
+++ b/src/components/mini-widgets/VeryGenericIndicator.vue
@@ -12,7 +12,7 @@
     </div>
   </div>
   <v-dialog
-    v-model="miniWidget.managerVars.configMenuOpen"
+    v-model="widgetStore.miniWidgetManagerVars(miniWidget.hash).configMenuOpen"
     persistent
     class="w-[100vw] flex justify-center items-center"
   >
@@ -223,7 +223,7 @@ const updateLoggedMiniWidgets = (): void => {
 // prevent closing the configuration menu if no variable and name are selected
 const closeDialog = async (): Promise<void> => {
   const { variableName, displayName } = miniWidget.value.options
-  const { managerVars } = miniWidget.value
+  const managerVars = widgetStore.miniWidgetManagerVars(miniWidget.value.hash)
 
   if (variableName === '' || displayName === '') {
     await Swal.fire({
@@ -265,7 +265,7 @@ const logCurrentState = (): void => {
 watch(
   finalValue,
   () => {
-    if (miniWidget.value.managerVars.configMenuOpen === false) {
+    if (widgetStore.miniWidgetManagerVars(miniWidget.value.hash).configMenuOpen === false) {
       logCurrentState()
     }
   },
@@ -353,13 +353,13 @@ const chooseIcon = (iconName: string): void => {
 
 watch(showVariableChooseModal, async (newValue) => {
   if (newValue === true && variableNamesToShow.value.isEmpty()) {
-    miniWidget.value.managerVars.configMenuOpen = false
+    widgetStore.miniWidgetManagerVars(miniWidget.value.hash).configMenuOpen = false
     showVariableChooseModal.value = false
     await Swal.fire({
       text: 'No variables found to choose from. Please make sure your vehicle is connected.',
       icon: 'error',
     })
-    miniWidget.value.managerVars.configMenuOpen = true
+    widgetStore.miniWidgetManagerVars(miniWidget.value.hash).configMenuOpen = true
   }
 })
 
@@ -376,7 +376,7 @@ const setIndicatorFromTemplate = (template: VeryGenericIndicatorPreset): void =>
 // Pops open the config menu if the mini-widget is a non-configured VeryGenericIndicator
 watchEffect(() => {
   if (miniWidget.value.component === 'VeryGenericIndicator' && miniWidget.value.options.displayName === '') {
-    miniWidget.value.managerVars.configMenuOpen = true
+    widgetStore.miniWidgetManagerVars(miniWidget.value.hash).configMenuOpen = true
   }
 })
 </script>

--- a/src/components/widgets/Attitude.vue
+++ b/src/components/widgets/Attitude.vue
@@ -2,7 +2,7 @@
   <div class="main">
     <canvas ref="canvasRef" :width="canvasSize.width" :height="canvasSize.height" />
   </div>
-  <v-dialog v-model="widget.managerVars.configMenuOpen" min-width="400" max-width="35%">
+  <v-dialog v-model="widgetStore.widgetManagerVars(widget.hash).configMenuOpen" min-width="400" max-width="35%">
     <v-card class="pa-2">
       <v-card-title>Attitude widget config</v-card-title>
       <v-card-text>

--- a/src/components/widgets/Compass.vue
+++ b/src/components/widgets/Compass.vue
@@ -7,7 +7,7 @@
       class="rounded-[15%] bg-slate-950/70"
     ></canvas>
   </div>
-  <Dialog v-model:show="widget.managerVars.configMenuOpen" class="w-72">
+  <Dialog v-model:show="widgetStore.widgetManagerVars(widget.hash).configMenuOpen" class="w-72">
     <div class="w-full h-full">
       <div class="flex flex-col items-center justify-around">
         <div class="flex items-center justify-between w-full my-1">

--- a/src/components/widgets/CompassHUD.vue
+++ b/src/components/widgets/CompassHUD.vue
@@ -2,7 +2,7 @@
   <div class="main">
     <canvas ref="canvasRef" :width="canvasSize.width" :height="canvasSize.height" />
   </div>
-  <v-dialog v-model="widget.managerVars.configMenuOpen" min-width="400" max-width="35%">
+  <v-dialog v-model="widgetStore.widgetManagerVars(widget.hash).configMenuOpen" min-width="400" max-width="35%">
     <v-card class="pa-2">
       <v-card-title>HUD Compass widget config</v-card-title>
       <v-card-text>

--- a/src/components/widgets/DepthHUD.vue
+++ b/src/components/widgets/DepthHUD.vue
@@ -2,7 +2,7 @@
   <div class="main">
     <canvas ref="canvasRef" :width="canvasSize.width" :height="canvasSize.height" />
   </div>
-  <v-dialog v-model="widget.managerVars.configMenuOpen" min-width="400" max-width="35%">
+  <v-dialog v-model="widgetStore.widgetManagerVars(widget.hash).configMenuOpen" min-width="400" max-width="35%">
     <v-card class="pa-2">
       <v-card-title>Depth HUD config</v-card-title>
       <v-card-text>

--- a/src/components/widgets/IFrame.vue
+++ b/src/components/widgets/IFrame.vue
@@ -9,7 +9,7 @@
         @load="loadFinished"
       />
     </teleport>
-    <v-dialog v-model="widget.managerVars.configMenuOpen" min-width="400" max-width="35%">
+    <v-dialog v-model="widgetStore.widgetManagerVars(widget.hash).configMenuOpen" min-width="400" max-width="35%">
       <v-card class="pa-2">
         <v-card-title>Settings</v-card-title>
         <v-card-text>
@@ -29,7 +29,9 @@
           <v-slider v-model="transparency" label="Transparency" :min="0" :max="90" />
         </v-card-text>
         <v-card-actions>
-          <v-btn color="primary" @click="widget.managerVars.configMenuOpen = false">Close</v-btn>
+          <v-btn color="primary" @click="widgetStore.widgetManagerVars(widget.hash).configMenuOpen = false">
+            Close
+          </v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>
@@ -53,7 +55,7 @@ import { isValidURL } from '@/libs/utils'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
 import type { Widget } from '@/types/widgets'
 
-const widgetManagerStore = useWidgetManagerStore()
+const widgetStore = useWidgetManagerStore()
 
 const props = defineProps<{
   /**
@@ -107,11 +109,11 @@ const iframeStyle = computed<string>(() => {
   newStyle = newStyle.concat(' ', `width: ${widget.value.size.width * windowWidth.value}px;`)
   newStyle = newStyle.concat(' ', `height: ${widget.value.size.height * windowHeight.value}px;`)
 
-  if (widgetManagerStore.editingMode) {
+  if (widgetStore.editingMode) {
     newStyle = newStyle.concat(' ', 'pointer-events:none; border:0;')
   }
 
-  if (!widgetManagerStore.isWidgetVisible(widget.value)) {
+  if (!widgetStore.isWidgetVisible(widget.value)) {
     newStyle = newStyle.concat(' ', 'display: none;')
   }
 
@@ -133,7 +135,7 @@ function loadFinished(): void {
 watch(
   widget,
   () => {
-    if (widget.value.managerVars.configMenuOpen === false) {
+    if (widgetStore.widgetManagerVars(widget.value.hash).configMenuOpen === false) {
       if (validateURL(inputURL.value) !== true) {
         inputURL.value = widget.value.options.source
       }

--- a/src/components/widgets/ImageView.vue
+++ b/src/components/widgets/ImageView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="w-full h-full">
     <img :src="src" draggable="false" />
-    <v-dialog v-model="widget.managerVars.configMenuOpen" min-width="400" max-width="35%">
+    <v-dialog v-model="widgetStore.widgetManagerVars(widget.hash).configMenuOpen" min-width="400" max-width="35%">
       <v-card class="pa-2">
         <v-card-title>Image URL</v-card-title>
         <v-card-text>
@@ -17,7 +17,9 @@
           </div>
         </v-card-text>
         <v-card-actions>
-          <v-btn color="primary" @click="widget.managerVars.configMenuOpen = false">Close</v-btn>
+          <v-btn color="primary" @click="widgetStore.widgetManagerVars(widget.hash).configMenuOpen = false">
+            Close
+          </v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>
@@ -27,9 +29,12 @@
 <script setup lang="ts">
 import { computed, onBeforeMount, toRefs } from 'vue'
 
+import { useWidgetManagerStore } from '@/stores/widgetManager'
 import type { Widget } from '@/types/widgets'
 
 import Dropdown from '../Dropdown.vue'
+
+const widgetStore = useWidgetManagerStore()
 
 const props = defineProps<{
   /**

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -55,7 +55,7 @@
     </ul>
   </div>
 
-  <v-dialog v-model="widget.managerVars.configMenuOpen" width="auto">
+  <v-dialog v-model="widgetStore.widgetManagerVars(widget.hash).configMenuOpen" width="auto">
     <v-card class="pa-2">
       <v-card-title>Map widget settings</v-card-title>
       <v-card-text>

--- a/src/components/widgets/MiniWidgetsBar.vue
+++ b/src/components/widgets/MiniWidgetsBar.vue
@@ -4,8 +4,8 @@
       :container="widget.options.miniWidgetsContainer"
       :wrap="true"
       :allow-editing="widgetStore.editingMode"
-      @choose-mini-widget="widget.managerVars.allowMoving = false"
-      @unchoose-mini-widget="widget.managerVars.allowMoving = true"
+      @choose-mini-widget="widgetStore.widgetManagerVars(widget.hash).allowMoving = false"
+      @unchoose-mini-widget="widgetStore.widgetManagerVars(widget.hash).allowMoving = true"
     />
   </div>
 </template>

--- a/src/components/widgets/URLVideoPlayer.vue
+++ b/src/components/widgets/URLVideoPlayer.vue
@@ -11,7 +11,7 @@
     >
       <source :src="widget.options.source" />
     </video>
-    <v-dialog v-model="widget.managerVars.configMenuOpen" min-width="400" max-width="35%">
+    <v-dialog v-model="widgetStore.widgetManagerVars(widget.hash).configMenuOpen" min-width="400" max-width="35%">
       <v-card class="pa-2">
         <v-card-title>Video Source</v-card-title>
         <v-card-text>
@@ -38,7 +38,9 @@
           </div>
         </v-card-text>
         <v-card-actions>
-          <v-btn color="primary" @click="widget.managerVars.configMenuOpen = false">Close</v-btn>
+          <v-btn color="primary" @click="widgetStore.widgetManagerVars(widget.hash).configMenuOpen = false">
+            Close
+          </v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>
@@ -49,7 +51,10 @@
 import { onBeforeMount, ref, toRefs, watch } from 'vue'
 
 import Dropdown from '@/components/Dropdown.vue'
+import { useWidgetManagerStore } from '@/stores/widgetManager'
 import type { Widget } from '@/types/widgets'
+
+const widgetStore = useWidgetManagerStore()
 
 const props = defineProps<{
   /**

--- a/src/components/widgets/VideoPlayer.vue
+++ b/src/components/widgets/VideoPlayer.vue
@@ -39,7 +39,7 @@
       Your browser does not support the video tag.
     </video>
   </div>
-  <v-dialog v-model="widget.managerVars.configMenuOpen" width="auto">
+  <v-dialog v-model="widgetStore.widgetManagerVars(widget.hash).configMenuOpen" width="auto">
     <v-card class="pa-2">
       <v-card-title>Video widget config</v-card-title>
       <v-card-text>
@@ -98,9 +98,12 @@ import { computed, onBeforeMount, onBeforeUnmount, ref, toRefs, watch } from 'vu
 
 import { isEqual } from '@/libs/utils'
 import { useVideoStore } from '@/stores/video'
+import { useWidgetManagerStore } from '@/stores/widgetManager'
 import type { Widget } from '@/types/widgets'
 
 const videoStore = useVideoStore()
+const widgetStore = useWidgetManagerStore()
+
 const { namesAvailableStreams } = storeToRefs(videoStore)
 
 const props = defineProps<{

--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -38,6 +38,62 @@ export enum MiniWidgetType {
   ViewSelector = 'ViewSelector',
 }
 
+/**
+ * External variables used by the widget manager
+ */
+export type WidgetManagerVars = {
+  /**
+   * Number of times the widget was mounted
+   */
+  everMounted: boolean
+  /**
+   * If the configuration menu is open or not
+   */
+  configMenuOpen: boolean
+  /**
+   * If the widget should be allowed to move
+   */
+  allowMoving: boolean
+  /**
+   * Last widget X position when it wasn't maximized
+   */
+  lastNonMaximizedX: number
+  /**
+   * Last widget Y position when it wasn't maximized
+   */
+  lastNonMaximizedY: number
+  /**
+   * Last widget width when it wasn't maximized
+   */
+  lastNonMaximizedWidth: number
+  /**
+   * Last widget height when it wasn't maximized
+   */
+  lastNonMaximizedHeight: number
+  /**
+   * Wether thewidget should be highlited or not
+   */
+  highlighted: boolean
+}
+
+/**
+ * External variables used by the widget manager
+ */
+export type MiniWidgetManagerVars = {
+  /**
+   * Number of times the mini-widget was mounted
+   */
+  everMounted: boolean
+  /**
+   * If the configuration menu is open or not
+   */
+  configMenuOpen: boolean
+  /**
+   * Wether the mini-widget should be highlited or not
+   */
+  highlighted: boolean
+}
+
 export type Widget = {
   /**
    * Unique identifier for the widget
@@ -63,43 +119,6 @@ export type Widget = {
    * Internal options of the widget
    */
   options: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
-  /**
-   * External variables used by the widget manager
-   */
-  managerVars: {
-    /**
-     * Number of times the widget was mounted
-     */
-    everMounted: boolean
-    /**
-     * If the configuration menu is open or not
-     */
-    configMenuOpen: boolean
-    /**
-     * If the widget should be allowed to move
-     */
-    allowMoving: boolean
-    /**
-     * Last widget X position when it wasn't maximized
-     */
-    lastNonMaximizedX: number
-    /**
-     * Last widget Y position when it wasn't maximized
-     */
-    lastNonMaximizedY: number
-    /**
-     * Last widget width when it wasn't maximized
-     */
-    lastNonMaximizedWidth: number
-    /**
-     * Last widget height when it wasn't maximized
-     */
-    lastNonMaximizedHeight: number
-    /**
-     * Wether thewidget should be highlited or not
-     */
-    highlighted: boolean
-  }
 }
 
 export type MiniWidget = {
@@ -119,23 +138,6 @@ export type MiniWidget = {
    * Internal options of the widget
    */
   options: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
-  /**
-   * External variables used by the widget manager
-   */
-  managerVars: {
-    /**
-     * Number of times the mini-widget was mounted
-     */
-    everMounted: boolean
-    /**
-     * If the configuration menu is open or not
-     */
-    configMenuOpen: boolean
-    /**
-     * Wether the mini-widget should be highlited or not
-     */
-    highlighted: boolean
-  }
 }
 
 export type MiniWidgetContainer = {

--- a/src/views/WidgetsView.vue
+++ b/src/views/WidgetsView.vue
@@ -7,7 +7,7 @@
         <WidgetHugger
           v-if="Object.values(WidgetType).includes(widget.component)"
           :widget="widget"
-          :allow-moving="widget.managerVars.allowMoving"
+          :allow-moving="store.widgetManagerVars(widget.hash).allowMoving"
           :allow-resizing="store.editingMode"
         >
           <component :is="componentFromType(widget.component)" :widget="widget" />


### PR DESCRIPTION
This PR removes the `managerVars` object from the structure of the widgets and mini-widgets.
Those variables, that are part of the state of the application session, and not of the object itself, won't be carried around with them anymore.
The biggest advantage of doing that is that the widget settings objects won't be updated anymore when a widget variable state is updated, so features that react to that, like the BlueOS settings sync, won't be triggered anymore unnecessarily.

I've tried to bind the `managerVars` method to the objects, so we wouldn't need to access this method through the store itself, but I had several troubles with this implementation regarding the serialization of this object, so I decided to not carry with this since we are approach a release candidate and this patch is critical. 

For those testing this PR, I ask you to try messing around in edit-mode and see if anything is changes. It shouldn't.

Fix #1094 