### PR TITLE
Lazy load data lake variables in menu

### DIFF
--- a/src/views/ToolsDataLakeView.vue
+++ b/src/views/ToolsDataLakeView.vue
@@ -155,7 +155,6 @@ const setupVariableListeners = (): void => {
 
 const cleanupVariableListeners = (): void => {
   Object.entries(listeners.value).forEach(([id, listenerId]) => {
-    console.log(`Unlistening to ${id}.`)
     unlistenDataLakeVariable(id, listenerId)
   })
 }


### PR DESCRIPTION
Otherwise we are setting listeners to all variables in the lake, which will usually be 300+, and this will trigger a lot of unnecessary screen updates and resource usage, which can slow down the application while this menu is open.