### PR TITLE
Fix usage of hardcoded numbers on MAVLink Message Actions

### DIFF
--- a/src/libs/actions/mavlink-message-actions.ts
+++ b/src/libs/actions/mavlink-message-actions.ts
@@ -9,13 +9,13 @@ import {
   registerActionCallback,
   registerNewAction,
 } from '../joystick/protocols/cockpit-actions'
+import { isNumber } from '../utils'
 import {
   findDataLakeInputsInString,
   getDataLakeVariableIdFromInput,
   replaceDataLakeInputsInJsonString,
 } from '../utils-data-lake'
 import { getDataLakeVariableData } from './data-lake'
-
 const mavlinkMessageActionIdPrefix = 'mavlink-message-action'
 
 /**
@@ -146,12 +146,13 @@ const processMessageConfig = (config: MavlinkMessageConfig): Record<string, any>
         processedConfig[k] = { type: v.value }
       } else {
         const inputs = findDataLakeInputsInString(v.value)
+        const isNumberValue = isNumber(v.value)
         if (inputs.length === 0) {
-          processedConfig[k] = v.value
+          processedConfig[k] = isNumberValue ? Number(v.value) : v.value
         } else {
           const variableId = getDataLakeVariableIdFromInput(inputs[0])
           if (!variableId) {
-            processedConfig[k] = v.value
+            processedConfig[k] = isNumberValue ? Number(v.value) : v.value
           } else {
             const variableData = getDataLakeVariableData(variableId)
             processedConfig[k] = variableData

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -195,3 +195,20 @@ export const copyToClipboard = async (text: string): Promise<void> => {
     throw new Error(`Failed to copy text. Error: ${error}`)
   }
 }
+
+/**
+ * Check if a string represents a valid number
+ * @param {string} str The string to check
+ * @returns {boolean} True if the string represents a valid number, false otherwise
+ */
+export const isNumber = (str: string): boolean => {
+  if (typeof str !== 'string') {
+    return false
+  }
+  // Handle empty strings
+  if (str.trim() === '') {
+    return false
+  }
+  // Convert string to number and check if it's valid
+  return !isNaN(Number(str)) && isFinite(Number(str))
+}


### PR DESCRIPTION
When the user used one of the templates (COMMAND_LONG or COMMAND_INT), if they write a hardcoded number, it was not being casted to a number, being sent as a string instead, which is not accepted by mavlink2rest, resulting in failure of delivery.