### PR TITLE
vgi: Always use full available size for the display name

### DIFF
--- a/src/components/mini-widgets/VeryGenericIndicator.vue
+++ b/src/components/mini-widgets/VeryGenericIndicator.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="h-12 p-1 text-white transition-all w-[8.5rem] relative scroll-container">
     <span class="h-full left-[0.5rem] bottom-[5%] absolute mdi text-[2.25rem]" :class="[miniWidget.options.iconName]" />
-    <div class="absolute left-[3rem] h-full select-none font-semibold scroll-container">
-      <div class="max-w-full" :class="{ 'scroll-text': valueIsOverflowing }">
+    <div class="absolute left-[3rem] h-full select-none font-semibold scroll-container w-[5.5rem]">
+      <div class="w-full" :class="{ 'scroll-text': valueIsOverflowing }">
         <span class="font-mono text-xl leading-6">{{ parsedState }}</span>
         <span class="text-xl leading-6"> {{ String.fromCharCode(0x20) }} {{ miniWidget.options.variableUnit }} </span>
       </div>


### PR DESCRIPTION
In situations where the value+unit was not using the full width of the widget, the display name was being cropped unnecessarily.

Before/after:
<img width="164" alt="image" src="https://github.com/user-attachments/assets/a2b1194e-a17b-431d-86c3-263377bd83a9">

<img width="163" alt="image" src="https://github.com/user-attachments/assets/46b48f2d-dcd0-485f-9394-bc31235f7dea">
