### PR TITLE
Add instantaneous power and total power consumption

### DIFF
--- a/src/components/mini-widgets/BatteryIndicator.vue
+++ b/src/components/mini-widgets/BatteryIndicator.vue
@@ -1,30 +1,83 @@
 <template>
-  <div
-    v-tooltip="'Your vehicle does not provide state-of-charge. Displaying voltage and current instead.'"
-    class="flex items-center w-[5.5rem] h-12 text-white justify-center"
-  >
+  <div v-tooltip="'Battery information'" class="flex items-center w-[5.5rem] h-12 text-white justify-center">
     <span class="relative w-[1.5rem] mdi battery-icon" :class="[batteryIconClass]">
       <span class="absolute text-sm text-yellow-400 -bottom-[2px] -right-[7px] mdi mdi-alert-circle"></span>
     </span>
     <div class="flex flex-col w-[4rem] select-none text-sm font-semibold leading-4 text-end">
-      <div class="w-full">
-        <span class="font-mono">{{ voltageDisplayValue }}</span>
-        <span> V</span>
-      </div>
-      <div class="w-full">
-        <span class="font-mono">{{ currentDisplayValue }}</span>
-        <span> A</span>
-      </div>
+      <template v-if="showVoltageAndCurrent">
+        <div class="w-full">
+          <span class="font-mono">{{ voltageDisplayValue }}</span>
+          <span> V</span>
+        </div>
+        <div class="w-full">
+          <span class="font-mono">{{ currentDisplayValue }}</span>
+          <span> A</span>
+        </div>
+      </template>
+      <template v-else>
+        <div class="w-full">
+          <span class="font-mono">{{ instantaneousWattsDisplayValue }}</span>
+          <span> W</span>
+        </div>
+        <div class="w-full">
+          <span class="font-mono">{{ totalConsumedWattsDisplayValue }}</span>
+          <span> Wh</span>
+        </div>
+      </template>
     </div>
   </div>
+  <v-dialog v-model="widgetStore.miniWidgetManagerVars(miniWidget.hash).configMenuOpen" width="auto">
+    <v-card class="pa-4 text-white" style="border-radius: 15px" :style="interfaceStore.globalGlassMenuStyles">
+      <v-card-title class="text-center">Battery Indicator Config</v-card-title>
+      <v-card-text class="flex flex-col gap-y-4">
+        <v-checkbox v-model="miniWidget.options.showVoltageAndCurrent" label="Show Voltage and Current" hide-details />
+        <v-checkbox
+          v-model="miniWidget.options.showPowerAndConsumption"
+          label="Show Power and Consumption"
+          hide-details
+        />
+        <v-text-field
+          v-if="miniWidget.options.showVoltageAndCurrent && miniWidget.options.showPowerAndConsumption"
+          v-model.number="miniWidget.options.toggleInterval"
+          label="Toggle Interval (ms)"
+          type="number"
+          min="1000"
+          step="100"
+          density="compact"
+          variant="outlined"
+          hide-details
+        />
+      </v-card-text>
+    </v-card>
+  </v-dialog>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, onBeforeMount, onUnmounted, ref, toRefs, watch } from 'vue'
 
+import { datalogger, DatalogVariable } from '@/libs/sensors-logging'
+import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
+import { useWidgetManagerStore } from '@/stores/widgetManager'
+import type { MiniWidget } from '@/types/widgets'
+
+/**
+ * Props for the BatteryIndicator component
+ */
+const props = defineProps<{
+  /**
+   * Configuration of the widget
+   */
+  miniWidget: MiniWidget
+}>()
+const miniWidget = toRefs(props).miniWidget
 
 const store = useMainVehicleStore()
+const widgetStore = useWidgetManagerStore()
+const interfaceStore = useAppInterfaceStore()
+
+const showVoltageAndCurrent = ref(true)
+const toggleIntervaler = ref<ReturnType<typeof setInterval> | undefined>(undefined)
 
 const voltageDisplayValue = computed(() => {
   if (store?.powerSupply?.voltage === undefined) return NaN
@@ -40,10 +93,54 @@ const currentDisplayValue = computed(() => {
     : store.powerSupply.current.toFixed(1)
 })
 
-// TODO: With a proper percentage model in hand, we should use different icons for each battery level.
-// TODO: We can also allow the user to set it's 100% and 0% voltages and use a linear fit accordingly
+const instantaneousWattsDisplayValue = computed(() => {
+  return store.instantaneousWatts ? store.instantaneousWatts.toFixed(1) : NaN
+})
+
+const totalConsumedWattsDisplayValue = computed(() => {
+  return store.totalConsumedWatts.toFixed(1)
+})
+
 const batteryIconClass = computed(() => {
   return 'mdi-battery'
+})
+
+const setupToggleInterval = (): void => {
+  if (toggleIntervaler.value) {
+    clearInterval(toggleIntervaler.value)
+  }
+
+  if (miniWidget.value.options.showVoltageAndCurrent && miniWidget.value.options.showPowerAndConsumption) {
+    toggleIntervaler.value = setInterval(() => {
+      showVoltageAndCurrent.value = !showVoltageAndCurrent.value
+    }, miniWidget.value.options.toggleInterval)
+  } else {
+    showVoltageAndCurrent.value = miniWidget.value.options.showVoltageAndCurrent
+  }
+}
+
+watch(() => miniWidget.value.options, setupToggleInterval, { deep: true })
+
+onBeforeMount(() => {
+  // Set default options if not already set
+  const defaultOptions = {
+    showVoltageAndCurrent: true,
+    showPowerAndConsumption: true,
+    toggleInterval: 3000,
+  }
+  miniWidget.value.options = Object.assign({}, defaultOptions, miniWidget.value.options)
+
+  setupToggleInterval()
+
+  // Register new variables for logging
+  datalogger.registerUsage('Instantaneous Watts' as DatalogVariable)
+  datalogger.registerUsage('Total Consumed Wh' as DatalogVariable)
+})
+
+onUnmounted(() => {
+  if (toggleIntervaler.value) {
+    clearInterval(toggleIntervaler.value)
+  }
 })
 </script>
 

--- a/src/components/mini-widgets/MiniVideoRecorder.vue
+++ b/src/components/mini-widgets/MiniVideoRecorder.vue
@@ -257,7 +257,7 @@ const updateCurrentStream = async (internalStreamName: string | undefined): Prom
 
 let streamConnectionRoutine: ReturnType<typeof setInterval> | undefined = undefined
 
-if (widgetStore.isRealMiniWidget(miniWidget.value)) {
+if (widgetStore.isRealMiniWidget(miniWidget.value.hash)) {
   streamConnectionRoutine = setInterval(() => {
     // If the video recording widget is cold booted, assign the first stream to it
     if (miniWidget.value.options.internalStreamName === undefined && !namesAvailableStreams.value.isEmpty()) {

--- a/src/libs/sensors-logging.ts
+++ b/src/libs/sensors-logging.ts
@@ -29,6 +29,8 @@ export enum DatalogVariable {
   missionName = 'Mission name',
   time = 'Time',
   date = 'Date',
+  instantaneousPower = 'Instantaneous power',
+  totalConsumedWh = 'Consumed power',
 }
 
 const logDateFormat = 'LLL dd, yyyy'
@@ -275,6 +277,8 @@ class DataLogger {
         [DatalogVariable.missionName]: { value: missionStore.missionName || 'Cockpit', hideLabel: true, ...timeNowObj },
         [DatalogVariable.time]: { value: format(timeNow, 'HH:mm:ss O'), hideLabel: true, ...timeNowObj },
         [DatalogVariable.date]: { value: format(timeNow, 'LLL dd, yyyy'), hideLabel: true, ...timeNowObj },
+        [DatalogVariable.instantaneousPower]: { value: `${vehicleStore.instantaneousWatts?.toFixed(1)} W` || 'Unknown', ...timeNowObj },
+        [DatalogVariable.totalConsumedWh]: { value: `${vehicleStore.totalConsumedWatts.toFixed(1)} Wh`, ...timeNowObj },
       }
 
       /* eslint-enable vue/max-len, prettier/prettier, max-len */

--- a/src/stores/widgetManager.ts
+++ b/src/stores/widgetManager.ts
@@ -69,6 +69,9 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
   }
 
   const miniWidgetManagerVars = (miniWidgetHash: string): MiniWidgetManagerVars => {
+    if (!isRealMiniWidget(miniWidgetHash)) {
+      return { ...defaultMiniWidgetManagerVars }
+    }
     if (!_miniWidgetManagerVars.value[miniWidgetHash]) {
       _miniWidgetManagerVars.value[miniWidgetHash] = { ...defaultMiniWidgetManagerVars }
     }
@@ -456,17 +459,16 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
   /**
    * States whether the given mini-widget is a real mini-widget
    * Fake mini-widgets are those used as placeholders, in the edit-menu, for example
-   * @param { MiniWidget } miniWidget - Mini-widget
+   * @param { string } miniWidgetHash - Hash of the mini-widget
    * @returns { boolean }
    */
-  function isRealMiniWidget(miniWidget: MiniWidget): boolean {
-    return savedProfiles.value.some((profile) =>
-      profile.views.some((view) =>
-        view.miniWidgetContainers.some((container) =>
-          container.widgets.some((widget) => widget.hash === miniWidget.hash)
-        )
-      )
-    )
+  function isRealMiniWidget(miniWidgetHash: string): boolean {
+    const allContainers = [
+      ...savedProfiles.value.flatMap((profile) => profile.views.flatMap((view) => view.miniWidgetContainers)),
+      ...currentMiniWidgetsProfile.value.containers,
+    ]
+
+    return allContainers.some((container) => container.widgets.some((widget) => widget.hash === miniWidgetHash))
   }
 
   const fullScreenPosition = { x: 0, y: 0 }


### PR DESCRIPTION
Adds instantaneous power and total power consumption to the BatteryIndicator widget.

https://github.com/user-attachments/assets/fa160e7c-e3cf-4678-9d9c-069902542f88

<img width="376" alt="image" src="https://github.com/user-attachments/assets/cd791990-b037-4471-be65-b22347027ec8">


Fix #1368