### PR TITLE
defaults: Fix once and for all (?) the global address

### DIFF
--- a/src/assets/defaults.ts
+++ b/src/assets/defaults.ts
@@ -39,7 +39,7 @@ export const defaultMiniWidgetManagerVars: MiniWidgetManagerVars = {
 
 const hostname = window.location.hostname
 export const defaultBlueOsAddress = 'http://blueos-avahi.local'
-export const defaultGlobalAddress = hostname == '' || hostname == undefined ? defaultBlueOsAddress : hostname
+export const defaultGlobalAddress = !hostname || hostname == 'localhost' ? defaultBlueOsAddress : hostname
 export const defaultUIGlassColor = { opacity: 0.8, bgColor: '#4F4F4F1A', fontColor: '#FFFFFF', blur: 25 }
 export const widgetProfiles: Profile[] = [
   {

--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -70,7 +70,18 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
   const ws_protocol = location?.protocol === 'https:' ? 'wss' : 'ws'
 
   const cpuLoad = ref<number>()
-  const globalAddress = useStorage('cockpit-vehicle-address', defaultGlobalAddress)
+  const rawGlobalAddress = useStorage('cockpit-vehicle-address', defaultGlobalAddress)
+  const globalAddress = computed({
+    get() {
+      if (rawGlobalAddress.value.includes('://')) {
+        return rawGlobalAddress.value.split('://')[1]
+      }
+      return rawGlobalAddress.value
+    },
+    set(newValue) {
+      rawGlobalAddress.value = newValue
+    },
+  })
 
   const defaultMainConnectionURI = computed(() => `${ws_protocol}://${globalAddress.value}/mavlink2rest/ws/mavlink`)
   const defaultWebRTCSignallingURI = computed(() => `${ws_protocol}://${globalAddress.value}:6021/`)


### PR DESCRIPTION
This solves the case of the electron app (which has "localhost" as hostname) not automatically connecting.

It also automatically removes the protocol part of the address if for some reason it got there.