### PR TITLE
Do not show devices other than BlueOS vehicles in the vehicle discovery

### DIFF
--- a/src/components/VehicleDiscoveryDialog.vue
+++ b/src/components/VehicleDiscoveryDialog.vue
@@ -17,10 +17,10 @@
         </div>
 
         <div v-else-if="vehicles.length > 0" class="flex flex-col gap-2 mb-3">
-          <div class="h-4 font-weight-bold mb-5">Vehicles found!</div>
+          <div class="h-4 font-weight-bold text-center mb-5">Vehicles found!</div>
           <div v-for="vehicle in vehicles" :key="vehicle.address" class="flex items-center gap-2">
-            <v-btn variant="tonal" class="w-full justify-start" @click="selectVehicle(vehicle.address)">
-              {{ vehicle.name }}
+            <v-btn variant="tonal" class="max-w-[500px] justify-start truncate" @click="selectVehicle(vehicle.address)">
+              <span class="max-w-[300px] truncate">{{ vehicle.name }}</span>
               <span class="text-xs ml-2 opacity-50">({{ vehicle.address }})</span>
             </v-btn>
           </div>

--- a/src/libs/electron/vehicle-discovery.ts
+++ b/src/libs/electron/vehicle-discovery.ts
@@ -47,6 +47,12 @@ class VehicleDiscover {
       const statusResponse = await ky.get(`http://${address}/status`, { timeout: 3000 })
       if (!statusResponse.ok) return null
 
+      // Check if the vehicle is a BlueOS vehicle
+      const beaconResponse = await ky.get(`http://${address}/beacon/`, { timeout: 5000 })
+      if (!beaconResponse.ok) return null
+      const beaconText = await beaconResponse.text()
+      if (!beaconText.toLowerCase().includes('beacon')) return null
+
       // Try to get the vehicle name
       const nameResponse = await ky.get(`http://${address}/beacon/v1.0/vehicle_name`, { timeout: 5000 })
       if (!nameResponse.ok) return null


### PR DESCRIPTION
Turns out some devices like routers return 404 pages with status code 200 if you try to access inexistent subdomains of them.

Fix #1551 