### PR TITLE
Widgets: add support for Widget discovery from BlueOS

### DIFF
--- a/src/components/EditMenu.vue
+++ b/src/components/EditMenu.vue
@@ -472,7 +472,7 @@
           <v-btn
             type="flat"
             class="bg-[#FFFFFF33] text-white w-[95%]"
-            @click="store.addWidget(WidgetType.CustomWidgetBase, store.currentView)"
+            @click="store.addWidget(makeNewWidget(WidgetType.CustomWidgetBase), store.currentView)"
             >Add widget base
           </v-btn>
         </div>
@@ -712,7 +712,36 @@ watch(
   }
 )
 
-const availableWidgetTypes = computed(() =>
+const findUniqueName = (name: string): string => {
+  let newName = name
+  let i = 1
+  const existingNames = store.currentView.widgets.map((widget) => widget.name)
+  while (existingNames.includes(newName)) {
+    newName = `${name} ${i}`
+    i++
+  }
+  return newName
+}
+/*
+ * Makes a new widget with an unique name
+ */
+const makeNewWidget = (widget: WidgetType, name?: string, options?: Record<string, any>): InternalWidgetSetupInfo => {
+  const newName = name || widget
+  return {
+    name: findUniqueName(newName),
+    component: widget,
+    options: options || {},
+  }
+}
+
+const makeWidgetUnique = (widget: InternalWidgetSetupInfo): InternalWidgetSetupInfo => {
+  return {
+    ...widget,
+    name: findUniqueName(widget.name),
+  }
+}
+
+const availableInternalWidgets = computed(() =>
   Object.values(WidgetType).map((widgetType) => {
     return {
       component: widgetType,
@@ -1018,8 +1047,8 @@ const onRegularWidgetDragStart = (event: DragEvent): void => {
   }
 }
 
-const onRegularWidgetDragEnd = (widgetType: ExtendedWidget): void => {
-  store.addWidget(widgetType, store.currentView)
+const onRegularWidgetDragEnd = (widget: InternalWidgetSetupInfo): void => {
+  store.addWidget(makeWidgetUnique(widget), store.currentView)
 
   const widgetCards = document.querySelectorAll('[draggable="true"]')
   widgetCards.forEach((card) => {

--- a/src/stores/widgetManager.ts
+++ b/src/stores/widgetManager.ts
@@ -36,6 +36,7 @@ import {
   type Widget,
   CustomWidgetElement,
   CustomWidgetElementContainer,
+  InternalWidgetSetupInfo,
   MiniWidgetManagerVars,
   validateProfile,
   validateView,
@@ -555,22 +556,22 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
 
   /**
    * Add widget with given type to given view
-   * @param { WidgetType } widgetType - Type of the widget
+   * @param { WidgetType } widget - Type of the widget
    * @param { View } view - View
    */
-  function addWidget(widgetType: WidgetType, view: View): void {
+  function addWidget(widget: InternalWidgetSetupInfo, view: View): void {
     const widgetHash = uuid4()
 
-    const widget = {
+    const newWidget = {
       hash: widgetHash,
-      name: widgetType,
-      component: widgetType,
+      name: widget.name,
+      component: widget.component,
       position: { x: 0.4, y: 0.32 },
       size: { width: 0.2, height: 0.36 },
-      options: {},
+      options: widget.options,
     }
 
-    if (widgetType === WidgetType.CustomWidgetBase) {
+    if (widget.component === WidgetType.CustomWidgetBase) {
       widget.options = {
         elementContainers: defaultCustomWidgetContainers,
         columns: 1,
@@ -581,8 +582,8 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
       }
     }
 
-    view.widgets.unshift(widget)
-    Object.assign(widgetManagerVars(widget.hash), {
+    view.widgets.unshift(newWidget)
+    Object.assign(widgetManagerVars(newWidget.hash), {
       ...defaultWidgetManagerVars,
       ...{ allowMoving: true },
     })

--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -3,6 +3,47 @@ import { CockpitAction } from '@/libs/joystick/protocols/cockpit-actions'
 import type { Point2D, SizeRect2D } from './general'
 
 /**
+ * Widget configuration object as received from BlueOS or another external source
+ */
+export interface ExternalWidgetSetupInfo {
+  /**
+   * Name of the widget, this is displayed on edit mode widget browser
+   */
+  name: string
+  /**
+   * The URL at which the widget is located
+   * This is expected to be an absolute url
+   */
+  iframe_url: string
+
+  /**
+   * The icon of the widget, this is displayed on the widget browser
+   */
+  iframe_icon: string
+}
+
+/**
+ * Internal data used for setting up a new widget. This includes WidgetType, a custom name, options, and icon
+ */ export interface InternalWidgetSetupInfo {
+  /**
+   *  Widget type
+   */
+  component: WidgetType
+  /**
+   *  Widget name, this will be displayed on edit mode
+   */
+  name: string
+  /**
+   *  Widget options, this is the configuration that will be passed to the widget when it is created
+   */
+  options: Record<string, unknown>
+  /**
+   *  Widget icon, this is the icon that will be displayed on the widget browser
+   */
+  icon: string
+}
+
+/**
  * Available components to be used in the Widget system
  * The enum value is equal to the component's filename, without the '.vue' extension
  */


### PR DESCRIPTION
Edit:

Current discovery method:

A new field "extras" is added to /register_service:

```json
{
   "name":"Ping Viewer Next",
   "description":"A ping protocol extension for expose devices to web.",
   "icon":"mdi-compass-outline",
   "company":"BlueRobotics",
   "version":"0.0.0",
   "new_page":false,
   "webpage":"https://github.com/RaulTrombin/navigator-assistant",
   "api":"/docs",
   "extras":{
      "cockpit":"/cockpit_extras.json"
   }
}
```

/cockpit_extras.json looks like this:

```json
{
   "target_system":"Cockpit",
   "target_cockpit_api_version":"1.0.0",
   "widgets":[
      {
         "name":"ping360",
         "config_iframe_url":null,
         "iframe_url":"/addons/widget/ping360/?uuid=00000000-0000-0000-d9fb-222b5f8a865d",
         "version":"1.0.0"
      }
   ]
}
```

The consumer (in this case cockpit), should validate the file target_system and integration api version (in this case, cockpit's widget api). The rest of it is defined by the consumer.

In cockpit we need a name, an iframe url, and optionally an iframe for the configuration interface. The version can be used for (in)validating widget settings.