### PR TITLE
Allow using data-lake variables in the URL of HTTP request actions

### DIFF
--- a/src/components/configuration/HttpRequestActionConfig.vue
+++ b/src/components/configuration/HttpRequestActionConfig.vue
@@ -35,7 +35,9 @@
               </td>
               <td>
                 <div :id="item.id" class="flex items-center justify-center rounded-xl mx-1 w-[200px]">
-                  <p class="whitespace-nowrap overflow-hidden text-overflow-ellipsis">{{ item.url }}</p>
+                  <p class="whitespace-nowrap overflow-hidden text-overflow-ellipsis">
+                    {{ replaceDataLakeInputsInString(item.url) }}
+                  </p>
                 </div>
               </td>
               <td class="w-[200px] text-right">
@@ -317,6 +319,7 @@ import {
   registerHttpRequestActionConfig,
 } from '@/libs/actions/http-request'
 import { executeActionCallback } from '@/libs/joystick/protocols/cockpit-actions'
+import { replaceDataLakeInputsInString } from '@/libs/utils-data-lake'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 const interfaceStore = useAppInterfaceStore()
 

--- a/src/components/configuration/HttpRequestActionConfig.vue
+++ b/src/components/configuration/HttpRequestActionConfig.vue
@@ -2,7 +2,17 @@
   <ExpansiblePanel no-top-divider no-bottom-divider :is-expanded="!interfaceStore.isOnPhoneScreen">
     <template #title>HTTP Request Actions</template>
     <template #info>
-      <p>View, manage, and create HTTP request actions.</p>
+      <li>View, manage, and create HTTP request actions.</li>
+      <li>Use these actions to call external APIs, like servers, vehicles, cameras, etc.</li>
+      <li>
+        You can use <code>&#123;&#123; variable-id &#125;&#125;</code> to refer to data-lake variables on the URL and
+        body. You can also use data-lake variables in the URL parameters by simply selecting them from the dropdown.
+      </li>
+      <li>
+        There are two very handy variables you can use in the URL: 'vehicle-address' and 'mavlink2rest-http-endpoint'.
+        The former is the address of the vehicle, without the protocol (http:// or https://) or port, while the latter
+        is the endpoint of the MAVLink2REST API.
+      </li>
     </template>
     <template #content>
       <div class="flex justify-center flex-col ml-2 mb-8 mt-2 w-[640px]">
@@ -30,12 +40,12 @@
             <tr>
               <td>
                 <div :id="item.id" class="flex items-center justify-left rounded-xl mx-1 w-[140px]">
-                  <p class="whitespace-nowrap overflow-hidden text-overflow-ellipsis">{{ item.name }}</p>
+                  <p class="whitespace-nowrap overflow-hidden text-ellipsis">{{ item.name }}</p>
                 </div>
               </td>
               <td>
                 <div :id="item.id" class="flex items-center justify-center rounded-xl mx-1 w-[200px]">
-                  <p class="whitespace-nowrap overflow-hidden text-overflow-ellipsis">
+                  <p class="whitespace-nowrap overflow-hidden text-ellipsis">
                     {{ replaceDataLakeInputsInString(item.url) }}
                   </p>
                 </div>
@@ -323,15 +333,19 @@ import { replaceDataLakeInputsInString } from '@/libs/utils-data-lake'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 const interfaceStore = useAppInterfaceStore()
 
-const actionsConfigs = reactive<Record<string, HttpRequestActionConfig>>({})
-const newActionConfig = ref<HttpRequestActionConfig>({
-  name: '',
-  method: HttpRequestMethod.GET,
-  url: '',
-  headers: {},
+const defaultActionConfig = {
+  name: 'New HTTP Action',
+  method: HttpRequestMethod.POST,
+  url: 'http://{{ vehicle-address }}',
+  headers: {
+    'Content-Type': 'application/json',
+  },
   urlParams: {},
   body: '',
-})
+}
+
+const actionsConfigs = reactive<Record<string, HttpRequestActionConfig>>({})
+const newActionConfig = ref<HttpRequestActionConfig>(defaultActionConfig)
 
 const bodyInputError = ref('')
 
@@ -551,14 +565,7 @@ const saveActionConfig = (): void => {
 }
 
 const resetNewAction = (): void => {
-  newActionConfig.value = {
-    name: '',
-    method: HttpRequestMethod.GET,
-    url: '',
-    headers: {},
-    urlParams: {},
-    body: '',
-  }
+  newActionConfig.value = JSON.parse(JSON.stringify(defaultActionConfig))
   bodyInputError.value = ''
   editMode.value = false
 }

--- a/src/libs/actions/http-request.ts
+++ b/src/libs/actions/http-request.ts
@@ -6,7 +6,7 @@ import {
   registerActionCallback,
   registerNewAction,
 } from '../joystick/protocols/cockpit-actions'
-import { getDataLakeVariableData, getDataLakeVariableInfo } from './data-lake'
+import { replaceDataLakeInputsInJsonString, replaceDataLakeInputsInString } from '../utils-data-lake'
 
 const httpRequestActionIdPrefix = 'http-request-action'
 
@@ -114,115 +114,19 @@ export const getHttpRequestActionCallback = (id: string): HttpRequestActionCallb
   return () => {
     try {
       const action = getHttpRequestActionConfig(id)
-      if (!action) {
-        throw new Error(`Action with id ${id} not found.`)
-      }
+      if (!action) throw new Error(`Action with id ${id} not found.`)
 
-      let parsedBody = action.body
-      const parsedUrlParams = { ...action.urlParams }
-      let parsedUrl = action.url
+      // Parse the body variables
+      const parsedBody = replaceDataLakeInputsInJsonString(action.body)
 
-      // Parse body variables
-      try {
-        const cockpitInputsInBody = action.body.match(/{{\s*([^{}\s]+)\s*}}/g)
-        if (cockpitInputsInBody) {
-          for (const input of cockpitInputsInBody) {
-            try {
-              const parsedInput = input.replace('{{', '').replace('}}', '').trim()
-              const inputData = getDataLakeVariableData(parsedInput)
-              const variableInfo = getDataLakeVariableInfo(parsedInput)
-
-              if (inputData !== undefined) {
-                let valueToReplace: string
-
-                try {
-                  // Determine type either from variable info or by parsing the value
-                  const type =
-                    variableInfo?.type ||
-                    (() => {
-                      const strValue = inputData.toString().toLowerCase()
-                      // Check if it's a boolean
-                      if (strValue === 'true' || strValue === 'false') {
-                        return 'boolean'
-                      }
-                      // Check if it's a number
-                      if (!isNaN(Number(strValue)) && strValue !== '') {
-                        return 'number'
-                      }
-                      return 'string'
-                    })()
-
-                  // Cast the value based on the determined type
-                  switch (type) {
-                    case 'number':
-                    case 'boolean':
-                      valueToReplace = inputData.toString()
-                      // Remove quotes if they exist around the placeholder
-                      parsedBody = parsedBody.replace(`"${input}"`, valueToReplace)
-                      // If no quotes found, replace the placeholder directly
-                      if (parsedBody.includes(input)) {
-                        parsedBody = parsedBody.replace(input, valueToReplace)
-                      }
-                      break
-                    case 'string':
-                      valueToReplace = `"${inputData.toString()}"`
-                      // Replace the placeholder, maintaining the quotes if they exist
-                      parsedBody = parsedBody.replace(`"${input}"`, valueToReplace)
-                      // If no quotes found, replace and add them
-                      if (parsedBody.includes(input)) {
-                        parsedBody = parsedBody.replace(input, valueToReplace)
-                      }
-                      break
-                  }
-                } catch (error) {
-                  console.warn(`Error parsing value for ${input}, using as string:`, error)
-                  // Fallback to string if parsing fails
-                  valueToReplace = `"${inputData.toString()}"`
-                  parsedBody = parsedBody.replace(input, valueToReplace)
-                }
-              }
-            } catch (error) {
-              console.warn(`Error processing body variable ${input}:`, error)
-            }
-          }
-        }
-      } catch (error) {
-        console.error('Error parsing body variables:', error)
-      }
-
-      // Parse URL parameters
-      try {
-        const cockpitInputsInUrlParams = Object.entries(action.urlParams).filter(
-          ([, value]) => typeof value === 'string' && value.startsWith('{{') && value.endsWith('}}')
-        )
-        if (cockpitInputsInUrlParams) {
-          for (const [key, value] of cockpitInputsInUrlParams) {
-            try {
-              const parsedInput = value.replace('{{', '').replace('}}', '').trim()
-              const inputData = getDataLakeVariableData(parsedInput)
-              if (inputData) {
-                parsedUrlParams[key] = inputData.toString()
-              }
-            } catch (error) {
-              console.warn(`Error processing URL parameter ${key}:`, error)
-            }
-          }
-        }
-      } catch (error) {
-        console.error('Error parsing URL parameters:', error)
-      }
+      // Parse the URL parameters
+      const parsedUrlParams: Record<string, string> = {}
+      Object.entries(action.urlParams).forEach(([key, value]) => {
+        parsedUrlParams[key] = replaceDataLakeInputsInString(value)
+      })
 
       // Parse the URL as well for any datalake variables
-      const cockpitInputsInUrl = parsedUrl.match(/{{\s*([^{}\s]+)\s*}}/g)
-      if (cockpitInputsInUrl) {
-        for (const input of cockpitInputsInUrl) {
-          const variableId = input.replace('{{', '').replace('}}', '').trim()
-          const inputData = getDataLakeVariableData(variableId)
-          if (inputData) {
-            parsedUrl = parsedUrl.replace(input, inputData.toString())
-          }
-        }
-      }
+      const parsedUrl = replaceDataLakeInputsInString(action.url)
 
       // Make the request
       try {

--- a/src/libs/utils-data-lake.ts
+++ b/src/libs/utils-data-lake.ts
@@ -1,0 +1,97 @@
+import { getDataLakeVariableData, getDataLakeVariableInfo } from './actions/data-lake'
+
+/**
+ * Guess the type of a string
+ * @param {string} str The string to guess the type of
+ * @returns {'boolean' | 'number' | 'string'} The guessed type of the string
+ */
+export const guessedTypeFromString = (str: string): 'boolean' | 'number' | 'string' => {
+  const strValue = str.toString().toLowerCase()
+  // Check if it's a boolean
+  if (strValue === 'true' || strValue === 'false') {
+    return 'boolean'
+  }
+  // Check if it's a number
+  if (!isNaN(Number(strValue)) && strValue !== '') {
+    return 'number'
+  }
+  return 'string'
+}
+
+/**
+ * Regex to find all data lake inputs in a string.
+ * The inputs include the {{ and }}, so they can be used to replace the input in original string.
+ * @type {RegExp}
+ */
+export const dataLakeInputRegex = /{{\s*([^{}\s]+)\s*}}/g
+
+/**
+ * Find all data lake inputs in a string.
+ * The inputs include the {{ and }}, so they can be used to replace the input in original string.
+ * @param {string} input The string to search for data lake inputs
+ * @returns {string[]} An array of possible data lake inputs. If there are no data lake inputs, an empty array is returned.
+ */
+export const findDataLakeInputsInString = (input: string): string[] => {
+  if (typeof input !== 'string') return []
+  return input.match(dataLakeInputRegex) || []
+}
+
+/**
+ * Get the id of a data lake variable from an input string.
+ * @param {string} input The string to search for a data lake variable id
+ * @returns {string | null} The id of the data lake variable or null if no id is found
+ */
+export const getDataLakeVariableIdFromInput = (input: string): string | null => {
+  const match = input.match(dataLakeInputRegex)
+  if (!match) return null
+  return match[0].replace('{{', '').replace('}}', '').trim()
+}
+
+/**
+ * Replace all data lake inputs in a string with values from the data lake.
+ * If a possible input is not found in the data lake, it will be left unchanged.
+ * @param {string} input The string to replace data lake inputs in
+ * @param {Function} replaceFunction The function to use to replace the data lake inputs. If not provided, the default function will be used.
+ * @returns {string} The string with data lake inputs replaced
+ */
+export const replaceDataLakeInputsInString = (input: string, replaceFunction?: (match: string) => string): string => {
+  if (typeof input !== 'string') return input
+
+  const defaultReplaceFunction = (match: string): string => {
+    const variableId = getDataLakeVariableIdFromInput(match)
+    if (!variableId) return match
+    const variableData = getDataLakeVariableData(variableId)
+    if (variableData === undefined) return match
+    return variableData.toString()
+  }
+
+  const replaceFunctionToUse = replaceFunction || defaultReplaceFunction
+
+  return input.toString().replace(dataLakeInputRegex, (match) => replaceFunctionToUse(match))
+}
+
+export const replaceDataLakeInputsInJsonString = (jsonString: string): string => {
+  let parsedJson = jsonString
+
+  const inputs = findDataLakeInputsInString(parsedJson)
+  inputs.forEach((input) => {
+    const variableId = getDataLakeVariableIdFromInput(input)
+    if (!variableId) return input
+    const variableInfo = getDataLakeVariableInfo(variableId)
+    const variableData = getDataLakeVariableData(variableId)
+    if (variableInfo === undefined || variableData === undefined) return input
+
+    // Determine type either from variable info or by parsing the value
+    const type = variableInfo.type || guessedTypeFromString(variableData?.toString() || '')
+
+    if (type === 'string') {
+      parsedJson = parsedJson.replace(input, variableData.toString())
+    } else if (type === 'number' || type === 'boolean') {
+      parsedJson = parsedJson.replace(`"${input}"`, variableData.toString())
+    } else {
+      return input
+    }
+  })
+
+  return parsedJson
+}

--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -7,6 +7,8 @@ import { computed, reactive, ref, watch } from 'vue'
 import { defaultGlobalAddress } from '@/assets/defaults'
 import { useBlueOsStorage } from '@/composables/settingsSyncer'
 import { useSnackbar } from '@/composables/snackbar'
+import { DataLakeVariable, setDataLakeVariableData } from '@/libs/actions/data-lake'
+import { createDataLakeVariable } from '@/libs/actions/data-lake'
 import { altitude_setpoint } from '@/libs/altitude-slider'
 import {
   getCpuTempCelsius,
@@ -153,6 +155,27 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     if (isOnline) return
     currentlyConnectedVehicleId.value = undefined
   })
+
+  watch(
+    globalAddress,
+    (newAddress) => {
+      if (newAddress === undefined) return
+
+      const vehicleAddressVariableId = 'vehicle-address'
+      if (!getDataLakeVariableInfo(vehicleAddressVariableId)) {
+        const vehicleAddressVariable = new DataLakeVariable(
+          vehicleAddressVariableId,
+          'Vehicle Address',
+          'string',
+          'The address of the vehicle, without protocol.'
+        )
+        createDataLakeVariable(vehicleAddressVariable)
+      }
+
+      setDataLakeVariableData(vehicleAddressVariableId, newAddress)
+    },
+    { immediate: true }
+  )
 
   const rtcConfiguration = computed(() => {
     const queryWebRtcConfiguration = new URLSearchParams(window.location.search).get('webRTCConfiguration')

--- a/src/views/ConfigurationGeneralView.vue
+++ b/src/views/ConfigurationGeneralView.vue
@@ -111,7 +111,7 @@
           </template>
         </ExpansiblePanel>
         <ExpansiblePanel no-top-divider :is-expanded="!interfaceStore.isOnPhoneScreen">
-          <template #title>Autopilot telemetry connection (MAVLink2REST)</template>
+          <template #title>MAVLink2REST Websocket URI</template>
           <template #subtitle>
             Current address: {{ ConnectionManager.mainConnection()?.uri().toString() ?? 'none' }}<br />
             Status:
@@ -133,8 +133,8 @@
                   :class="interfaceStore.isOnSmallScreen ? 'scale-80 w-[80%]' : 'scale-100 w-[76%]'"
                 >
                   <v-text-field
-                    v-model="mainConnectionURI"
-                    :disabled="!mainVehicleStore.customMainConnectionURI.enabled"
+                    v-model="mavlink2RestWebsocketURI"
+                    :disabled="!mainVehicleStore.customMAVLink2RestWebsocketURI.enabled"
                     variant="filled"
                     type="input"
                     density="compact"
@@ -145,7 +145,7 @@
                       <v-icon
                         v-tooltip.bottom="'Reset to default'"
                         color="white"
-                        :disabled="!mainVehicleStore.customMainConnectionURI.enabled"
+                        :disabled="!mainVehicleStore.customMAVLink2RestWebsocketURI.enabled"
                         @click="resetMainVehicleConnectionURI"
                       >
                         mdi-refresh
@@ -156,7 +156,7 @@
                 <v-btn
                   :size="interfaceStore.isOnSmallScreen ? 'small' : 'default'"
                   class="bg-transparent -mt-5 -ml-6"
-                  :disabled="!mainVehicleStore.customMainConnectionURI.enabled"
+                  :disabled="!mainVehicleStore.customMAVLink2RestWebsocketURI.enabled"
                   variant="text"
                   type="submit"
                 >
@@ -169,14 +169,14 @@
                   :class="interfaceStore.isOnSmallScreen ? '-mt-3' : '-mt-5'"
                 >
                   <v-switch
-                    v-model="mainVehicleStore.customMainConnectionURI.enabled"
+                    v-model="mainVehicleStore.customMAVLink2RestWebsocketURI.enabled"
                     v-tooltip.bottom="'Enable custom'"
                     class="-mt-5 bg-transparent mr-1 mb-[7px]"
                     density="compact"
                     hide-details
                   />
                   <div class="-mt-[4px]">
-                    {{ mainVehicleStore.customMainConnectionURI.enabled ? 'Enabled' : 'Disabled' }}
+                    {{ mainVehicleStore.customMAVLink2RestWebsocketURI.enabled ? 'Enabled' : 'Disabled' }}
                   </div>
                 </div>
               </div>
@@ -362,10 +362,10 @@ watch(
 
 const mainConnectionForm = ref()
 const mainConnectionFormValid = ref(false)
-const mainConnectionURI = ref(mainVehicleStore.mainConnectionURI)
+const mavlink2RestWebsocketURI = ref(mainVehicleStore.MAVLink2RestWebsocketURI)
 
 const addNewVehicleConnection = async (conn: Connection.URI): Promise<void> => {
-  mainConnectionURI.value = conn
+  mavlink2RestWebsocketURI.value = conn
   vehicleConnected.value = undefined
   setTimeout(() => (vehicleConnected.value ??= false), 5000)
   try {
@@ -379,9 +379,9 @@ const addNewVehicleConnection = async (conn: Connection.URI): Promise<void> => {
 }
 
 watch(
-  () => mainVehicleStore.mainConnectionURI,
+  () => mainVehicleStore.MAVLink2RestWebsocketURI,
   (val: Connection.URI) => {
-    if (val.toString() === mainConnectionURI.value.toString()) {
+    if (val.toString() === mavlink2RestWebsocketURI.value.toString()) {
       return
     }
 
@@ -396,18 +396,18 @@ const setMainVehicleConnectionURI = async (): Promise<void> => {
     return
   }
 
-  mainVehicleStore.customMainConnectionURI = {
-    data: mainConnectionURI.value.toString(),
+  mainVehicleStore.customMAVLink2RestWebsocketURI = {
+    data: mavlink2RestWebsocketURI.value.toString(),
     enabled: true,
   }
 
-  addNewVehicleConnection(mainConnectionURI.value)
+  addNewVehicleConnection(mavlink2RestWebsocketURI.value)
 }
 
 const resetMainVehicleConnectionURI = async (): Promise<void> => {
-  mainVehicleStore.customMainConnectionURI = {
+  mainVehicleStore.customMAVLink2RestWebsocketURI = {
     enabled: false,
-    data: mainVehicleStore.defaultMainConnectionURI.toString(),
+    data: mainVehicleStore.defaultMAVLink2RestWebsocketURI.toString(),
   }
 }
 
@@ -418,7 +418,7 @@ const webRTCSignallingURI = ref(mainVehicleStore.webRTCSignallingURI)
 const addWebRTCConnection = async (conn: Connection.URI): Promise<void> => {
   webRTCSignallingURI.value = conn
 
-  // This works as a reset for the custom URI, and its not needed in mainConnectionURI since on Add from
+  // This works as a reset for the custom URI, and its not needed in MAVLink2RestWebsocketURI since on Add from
   // ConnectionManager it will be set.
   if (!mainVehicleStore.customWebRTCSignallingURI.enabled) {
     mainVehicleStore.customWebRTCSignallingURI.data = conn.toString()


### PR DESCRIPTION
This also adds the vehicle address to the datalake. This way people can use the vehicle address in the URL, like so:


<img width="483" alt="image" src="https://github.com/user-attachments/assets/d7bbc545-5e6b-4a92-ab55-067fa579639c" />


This prevents the need for editing the URL of every single action that uses the vehicle address if it changes.

Edit: also added a variable that points directly to the MAVLink2REST http endpoint:


<img width="485" alt="image" src="https://github.com/user-attachments/assets/3baabd13-2347-4ed8-9ba2-d78057400133" />
