### PR TITLE
electron: Auto-hide menu bar

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -29,6 +29,7 @@ function createWindow(): void {
       contextIsolation: true,
       nodeIntegration: false,
     },
+    autoHideMenuBar: true,
     width: store.get('windowBounds')?.width ?? screen.getPrimaryDisplay().workAreaSize.width,
     height: store.get('windowBounds')?.height ?? screen.getPrimaryDisplay().workAreaSize.height,
     x: store.get('windowBounds')?.x ?? screen.getPrimaryDisplay().bounds.x,


### PR DESCRIPTION
In Windows and some Linux window-managers it was on the top of the window adding nothing to the application and wasting space.