### PR TITLE
Add quick access to widgets configs

### DIFF
--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -1,0 +1,165 @@
+<template>
+  <teleport to="body">
+    <Transition name="fade">
+      <div v-if="isContextMenuOpen" class="fixed z-[99999]" :style="positionStyles" @click.stop>
+        <div
+          class="flex flex-col rounded-md shadow-lg"
+          :style="[
+            interfaceStore.globalGlassMenuStyles,
+            { background: '#33333333', border: '1px solid #FFFFFF44' },
+            { width: width },
+          ]"
+        >
+          <template v-if="menuItems">
+            <div
+              v-for="(item, index) in menuItems"
+              :key="index"
+              class="flex justify-between items-center px-4 h-10 hover:bg-[#FFFFFF11] cursor-pointer text-[14px]"
+              @click="handleItemClick(item)"
+            >
+              <p class="mb-1">{{ item.item }}</p>
+              <v-icon v-if="item.icon" :icon="item.icon" size="16" class="text-[#FFFFFF88] ml-4" />
+            </div>
+            <v-divider v-if="menuItems.length > 1 || ($slots.default && menuItems.length === 1)" />
+          </template>
+          <template v-if="$slots.default">
+            <slot :close="handleClose" />
+          </template>
+        </div>
+      </div>
+    </Transition>
+  </teleport>
+</template>
+
+<script setup lang="ts">
+import {
+  computed,
+  CSSProperties,
+  defineEmits,
+  defineExpose,
+  defineProps,
+  getCurrentInstance,
+  onBeforeUnmount,
+  onMounted,
+  reactive,
+  ref,
+  watch,
+} from 'vue'
+
+import { useAppInterfaceStore } from '@/stores/appInterface'
+import { useWidgetManagerStore } from '@/stores/widgetManager'
+import { ContextMenuItem } from '@/types/user-interface'
+
+const props = defineProps<{
+  /**
+   *
+   */
+  visible: boolean
+  /**
+   *
+   */
+  menuItems?: ContextMenuItem[]
+  /**
+   *
+   */
+  width?: string
+}>()
+
+const emit = defineEmits<{ (e: 'close'): void }>()
+const interfaceStore = useAppInterfaceStore()
+const widgetStore = useWidgetManagerStore()
+
+const isContextMenuOpen = ref(false)
+
+watch(
+  () => props.visible,
+  (newValue) => {
+    isContextMenuOpen.value = newValue
+  }
+)
+
+const internalPosition = reactive({ x: 0, y: 0 })
+
+const positionStyles = computed<CSSProperties>(() => {
+  const isAboveCenter = internalPosition.y < window.innerHeight / 2
+  const isInLastQuarter = internalPosition.x > window.innerWidth * 0.75
+
+  const style: CSSProperties = {
+    userSelect: 'none',
+    top: isAboveCenter ? internalPosition.y + 'px' : 'auto',
+    bottom: !isAboveCenter ? window.innerHeight - internalPosition.y + 'px' : 'auto',
+  }
+
+  if (isInLastQuarter) {
+    style.right = window.innerWidth - internalPosition.x + 'px'
+  } else {
+    style.left = internalPosition.x + 'px'
+  }
+
+  return style
+})
+
+const width = computed(() => props.width || 'auto')
+
+const handleItemClick = (item: ContextMenuItem): void => {
+  item.action?.()
+  handleClose()
+}
+
+const handleClose = (): void => {
+  isContextMenuOpen.value = false
+  if (widgetStore.currentContextMenu === instance) {
+    widgetStore.currentContextMenu = null
+  }
+  emit('close')
+}
+
+const handleOutsideClick = (): void => {
+  handleClose()
+}
+
+onMounted(() => {
+  document.addEventListener('click', handleOutsideClick)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('click', handleOutsideClick)
+})
+
+const instance = getCurrentInstance()
+
+// Position the context menu at the given coordinates.
+const openAt = (event: MouseEvent | TouchEvent): void => {
+  let x = 0,
+    y = 0
+  if ('clientX' in event) {
+    x = event.clientX
+    y = event.clientY
+  } else if (event.touches && event.touches.length) {
+    x = event.touches[0].clientX
+    y = event.touches[0].clientY
+  }
+  internalPosition.x = x
+  internalPosition.y = y
+
+  if (widgetStore.currentContextMenu && widgetStore.currentContextMenu !== instance) {
+    widgetStore.currentContextMenu.exposed?.handleClose()
+  }
+  widgetStore.currentContextMenu = instance
+
+  isContextMenuOpen.value = true
+}
+
+defineExpose({ openAt, handleClose })
+</script>
+
+<style scoped>
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s;
+}
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/src/components/InputElementConfig.vue
+++ b/src/components/InputElementConfig.vue
@@ -1,6 +1,7 @@
 <template>
   <div
-    class="flex fixed w-[250px] h-[78vh] right-0 top-0 border-l-[1px] border-[#FFFFFF44] text-white elevation-5 bg-[#051e2d]"
+    class="flex fixed w-[250px] right-0 top-0 border-l-[1px] border-[#FFFFFF44] text-white elevation-5 bg-[#051e2d]"
+    :style="getMarginsFromBarsHeight"
   >
     <div class="flex flex-col text-center">
       <v-btn
@@ -429,6 +430,15 @@ watch(
     }
   }
 )
+
+const getMarginsFromBarsHeight = computed(() => {
+  return {
+    marginTop: widgetStore.currentTopBarHeightPixels + 'px',
+    marginBottom: widgetStore.currentBottomBarHeightPixels + 'px',
+    height:
+      window.innerHeight - widgetStore.currentTopBarHeightPixels - widgetStore.currentBottomBarHeightPixels - 1 + 'px',
+  }
+})
 
 const handleResetVariable = (): void => {
   currentElement.value!.options.dataLakeVariable = undefined

--- a/src/components/MiniWidgetInstantiator.vue
+++ b/src/components/MiniWidgetInstantiator.vue
@@ -1,13 +1,39 @@
 <template>
-  <component :is="componentFromType(miniWidget.component)" :mini-widget="miniWidget" />
+  <div v-contextmenu="handleContextMenu" :style="{ opacity: miniWidget.options.opacity ?? 1 }">
+    <component :is="componentFromType(miniWidget.component)" :mini-widget="miniWidget" />
+  </div>
+  <ContextMenu
+    ref="contextMenuRef"
+    :visible="contextMenuVisible"
+    :menu-items="contextMenuItems"
+    width="200px"
+    @close="contextMenuVisible = false"
+  >
+    <template #default>
+      <div class="flex justify-between items-center pr-4 h-10 hover:bg-[#FFFFFF11] text-[14px]">
+        <div class="w-full -ml-1">
+          <v-slider
+            v-model="OpacitySlider"
+            color="white"
+            min="0.2"
+            max="1"
+            step="0.01"
+            class="scale-75 h-[32px] opacity-75"
+          />
+        </div>
+        <v-icon icon="mdi-circle-opacity" size="16" class="text-[#FFFFFF88] rotate-180" />
+      </div>
+    </template>
+  </ContextMenu>
 </template>
 
 <script setup lang="ts">
-import { defineAsyncComponent, onMounted, toRefs } from 'vue'
+import { computed, defineAsyncComponent, onMounted, ref, toRefs } from 'vue'
 
+import ContextMenu from '@/components/ContextMenu.vue'
 import { createDataLakeVariable, getDataLakeVariableInfo } from '@/libs/actions/data-lake'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
-import { type MiniWidget, CustomWidgetElement } from '@/types/widgets'
+import { type MiniWidget, CustomWidgetElement, isMiniWidgetConfigurable, MiniWidgetType } from '@/types/widgets'
 
 const widgetStore = useWidgetManagerStore()
 
@@ -19,8 +45,47 @@ const props = defineProps<{
 }>()
 
 const miniWidget = toRefs(props).miniWidget
-
 const componentCache: Record<string, ReturnType<typeof defineAsyncComponent>> = {}
+const contextMenuRef = ref()
+const contextMenuVisible = ref(false)
+
+const handleContextMenu = {
+  open: (event: MouseEvent | TouchEvent) => {
+    contextMenuRef.value.openAt(event)
+    contextMenuVisible.value = true
+  },
+  close: () => {
+    contextMenuVisible.value = false
+  },
+}
+
+const OpacitySlider = computed({
+  get() {
+    return miniWidget.value.options?.opacity ?? 1
+  },
+  set(newValue) {
+    if (miniWidget.value.options) {
+      miniWidget.value.options.opacity = newValue
+    }
+  },
+})
+
+const isConfigMenuDisabled = computed(() => {
+  if ('isCustomElement' in miniWidget.value && miniWidget.value.isCustomElement) return false
+  if (isMiniWidgetConfigurable[miniWidget.value.component as MiniWidgetType]) {
+    return false
+  }
+  return true
+})
+
+const openWidgetConfig = (): void => {
+  contextMenuVisible.value = false
+  widgetStore.miniWidgetManagerVars(miniWidget.value.hash).configMenuOpen = true
+}
+
+const contextMenuItems = computed(() =>
+  isConfigMenuDisabled.value ? [] : [{ item: 'Options', action: openWidgetConfig, icon: 'mdi-cog' }]
+)
 
 const componentFromType = (componentType: string): ReturnType<typeof defineAsyncComponent> => {
   if (!componentCache[componentType]) {

--- a/src/components/widgets/CollapsibleContainer.vue
+++ b/src/components/widgets/CollapsibleContainer.vue
@@ -153,93 +153,102 @@
   </div>
 
   <Teleport to="body">
-    <GlassModal :is-visible="widgetStore.widgetManagerVars(widget.hash).configMenuOpen">
-      <v-card class="px-8 pb-6 pt-2 rounded-lg w-[400px] bg-transparent">
-        <v-card-title class="text-center -mt-1">Custom Widget options</v-card-title>
-        <v-btn
-          class="absolute top-3 right-0 text-lg rounded-full"
-          variant="text"
-          size="small"
-          @click="widgetStore.widgetManagerVars(widget.hash).configMenuOpen = false"
+    <v-dialog v-model="widgetStore.widgetManagerVars(widget.hash).configMenuOpen" persistent>
+      <GlassModal :is-visible="widgetStore.widgetManagerVars(widget.hash).configMenuOpen">
+        <v-card class="px-8 pb-6 pt-2 rounded-lg w-[400px] bg-transparent">
+          <v-card-title class="text-center -mt-1">Custom Widget options</v-card-title>
+          <v-btn
+            class="absolute top-3 right-0 text-lg rounded-full"
+            variant="text"
+            size="small"
+            @click="widgetStore.widgetManagerVars(widget.hash).configMenuOpen = false"
+          >
+            <v-icon>mdi-close</v-icon>
+          </v-btn>
+          <div class="flex flex-col justify-start items-start gap-x-4 mt-3 w-full">
+            <p class="text-start">Name:</p>
+            <v-text-field ref="nameInput" v-model="widget.name" density="compact" class="w-3/4" />
+            <p class="text-start">Columns:</p>
+            <v-text-field
+              ref="nameInput"
+              v-model="widget.options.columns"
+              min="1"
+              max="2"
+              type="number"
+              density="compact"
+              class="w-1/4"
+            />
+            <p class="mt-1">Background color</p>
+            <input v-model="widget.options.backgroundColor" type="color" class="p-0 w-20 mr-4" />
+            <p class="mt-3">Background opacity:</p>
+            <v-slider
+              v-model="widget.options.backgroundOpacity"
+              min="0"
+              max="1"
+              color="white"
+              thumb-label
+              width="250"
+            />
+            <p class="mt-3">Background blur:</p>
+            <v-slider v-model="widget.options.backgroundBlur" min="0" max="100" color="white" thumb-label width="250" />
+          </div>
+        </v-card>
+      </GlassModal>
+
+      <Transition>
+        <div
+          v-if="showWidgetTrashArea"
+          ref="widgetTrashArea"
+          class="absolute w-32 h-32 -translate-x-32 -translate-y-32 bottom-[20%] left-1/3 bg-[#FF000055] z-[65] rounded-xl flex items-center justify-center hover:bg-slate-200/50 transition-all"
         >
-          <v-icon>mdi-close</v-icon>
-        </v-btn>
-        <div class="flex flex-col justify-start items-start gap-x-4 mt-3 w-full">
-          <p class="text-start">Name:</p>
-          <v-text-field ref="nameInput" v-model="widget.name" density="compact" class="w-3/4" />
-          <p class="text-start">Columns:</p>
-          <v-text-field
-            ref="nameInput"
-            v-model="widget.options.columns"
-            min="1"
-            max="2"
-            type="number"
-            density="compact"
-            class="w-1/4"
-          />
-          <p class="mt-1">Background color</p>
-          <input v-model="widget.options.backgroundColor" type="color" class="p-0 w-20 mr-4" />
-          <p class="mt-3">Background opacity:</p>
-          <v-slider v-model="widget.options.backgroundOpacity" min="0" max="1" color="white" thumb-label width="250" />
-          <p class="mt-3">Background blur:</p>
-          <v-slider v-model="widget.options.backgroundBlur" min="0" max="100" color="white" thumb-label width="250" />
-        </div>
-      </v-card>
-    </GlassModal>
-
-    <Transition>
-      <div
-        v-if="showWidgetTrashArea"
-        ref="widgetTrashArea"
-        class="absolute w-32 h-32 -translate-x-32 -translate-y-32 bottom-[20%] left-1/3 bg-[#FF000055] z-[65] rounded-xl flex items-center justify-center hover:bg-slate-200/50 transition-all"
-      >
-        <div class="relative flex justify-center items-center w-full h-full">
-          <FontAwesomeIcon
-            icon="fa-solid fa-trash"
-            class="absolute h-16 transition-all -translate-x-7 -translate-y-8 top-1/2 left-1/2 text-white"
-          />
-          <VueDraggable
-            v-model="trashList"
-            :animation="150"
-            group="generalGroup"
-            class="flex flex-wrap items-center justify-center w-full h-full gap-2"
-            @add="handleDeleteWidget"
-          >
-            <div v-for="miniWidget in trashList" :key="miniWidget.hash">
-              <div class="select-none">
-                <MiniWidgetInstantiator :mini-widget="miniWidget" />
-              </div>
-            </div>
-          </VueDraggable>
-        </div>
-      </div>
-    </Transition>
-
-    <GlassModal :is-visible="selectViewToShareDialog">
-      <v-card class="px-3 pb-6 pt-2 rounded-lg w-auto bg-transparent z-40">
-        <v-card-title class="flex justify-around -mt-1 w-full px-0">
-          <div />
-          <p class="mx-8">Clone widget to</p>
-          <v-icon class="cursor-pointer self-end" @click="selectViewToShareDialog = false">mdi-close</v-icon>
-        </v-card-title>
-        <div class="flex w-full justify-center items-center mt-4">
-          <select
-            v-model="selectedViewToShareWidget"
-            class="bg-[#50505022] dark:bg-gray-800 dark:text-white w-[180px] p-2 border border-gray-300 dark:border-gray-600 rounded appearance-none"
-            @change="handleCopyWidgetToView"
-          >
-            <option
-              v-for="view in widgetStore.currentProfile.views"
-              :key="view.name"
-              :value="view.name"
-              class="bg-gray-800 dark:bg-gray-800 dark:text-white"
+          <div class="relative flex justify-center items-center w-full h-full">
+            <FontAwesomeIcon
+              icon="fa-solid fa-trash"
+              class="absolute h-16 transition-all -translate-x-7 -translate-y-8 top-1/2 left-1/2 text-white"
+            />
+            <VueDraggable
+              v-model="trashList"
+              :animation="150"
+              group="generalGroup"
+              class="flex flex-wrap items-center justify-center w-full h-full gap-2"
+              @add="handleDeleteWidget"
             >
-              {{ view.name }}
-            </option>
-          </select>
+              <div v-for="miniWidget in trashList" :key="miniWidget.hash">
+                <div class="select-none">
+                  <MiniWidgetInstantiator :mini-widget="miniWidget" />
+                </div>
+              </div>
+            </VueDraggable>
+          </div>
         </div>
-      </v-card>
-    </GlassModal>
+      </Transition>
+
+      <GlassModal :is-visible="selectViewToShareDialog">
+        <v-card class="px-3 pb-6 pt-2 rounded-lg w-auto bg-transparent z-40">
+          <v-card-title class="flex justify-around -mt-1 w-full px-0">
+            <div />
+            <p class="mx-8">Clone widget to</p>
+            <v-icon class="cursor-pointer self-end" @click="selectViewToShareDialog = false">mdi-close</v-icon>
+          </v-card-title>
+          <div class="flex w-full justify-center items-center mt-4">
+            <select
+              v-model="selectedViewToShareWidget"
+              class="bg-[#50505022] dark:bg-gray-800 dark:text-white w-[180px] p-2 border border-gray-300 dark:border-gray-600 rounded appearance-none"
+              @change="handleCopyWidgetToView"
+            >
+              <option
+                v-for="view in widgetStore.currentProfile.views"
+                :key="view.name"
+                :value="view.name"
+                class="bg-gray-800 dark:bg-gray-800 dark:text-white"
+              >
+                {{ view.name }}
+              </option>
+            </select>
+          </div>
+        </v-card>
+      </GlassModal>
+    </v-dialog>
   </Teleport>
 </template>
 

--- a/src/directives/contextMenu.ts
+++ b/src/directives/contextMenu.ts
@@ -1,0 +1,84 @@
+import { DirectiveBinding } from 'vue'
+
+/**
+ * Context menu opener type
+ */
+export interface ContextMenu {
+  /**
+   * Open the context menu
+   */
+  open: (event: MouseEvent | TouchEvent) => void
+  /**
+   * Close the context menu
+   */
+  close: () => void
+}
+
+// Global reference to the currently open context menu opener
+let currentContextMenu: {
+  /**
+   * Open/closes the context menu
+   */
+  close: () => void
+} | null = null
+
+const longPressDuration = 500
+let touchTimer: ReturnType<typeof setTimeout> | null = null
+
+export const contextMenu = {
+  mounted(el: HTMLElement, binding: DirectiveBinding<ContextMenu>) {
+    const { value: opener } = binding
+
+    if (typeof opener.open !== 'function' || typeof opener.close !== 'function') {
+      console.warn('v-contextmenu-opener binding value must be an object with open and close functions')
+      return
+    }
+
+    const onContextMenu = (event: MouseEvent): void => {
+      event.preventDefault()
+      event.stopPropagation()
+      // If there is another open context menu (from a different element), close it.
+      if (currentContextMenu && currentContextMenu !== opener) {
+        currentContextMenu.close()
+      }
+      opener.open(event)
+      currentContextMenu = opener
+    }
+
+    const onTouchStart = (event: TouchEvent): void => {
+      touchTimer = setTimeout(() => {
+        if (currentContextMenu && currentContextMenu !== opener) {
+          currentContextMenu.close()
+        }
+        opener.open(event)
+        currentContextMenu = opener
+      }, longPressDuration)
+    }
+
+    const onTouchEnd = (): void => {
+      if (touchTimer) {
+        clearTimeout(touchTimer)
+        touchTimer = null
+      }
+    }
+
+    el.addEventListener('contextmenu', onContextMenu)
+    el.addEventListener('touchstart', onTouchStart)
+    el.addEventListener('touchend', onTouchEnd)
+    el.addEventListener('touchcancel', onTouchEnd)
+
+    // Store the event listeners for cleanup.
+    ;(el as any).__contextMenuHandlers = { onContextMenu, onTouchStart, onTouchEnd }
+  },
+
+  unmounted(el: HTMLElement) {
+    const handlers = (el as any).__contextMenuHandlers
+    if (handlers) {
+      el.removeEventListener('contextmenu', handlers.onContextMenu)
+      el.removeEventListener('touchstart', handlers.onTouchStart)
+      el.removeEventListener('touchend', handlers.onTouchEnd)
+      el.removeEventListener('touchcancel', handlers.onTouchEnd)
+      delete (el as any).__contextMenuHandlers
+    }
+  },
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ import eventTracker from '@/libs/external-telemetry/event-tracking'
 import { runMigrations } from '@/utils/migrations'
 
 import App from './App.vue'
+import { contextMenu } from './directives/contextMenu'
 import { setupPredefinedLakeAndActionResources } from './libs/joystick/protocols/predefined-resources'
 import { setupPostPiniaConnections } from './libs/post-pinia-connections'
 import vuetify from './plugins/vuetify'
@@ -55,6 +56,7 @@ if (window.localStorage.getItem('cockpit-enable-usage-statistics-telemetry') && 
 
 app.component('FontAwesomeIcon', FontAwesomeIcon)
 app.component('VueDraggableResizable', VueDraggableResizable)
+app.directive('contextmenu', contextMenu)
 app.use(router).use(vuetify).use(createPinia()).use(FloatingVue).use(VueVirtualScroller)
 app.mount('#app')
 

--- a/src/stores/widgetManager.ts
+++ b/src/stores/widgetManager.ts
@@ -17,7 +17,6 @@ import { miniWidgetsProfile } from '@/assets/defaults'
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { resetJustMadeKey, useBlueOsStorage } from '@/composables/settingsSyncer'
 import { openSnackbar } from '@/composables/snackbar'
-import { useSnackbar } from '@/composables/snackbar'
 import { MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import * as Words from '@/libs/funny-name/words'
 import {
@@ -45,7 +44,6 @@ import {
 } from '@/types/widgets'
 
 const { showDialog } = useInteractionDialog()
-const { openSnackbar } = useSnackbar()
 
 export const savedProfilesKey = 'cockpit-saved-profiles-v8'
 

--- a/src/stores/widgetManager.ts
+++ b/src/stores/widgetManager.ts
@@ -71,6 +71,7 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
   const widgetToEdit = ref<Widget>()
   const miniWidgetLastValues = useBlueOsStorage<Record<string, any>>('cockpit-mini-widget-last-values', {})
   const floatingWidgetContainers = ref<MiniWidgetContainer[]>([])
+  const currentContextMenu = ref<any | null>(null)
 
   const editWidgetByHash = (hash: string): Widget | undefined => {
     widgetToEdit.value = currentProfile.value.views
@@ -934,5 +935,6 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
     setMiniWidgetLastValue,
     getMiniWidgetLastValue,
     copyWidgetToView,
+    currentContextMenu,
   }
 })

--- a/src/types/user-interface.ts
+++ b/src/types/user-interface.ts
@@ -1,0 +1,31 @@
+/**
+ * Context menu
+ */
+export interface IContextMenu {
+  /**
+   * Close the context menu
+   */
+  handleClose: () => void
+  /**
+   * The position of the context menu
+   */
+  openAt: (event: MouseEvent | TouchEvent) => void
+}
+
+/**
+ * Context Menu Item
+ */
+export interface ContextMenuItem {
+  /**
+   * The item name to display
+   */
+  item: string
+  /**
+   * The icon to display
+   */
+  icon?: string
+  /**
+   * The action to perform
+   */
+  action: () => void
+}


### PR DESCRIPTION
- Users can now use a right-click or a long press to open a context menu on the widgets;
- Widgets and mini widgets are now configurable outside edit-mode;
- Cockpit elements opacity can be quickly set using the context menu;
- `v-contextmenu` directive added for easy binding the context menu's triggering and opening location;

https://github.com/user-attachments/assets/fc9d4849-0fbd-4d5c-8fae-5fc39bbc510c

Closes #1610 
