### PR TITLE
edit-menu: Disable cog icon for widgets that are not configurable

### DIFF
--- a/src/components/EditMenu.vue
+++ b/src/components/EditMenu.vue
@@ -294,6 +294,7 @@
                   />
                   <div
                     class="icon-btn mdi mdi-cog"
+                    :class="{ 'opacity-20 cursor-not-allowed': !isWidgetConfigurable[widget.component as WidgetType] }"
                     @click="store.widgetManagerVars(widget.hash).configMenuOpen = true"
                   />
                   <div class="icon-btn mdi mdi-trash-can" @click="store.deleteWidget(widget)" />
@@ -360,6 +361,7 @@
                     <v-divider vertical class="opacity-10 mr-1" />
                     <div
                       class="icon-btn mdi mdi-cog"
+                      :class="{ 'opacity-20 cursor-not-allowed': !isMiniWidgetConfigurable[widget.component as MiniWidgetType] }"
                       @click="store.miniWidgetManagerVars(widget.hash).configMenuOpen = true"
                     />
                     <div class="icon-btn mdi mdi-trash-can" @click="store.deleteMiniWidget(widget)" />
@@ -429,6 +431,7 @@
                     <v-divider vertical class="opacity-10 mr-1" />
                     <div
                       class="icon-btn mdi mdi-cog"
+                      :class="{ 'opacity-20 cursor-not-allowed': !isMiniWidgetConfigurable[widget.component as MiniWidgetType] }"
                       @click="store.miniWidgetManagerVars(widget.hash).configMenuOpen = true"
                     />
                     <div class="icon-btn mdi mdi-trash-can" @click="store.deleteMiniWidget(widget)" />
@@ -664,6 +667,8 @@ import {
   CustomWidgetElementType,
   ExternalWidgetSetupInfo,
   InternalWidgetSetupInfo,
+  isMiniWidgetConfigurable,
+  isWidgetConfigurable,
   MiniWidgetType,
   WidgetType,
 } from '@/types/widgets'

--- a/src/components/mini-widgets/JoystickCommIndicator.vue
+++ b/src/components/mini-widgets/JoystickCommIndicator.vue
@@ -2,7 +2,12 @@
   <div>
     <v-tooltip :text="tooltipText" location="bottom">
       <template #activator="{ props: tooltipProps }">
-        <div v-bind="tooltipProps" class="relative cursor-pointer" :class="indicatorClass" @click="showDialog = true">
+        <div
+          v-bind="tooltipProps"
+          class="relative cursor-pointer"
+          :class="indicatorClass"
+          @click="widgetStore.miniWidgetManagerVars(miniWidget.hash).configMenuOpen = true"
+        >
           <FontAwesomeIcon icon="fa-solid fa-gamepad" size="xl" />
           <FontAwesomeIcon
             v-if="!joystickConnected || !controllerStore.enableForwarding"
@@ -15,7 +20,7 @@
     </v-tooltip>
 
     <InteractionDialog
-      v-model="showDialog"
+      v-model="widgetStore.miniWidgetManagerVars(miniWidget.hash).configMenuOpen"
       :title="joystickConnected ? 'Joystick connected' : 'Joystick disconnected'"
       max-width="400px"
       variant="text-only"
@@ -33,22 +38,35 @@
         </div>
       </template>
       <template #actions>
-        <v-btn @click="showDialog = false">Close</v-btn>
+        <v-btn @click="widgetStore.miniWidgetManagerVars(miniWidget.hash).configMenuOpen = false">Close</v-btn>
       </template>
     </InteractionDialog>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, toRefs } from 'vue'
 
 import InteractionDialog from '@/components/InteractionDialog.vue'
 import { joystickManager } from '@/libs/joystick/manager'
 import { useControllerStore } from '@/stores/controller'
+import { useWidgetManagerStore } from '@/stores/widgetManager'
+import type { MiniWidget } from '@/types/widgets'
 
+/**
+ * Props for the JoystickCommIndicator component
+ */
+const props = defineProps<{
+  /**
+   * Configuration of the widget
+   */
+  miniWidget: MiniWidget
+}>()
+const miniWidget = toRefs(props).miniWidget
+
+const widgetStore = useWidgetManagerStore()
 const controllerStore = useControllerStore()
 const joystickConnected = ref(false)
-const showDialog = ref(false)
 
 onMounted(() => {
   joystickManager.onJoystickUpdate((event) => {

--- a/src/components/mini-widgets/MissionIdentifier.vue
+++ b/src/components/mini-widgets/MissionIdentifier.vue
@@ -2,7 +2,7 @@
   <div
     class="flex items-center justify-start h-full px-4 mr-1 transition-all cursor-pointer hover:bg-slate-200/30 min-w-[20%] select-none"
     :class="widgetStore.editingMode ? 'pointer-events-none' : 'pointer-events-auto'"
-    @click="showMissionOptionsDialog = true"
+    @click="widgetStore.miniWidgetManagerVars(miniWidget.hash).configMenuOpen = true"
   >
     <div class="flex items-center overflow-hidden text-lg font-medium text-white whitespace-nowrap">
       <p v-if="store.missionName" class="overflow-x-hidden text-ellipsis">{{ store.missionName }}</p>
@@ -14,7 +14,7 @@
   </div>
 
   <teleport to="body">
-    <v-dialog v-model="showMissionOptionsDialog" width="50%">
+    <v-dialog v-model="widgetStore.miniWidgetManagerVars(miniWidget.hash).configMenuOpen" width="50%">
       <v-card class="pa-2 bg-[#20202022] backdrop-blur-2xl text-white rounded-lg">
         <v-card-title class="flex justify-between">
           <div />
@@ -25,7 +25,7 @@
             :height="34"
             variant="text"
             class="bg-transparent -mt-1 -mr-3"
-            @click="showMissionOptionsDialog = false"
+            @click="widgetStore.miniWidgetManagerVars(miniWidget.hash).configMenuOpen = false"
           >
             <v-icon
               :size="interfaceStore.isOnSmallScreen ? 22 : 26"
@@ -51,17 +51,28 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { toRefs } from 'vue'
 
 import { coolMissionNames } from '@/libs/funny-name/words'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMissionStore } from '@/stores/mission'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
+import type { MiniWidget } from '@/types/widgets'
+
+/**
+ * Props for the BatteryIndicator component
+ */
+const props = defineProps<{
+  /**
+   * Configuration of the widget
+   */
+  miniWidget: MiniWidget
+}>()
+const miniWidget = toRefs(props).miniWidget
 
 const store = useMissionStore()
 const widgetStore = useWidgetManagerStore()
 const interfaceStore = useAppInterfaceStore()
 
-const showMissionOptionsDialog = ref(false)
 const randomMissionName = coolMissionNames.random()
 </script>

--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -810,6 +810,41 @@ export type Profile = {
   name: string
 }
 
+export const isWidgetConfigurable: Record<WidgetType, boolean> = {
+  [WidgetType.Attitude]: true,
+  [WidgetType.Compass]: true,
+  [WidgetType.CompassHUD]: true,
+  [WidgetType.CustomWidgetBase]: true,
+  [WidgetType.DepthHUD]: true,
+  [WidgetType.IFrame]: true,
+  [WidgetType.ImageView]: true,
+  [WidgetType.Map]: true,
+  [WidgetType.MiniWidgetsBar]: false,
+  [WidgetType.Plotter]: true,
+  [WidgetType.URLVideoPlayer]: true,
+  [WidgetType.VideoPlayer]: true,
+  [WidgetType.VirtualHorizon]: false,
+}
+
+export const isMiniWidgetConfigurable: Record<MiniWidgetType, boolean> = {
+  [MiniWidgetType.Alerter]: false,
+  [MiniWidgetType.ArmerButton]: false,
+  [MiniWidgetType.BaseCommIndicator]: false,
+  [MiniWidgetType.BatteryIndicator]: true,
+  [MiniWidgetType.ChangeAltitudeCommander]: false,
+  [MiniWidgetType.Clock]: false,
+  [MiniWidgetType.DepthIndicator]: false,
+  [MiniWidgetType.MissionIdentifier]: true,
+  [MiniWidgetType.RelativeAltitudeIndicator]: false,
+  [MiniWidgetType.TakeoffLandCommander]: false,
+  [MiniWidgetType.VeryGenericIndicator]: true,
+  [MiniWidgetType.JoystickCommIndicator]: true,
+  [MiniWidgetType.MiniVideoRecorder]: true,
+  [MiniWidgetType.ModeSelector]: false,
+  [MiniWidgetType.SatelliteIndicator]: false,
+  [MiniWidgetType.ViewSelector]: false,
+}
+
 export const validateWidget = (maybeWidget: Widget): maybeWidget is Widget => {
   if (maybeWidget.hash === undefined) throw new Error('Widget validation failed: property hash is missing.')
 


### PR DESCRIPTION
The end of an era...

<img width="319" alt="image" src="https://github.com/user-attachments/assets/3468d042-f265-4ab0-a79a-3f88d27ee3e4" />

The cursor also changes to the not-allowed type when hovering a not-configurable one.

Fix #541 