### PR TITLE
Components: Tutorial: Make highlights more visible - color and duration

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -184,8 +184,8 @@
                   :icon-size="buttonSize * 0.5"
                   :style="
                     interfaceStore.highlightedComponent === menuitem.title && {
-                      animation: 'highlightBackground 0.5s alternate 20',
-                      borderRadius: '8px',
+                      animation: 'highlightBackground 0.5s alternate 50',
+                      borderRadius: '4px',
                     }
                   "
                   @click="toggleConfigComponent(menuitem.component)"

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -63,6 +63,6 @@ select:focus {
 }
 
 @keyframes highlightBackground {
-    0% { background-color: rgba(59, 120, 168, 0.4); }
+    0% { background-color: rgba(255, 234, 43, 0.438); }
     100% { background-color: transparent; }
   }


### PR DESCRIPTION
* Changed the highlight color to 'bight yellow'
* Changed the highlight duration from 20 to 50 seconds

![image](https://github.com/user-attachments/assets/e3a47d89-bbc1-4d10-8529-94c66395a0c5)

Fix #1335 