### PR TITLE
Cockpit should have a permanent link to the video library

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -198,6 +198,7 @@
         <GlassModal
           :is-visible="currentConfigMenuComponent !== null && mainMenuStep !== 1"
           position="menuitem"
+          :class="interfaceStore.isVideoLibraryVisible ? 'opacity-0' : 'opacity-100'"
           @close-modal="currentConfigMenuComponent = null"
         >
           <component :is="currentConfigMenuComponent"></component>
@@ -286,6 +287,7 @@
     </v-main>
   </v-app>
   <About v-if="showAboutDialog" @update:show-about-dialog="showAboutDialog = $event" />
+  <VideoLibraryModal :open-modal="interfaceStore.isVideoLibraryVisible" />
 </template>
 
 <script setup lang="ts">
@@ -294,6 +296,7 @@ import { computed, DefineComponent, markRaw, onBeforeUnmount, onMounted, ref, wa
 import { useRoute } from 'vue-router'
 
 import GlassModal from '@/components/GlassModal.vue'
+import VideoLibraryModal from '@/components/VideoLibraryModal.vue'
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import {
   availableCockpitActions,

--- a/src/components/VideoLibraryModal.vue
+++ b/src/components/VideoLibraryModal.vue
@@ -591,6 +591,7 @@ const closeModal = (): void => {
   deselectAllVideos()
   lastSelectedVideo.value = null
   isMultipleSelectionMode.value = false
+  interfaceStore.setVideoLibraryVisibility(false)
 }
 
 // Extracts a date or any string enclosed within parentheses from a given title string
@@ -978,6 +979,7 @@ watch(isVisible, (newValue) => {
     isMultipleSelectionMode.value = false
     lastSelectedVideo.value = null
     showOnScreenProgress.value = false
+    interfaceStore.setVideoLibraryVisibility(false)
   }
 })
 
@@ -1104,6 +1106,7 @@ onBeforeUnmount(() => {
   Object.values(hammerInstances.value).forEach((instance) => {
     instance.destroy()
   })
+  interfaceStore.setVideoLibraryVisibility(false)
 })
 </script>
 

--- a/src/components/mini-widgets/MiniVideoRecorder.vue
+++ b/src/components/mini-widgets/MiniVideoRecorder.vue
@@ -1,8 +1,7 @@
 <template>
   <div
     ref="recorderWidget"
-    class="flex justify-around px-2 py-1 text-center rounded-lg h-9 align-center bg-slate-800/60"
-    :class="{ 'w-48': numberOfVideosOnDB > 0, 'w-32': numberOfVideosOnDB <= 0 }"
+    class="flex justify-around px-2 py-1 text-center rounded-lg w-40 h-9 align-center bg-slate-800/60"
   >
     <div
       v-if="!isProcessingVideo"
@@ -32,18 +31,16 @@
     <div v-else-if="isProcessingVideo" class="w-16 text-justify text-slate-100">
       <div class="text-xs text-center text-white select-none flex-nowrap">Processing video...</div>
     </div>
-    <div v-if="numberOfVideosOnDB > 0" class="flex justify-center w-8">
-      <v-divider vertical class="h-6" />
+    <div class="flex justify-center w-6">
+      <v-divider vertical class="h-6 ml-1" />
       <v-badge
         color="info"
         :content="numberOfVideosOnDB"
         :dot="isOutside || isVideoLibraryDialogOpen"
         class="cursor-pointer"
-        @click="isVideoLibraryDialogOpen = true"
+        @click="openVideoLibraryModal"
       >
-        <v-icon class="w-6 h-6 ml-3 text-slate-100" @click="isVideoLibraryDialogOpen = true">
-          mdi-video-box
-        </v-icon></v-badge
+        <v-icon class="w-6 h-6 ml-1 text-slate-100" @click="openVideoLibraryModal"> mdi-video-box </v-icon></v-badge
       >
     </div>
   </div>
@@ -88,7 +85,6 @@
       </div>
     </div>
   </v-dialog>
-  <VideoLibrary :open-modal="isVideoLibraryDialogOpen" @update:open-modal="handleModalUpdate" />
 </template>
 
 <script setup lang="ts">
@@ -103,8 +99,6 @@ import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useVideoStore } from '@/stores/video'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
 import type { MiniWidget } from '@/types/widgets'
-
-import VideoLibrary from '../VideoLibraryModal.vue'
 
 const { showDialog } = useInteractionDialog()
 const interfaceStore = useAppInterfaceStore()
@@ -134,6 +128,10 @@ const externalStreamId = computed(() => {
   return nameSelectedStream.value ? videoStore.externalStreamId(nameSelectedStream.value) : undefined
 })
 
+const openVideoLibraryModal = (): void => {
+  interfaceStore.setVideoLibraryVisibility(true)
+}
+
 watch(
   () => videoStore.streamsCorrespondency,
   () => (mediaStream.value = undefined),
@@ -141,7 +139,7 @@ watch(
 )
 
 onMounted(async () => {
-  await fetchNumebrOfTempVideos()
+  await fetchNumberOfTempVideos()
 })
 
 onBeforeMount(async () => {
@@ -159,12 +157,8 @@ watch(nameSelectedStream, () => {
   mediaStream.value = undefined
 })
 
-const handleModalUpdate = (newVal: boolean): void => {
-  isVideoLibraryDialogOpen.value = newVal
-}
-
 // Fetch number of temporary videos on storage
-const fetchNumebrOfTempVideos = async (): Promise<void> => {
+const fetchNumberOfTempVideos = async (): Promise<void> => {
   const nProcessedVideos = (await videoStore.videoStoringDB.keys()).filter((k) => videoStore.isVideoFilename(k)).length
   const nFailedUnprocessedVideos = Object.keys(videoStore.keysFailedUnprocessedVideos).length
   numberOfVideosOnDB.value = nProcessedVideos + nFailedUnprocessedVideos
@@ -288,20 +282,20 @@ watch(
   () => videoStore.areThereVideosProcessing,
   (newValue) => {
     isProcessingVideo.value = newValue
-    fetchNumebrOfTempVideos()
+    fetchNumberOfTempVideos()
   }
 )
 
 watch(
   () => videoStore.keysFailedUnprocessedVideos,
-  () => fetchNumebrOfTempVideos()
+  () => fetchNumberOfTempVideos()
 )
 
 watch(
   () => isVideoLibraryDialogOpen.value,
   async (newValue) => {
     if (newValue === false) {
-      await fetchNumebrOfTempVideos()
+      await fetchNumberOfTempVideos()
     }
   }
 )

--- a/src/stores/appInterface.ts
+++ b/src/stores/appInterface.ts
@@ -12,6 +12,7 @@ export const useAppInterfaceStore = defineStore('responsive', {
     width: windowWidth.value,
     height: windowHeight.value,
     configModalVisibility: false,
+    videoLibraryVisibility: false,
     UIGlassEffect: useBlueOsStorage('cockpit-ui-glass-effect', {
       opacity: 0.8,
       bgColor: '#4F4F4F1A',
@@ -24,6 +25,9 @@ export const useAppInterfaceStore = defineStore('responsive', {
   actions: {
     updateWidth() {
       this.width = windowWidth.value
+    },
+    setVideoLibraryVisibility(value: boolean) {
+      this.videoLibraryVisibility = value
     },
     setConfigModalVisibility(value: boolean) {
       this.configModalVisibility = value
@@ -71,6 +75,7 @@ export const useAppInterfaceStore = defineStore('responsive', {
       return 130
     },
     isConfigModalVisible: (state) => state.configModalVisibility,
+    isVideoLibraryVisible: (state) => state.videoLibraryVisibility,
     getUIGlassEffect: (state) => {
       state.UIGlassEffect
     },

--- a/src/views/ConfigurationVideoView.vue
+++ b/src/views/ConfigurationVideoView.vue
@@ -148,7 +148,7 @@
           <template #title>Video library options:</template>
           <template #info>
             <li>
-              CHoose to process videos manual or automatically after recorfing ends. In some low end hardware systems
+              Choose to process videos manual or automatically after recording ends. In some low end hardware systems
               and for long durations videos, auto-processing could take some time.
             </li>
             <li>
@@ -159,13 +159,24 @@
             </li>
           </template>
           <template #content>
-            <div class="flex items-center justify-start w-[50%] ml-2">
+            <div class="flex items-center justify-between w-[96%] ml-2">
               <v-checkbox
                 v-model="videoStore.autoProcessVideos"
                 label="Auto process videos"
                 class="text-sm mx-2"
                 hide-details
               />
+              <v-btn variant="flat" class="bg-[#FFFFFF22] px-3 elevation-1" @click="openVideoLibrary">
+                <template #append>
+                  <v-divider vertical></v-divider>
+                  <v-badge color="info" dot class="cursor-pointer" @click="openVideoLibrary">
+                    <v-icon class="w-6 h-6 ml-1 text-slate-100" @click="openVideoLibrary">
+                      mdi-video-box
+                    </v-icon></v-badge
+                  >
+                </template>
+                Video Library
+              </v-btn>
             </div>
             <div class="flex items-center justify-start w-[50%] ml-2">
               <v-checkbox
@@ -206,6 +217,10 @@ onMounted(() => {
     allowedIceProtocols.value = availableICEProtocols
   }
 })
+
+const openVideoLibrary = (): void => {
+  interfaceStore.setVideoLibraryVisibility(true)
+}
 
 /**
  * Handles the input for setting the jitter buffer target


### PR DESCRIPTION
From a @ES-Alexander and Kurt discussion, was decided that we should provide a permanent link to the Video Library, even if there is no file stored there.
Anyway, soon the video storage on BlueOS cloud will be implemented and we would have to provide this permanent link.

On the image, (1) and (2) are permanent links.
![image](https://github.com/user-attachments/assets/c5823710-c9e4-4864-a9d0-9330cf1cc8f9)
