### PR TITLE
.github: Issue template: bugs.yml: switch bug label to Bug type

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugs.yml
+++ b/.github/ISSUE_TEMPLATE/bugs.yml
@@ -1,7 +1,6 @@
 name: Report bug
 description: Report a bug found
-title: "bug: "
-labels: ["bug", "ui"]
+type: "Bug"
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
GitHub has new [org-level Issue "types"](https://github.blog/changelog/2025-01-13-evolving-github-issues-public-preview/#organize-your-work-with-issue-types), that can help improve consistency between repositories, and adds an abstraction level so standard labels can be used for the lower level specifics instead.