### PR TITLE
general: Inject dynamic version to about page

### DIFF
--- a/src/components/About.vue
+++ b/src/components/About.vue
@@ -1,11 +1,11 @@
 <template>
   <teleport to="body">
-    <InteractionDialog :show-dialog="showDialog" max-width="740" variant="text-only">
+    <InteractionDialog v-model="showDialog" max-width="740" variant="text-only">
       <template #content>
         <div class="flex absolute top-0 right-0"><v-btn icon="mdi-close" variant="text" @click="closeDialog" /></div>
         <div class="flex flex-col justify-center align-center w-full h-full">
           <img :src="CockpitLogo" alt="Cockpit Logo" class="w-64 my-4" />
-          <div class="w-[90%] flex justify-between my-8 py-3">
+          <div class="w-[90%] flex justify-between my-6 py-3">
             <div class="w-[45%] flex flex-col text-start">
               <p class="mb-1">
                 Cockpit is an intuitive and customizable cross-platform ground control station for remote vehicles of

--- a/src/components/About.vue
+++ b/src/components/About.vue
@@ -18,7 +18,7 @@
               </p>
             </div>
             <div class="w-[45%] flex flex-col justify-end text-end">
-              <p class="mb-1">Version 1.0.1</p>
+              <p class="mb-1">Version {{ app_version }}</p>
               <p class="my-3">Created by Blue Robotics</p>
               <p class="mt-1">Licensed under AGPL-3.0-only or LicenseRef-Cockpit-Custom</p>
             </div>
@@ -63,6 +63,7 @@ import { onUnmounted, ref, watch } from 'vue'
 
 import CockpitLogo from '@/assets/cockpit-logo.png'
 import InteractionDialog from '@/components/InteractionDialog.vue'
+import { app_version } from '@/libs/cosmos'
 
 const showDialog = ref(true)
 const emit = defineEmits(['update:showAboutDialog'])

--- a/src/components/About.vue
+++ b/src/components/About.vue
@@ -18,7 +18,14 @@
               </p>
             </div>
             <div class="w-[45%] flex flex-col justify-end text-end">
-              <p class="mb-1">Version {{ app_version }}</p>
+              <p class="mb-1">
+                Version
+                <a :href="app_version.link" target="_blank" class="text-primary hover:underline">
+                  {{ app_version.version }}
+                </a>
+                <br />
+                <span class="text-sm text-gray-500">Released: {{ app_version.date }}</span>
+              </p>
               <p class="my-3">Created by Blue Robotics</p>
               <p class="mt-1">Licensed under AGPL-3.0-only or LicenseRef-Cockpit-Custom</p>
             </div>

--- a/src/libs/cosmos.ts
+++ b/src/libs/cosmos.ts
@@ -172,6 +172,33 @@ Array.prototype.sum = function (this: number[]): number {
 }
 
 declare const __APP_VERSION__: string
-export const app_version = __APP_VERSION__
+declare const __APP_VERSION_DATE__: string
+declare const __APP_VERSION_LINK__: string
+
+/**
+ * Interface representing version information for the application
+ */
+export interface AppVersionInfo {
+  /**
+   * @property {string} version - The version number or commit hash of the application, or 'unknown' in last case.
+   * If the version is a tag prefixed with "v", it is stripped.
+   * If a tag is not found, the commit hash is used.
+   * If a commit hash is not found, 'unknown' is used.
+   */
+  version: string
+  /**
+   * @property {string} date - The release date for tags or commit date for commits
+   */
+  date: string
+  /**
+   * @property {string} link - URL to the GitHub release page for tags or commit page for commits
+   */
+  link: string
+}
+export const app_version: AppVersionInfo = {
+  version: __APP_VERSION__,
+  date: __APP_VERSION_DATE__,
+  link: __APP_VERSION_LINK__,
+}
 
 export default global!

--- a/src/libs/cosmos.ts
+++ b/src/libs/cosmos.ts
@@ -171,4 +171,7 @@ Array.prototype.sum = function (this: number[]): number {
   return this.reduce((a, b) => a + b, 0)
 }
 
+declare const __APP_VERSION__: string
+export const app_version = __APP_VERSION__
+
 export default global!

--- a/src/libs/non-browser-utils.ts
+++ b/src/libs/non-browser-utils.ts
@@ -1,27 +1,47 @@
 import { execSync } from 'child_process'
 
+import type { AppVersionInfo } from './cosmos'
+
 /**
- * Returns the version of the application.
- * Uses the git describe command to get the latest tag, or the commit hash if no tags exist.
- * Returns a fallback version 'unknown' if git commands fails.
- * @returns {string}
+ * Returns the version information of the application.
+ * Uses git commands to get the version (tag or commit), date, and link to GitHub.
+ * Returns fallback values if git commands fail.
+ * @returns {AppVersionInfo}
  */
-export function getVersion(): string {
+export function getVersion(): AppVersionInfo {
+  const repoUrl = 'https://github.com/bluerobotics/cockpit'
+  const fallback: AppVersionInfo = {
+    version: 'unknown',
+    date: 'unknown',
+    link: repoUrl,
+  }
+
   try {
     // Try to get the latest tag
     const tag = execSync('git describe --tags --abbrev=0', { encoding: 'utf8' }).trim()
-    if (tag.startsWith('v')) {
-      return tag.substring(1)
+    if (tag) {
+      // Get the tag date
+      const date = execSync(`git log -1 --format=%ai ${tag}`, { encoding: 'utf8' }).trim()
+      return {
+        version: tag.startsWith('v') ? tag.substring(1) : tag,
+        date: date.split(' ')[0], // Get just the date part
+        link: `${repoUrl}/releases/tag/${tag}`,
+      }
     }
-    return tag
   } catch {
     try {
       // If no tags exist, get the commit hash
       const commitHash = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim()
-      return commitHash.substring(0, 8)
+      const date = execSync('git show -s --format=%ai HEAD', { encoding: 'utf8' }).trim()
+      return {
+        version: commitHash.substring(0, 8),
+        date: date.split(' ')[0], // Get just the date part
+        link: `${repoUrl}/commit/${commitHash}`,
+      }
     } catch {
-      // If git commands fail, return a fallback version
-      return 'unknown'
+      // If git commands fail, return fallback values
+      return fallback
     }
   }
+  return fallback
 }

--- a/src/libs/non-browser-utils.ts
+++ b/src/libs/non-browser-utils.ts
@@ -1,0 +1,27 @@
+import { execSync } from 'child_process'
+
+/**
+ * Returns the version of the application.
+ * Uses the git describe command to get the latest tag, or the commit hash if no tags exist.
+ * Returns a fallback version 'unknown' if git commands fails.
+ * @returns {string}
+ */
+export function getVersion(): string {
+  try {
+    // Try to get the latest tag
+    const tag = execSync('git describe --tags --abbrev=0', { encoding: 'utf8' }).trim()
+    if (tag.startsWith('v')) {
+      return tag.substring(1)
+    }
+    return tag
+  } catch {
+    try {
+      // If no tags exist, get the commit hash
+      const commitHash = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim()
+      return commitHash.substring(0, 8)
+    } catch {
+      // If git commands fail, return a fallback version
+      return 'unknown'
+    }
+  }
+}

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,0 +1,24 @@
+import { execSync } from 'child_process'
+
+/**
+ * Returns the version of the application.
+ * Uses the git describe command to get the latest tag, or the commit hash if no tags exist.
+ * Returns a fallback version 'unknown' if git commands fails.
+ * @returns {string}
+ */
+export function getVersion(): string {
+  try {
+    // Try to get the latest tag
+    const latestTag = execSync('git describe --tags --abbrev=0', { encoding: 'utf8' }).trim()
+    return latestTag
+  } catch {
+    try {
+      // If no tags exist, get the commit hash
+      const commitHash = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim()
+      return commitHash.substring(0, 8)
+    } catch {
+      // If git commands fail, return a fallback version
+      return 'unknown'
+    }
+  }
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,5 +1,5 @@
 {
-  "include": ["env.d.ts", "src/**/*", "src/**/*.vue"],
+  "include": ["env.d.ts", "src/**/*", "src/**/*.vue", "src/**/*.ts"],
   "exclude": ["src/**/__tests__/*"],
   "compilerOptions": {
     "composite": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,11 @@
 import vue from '@vitejs/plugin-vue'
+import path from 'path'
 import { defineConfig } from 'vite'
 import electron, { startup, treeKillSync } from 'vite-plugin-electron'
 import { VitePWA } from 'vite-plugin-pwa'
 import vuetify from 'vite-plugin-vuetify'
 
-const path = require('path') // eslint-disable-line @typescript-eslint/no-var-requires
+import { getVersion } from './src/libs/non-browser-utils'
 
 // Check if we're running in Electron mode or building the application
 const isElectron = process.env.ELECTRON === 'true'
@@ -41,7 +42,10 @@ export default defineConfig({
       includeAssets: ['favicon.ico', 'apple-touch-icon.png', 'masked-icon.svg'],
     }),
   ].filter(Boolean),
-  define: { 'process.env': {} },
+  define: {
+    'process.env': {},
+    '__APP_VERSION__': JSON.stringify(getVersion()),
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,7 +44,9 @@ export default defineConfig({
   ].filter(Boolean),
   define: {
     'process.env': {},
-    '__APP_VERSION__': JSON.stringify(getVersion()),
+    '__APP_VERSION__': JSON.stringify(getVersion().version),
+    '__APP_VERSION_DATE__': JSON.stringify(getVersion().date),
+    '__APP_VERSION_LINK__': JSON.stringify(getVersion().link),
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Calculates version based on last git tag or current commit hash (fallback). Works on browser, dev mode and Electron.

Also fixes the problem of not being able to reopen the about page after closing it by clicking outside the dialog.

<br/>
<p align="center">
  <img width="500" alt="image" src="https://github.com/user-attachments/assets/a15bcc4a-08d6-4b93-9f5f-0f79075c6af7">
<p/>
<br/>

Fix #1315 