### PR TITLE
generic-variables: Allow generic variables with array values

### DIFF
--- a/src/libs/vehicle/ardupilot/ardupilot.ts
+++ b/src/libs/vehicle/ardupilot/ardupilot.ts
@@ -267,7 +267,7 @@ export abstract class ArduPilotVehicle<Modes> extends Vehicle.AbstractVehicle<Mo
      */
     const getDeepVariables = (obj: Record<string, unknown>, acc: string[], baseKey?: string): void => {
       Object.entries(obj).forEach(([k, v]) => {
-        if (v instanceof Object) {
+        if (v instanceof Object && !Array.isArray(v)) {
           let identifier: string | undefined = undefined
           Object.keys(v).forEach((subKey) => {
             if (mavlinkIdentificationKeys.includes(subKey)) {


### PR DESCRIPTION
With how it was till now, arrays would be broken and not proper paths.

Can be tested by checking that previously the `GIMBAL_DEVICE_ATTITUDE_STATUS` message in the MAVLink stream wouldn't have the `q` property properly parsed. Now it is.
