### PR TITLE
1663 input widget configuration persists outside edit mode

### DIFF
--- a/src/components/InputElementConfig.vue
+++ b/src/components/InputElementConfig.vue
@@ -247,7 +247,7 @@
           <div class="flex flex-col items-center mb-4 -ml-[7px] w-[248px]">
             <template v-if="currentElement.component !== CustomWidgetElementType.Button">
               <div class="flex w-full justify-between items-center h-[40px] border-b-[1px] border-[#FFFFFF33]">
-                <p class="text-center w-full text-sm">Action URL parameter</p>
+                <p class="text-center w-full text-sm">Data-lake variable</p>
                 <v-btn
                   v-if="
                     openNewDataLakeVariableForm === false && currentElement.options.dataLakeVariable?.name === undefined

--- a/src/stores/widgetManager.ts
+++ b/src/stores/widgetManager.ts
@@ -728,6 +728,13 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
     { deep: true }
   )
 
+  // Closes the side config panel on view change and edit mode exit
+  watch([editingMode, currentViewIndex], ([isInEditMode, newViewIdx], [, oldViewIdx]) => {
+    if (!isInEditMode || newViewIdx !== oldViewIdx) {
+      elementToShowOnDrawer.value = undefined
+    }
+  })
+
   const isFullScreen = (widget: Widget): boolean => {
     return isEqual(widget.position, fullScreenPosition) && isEqual(widget.size, fullScreenSize)
   }


### PR DESCRIPTION
- Fixed the panel closure conditions;
- Fixed the text on the Side config panel that has a incorrect reference to URL parameters;

Fixes #1663 