### PR TITLE
vehicle-discovery: Allow finding IPs generated by a DHCP server in the vehicle

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron'
 
 contextBridge.exposeInMainWorld('electronAPI', {
-  getNetworkInfo: () => ipcRenderer.invoke('get-network-info'),
+  getInfoOnSubnets: () => ipcRenderer.invoke('get-info-on-subnets'),
 })

--- a/src/components/VehicleDiscoveryDialog.vue
+++ b/src/components/VehicleDiscoveryDialog.vue
@@ -30,7 +30,9 @@
 
         <div v-if="!searching && !searched" class="flex flex-col gap-2 items-center justify-center text-center">
           <p v-if="props.showAutoSearchOption" class="font-bold">It looks like you're not connected to a vehicle!</p>
-          <p class="max-w-[25rem] mb-2">This tool allows you to locate and connect to vehicles within your network.</p>
+          <p class="max-w-[25rem] mb-2">
+            This tool allows you to locate and connect to BlueOS vehicles within your network.
+          </p>
         </div>
 
         <div v-if="!searching" class="flex justify-center items-center">
@@ -49,6 +51,7 @@ import { ref, watch } from 'vue'
 
 import { useSnackbar } from '@/composables/snackbar'
 import vehicleDiscover, { NetworkVehicle } from '@/libs/electron/vehicle-discovery'
+import { reloadCockpit } from '@/libs/utils'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 
 import InteractionDialog, { Action } from './InteractionDialog.vue'
@@ -116,9 +119,10 @@ const searchVehicles = async (): Promise<void> => {
   searched.value = true
 }
 
-const selectVehicle = (address: string): void => {
+const selectVehicle = async (address: string): Promise<void> => {
   mainVehicleStore.globalAddress = address
   isOpen.value = false
+  await reloadCockpit()
   showSnackbar({ message: 'Vehicle address updated', variant: 'success', duration: 5000 })
 }
 

--- a/src/libs/cosmos.ts
+++ b/src/libs/cosmos.ts
@@ -1,5 +1,7 @@
 import { isBrowser } from 'browser-or-node'
 
+import { NetworkInfo } from '@/types/network'
+
 import {
   cockpitActionVariableData,
   createCockpitActionVariable,
@@ -110,7 +112,7 @@ declare global {
        * Get network information from the main process
        * @returns Promise containing subnet information
        */
-      getNetworkInfo: () => Promise<{ subnet: string }>
+      getInfoOnSubnets: () => Promise<NetworkInfo[]>
     }
   }
   /* eslint-enable jsdoc/require-jsdoc */

--- a/src/types/network.ts
+++ b/src/types/network.ts
@@ -1,0 +1,21 @@
+/**
+ * Information about the network
+ */
+export interface NetworkInfo {
+  /**
+   * The top side address of the local machine
+   */
+  topSideAddress: string
+  /**
+   * The MAC address of the local machine
+   */
+  macAddress: string
+  /**
+   * The name of the network interface
+   */
+  interfaceName: string
+  /**
+   * The CIDR of the local machine
+   */
+  availableAddresses: string[]
+}


### PR DESCRIPTION
The vehicle usually has some IPs generated by it's own servers (e.g.: 192.168.3.1 for USB C connections), which offers a dynamic IP for the topside computer. With this change, those IPs are also findable.

Before and after:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/6e59fd0f-4dc9-4a6a-81ff-58c827f7cea7"> <img width="300" alt="image" src="https://github.com/user-attachments/assets/d8afa3a5-ce6f-45a6-b2c3-14474779e883">


This commit is the correct implementation that I changed during the review process, and should be [in the original PR](https://github.com/bluerobotics/cockpit/pull/1471), but I lost it during the rebase. My bad.