### PR TITLE
system-logs: Do not log to console when system-logging is enabled

### DIFF
--- a/src/libs/system-logging.ts
+++ b/src/libs/system-logging.ts
@@ -47,6 +47,11 @@ const saveLogEventInDB = (event: LogEvent): void => {
 
 const enableSystemLogging = localStorage.getItem(systemLoggingEnablingKey)
 if (enableSystemLogging === 'true') {
+  console.log(`
+    System logging is enabled.
+    This means that all console logs will be saved to the database, and won't be displayed in the console.
+    To disable system logging go to "Configuration" -> "Development".
+  `)
   const oldConsoleFunction = {
     error: console.error,
     warn: console.warn,
@@ -55,10 +60,9 @@ if (enableSystemLogging === 'true') {
     trace: console.trace,
     log: console.log,
   }
-  Object.entries(oldConsoleFunction).forEach(([level, fn]) => {
+  Object.entries(oldConsoleFunction).forEach(([level]) => {
     // @ts-ignore
     window.console[level] = (...o: any[]) => {
-      fn(...o)
       let wholeMessage = ''
       o.forEach((m) => {
         let msg = m


### PR DESCRIPTION
Console logs can have a huge impact on performance, especially on low-end devices.

Also allows user to delete one or multiple logs.

I've also added a message to the console, before disabling it, so users that want to see the console know what to do.

<img width="823" alt="image" src="https://github.com/user-attachments/assets/00764c24-b9cc-4f55-8302-67880879293f">
