### PR TITLE
Save videos directly to the filesystem (electron-only)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -5,6 +5,7 @@ import { join } from 'path'
 import { setupAutoUpdater } from './services/auto-update'
 import store from './services/config-store'
 import { setupNetworkService } from './services/network'
+import { setupFilesystemStorage } from './services/storage'
 
 // If the app is packaged, push logs to the system instead of the console
 if (app.isPackaged) {
@@ -71,6 +72,7 @@ protocol.registerSchemesAsPrivileged([
   },
 ])
 
+setupFilesystemStorage()
 setupNetworkService()
 
 app.whenReady().then(async () => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -31,4 +31,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
   keys: async (subFolders?: string[]) => {
     return await ipcRenderer.invoke('keys', { subFolders })
   },
+  openCockpitFolder: () => ipcRenderer.invoke('open-cockpit-folder'),
+  openVideoFolder: () => ipcRenderer.invoke('open-video-folder'),
 })

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -14,4 +14,21 @@ contextBridge.exposeInMainWorld('electronAPI', {
   downloadUpdate: () => ipcRenderer.send('download-update'),
   installUpdate: () => ipcRenderer.send('install-update'),
   cancelUpdate: () => ipcRenderer.send('cancel-update'),
+  setItem: async (key: string, value: Blob, subFolders?: string[]) => {
+    const arrayBuffer = await value.arrayBuffer()
+    await ipcRenderer.invoke('setItem', { key, value: new Uint8Array(arrayBuffer), subFolders })
+  },
+  getItem: async (key: string, subFolders?: string[]) => {
+    const arrayBuffer = await ipcRenderer.invoke('getItem', { key, subFolders })
+    return arrayBuffer ? new Blob([arrayBuffer]) : null
+  },
+  removeItem: async (key: string, subFolders?: string[]) => {
+    await ipcRenderer.invoke('removeItem', { key, subFolders })
+  },
+  clear: async (subFolders?: string[]) => {
+    await ipcRenderer.invoke('clear', { subFolders })
+  },
+  keys: async (subFolders?: string[]) => {
+    return await ipcRenderer.invoke('keys', { subFolders })
+  },
 })

--- a/electron/services/storage.ts
+++ b/electron/services/storage.ts
@@ -1,10 +1,10 @@
-import { ipcMain } from 'electron'
+import { ipcMain, shell } from 'electron'
 import { app } from 'electron'
 import * as fs from 'fs/promises'
 import { dirname, join } from 'path'
 
 // Create a new storage interface for filesystem
-const cockpitFolderPath = join(app.getPath('home'), 'Cockpit')
+export const cockpitFolderPath = join(app.getPath('home'), 'Cockpit')
 fs.mkdir(cockpitFolderPath, { recursive: true })
 
 export const filesystemStorage = {
@@ -57,5 +57,14 @@ export const setupFilesystemStorage = (): void => {
   })
   ipcMain.handle('keys', async (_, data) => {
     return await filesystemStorage.keys(data.subFolders)
+  })
+  ipcMain.handle('open-cockpit-folder', async () => {
+    await fs.mkdir(cockpitFolderPath, { recursive: true })
+    await shell.openPath(cockpitFolderPath)
+  })
+  ipcMain.handle('open-video-folder', async () => {
+    const videoFolderPath = join(cockpitFolderPath, 'videos')
+    await fs.mkdir(videoFolderPath, { recursive: true })
+    await shell.openPath(videoFolderPath)
   })
 }

--- a/electron/services/storage.ts
+++ b/electron/services/storage.ts
@@ -1,0 +1,61 @@
+import { ipcMain } from 'electron'
+import { app } from 'electron'
+import * as fs from 'fs/promises'
+import { dirname, join } from 'path'
+
+// Create a new storage interface for filesystem
+const cockpitFolderPath = join(app.getPath('home'), 'Cockpit')
+fs.mkdir(cockpitFolderPath, { recursive: true })
+
+export const filesystemStorage = {
+  async setItem(key: string, value: ArrayBuffer, subFolders?: string[]): Promise<void> {
+    const buffer = Buffer.from(value)
+    const filePath = join(cockpitFolderPath, ...(subFolders ?? []), key)
+    await fs.mkdir(dirname(filePath), { recursive: true })
+    await fs.writeFile(filePath, buffer)
+  },
+  async getItem(key: string, subFolders?: string[]): Promise<ArrayBuffer | null> {
+    const filePath = join(cockpitFolderPath, ...(subFolders ?? []), key)
+    try {
+      return await fs.readFile(filePath)
+    } catch (error) {
+      if (error.code === 'ENOENT') return null
+      throw error
+    }
+  },
+  async removeItem(key: string, subFolders?: string[]): Promise<void> {
+    const filePath = join(cockpitFolderPath, ...(subFolders ?? []), key)
+    await fs.unlink(filePath)
+  },
+  async clear(subFolders?: string[]): Promise<void> {
+    const dirPath = join(cockpitFolderPath, ...(subFolders ?? []))
+    await fs.rm(dirPath, { recursive: true })
+  },
+  async keys(subFolders?: string[]): Promise<string[]> {
+    const dirPath = join(cockpitFolderPath, ...(subFolders ?? []))
+    try {
+      return await fs.readdir(dirPath)
+    } catch (error) {
+      if (error.code === 'ENOENT') return []
+      throw error
+    }
+  },
+}
+
+export const setupFilesystemStorage = (): void => {
+  ipcMain.handle('setItem', async (_, data) => {
+    await filesystemStorage.setItem(data.key, data.value, data.subFolders)
+  })
+  ipcMain.handle('getItem', async (_, data) => {
+    return await filesystemStorage.getItem(data.key, data.subFolders)
+  })
+  ipcMain.handle('removeItem', async (_, data) => {
+    await filesystemStorage.removeItem(data.key, data.subFolders)
+  })
+  ipcMain.handle('clear', async (_, data) => {
+    await filesystemStorage.clear(data.subFolders)
+  })
+  ipcMain.handle('keys', async (_, data) => {
+    return await filesystemStorage.keys(data.subFolders)
+  })
+}

--- a/src/components/VideoLibraryModal.vue
+++ b/src/components/VideoLibraryModal.vue
@@ -889,11 +889,12 @@ const fetchVideosAndLogData = async (): Promise<void> => {
   const logFileOperations: Promise<VideoLibraryLogFile>[] = []
 
   // Fetch processed videos and logs
-  await videoStore.videoStoringDB.iterate((value, key) => {
+  const keys = await videoStore.videoStorage.keys()
+  for (const key of keys) {
     if (videoStore.isVideoFilename(key)) {
       videoFilesOperations.push(
         (async () => {
-          const videoBlob = await videoStore.videoStoringDB.getItem<Blob>(key)
+          const videoBlob = await videoStore.videoStorage.getItem(key)
           let url = ''
           let isProcessed = true
           if (videoBlob instanceof Blob) {
@@ -910,7 +911,7 @@ const fetchVideosAndLogData = async (): Promise<void> => {
     if (key.endsWith('.ass')) {
       logFileOperations.push(
         (async () => {
-          const videoBlob = await videoStore.videoStoringDB.getItem<Blob>(key)
+          const videoBlob = await videoStore.videoStorage.getItem(key)
           let url = ''
           if (videoBlob instanceof Blob) {
             url = URL.createObjectURL(videoBlob)
@@ -923,7 +924,7 @@ const fetchVideosAndLogData = async (): Promise<void> => {
         })()
       )
     }
-  })
+  }
 
   // Fetch unprocessed videos
   const unprocessedVideos = await videoStore.unprocessedVideos

--- a/src/components/VideoLibraryModal.vue
+++ b/src/components/VideoLibraryModal.vue
@@ -484,6 +484,7 @@ import { ref, watch } from 'vue'
 
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { useSnackbar } from '@/composables/snackbar'
+import { isElectron } from '@/libs/utils'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useVideoStore } from '@/stores/video'
 import { DialogActions } from '@/types/general'
@@ -580,7 +581,30 @@ const fileActionButtons = computed(() => [
     disabled: showOnScreenProgress.value === true || isPreparingDownload.value === true,
     action: () => downloadVideoAndTelemetryFiles(),
   },
+  {
+    name: 'Open Folder',
+    icon: 'mdi-folder-outline',
+    size: 28,
+    tooltip: 'Open videos folder',
+    confirmAction: false,
+    show: isElectron(),
+    disabled: false,
+    action: () => openVideoFolder(),
+  },
 ])
+
+const openVideoFolder = (): void => {
+  if (isElectron() && window.electronAPI) {
+    window.electronAPI?.openVideoFolder()
+  } else {
+    showSnackbar({
+      message: 'This feature is only available in the desktop version of Cockpit.',
+      duration: 3000,
+      variant: 'error',
+      closeButton: true,
+    })
+  }
+}
 
 const closeModal = (): void => {
   isVisible.value = false

--- a/src/components/mini-widgets/MiniVideoRecorder.vue
+++ b/src/components/mini-widgets/MiniVideoRecorder.vue
@@ -188,7 +188,8 @@ watch(nameSelectedStream, (newName) => {
 
 // Fetch number of temporary videos on storage
 const fetchNumberOfTempVideos = async (): Promise<void> => {
-  const nProcessedVideos = (await videoStore.videoStoringDB.keys()).filter((k) => videoStore.isVideoFilename(k)).length
+  const keys = await videoStore.videoStorage.keys()
+  const nProcessedVideos = keys.filter((k) => videoStore.isVideoFilename(k)).length
   const nFailedUnprocessedVideos = Object.keys(videoStore.keysFailedUnprocessedVideos).length
   numberOfVideosOnDB.value = nProcessedVideos + nFailedUnprocessedVideos
 }

--- a/src/libs/cosmos.ts
+++ b/src/libs/cosmos.ts
@@ -224,6 +224,14 @@ declare global {
        * Register callback for download progress event
        */
       onDownloadProgress: (callback: (info: any) => void) => void
+      /**
+       * Open cockpit folder
+       */
+      openCockpitFolder: () => void
+      /**
+       * Open video folder
+       */
+      openVideoFolder: () => void
     }
   }
 }

--- a/src/libs/cosmos.ts
+++ b/src/libs/cosmos.ts
@@ -1,5 +1,6 @@
 import { isBrowser } from 'browser-or-node'
 
+import { ElectronStorageDB } from '@/types/general'
 import { NetworkInfo } from '@/types/network'
 
 import {
@@ -185,7 +186,7 @@ declare global {
     /**
      * Electron API exposed through preload script
      */
-    electronAPI?: {
+    electronAPI?: ElectronStorageDB & {
       /**
        * Get network information from the main process
        * @returns Promise containing subnet information

--- a/src/libs/videoStorage.ts
+++ b/src/libs/videoStorage.ts
@@ -1,0 +1,127 @@
+import localforage from 'localforage'
+
+import type { ElectronStorageDB, StorageDB } from '@/types/general'
+
+import { isElectron } from './utils'
+
+const throwIfNotElectron = (): void => {
+  if (!isElectron()) {
+    console.warn('Filesystem storage is only available in Electron.')
+    return
+  }
+  if (!window.electronAPI) {
+    console.error('electronAPI is not available on window object')
+    console.debug('Available window properties:', Object.keys(window))
+    throw new Error('Electron filesystem API is not properly initialized. This is likely a setup issue.')
+  }
+}
+
+/**
+ * Electron storage implementation.
+ * Uses the exposed IPC renderer API to store and retrieve data in the filesystem.
+ */
+class ElectronStorage implements ElectronStorageDB {
+  subFolders: string[]
+  electronAPI: ElectronStorageDB
+
+  /**
+   * Creates a new instance of the ElectronStorage class.
+   * @param {string[]} subFolders - The subfolders to store the data in.
+   */
+  constructor(subFolders: string[]) {
+    throwIfNotElectron()
+
+    this.subFolders = subFolders
+    this.electronAPI = window.electronAPI as StorageDB
+  }
+
+  setItem = async (key: string, value: Blob): Promise<void> => {
+    throwIfNotElectron()
+    await this.electronAPI.setItem(key, value, this.subFolders)
+  }
+
+  getItem = async (key: string): Promise<Blob | null | undefined> => {
+    throwIfNotElectron()
+    return await this.electronAPI.getItem(key, this.subFolders)
+  }
+
+  removeItem = async (key: string): Promise<void> => {
+    throwIfNotElectron()
+    await this.electronAPI.removeItem(key, this.subFolders)
+  }
+
+  clear = async (): Promise<void> => {
+    throwIfNotElectron()
+    await this.electronAPI.clear(this.subFolders)
+  }
+
+  keys = async (): Promise<string[]> => {
+    throwIfNotElectron()
+    return await this.electronAPI.keys(this.subFolders)
+  }
+}
+
+/**
+ * LocalForage storage implementation.
+ * Uses the localforage library to store and retrieve data in the IndexedDB.
+ */
+class LocalForageStorage implements StorageDB {
+  localForage: LocalForage
+
+  /**
+   * Creates a new instance of the LocalForageStorage class.
+   * @param {string} name - The name of the localforage instance.
+   * @param {string} storeName - The name of the store to store the data in.
+   * @param {number} version - The version of the localforage instance.
+   * @param {string} description - The description of the localforage instance.
+   */
+  constructor(name: string, storeName: string, version: number, description: string) {
+    this.localForage = localforage.createInstance({
+      driver: localforage.INDEXEDDB,
+      name: name,
+      storeName: storeName,
+      version: version,
+      description: description,
+    })
+  }
+
+  setItem = async (key: string, value: Blob): Promise<void> => {
+    await this.localForage.setItem(key, value)
+  }
+
+  getItem = async (key: string): Promise<Blob | null | undefined> => {
+    return await this.localForage.getItem(key)
+  }
+
+  removeItem = async (key: string): Promise<void> => {
+    await this.localForage.removeItem(key)
+  }
+
+  clear = async (): Promise<void> => {
+    await this.localForage.clear()
+  }
+
+  keys = async (): Promise<string[]> => {
+    return await this.localForage.keys()
+  }
+}
+
+const tempVideoChunksIndexdedDB: StorageDB = new LocalForageStorage(
+  'Cockpit - Temporary Video',
+  'cockpit-temp-video-db',
+  1.0,
+  'Database for storing the chunks of an ongoing recording, to be merged afterwards.'
+)
+
+const videoStoringIndexedDB: StorageDB = new LocalForageStorage(
+  'Cockpit - Video Recovery',
+  'cockpit-video-recovery-db',
+  1.0,
+  'Cockpit video recordings and their corresponding telemetry subtitles.'
+)
+
+const electronVideoStorage = new ElectronStorage(['videos'])
+const temporaryElectronVideoStorage = new ElectronStorage(['videos', 'temporary-video-chunks'])
+
+export const videoStorage = isElectron() ? electronVideoStorage : videoStoringIndexedDB
+export const tempVideoStorage = isElectron() ? temporaryElectronVideoStorage : tempVideoChunksIndexdedDB

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -639,7 +639,7 @@ export const useVideoStore = defineStore('video', () => {
       updateLastProcessingUpdate(hash)
 
       debouncedUpdateFileProgress(info.fileName, 75, `Saving video file.`)
-      await videoStoringDB.setItem(`${info.fileName}.${extensionContainer || '.webm'}`, durFixedBlob ?? mergedBlob)
+      await videoStoringDB.setItem(`${info.fileName}.${extensionContainer || 'webm'}`, durFixedBlob ?? mergedBlob)
 
       updateLastProcessingUpdate(hash)
 

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -21,10 +21,10 @@ import { isEqual, sleep } from '@/libs/utils'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useMissionStore } from '@/stores/mission'
 import { Alert, AlertLevel } from '@/types/alert'
+import { StorageDB } from '@/types/general'
 import {
   type DownloadProgressCallback,
   type FileDescriptor,
-  type StorageDB,
   type StreamData,
   type UnprocessedVideoInfo,
   type VideoProcessingDetails,

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -33,3 +33,34 @@ export interface DialogActions {
 }
 
 export type ConfigComponent = DefineComponent<Record<string, never>, Record<string, never>, unknown> | null
+
+export interface StorageDB {
+  getItem: (key: string) => Promise<Blob | null | undefined>
+  setItem: (key: string, value: Blob) => Promise<void>
+  removeItem: (key: string) => Promise<void>
+  clear: () => Promise<void>
+  keys: () => Promise<string[]>
+}
+
+export interface ElectronStorageDB {
+  /**
+   * Set an item in the filesystem storage
+   */
+  setItem: (key: string, value: Blob, subFolders?: string[]) => Promise<void>
+  /**
+   * Get an item from the filesystem storage
+   */
+  getItem: (key: string, subFolders?: string[]) => Promise<Blob | null | undefined>
+  /**
+   * Remove an item from the filesystem storage
+   */
+  removeItem: (key: string, subFolders?: string[]) => Promise<void>
+  /**
+   * Clear the filesystem storage
+   */
+  clear: (subFolders?: string[]) => Promise<void>
+  /**
+   * Get all keys from the filesystem storage
+   */
+  keys: (subFolders?: string[]) => Promise<string[]>
+}

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -108,10 +108,6 @@ export interface FileDescriptor {
   filename: string
 }
 
-export interface StorageDB {
-  getItem: (key: string) => Promise<Blob | null | undefined>
-}
-
 export type DownloadProgressCallback = (progress: number, total: number) => Promise<void>
 
 export enum VideoExtensionContainer {

--- a/src/views/ConfigurationGeneralView.vue
+++ b/src/views/ConfigurationGeneralView.vue
@@ -32,9 +32,20 @@
                   @click="missionStore.changeUsername"
                 />
               </div>
-              <v-btn size="x-small" class="bg-[#FFFFFF22] -mt-3 mb-4 shadow-2" variant="flat" @click="openTutorial">
-                Show tutorial
-              </v-btn>
+              <div class="flex flex-row">
+                <v-btn size="x-small" class="bg-[#FFFFFF22] -mt-3 mb-4 shadow-2" variant="flat" @click="openTutorial">
+                  Show tutorial
+                </v-btn>
+                <v-btn
+                  v-if="isElectron()"
+                  size="x-small"
+                  class="bg-[#FFFFFF22] -mt-3 mb-4 ml-2 shadow-2"
+                  variant="flat"
+                  @click="openCockpitFolder"
+                >
+                  Open Cockpit folder
+                </v-btn>
+              </div>
             </div>
           </template>
         </ExpansiblePanel>
@@ -292,6 +303,7 @@ import { onMounted, ref, watch } from 'vue'
 import { defaultGlobalAddress } from '@/assets/defaults'
 import ExpansiblePanel from '@/components/ExpansiblePanel.vue'
 import VehicleDiscoveryDialog from '@/components/VehicleDiscoveryDialog.vue'
+import { useSnackbar } from '@/composables/snackbar'
 import * as Connection from '@/libs/connection/connection'
 import { ConnectionManager } from '@/libs/connection/connection-manager'
 import { isValidNetworkAddress, reloadCockpit } from '@/libs/utils'
@@ -306,6 +318,7 @@ import BaseConfigurationView from './BaseConfigurationView.vue'
 const mainVehicleStore = useMainVehicleStore()
 const interfaceStore = useAppInterfaceStore()
 const missionStore = useMissionStore()
+const { showSnackbar } = useSnackbar()
 
 const globalAddressForm = ref()
 const globalAddressFormValid = ref(false)
@@ -517,6 +530,19 @@ onMounted(() => {
 })
 
 const showDiscoveryDialog = ref(false)
+
+const openCockpitFolder = (): void => {
+  if (isElectron() && window.electronAPI) {
+    window.electronAPI?.openCockpitFolder()
+  } else {
+    showSnackbar({
+      message: 'This feature is only available in the desktop version of Cockpit.',
+      duration: 3000,
+      variant: 'error',
+      closeButton: true,
+    })
+  }
+}
 </script>
 <style scoped>
 .uri-input {


### PR DESCRIPTION
This PR changes the behavior of the Electron-based application.

Instead of saving the video chunks, video files and telemetry logs to the IndexedDB, we now save them directly to the filesystem.

The main advantage for the user is that it stops risking losing videos on a browser cache cleanup, which was the main cause of video loss. As a side-effect, the user has also the video files directly on their machine, without the need to download them, keeping everything always organized and in sync.

https://github.com/user-attachments/assets/130f10f4-1915-4f1b-8996-f6caa8bfb25d

The implementation is done over the renderer/main IPC system, so we don't leave unnecessary filesystem permissions for the client, making everything safe.

Fix #1292.