### PR TITLE
bug fix: Slider Input widget colour leaves the label white

### DIFF
--- a/src/components/custom-widget-elements/Slider.vue
+++ b/src/components/custom-widget-elements/Slider.vue
@@ -9,7 +9,11 @@
     @click="widgetStore.editingMode && widgetStore.showElementPropsDrawer(miniWidget.hash)"
   >
     <div :style="{ minWidth: miniWidget.options.layout?.labelWidth + 'px' }">
-      <p v-if="miniWidget.options.layout?.label !== ''" class="mr-3 mb-[3px]">
+      <p
+        v-if="miniWidget.options.layout?.label !== ''"
+        :style="{ color: miniWidget.options.layout?.coloredLabel ? miniWidget.options.layout?.color : '#FFFFFF' }"
+        class="mr-3 mb-[3px]"
+      >
         {{ miniWidget.options.layout?.label }}
       </p>
     </div>
@@ -88,6 +92,7 @@ onMounted(() => {
         maxValue: 100,
         showTooltip: true,
         color: '#FFFFFF',
+        coloredLabel: false,
         labelWidth: miniWidget.value.options.layout?.labelWidth || 0,
       },
       variableType: 'number',

--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -487,6 +487,10 @@ export type CustomWidgetElementOptions = {
          */
         color: string
         /**
+         * Apply color to the label
+         */
+        coloredLabel: boolean
+        /**
          * The minimum value of the slider
          */
         minValue: number


### PR DESCRIPTION
- Now there is a checkbox to also apply the color to the label.

![image](https://github.com/user-attachments/assets/ab07c77f-9a45-4ce4-95cd-84d3b11398e9)

Fix  #1529 