### PR TITLE
Add framerate logging for both application rendering and video streams

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ import App from './App.vue'
 import vuetify from './plugins/vuetify'
 import { loadFonts } from './plugins/webfontloader'
 import router from './router'
+import { useOmniscientLoggerStore } from './stores/omniscientLogger'
 
 library.add(fas, far)
 loadFonts()
@@ -39,3 +40,6 @@ if (window.localStorage.getItem('cockpit-enable-usage-statistics-telemetry')) {
 app.component('FontAwesomeIcon', FontAwesomeIcon)
 app.use(router).use(vuetify).use(createPinia()).use(FloatingVue).use(VueVirtualScroller)
 app.mount('#app')
+
+// Initialize the logger store
+useOmniscientLoggerStore()

--- a/src/stores/omniscientLogger.ts
+++ b/src/stores/omniscientLogger.ts
@@ -1,0 +1,42 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+import { useVideoStore } from './video'
+
+export const useOmniscientLoggerStore = defineStore('omniscient-logger', () => {
+  const videoStore = useVideoStore()
+
+  // Routine to log the framerate of the video streams
+  const streamsFrameRateHistory = ref<{ [key in string]: number[] }>({})
+  let lastStreamAverageFramerateLog = new Date()
+  const streamAverageFramerateLogDelay = 1000
+  setInterval(() => {
+    Object.keys(videoStore.activeStreams).forEach((streamName) => {
+      if (videoStore.activeStreams[streamName] === undefined) return
+      videoStore.activeStreams[streamName]!.mediaStream?.getVideoTracks().forEach((track) => {
+        if (streamsFrameRateHistory.value[streamName] === undefined) streamsFrameRateHistory.value[streamName] = []
+        if (track.getSettings().frameRate === undefined) return
+
+        const streamHistory = streamsFrameRateHistory.value[streamName]
+        streamHistory.push(track.getSettings().frameRate as number)
+        streamHistory.splice(0, streamHistory.length - 10)
+        streamsFrameRateHistory.value[streamName] = streamHistory
+
+        const average = streamHistory.reduce((a, b) => a + b, 0) / streamHistory.length
+        const minThreshold = 0.9 * average
+        const newFrameRate = track.getSettings().frameRate as number
+
+        // Warn about drops in the framerate of the video stream
+        if (newFrameRate < minThreshold) {
+          console.warn(`Drop in the framerate detected for stream '${streamName}': ${newFrameRate.toFixed(2)} fps.`)
+        }
+
+        // Log the average framerate of the video stream recursively
+        if (new Date().getTime() - lastStreamAverageFramerateLog.getTime() > streamAverageFramerateLogDelay) {
+          console.debug(`Average frame rate for stream '${streamName}': ${average.toFixed(2)} fps.`)
+          lastStreamAverageFramerateLog = new Date()
+        }
+      })
+    })
+  }, 250)
+})

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -676,7 +676,7 @@ export const useVideoStore = defineStore('video', () => {
   const issueNoIpSelectedWarning = (): void => {
     showDialog({
       maxWidth: 600,
-      title: `Cockpit detected more than one IP address being used to route the video streaming. 
+      title: `Cockpit detected more than one IP address being used to route the video streaming.
         This often leads to video stuttering, especially if one of the IPs is from a non-wired connection.`,
       message: [
         'To prevent issues and achieve an optimal streaming experience, please:',
@@ -822,5 +822,6 @@ export const useVideoStore = defineStore('video', () => {
     overallProgress,
     processVideoChunksAndTelemetry,
     isVideoFilename,
+    activeStreams,
   }
 })


### PR DESCRIPTION
<img width="585" alt="image" src="https://github.com/user-attachments/assets/9cdabd70-c33d-423e-9675-3fc09b3e15fd">

The average framerate is logged at debug level every second, while the framerate drop logs happen if a 10% threshold is archieved.

I've evaluated the application for any performance loss but couldn't notice any.

Fix #1162
Fix #1163 