### PR TITLE
Prevent conflicts after resetting profiles

### DIFF
--- a/src/components/mini-widgets/MiniVideoRecorder.vue
+++ b/src/components/mini-widgets/MiniVideoRecorder.vue
@@ -106,7 +106,7 @@ import type { MiniWidget } from '@/types/widgets'
 
 import VideoLibrary from '../VideoLibraryModal.vue'
 
-const { showDialog, closeDialog } = useInteractionDialog()
+const { showDialog } = useInteractionDialog()
 const interfaceStore = useAppInterfaceStore()
 const widgetStore = useWidgetManagerStore()
 const videoStore = useVideoStore()
@@ -269,26 +269,6 @@ if (widgetStore.isRealMiniWidget(miniWidget.value)) {
     if (miniWidget.value.options.internalStreamName === undefined && !namesAvailableStreams.value.isEmpty()) {
       miniWidget.value.options.internalStreamName = namesAvailableStreams.value[0]
       nameSelectedStream.value = miniWidget.value.options.internalStreamName
-
-      // If there are multiple streams available, warn user that we chose one automatically and they should change if wanted
-      if (namesAvailableStreams.value.length > 1) {
-        const text = `You have multiple streams available, so we chose one randomly to start with.
-          If you want to change it, please open the widget configuration.`
-        showDialog({
-          maxWidth: 600,
-          title: 'Multiple streams detected',
-          message: text,
-          variant: 'info',
-          actions: [
-            {
-              text: 'Ok',
-              action: () => {
-                closeDialog()
-              },
-            },
-          ],
-        })
-      }
     }
 
     // If the stream name is defined, try to connect the widget to the MediaStream

--- a/src/components/widgets/VideoPlayer.vue
+++ b/src/components/widgets/VideoPlayer.vue
@@ -101,7 +101,6 @@
 import { storeToRefs } from 'pinia'
 import { computed, onBeforeMount, onBeforeUnmount, ref, toRefs, watch } from 'vue'
 
-import { useInteractionDialog } from '@/composables/interactionDialog'
 import { isEqual } from '@/libs/utils'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useVideoStore } from '@/stores/video'
@@ -109,7 +108,6 @@ import { useWidgetManagerStore } from '@/stores/widgetManager'
 import type { Widget } from '@/types/widgets'
 const interfaceStore = useAppInterfaceStore()
 
-const { showDialog } = useInteractionDialog()
 const videoStore = useVideoStore()
 const widgetStore = useWidgetManagerStore()
 
@@ -157,13 +155,6 @@ const streamConnectionRoutine = setInterval(() => {
   if (widget.value.options.internalStreamName === undefined && !namesAvailableStreams.value.isEmpty()) {
     widget.value.options.internalStreamName = namesAvailableStreams.value[0]
     nameSelectedStream.value = widget.value.options.internalStreamName
-
-    // If there are multiple streams available, warn user that we chose one automatically and he should change if wanted
-    if (namesAvailableStreams.value.length > 1) {
-      const text = `You have multiple streams available, so we chose one randomly to start with.
-        If you want to change it, please open the widget configuration on the edit-menu.`
-      showDialog({ maxWidth: 600, title: 'Multiple streams detected', message: text, variant: 'info' })
-    }
   }
 
   if (externalStreamId.value !== undefined) {

--- a/src/composables/settingsSyncer.ts
+++ b/src/composables/settingsSyncer.ts
@@ -15,6 +15,12 @@ import { savedProfilesKey } from '@/stores/widgetManager'
 import { useInteractionDialog } from './interactionDialog'
 import { openSnackbar } from './snackbar'
 
+export const resetJustMadeKey = 'cockpit-reset-just-made'
+const resetJustMade = useStorage(resetJustMadeKey, false)
+setTimeout(() => {
+  resetJustMade.value = false
+}, 10000)
+
 const getVehicleAddress = async (): Promise<string> => {
   const vehicleStore = useMainVehicleStore()
 
@@ -176,7 +182,9 @@ export function useBlueOsStorage<T>(key: string, defaultValue: MaybeRef<T>): Rem
       // local value or the one from BlueOS.
       // If the connected vehicle is different from the last connected vehicle, we just use the value from BlueOS, as we
       // don't want to overwrite the value on the new vehicle with the one from the previous vehicle.
-      if (lastConnectedUser === username && lastConnectedVehicleId === currentVehicleId) {
+      if (resetJustMade.value) {
+        useBlueOsValue = false
+      } else if (lastConnectedUser === username && lastConnectedVehicleId === currentVehicleId) {
         console.debug(`Conflict with BlueOS for key '${key}'. Asking user what to do.`)
         useBlueOsValue = await askIfUserWantsToUseBlueOsValue()
       }

--- a/src/composables/settingsSyncer.ts
+++ b/src/composables/settingsSyncer.ts
@@ -274,7 +274,7 @@ export function useBlueOsStorage<T>(key: string, defaultValue: MaybeRef<T>): Rem
     currentValue,
     async (newValue) => {
       clearTimeout(valueUpdateMethodTimeout)
-      valueUpdateMethodTimeout = setTimeout(() => maybeUpdateValueOnBlueOs(newValue, valueBeforeDebouncedChange), 3000)
+      valueUpdateMethodTimeout = setTimeout(() => maybeUpdateValueOnBlueOs(newValue, valueBeforeDebouncedChange), 1000)
     },
     { deep: true }
   )

--- a/src/stores/widgetManager.ts
+++ b/src/stores/widgetManager.ts
@@ -14,7 +14,7 @@ import {
 } from '@/assets/defaults'
 import { miniWidgetsProfile } from '@/assets/defaults'
 import { useInteractionDialog } from '@/composables/interactionDialog'
-import { useBlueOsStorage } from '@/composables/settingsSyncer'
+import { resetJustMadeKey, useBlueOsStorage } from '@/composables/settingsSyncer'
 import { MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import * as Words from '@/libs/funny-name/words'
 import {
@@ -216,10 +216,11 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
    * Reset saved profiles to original state
    */
   function resetSavedProfiles(): void {
+    localStorage.setItem(resetJustMadeKey, 'true')
     savedProfiles.value = widgetProfiles
     currentProfileIndex.value = 0
     currentViewIndex.value = 0
-    reloadCockpit(5000)
+    reloadCockpit(3000)
   }
 
   const exportProfile = (profile: Profile): void => {

--- a/src/stores/widgetManager.ts
+++ b/src/stores/widgetManager.ts
@@ -219,7 +219,7 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
     savedProfiles.value = widgetProfiles
     currentProfileIndex.value = 0
     currentViewIndex.value = 0
-    reloadCockpit()
+    reloadCockpit(5000)
   }
 
   const exportProfile = (profile: Profile): void => {


### PR DESCRIPTION
This solves the problem of someone resetting the widgets profiles and receiving a conflict in the next reload.