### PR TITLE
register_service: add google stun

### DIFF
--- a/public/register_service
+++ b/public/register_service
@@ -6,5 +6,6 @@
     "version": "0.0.0",
     "new_page": true,
     "webpage": "https://github.com/bluerobotics/BlueOS-docker",
-    "api": "https://github.com/bluerobotics/BlueOS-docker"
+    "api": "https://github.com/bluerobotics/BlueOS-docker",
+    "extra_query": "webRTCConfiguration={\"iceServers\":[{\"urls\":\"stun:stun.l.google.com:19302\"}]}"
 }


### PR DESCRIPTION
Also a follow-up to https://github.com/bluerobotics/BlueOS/pull/2815

We might want to do some testing, but the candidate whitelist should make stun a non-issue