### PR TITLE
Fix generation of arm64 flatpaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: Cockpit-${{ matrix.suffix }}-${{ matrix.arch }}-${{ env.VERSION }}.${{ matrix.extension }}
-          path: dist/Cockpit*.${{ matrix.extension }}
+          path: dist/Cockpit-${{ matrix.suffix }}-${{ matrix.arch }}-${{ env.VERSION }}.${{ matrix.extension }}
           if-no-files-found: error
 
       - name: Upload diff artifact (mac-only)
@@ -223,17 +223,30 @@ jobs:
       - name: Set version as environment variable (others)
         run: echo "VERSION=$(git describe --tags --abbrev=0 | sed 's/^v//')" >> $GITHUB_ENV
 
-      - name: Build electron
+      - name: Build electron (arm)
+        if: matrix.os == 'ubuntu-24-arm'
         run: |
           bun install --frozen-lockfile
           bun run build
-          env DEBUG="@malept/flatpak-bundler" bun run deploy:flatpak
+          env DEBUG="@malept/flatpak-bundler" bun run deploy:flatpak --arm64
+
+      - name: Build electron (x86_64)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          bun install --frozen-lockfile
+          bun run build
+          env DEBUG="@malept/flatpak-bundler" bun run deploy:flatpak --x64
+
+      - name: Rename 'aarch64' to 'arm64'
+        if: matrix.os == 'ubuntu-24-arm'
+        run: |
+          mv dist/Cockpit-${{ matrix.suffix }}-aarch64-${{ env.VERSION }}.${{ matrix.extension }} dist/Cockpit-${{ matrix.suffix }}-${{ matrix.arch }}-${{ env.VERSION }}.${{ matrix.extension }}
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
           name: Cockpit-${{ matrix.suffix }}-${{ matrix.arch }}-${{ env.VERSION }}.${{ matrix.extension }}
-          path: dist/Cockpit*.${{ matrix.extension }}
+          path: dist/Cockpit-${{ matrix.suffix }}-${{ matrix.arch }}-${{ env.VERSION }}.${{ matrix.extension }}
           if-no-files-found: error
 
       - name: Upload Release

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "coverage": "vitest --coverage",
     "deploy:electron:dir": "ELECTRON=true electron-builder --dir",
     "deploy:electron": "ELECTRON=true electron-builder --publish=never -c.extraMetadata.version=$(git describe --tags --abbrev=0 | sed 's/^v//')",
-    "deploy:flatpak": "ELECTRON=true electron-builder --x64 --publish=never --linux flatpak -c.extraMetadata.version=$(git describe --tags --abbrev=0 | sed 's/^v//')",
+    "deploy:flatpak": "ELECTRON=true electron-builder --linux flatpak --publish=never -c.extraMetadata.version=$(git describe --tags --abbrev=0 | sed 's/^v//')",
     "dev": "vite --host",
     "dev:electron": "ELECTRON=true vite --host",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --ignore-path .gitignore --max-warnings=0",


### PR DESCRIPTION
Apparently the arm64 flatpaks that were being generated (previously to all those CI changes) were actually just renamed x86 flatpaks. 

This got caught during the CI changes (making the actions fail) as we aren't forcing the artifact names anymore. 

This is now fixed.