### PR TITLE
Mission Planning improvements

### DIFF
--- a/src/components/mission-planning/ContextMenu.vue
+++ b/src/components/mission-planning/ContextMenu.vue
@@ -1,0 +1,101 @@
+<template>
+  <div
+    v-if="visible"
+    :style="{ top: `${position.y}px`, left: `${position.x}px` }"
+    class="context-menu absolute flex justify-center items-center z-[1000] text-white rounded-lg w-auto h-auto"
+  >
+    <div
+      class="flex flex-col rounded-md"
+      :style="[interfaceStore.globalGlassMenuStyles, { background: '#333333EE', border: '1px solid #FFFFFF44' }]"
+    >
+      <v-list-item class="flex items-center gap-x-2 pb-2" @click="handleToggleSurvey">
+        <v-icon
+          variant="text"
+          icon="mdi-transit-connection-variant"
+          rounded="full"
+          size="x-small"
+          color="white"
+          class="text-[16px]"
+        ></v-icon>
+        <span class="text-white text-sm ml-4">{{ surveyCreationButtonText }}</span>
+      </v-list-item>
+      <v-divider />
+      <v-list-item class="flex items-center gap-x-2 pb-2" @click="handleToggleSimpleMission">
+        <v-icon
+          variant="text"
+          icon="mdi-vector-polyline"
+          rounded="full"
+          size="x-small"
+          color="white"
+          class="text-[16px]"
+        ></v-icon>
+        <span class="text-white text-sm ml-4">{{ pathCreationButtonText }}</span>
+      </v-list-item>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, defineEmits, defineProps } from 'vue'
+
+import { useAppInterfaceStore } from '@/stores/appInterface'
+import { useMissionStore } from '@/stores/mission'
+
+const missionStore = useMissionStore()
+const interfaceStore = useAppInterfaceStore()
+
+/* eslint-disable jsdoc/require-jsdoc */
+const props = defineProps<{
+  visible: boolean
+  position: {
+    x: number
+    y: number
+  }
+  isCreatingSurvey: boolean
+  isCreatingSimpleMission: boolean
+}>()
+/* eslint-enable jsdoc/require-jsdoc */
+
+const emit = defineEmits<{
+  (event: 'close'): void
+  (event: 'toggleSurvey'): void
+  (event: 'toggleSimpleMission'): void
+}>()
+
+const surveyCreationButtonText = computed(() => {
+  if (props.isCreatingSurvey) {
+    return 'Close survey creation'
+  }
+  if (missionStore.currentPlanningWaypoints.length > 0) {
+    return 'Create survey'
+  }
+  return 'Add survey'
+})
+
+const pathCreationButtonText = computed(() => {
+  if (props.isCreatingSimpleMission) {
+    return 'Close simple path creation'
+  }
+  if (missionStore.currentPlanningWaypoints.length > 0) {
+    return 'Create simple path'
+  }
+  return 'Add simple path'
+})
+
+const handleToggleSurvey = (): void => {
+  emit('toggleSurvey')
+  emit('close')
+}
+
+const handleToggleSimpleMission = (): void => {
+  emit('toggleSimpleMission')
+  emit('close')
+}
+</script>
+
+<style scoped>
+.context-menu {
+  transform-origin: center;
+  animation: bloom 0.3s ease-out forwards;
+}
+</style>

--- a/src/components/mission-planning/ContextMenu.vue
+++ b/src/components/mission-planning/ContextMenu.vue
@@ -4,7 +4,68 @@
     :style="{ top: `${position.y}px`, left: `${position.x}px` }"
     class="context-menu absolute flex justify-center items-center z-[1000] text-white rounded-lg w-auto h-auto"
   >
+    <div v-if="selectedSurveyId" class="relative orbit-container">
+      <div class="central-element flex justify-start items-start">
+        <ScanDirectionDial
+          :angle="angle"
+          auto-update
+          :polygon-state="false"
+          @survey-lines-angle="onSurveyLinesAngleChange"
+          @regenerate-survey-waypoints="onRegenerateSurveyWaypoints"
+        />
+      </div>
+
+      <div id="button-1" class="orbit-button orbit-button-1">
+        <v-tooltip :text="isFirstWaypoints ? 'Create survey' : 'Add survey'">
+          <template #activator="{ props: tooltipProps0 }">
+            <v-btn
+              v-bind="tooltipProps0"
+              :style="[interfaceStore.globalGlassMenuStyles, { backgroundColor: '#333333EE' }]"
+              variant="elevated"
+              icon="mdi-transit-connection-variant"
+              rounded="full"
+              size="x-small"
+              color="#FFFFFF22"
+              class="text-[12px] rotate-[145deg]"
+              @click="handleToggleSurvey"
+            >
+            </v-btn>
+          </template>
+        </v-tooltip>
+      </div>
+
+      <div id="button-2" class="orbit-button orbit-button-2">
+        <v-tooltip :text="isFirstWaypoints ? 'Create simple path' : 'Add simple path'">
+          <template #activator="{ props: tooltipProps1 }">
+            <v-btn
+              v-bind="tooltipProps1"
+              :style="[interfaceStore.globalGlassMenuStyles, { backgroundColor: '#333333EE' }]"
+              variant="elevated"
+              icon="mdi-vector-polyline"
+              rounded="full"
+              size="x-small"
+              color="#FFFFFF22"
+              class="text-[13px] rotate-[170deg]"
+              @click="handleToggleSimpleMission"
+            ></v-btn>
+          </template>
+        </v-tooltip>
+      </div>
+      <v-tooltip text="Delete survey">
+        <template #activator="{ props: tooltipProps3 }">
+          <div
+            v-bind="tooltipProps3"
+            class="absolute text-[14px] mt-[10px] ml-[85px] bg-transparent rounded-full cursor-pointer elevation-4"
+            variant="text"
+            @click="handleDeleteSelectedSurvey"
+          >
+            <v-icon color="white" class="border-2 rounded-full bg-red">mdi-close</v-icon>
+          </div>
+        </template>
+      </v-tooltip>
+    </div>
     <div
+      v-else
       class="flex flex-col rounded-md"
       :style="[interfaceStore.globalGlassMenuStyles, { background: '#333333EE', border: '1px solid #FFFFFF44' }]"
     >
@@ -38,8 +99,10 @@
 <script setup lang="ts">
 import { computed, defineEmits, defineProps } from 'vue'
 
+import ScanDirectionDial from '@/components/mission-planning/ScanDirectionDial.vue'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMissionStore } from '@/stores/mission'
+import { Survey } from '@/types/mission'
 
 const missionStore = useMissionStore()
 const interfaceStore = useAppInterfaceStore()
@@ -51,6 +114,8 @@ const props = defineProps<{
     x: number
     y: number
   }
+  surveys: Survey[]
+  selectedSurveyId: string | null
   isCreatingSurvey: boolean
   isCreatingSimpleMission: boolean
 }>()
@@ -60,13 +125,24 @@ const emit = defineEmits<{
   (event: 'close'): void
   (event: 'toggleSurvey'): void
   (event: 'toggleSimpleMission'): void
+  (event: 'deleteSelectedSurvey'): void
+  (event: 'surveyLinesAngle', angle: number): void
+  (event: 'regenerateSurveyWaypoints', angle: number): void
 }>()
+
+const selectedSurveyId = computed(() => props.selectedSurveyId)
+
+const angle = computed(() => props.surveys.find((survey) => survey.id === props.selectedSurveyId)?.surveyLinesAngle)
+
+const isFirstWaypoints = computed(
+  () => props.surveys.length === 0 && missionStore.currentPlanningWaypoints.length === 0
+)
 
 const surveyCreationButtonText = computed(() => {
   if (props.isCreatingSurvey) {
     return 'Close survey creation'
   }
-  if (missionStore.currentPlanningWaypoints.length > 0) {
+  if (props.surveys.length === 0) {
     return 'Create survey'
   }
   return 'Add survey'
@@ -76,7 +152,7 @@ const pathCreationButtonText = computed(() => {
   if (props.isCreatingSimpleMission) {
     return 'Close simple path creation'
   }
-  if (missionStore.currentPlanningWaypoints.length > 0) {
+  if (props.surveys.length === 0) {
     return 'Create simple path'
   }
   return 'Add simple path'
@@ -91,11 +167,103 @@ const handleToggleSimpleMission = (): void => {
   emit('toggleSimpleMission')
   emit('close')
 }
+
+const handleDeleteSelectedSurvey = (): void => {
+  emit('deleteSelectedSurvey')
+}
+
+const onRegenerateSurveyWaypoints = (newAngle: number): void => {
+  emit('regenerateSurveyWaypoints', newAngle)
+}
+
+const onSurveyLinesAngleChange = (newAngle: number): void => {
+  emit('surveyLinesAngle', newAngle)
+}
 </script>
 
 <style scoped>
 .context-menu {
   transform-origin: center;
+  opacity: 0;
   animation: bloom 0.3s ease-out forwards;
+}
+
+@keyframes bloom {
+  0% {
+    transform: scale(0.15);
+    opacity: 0;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.orbit-container {
+  position: relative;
+  width: 80px;
+  height: 80px;
+}
+
+.central-element {
+  position: relative;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.orbit-button {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform-origin: center;
+  opacity: 0;
+}
+
+.orbit-button-1 {
+  animation: orbit-1 0.05s ease-out forwards;
+}
+
+.orbit-button-2 {
+  animation: orbit-2 0.05s ease-out forwards;
+  animation-delay: 0.05s;
+}
+
+.orbit-button-3 {
+  animation: orbit-3 0.05s ease-out forwards;
+  animation-delay: 0.05s;
+}
+
+@keyframes orbit-1 {
+  0% {
+    transform: translate(-50%, -50%) rotate(0deg) translateX(0);
+    opacity: 0;
+  }
+  100% {
+    transform: translate(-50%, -50%) rotate(-500deg) translateX(90px);
+    opacity: 1;
+  }
+}
+
+@keyframes orbit-2 {
+  0% {
+    transform: translate(-50%, -50%) rotate(0deg) translateX(0);
+    opacity: 0;
+  }
+  100% {
+    transform: translate(-50%, -50%) rotate(-541deg) translateX(90px);
+    opacity: 1;
+  }
+}
+
+@keyframes orbit-3 {
+  0% {
+    transform: translate(-50%, -50%) rotate(0deg) translateX(0);
+    opacity: 0;
+  }
+  100% {
+    transform: translate(-50%, -50%) rotate(-580deg) translateX(90px);
+    opacity: 1;
+  }
 }
 </style>

--- a/src/components/mission-planning/ContextMenu.vue
+++ b/src/components/mission-planning/ContextMenu.vue
@@ -51,6 +51,24 @@
           </template>
         </v-tooltip>
       </div>
+      <div v-if="enableUndo" id="button-3" class="orbit-button orbit-button-3">
+        <v-tooltip text="Edit survey's polygon">
+          <template #activator="{ props: tooltipProps2 }">
+            <v-btn
+              v-bind="tooltipProps2"
+              variant="elevated"
+              icon="mdi-pencil"
+              :style="{ backgroundColor: '#333333EE' }"
+              rounded="full"
+              :disabled="undoIsInProgress"
+              size="x-small"
+              color="#FFFFFF22"
+              class="text-[13px] rotate-[220deg]"
+              @click="handleUndoGenerateWaypoints"
+            ></v-btn>
+          </template>
+        </v-tooltip>
+      </div>
       <v-tooltip text="Delete survey">
         <template #activator="{ props: tooltipProps3 }">
           <div
@@ -118,6 +136,8 @@ const props = defineProps<{
   selectedSurveyId: string | null
   isCreatingSurvey: boolean
   isCreatingSimpleMission: boolean
+  undoIsInProgress: boolean
+  enableUndo: boolean
 }>()
 /* eslint-enable jsdoc/require-jsdoc */
 
@@ -126,6 +146,7 @@ const emit = defineEmits<{
   (event: 'toggleSurvey'): void
   (event: 'toggleSimpleMission'): void
   (event: 'deleteSelectedSurvey'): void
+  (event: 'undoGeneratedWaypoints'): void
   (event: 'surveyLinesAngle', angle: number): void
   (event: 'regenerateSurveyWaypoints', angle: number): void
 }>()
@@ -166,6 +187,10 @@ const handleToggleSurvey = (): void => {
 const handleToggleSimpleMission = (): void => {
   emit('toggleSimpleMission')
   emit('close')
+}
+
+const handleUndoGenerateWaypoints = (): void => {
+  emit('undoGeneratedWaypoints')
 }
 
 const handleDeleteSelectedSurvey = (): void => {

--- a/src/components/mission-planning/ScanDirectionDial.vue
+++ b/src/components/mission-planning/ScanDirectionDial.vue
@@ -1,0 +1,180 @@
+<template>
+  <div class="rounded-full transition-width bg-[#333333EE]" :class="hovering ? 'w-[180px]' : 'w-[80px]'">
+    <div class="relative flex items-start justify-start">
+      <div class="dial-container">
+        <div class="compass">
+          <div class="wind-direction-dial-container" @mousedown="startDrag">
+            <div class="dial-arrow" :style="{ transform: `rotate(${rotationAngle}deg)` }">
+              <v-icon class="text-[90px] scale-x-[.4]">mdi-arrow-up-thin</v-icon>
+            </div>
+          </div>
+
+          <p class="absolute top-0 left-[33px] text-[15px] pointer-events-none text-[#FFFFFF99]">N</p>
+          <p class="absolute top-[25px] right-1 text-[16px] pointer-events-none text-[#FFFFFF99]">E</p>
+          <p class="absolute bottom-0 left-[33px] pointer-events-none text-[#FFFFFF99]">S</p>
+          <p class="absolute top-[25px] left-1 text-[15px] pointer-events-none text-[#FFFFFF99]">W</p>
+        </div>
+      </div>
+      <div class="w-[150px] ml-auto">
+        <div v-show="hovering" class="flex flex-col items-center justify-center text-white mr-[14px] mt-[10px]">
+          <p class="text-xs -mb-1">Scan</p>
+          <p class="text-xs -mb-1">Direction</p>
+          <p class="font-bold text-[30px] text-center text-[#FFFF00]">
+            {{ getCardinalDirection(rotationAngle || 0) }}
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onUnmounted, ref, watch } from 'vue'
+
+/* eslint-disable jsdoc/require-jsdoc */
+const props = defineProps<{
+  autoUpdate?: boolean
+  angle: number | undefined
+  polygonState: boolean
+}>()
+/* eslint-enable jsdoc/require-jsdoc */
+
+const emit = defineEmits<{
+  (event: 'surveyLinesAngle', angle: number): void
+  (event: 'regenerateSurveyWaypoints', angle: number): void
+}>()
+
+const rotationAngle = ref(props.angle)
+const hovering = ref(false)
+const polygonStateEdit = ref(props.polygonState || false)
+
+watch(
+  () => props.angle,
+  (newAngle) => {
+    rotationAngle.value = newAngle
+  }
+)
+
+const updateLinesAngleOnParent = (): void => {
+  if (props.autoUpdate && !polygonStateEdit.value && rotationAngle.value) {
+    onRegenerateSurveyWaypoints(rotationAngle.value)
+  }
+  if (polygonStateEdit.value) {
+    onSurveyLinesAngleChange(rotationAngle.value || 0)
+  }
+}
+
+const startDrag = (event: MouseEvent): void => {
+  hovering.value = true
+  event.preventDefault()
+  const target = event.currentTarget as HTMLElement
+  const rect = target.getBoundingClientRect()
+
+  const handleDrag = (moveEvent: MouseEvent): void => {
+    const centerX = rect.left + rect.width / 2
+    const centerY = rect.top + rect.height / 2
+    const dx = moveEvent.clientX - centerX
+    const dy = moveEvent.clientY - centerY
+    let angle = (Math.atan2(dy, dx) * 180) / Math.PI
+    angle = (angle + 360 + 90) % 360
+
+    rotationAngle.value = angle
+    updateLinesAngleOnParent()
+  }
+
+  const stopDrag = (): void => {
+    hovering.value = false
+    document.removeEventListener('mousemove', handleDrag)
+    document.removeEventListener('mouseup', stopDrag)
+    updateLinesAngleOnParent()
+  }
+
+  document.addEventListener('mousemove', handleDrag)
+  document.addEventListener('mouseup', stopDrag)
+}
+
+const getCardinalDirection = (angle: number): string => {
+  const directions = [
+    'N',
+    'NNE',
+    'NE',
+    'ENE',
+    'E',
+    'ESE',
+    'SE',
+    'SSE',
+    'S',
+    'SSW',
+    'SW',
+    'WSW',
+    'W',
+    'WNW',
+    'NW',
+    'NNW',
+    'N',
+  ]
+  const normalizedAngle = ((angle % 360) + 360) % 360
+  const index = Math.round(normalizedAngle / 22.5) // 22.5 comes from 360 divided by 16, that results on the cardinal directions positions
+  return directions[index]
+}
+
+const onRegenerateSurveyWaypoints = (angle: number): void => {
+  emit('regenerateSurveyWaypoints', angle)
+}
+
+const onSurveyLinesAngleChange = (newAngle: number): void => {
+  emit('surveyLinesAngle', newAngle)
+}
+
+onUnmounted(() => {
+  document.removeEventListener('mousemove', startDrag)
+  document.removeEventListener('mouseup', startDrag)
+  hovering.value = false
+})
+</script>
+
+<style scoped>
+.overlay {
+  z-index: 100;
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+}
+
+.transition-width {
+  transition: width 0.2s ease-in-out;
+  animation-delay: 1s;
+}
+
+.dial-container {
+  display: flex;
+  align-items: start;
+  position: relative;
+}
+
+.compass {
+  position: relative;
+  width: 80px;
+  height: 80px;
+  border: 1px solid #ffffff22;
+  border-radius: 50%;
+  cursor: grab;
+}
+
+.wind-direction-dial-container {
+  position: relative;
+  width: 80px;
+  height: 80px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  user-select: none;
+}
+
+.dial-arrow {
+  color: #ffff00;
+  position: absolute;
+  margin-top: -5px;
+  margin-left: -5px;
+  transform-origin: center;
+}
+</style>

--- a/src/types/mission.ts
+++ b/src/types/mission.ts
@@ -79,6 +79,40 @@ export type CockpitMission = {
   waypoints: Waypoint[]
 }
 
+/**
+ * Survey object that contains the information about the survey to be performed.
+ */
+export interface Survey {
+  /**
+   * Unique identification for the survey.
+   */
+  id: string
+  /**
+   * Coordinates of the polygon that will be surveyed.
+   */
+  polygonCoordinates: WaypointCoordinates[]
+  /**
+   * Density of the scan.
+   */
+  distanceBetweenLines: number
+  /**
+   * Angle of the survey lines.
+   */
+  surveyLinesAngle: number
+  /**
+   * Executable mission waypoints.
+   */
+  waypoints: Waypoint[]
+}
+
+// TODO - Replace leaflet types with agnostic types
+export type SurveyPolygon = {
+  /**
+   * The coordinates of the polygon that will be converted into a survey.
+   */
+  polygonPositions: WaypointCoordinates[]
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const instanceOfCockpitMission = (maybeMission: any): maybeMission is CockpitMission => {
   const requiredKeys = ['version', 'settings', 'waypoints']


### PR DESCRIPTION
New Features List:

* Added a context menu for  mission planning creation and editing processes.
* Survey polygons can now be relocated by dragging them on the map.
* Surveys can be individually deleted.
* Users can select the angle at which the survey will be scanned.
* The scanning angle can also be edited after the survey is completed.
* Last survey can now be edited back to the polygon level, allowing users to adjust the distance between scan lines (scan density) and the scanning angle
* It is now possible to concatenate multiple surveys or simple paths to form a complex mission around a complex map scene


https://github.com/user-attachments/assets/e7e63da7-75b1-45e1-8a87-c76b117f303e

https://github.com/user-attachments/assets/581d9d36-352b-432e-910b-fd0b5d3f4b7f



closes #1355 
closes #1350 
