### PR TITLE
Allow setting the value of data-lake variables with joystick buttons

### DIFF
--- a/src/libs/joystick/protocols.ts
+++ b/src/libs/joystick/protocols.ts
@@ -1,6 +1,7 @@
 import { type ProtocolAction } from '@/types/joystick'
 
 import { availableCockpitActions } from './protocols/cockpit-actions'
+import { availableDataLakeActions } from './protocols/data-lake'
 import {
   availableMavlinkManualControlButtonFunctions,
   mavlinkManualControlAxes,
@@ -8,7 +9,11 @@ import {
 import { modifierKeyActions, otherAvailableActions } from './protocols/other'
 
 export const allAvailableAxes = (): ProtocolAction[] => {
-  return [...Object.values(mavlinkManualControlAxes), ...Object.values(otherAvailableActions)]
+  return [
+    ...Object.values(mavlinkManualControlAxes),
+    ...Object.values(otherAvailableActions),
+    ...Object.values(availableDataLakeActions()),
+  ]
 }
 
 export const allAvailableButtons = (): ProtocolAction[] => {
@@ -17,5 +22,6 @@ export const allAvailableButtons = (): ProtocolAction[] => {
     ...Object.values(availableMavlinkManualControlButtonFunctions),
     ...Object.values(otherAvailableActions),
     ...Object.values(modifierKeyActions),
+    ...Object.values(availableDataLakeActions()),
   ]
 }

--- a/src/libs/joystick/protocols/data-lake.ts
+++ b/src/libs/joystick/protocols/data-lake.ts
@@ -1,0 +1,63 @@
+import { type DataLakeVariable, getAllDataLakeVariablesInfo, setDataLakeVariableData } from '@/libs/actions/data-lake'
+import { setupPostPiniaConnection } from '@/libs/post-pinia-connections'
+import { useControllerStore } from '@/stores/controller'
+import { type ProtocolAction, CockpitModifierKeyOption, JoystickProtocol } from '@/types/joystick'
+
+import { modifierKeyActions } from './other'
+
+/**
+ * An action to set a data lake variable
+ */
+export class DataLakeVariableAction implements ProtocolAction {
+  readonly protocol = JoystickProtocol.DataLakeVariable
+  /**
+   * Variable ID
+   */
+  id: string
+  /**
+   * Human-readable name
+   */
+  name: string
+
+  /**
+   * Create a data lake variable action
+   * @param {DataLakeVariable} variable The data lake variable to create an action for
+   */
+  constructor(variable: DataLakeVariable) {
+    this.id = variable.id
+    this.name = variable.name
+  }
+}
+
+/**
+ * Get all available data lake variable actions
+ * @returns {DataLakeVariableAction[]} Array of available data lake variable actions
+ */
+export const availableDataLakeActions = (): Record<string, DataLakeVariableAction> => {
+  const variables = getAllDataLakeVariablesInfo()
+  const actions: Record<string, DataLakeVariableAction> = {}
+  Object.entries(variables).forEach(([id, variable]) => {
+    actions[id] = new DataLakeVariableAction(variable)
+  })
+  return actions
+}
+
+// Update data lake variables when joystick buttons are pressed
+setupPostPiniaConnection(() => {
+  const controllerStore = useControllerStore()
+  controllerStore.registerControllerUpdateCallback((joystickState, actionsMapping, activeActions) => {
+    if (!joystickState || !actionsMapping) return
+
+    const useShift = activeActions.map((a) => a.id).includes(modifierKeyActions.shift.id)
+    const modifierKeyId = useShift ? CockpitModifierKeyOption.shift : CockpitModifierKeyOption.regular
+
+    joystickState.buttons
+      .map((btnState, idx) => ({ id: idx, value: btnState }))
+      .forEach((btn) => {
+        const btnMapping = actionsMapping.buttonsCorrespondencies[modifierKeyId as CockpitModifierKeyOption][btn.id]
+        if (btnMapping && btnMapping.action && btnMapping.action.protocol === JoystickProtocol.DataLakeVariable) {
+          setDataLakeVariableData(btnMapping.action.id, Number(btn.value))
+        }
+      })
+  })
+})

--- a/src/libs/post-pinia-connections.ts
+++ b/src/libs/post-pinia-connections.ts
@@ -1,0 +1,18 @@
+const postPiniaConnections: (() => void)[] = []
+
+/**
+ * Add a function to be called after the pinia store is initialized
+ * @param {() => void} setupFunction - The function to be called after the pinia store is initialized
+ */
+export const setupPostPiniaConnection = (setupFunction: () => void): void => {
+  postPiniaConnections.push(setupFunction)
+}
+
+/**
+ * Call all the functions added to the postPiniaConnections array
+ */
+export const setupPostPiniaConnections = (): void => {
+  postPiniaConnections.forEach((setupFunction) => {
+    setupFunction()
+  })
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import { app_version } from '@/libs/cosmos'
 import eventTracker from '@/libs/external-telemetry/event-tracking'
 
 import App from './App.vue'
+import { setupPostPiniaConnections } from './libs/post-pinia-connections'
 import vuetify from './plugins/vuetify'
 import { loadFonts } from './plugins/webfontloader'
 import router from './router'
@@ -54,3 +55,6 @@ app.mount('#app')
 
 // Initialize the logger store
 useOmniscientLoggerStore()
+
+// Post-pinia connections setup
+setupPostPiniaConnections()

--- a/src/types/joystick.ts
+++ b/src/types/joystick.ts
@@ -8,6 +8,7 @@ export enum JoystickProtocol {
   CockpitModifierKey = 'cockpit-modifier-key',
   MAVLinkManualControl = 'mavlink-manual-control',
   CockpitAction = 'cockpit-action',
+  DataLakeVariable = 'data-lake-variable',
   Other = 'other',
 }
 

--- a/src/views/ConfigurationJoystickView.vue
+++ b/src/views/ConfigurationJoystickView.vue
@@ -639,7 +639,10 @@ watch(
 )
 
 const filteredProtocols = protocols.filter(
-  (protocol) => protocol === JoystickProtocol.MAVLinkManualControl || protocol === JoystickProtocol.CockpitAction
+  (protocol) =>
+    protocol === JoystickProtocol.MAVLinkManualControl ||
+    protocol === JoystickProtocol.CockpitAction ||
+    protocol === JoystickProtocol.DataLakeVariable
 )
 
 const warnIfJoystickDoesNotSupportExtendedManualControl = async (): Promise<void> => {


### PR DESCRIPTION
This works for both boolean and floating buttons, so one can use trigger/bumper buttons as well.

Fix #1657 