### PR TITLE
Joystick: Add visual feedback for functions importing

### DIFF
--- a/src/stores/controller.ts
+++ b/src/stores/controller.ts
@@ -293,6 +293,7 @@ export const useControllerStore = defineStore('controller', () => {
         return
       }
       protocolMapping.value = maybeFunctionsMapping
+      showDialog({ message: 'Functions mapping imported successful.', variant: 'success', timer: 2000 })
     }
     // @ts-ignore: We know the event type and need refactor of the event typing
     reader.readAsText(e.target.files[0])


### PR DESCRIPTION
Based on issue #728 where the user suggested a confirmation for successfully importing functions mapping onto the joystick profile.

Closes #728 