### PR TITLE
Filter custom widgets to be displayed on Edit-mode's left bar

### DIFF
--- a/src/components/EditMenu.vue
+++ b/src/components/EditMenu.vue
@@ -755,9 +755,9 @@ const miniWidgetsBars = computed(() => {
 })
 
 const getAllMiniWidgetFromCustomWidget = (): MiniWidgetContainer[] => {
-  const allCustomBases = store.currentProfile.views
-    .flatMap((view) => view.widgets)
-    .filter((widget) => widget.component === WidgetType.CollapsibleContainer)
+  const allCustomBases = store.currentView.widgets.filter(
+    (widget) => widget.component === WidgetType.CollapsibleContainer
+  )
 
   return allCustomBases.map((base) => {
     const baseName = base.name || 'Unnamed Custom Widget'


### PR DESCRIPTION
* Now edit mode's left panel will display only the custom components related to the selected view.

Closes #1633 