### PR TITLE
mavlink: Catch error when sending mavlink messages through the websocket connection

### DIFF
--- a/src/libs/communication/mavlink.ts
+++ b/src/libs/communication/mavlink.ts
@@ -19,7 +19,11 @@ export const sendMavlinkMessage = (message: MavMessage): void => {
     message: message,
   }
   const textEncoder = new TextEncoder()
-  ConnectionManager.write(textEncoder.encode(JSON.stringify(pack)))
+  try {
+    ConnectionManager.write(textEncoder.encode(JSON.stringify(pack)))
+  } catch (error) {
+    console.error('Error sending MAVLink message:', error)
+  }
 }
 
 /**


### PR DESCRIPTION
If the vehicle was still not connected and we tried sending any MAVLink message, this channel would die.