### PR TITLE
mavlink: Don't log "unconnected" error too frequently

### DIFF
--- a/src/libs/communication/mavlink.ts
+++ b/src/libs/communication/mavlink.ts
@@ -5,6 +5,8 @@ import { MavComponent, MAVLinkType } from '../connection/m2r/messages/mavlink2re
 import { type Message } from '../connection/m2r/messages/mavlink2rest-message'
 import { MavlinkManualControlState } from '../joystick/protocols/mavlink-manual-control'
 
+let lastTimeLoggedConnectionError = new Date(0)
+
 /**
  * Send a mavlink message
  * @param {MavMessage} message
@@ -22,7 +24,10 @@ export const sendMavlinkMessage = (message: MavMessage): void => {
   try {
     ConnectionManager.write(textEncoder.encode(JSON.stringify(pack)))
   } catch (error) {
+    // Don't log the error if it's too frequent
+    if (Date.now() < lastTimeLoggedConnectionError.getTime() + 10000) return
     console.error('Error sending MAVLink message:', error)
+    lastTimeLoggedConnectionError = new Date()
   }
 }
 


### PR DESCRIPTION
This was leading to hundreds of logs per second when the vehicle was disconnected, which could lead to slowdowns in the application.

<img width="345" alt="image" src="https://github.com/user-attachments/assets/db7404b8-cd17-4f82-ad57-0264a236961b" />


With this patch, we get 6 logs per minute at most.
