### PR TITLE
libs: joystick: improve "button slots full" error

### DIFF
--- a/src/libs/joystick/protocols/mavlink-manual-control.ts
+++ b/src/libs/joystick/protocols/mavlink-manual-control.ts
@@ -607,8 +607,8 @@ export class MavlinkManualControlManager {
       if (buttonAction === undefined) return
       showDialog({
         maxWidth: 600,
-        message: `There are no spots left in the vehicle for the MAVLink Manual Control function ${actionId}.
-        Consider mapping this function to a shift button.`,
+        message: `The autopilot's MAVLink Manual Control button slots are full - the ${actionId} function cannot be assigned.
+        Consider mapping it to a "shift"ed slot instead, or unmapping an unused autopilot button function first.`,
         variant: 'error',
         timer: 6000,
       })
@@ -620,8 +620,8 @@ export class MavlinkManualControlManager {
       if (buttonAction === undefined) return
       showDialog({
         maxWidth: 600,
-        message: `There are no spots left in the vehicle for the MAVLink Manual Control function ${actionId}.
-        Consider mapping this function to a shift button.`,
+        message: `The autopilot's MAVLink Manual Control button slots are full - the ${actionId} function cannot be assigned.
+        Consider mapping it to a "shift"ed slot instead, or unmapping an unused autopilot button function first.`,
         variant: 'error',
         timer: 6000,
       })


### PR DESCRIPTION
Reduced ambiguity about what is wrong, and what to do about it.

Original message was a source of confusion [in this forum post](https://discuss.bluerobotics.com/t/message-while-assigning-servo-function-to-controller-button/17990).

It would be nice if we could also recommend updating firmware where that's a viable solution, but that would require a dynamic check, and I believe there's already a message about it at the top of the joysticks page for users with a firmware that doesn't support the extended MAVLink Manual Control protocol (and the extra button slots it provides)