### PR TITLE
settings-sync: Remove profile and view indexes and global address from auto sync

### DIFF
--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -1,4 +1,4 @@
-import { useTimestamp, watchThrottled } from '@vueuse/core'
+import { useStorage, useTimestamp, watchThrottled } from '@vueuse/core'
 import { defineStore } from 'pinia'
 import { computed, reactive, ref, watch } from 'vue'
 
@@ -64,7 +64,7 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
   const ws_protocol = location?.protocol === 'https:' ? 'wss' : 'ws'
 
   const cpuLoad = ref<number>()
-  const globalAddress = useBlueOsStorage('cockpit-vehicle-address', defaultGlobalAddress)
+  const globalAddress = useStorage('cockpit-vehicle-address', defaultGlobalAddress)
 
   const defaultMainConnectionURI = ref<string>(`${ws_protocol}://${globalAddress.value}/mavlink2rest/ws/mavlink`)
   const defaultWebRTCSignallingURI = ref<string>(`${ws_protocol}://${globalAddress.value}:6021/`)

--- a/src/stores/widgetManager.ts
+++ b/src/stores/widgetManager.ts
@@ -1,6 +1,6 @@
 import '@/libs/cosmos'
 
-import { useDebounceFn, useWindowSize } from '@vueuse/core'
+import { useDebounceFn, useStorage, useWindowSize } from '@vueuse/core'
 import { saveAs } from 'file-saver'
 import { defineStore } from 'pinia'
 import Swal from 'sweetalert2'
@@ -43,8 +43,8 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
   const gridInterval = ref(0.01)
   const currentMiniWidgetsProfile = useBlueOsStorage('cockpit-mini-widgets-profile-v4', miniWidgetsProfile)
   const savedProfiles = useBlueOsStorage<Profile[]>(savedProfilesKey, [])
-  const currentViewIndex = useBlueOsStorage('cockpit-current-view-index', 0)
-  const currentProfileIndex = useBlueOsStorage('cockpit-current-profile-index', 0)
+  const currentViewIndex = useStorage('cockpit-current-view-index', 0)
+  const currentProfileIndex = useStorage('cockpit-current-profile-index', 0)
   const desiredTopBarHeightPixels = ref(48)
   const desiredBottomBarHeightPixels = ref(48)
   const visibleAreaMinClearancePixels = ref(20)


### PR DESCRIPTION
The global address does not make sense to sync, since when the user is already connected for the sync to work, and changing the address can only disconnect them.

The widgets profile and view index also does not make much sense since they are actually states, not settings. It may be something the user is messing around with before connection and will receive a conflict unnecessarily.