### PR TITLE
attitude: Fix horizon directions on attitude widgets

### DIFF
--- a/src/components/widgets/Attitude.vue
+++ b/src/components/widgets/Attitude.vue
@@ -237,7 +237,7 @@ const renderCanvas = (): void => {
   const pitchLinesStartRadius = 2.0 * aimRadius.value
 
   ctx.translate(halfCanvasWidth, halfCanvasHeight)
-  ctx.rotate(-radians(renderVars.rollDegrees))
+  ctx.rotate(radians(renderVars.rollDegrees))
 
   const centerPos = -angleY(renderVars.cameraTiltDeg + renderVars.pitchDegrees)
   // Draw line for each angle

--- a/src/components/widgets/VirtualHorizon.vue
+++ b/src/components/widgets/VirtualHorizon.vue
@@ -82,7 +82,7 @@ const renderCanvas = (): void => {
 
   ctx.save()
 
-  ctx.rotate(radians(-1 * renderVariables.rollAngleDegrees))
+  ctx.rotate(radians(renderVariables.rollAngleDegrees))
 
   // Draw circular clipping mask
   ctx.beginPath()
@@ -144,7 +144,7 @@ const renderCanvas = (): void => {
   // Draw current horizon fixed reference lines
   ctx.save()
   ctx.lineWidth = 0.8 * baseLineWidth
-  ctx.rotate(radians(-1 * renderVariables.rollAngleDegrees))
+  ctx.rotate(radians(renderVariables.rollAngleDegrees))
   ctx.beginPath()
   ctx.moveTo(-1 * outerCircleRadius, 0)
   ctx.lineTo(-0.85 * outerCircleRadius, 0)
@@ -188,7 +188,7 @@ const renderCanvas = (): void => {
   ctx.save()
   ctx.beginPath()
   ctx.rotate(radians(90))
-  ctx.rotate(radians(-1 * renderVariables.rollAngleDegrees))
+  ctx.rotate(radians(renderVariables.rollAngleDegrees))
   ctx.lineWidth = 0.01 * baseLineWidth
   ctx.fillStyle = 'rgb(221, 43, 43)'
   ctx.moveTo(-1 * outerCircleRadius, 0)


### PR DESCRIPTION
Turns out my camera was inverted, and the Attitude widget was rolling to the right direction. The one going to the wrong direction was the VirtualHorizon.

Shame on me for breaking things that were working. At least it served for us to find a problem in the VirtualHorizon. Thanks @Williangalvani for noticing.

For those reviewing this PR I ask that you check twice to make sure I didn't make the same mistake twice 😅 

<img width="1485" alt="image" src="https://github.com/user-attachments/assets/37aee37a-10dd-4ead-b63b-dbb91d42a377">
