### PR TITLE
Add a panel to list and edit mini-widgets inside custom mini-widgets containers

### DIFF
--- a/src/components/widgets/CustomWidgetBase.vue
+++ b/src/components/widgets/CustomWidgetBase.vue
@@ -415,6 +415,8 @@ const widgetAdded = (e: SortableEvent.SortableEvent, containerName: string): voi
     if (newWidget && e.pullMode === 'clone') {
       newWidget.hash = uuid()
       widgetStore.miniWidgetManagerVars(newWidget.hash).configMenuOpen = true
+      lastKnownHashes.value.set(containerName, currentHashes)
+      return
     }
     widgetStore.showElementPropsDrawer(newWidget.hash)
     lastKnownHashes.value.set(containerName, currentHashes)


### PR DESCRIPTION
- ~~Added a 'double click to configure' feature to mini and regular widgets inside edit mode, so any configurable widget will have a direct way to open its config screen~~;
- Added a panel to list and edit mini-widgets inside custom mini-widgets containers;


https://github.com/user-attachments/assets/d93187f3-1b30-45ad-8804-147c2be1c6f6

Fix #1531 