### PR TITLE
Seek and destroy main memory leak

### DIFF
--- a/src/components/mini-widgets/Alerter.vue
+++ b/src/components/mini-widgets/Alerter.vue
@@ -16,7 +16,7 @@
       :class="{ 'opacity-0 invisible': !isShowingExpandedAlerts }"
     >
       <div v-for="(alert, i) in sortedAlertsReversed" :key="alert.time_created.toISOString()">
-        <div v-tooltip.right="alert.message" class="flex items-center justify-between whitespace-nowrap">
+        <div :title="alert.message" class="flex items-center justify-between whitespace-nowrap">
           <p class="mx-1 overflow-hidden text-lg font-medium leading-none text-ellipsis">{{ alert.message }}</p>
           <div
             class="flex flex-col justify-center mx-1 font-mono text-xs font-semibold leading-3 text-right text-gray-100"


### PR DESCRIPTION
I performed about a week of testing with Cockpit to learn more about its performance issues.

A detailed report can be found [here](https://drive.google.com/file/d/16AU_I-ApkT_wr5BrxqQqev9EvYgOylnw/view?usp=sharing), but I will make a resume below.

# The main leak

I could find that we indeed have a big memory leak that causes the application to become slow after about 20 minutes and to crash after around an hour (depending on the computer specs). After a lot of tests I could determine that this leak is caused by a `v-tooltip` component that is used in the expanded list of the `Alerter.vue` widget. This component is instantiated for every alert in the list, and is never garbage-collected, so for every new alert added to the list, a series of zombie components are created and left there forever. This PR replaces that component, effectively removing the main memory leak.

Before:
<img width="543" alt="alerter-with-v-tooltip" src="https://github.com/user-attachments/assets/89cd316a-f400-4442-962c-636ecb24f192">

After:
<img width="539" alt="alerter-without-v-tooltip" src="https://github.com/user-attachments/assets/472aebfb-79aa-4750-a857-dd6b0b847968">

# Other leaks

I could also find that we have smaller memory leaks (with unknown sources) that grow very slowly, without interfering in most (99%?) user sessions, and that we have a concentrated memory leak when the joystick configuration page is open.

# Future work

This PR only fixes the main memory leak (from the `Alerter.vue` widget), but a following PR should be done fixing the problem in the joystick configuration page as well, as it affects every user that opens that view.

We should also eventually have a better solution than the `title` attribute to replace the buggy tooltip, as the attribute does not work on mobile and takes a somewhat long hovering time to shown, degrading the UX.

# Result

With this PR, the user can now effectively run Cockpit for hours without it becoming slow or crashing.