### PR TITLE
joystick-configuration-view: Remove extraneous attribute

### DIFF
--- a/src/views/ConfigurationJoystickView.vue
+++ b/src/views/ConfigurationJoystickView.vue
@@ -13,14 +13,7 @@
         >
           <p class="text-base text-center font-bold mt-6 mb-4">Connect a joystick and press any key.</p>
         </div>
-        <ExpansiblePanel
-          v-else
-          class="mt-3"
-          no-top-divider
-          no-bottom-divider
-          :is-expanded="!interfaceStore.isOnPhoneScreen"
-          compact
-        >
+        <ExpansiblePanel v-else no-top-divider no-bottom-divider :is-expanded="!interfaceStore.isOnPhoneScreen" compact>
           <template #title>General settings</template>
           <template #info>
             <div class="flex flex-col items-start px-5 font-medium">


### PR DESCRIPTION
This was leading to a huge amount of warnings in the console (hundreds per second).

<img width="748" alt="image" src="https://github.com/user-attachments/assets/76d9515e-1232-4709-9119-25370720b83c" />
