### PR TITLE
map: Add tooltips to buttons in the widget and mission planning view

### DIFF
--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -33,6 +33,7 @@
 
       <v-btn
         v-if="showButtons"
+        v-tooltip="'Download the mission that is stored in the vehicle.'"
         class="absolute m-3 bottom-button left-20 bg-slate-50"
         elevation="2"
         style="z-index: 1002; border-radius: 0px"
@@ -43,6 +44,7 @@
 
       <v-btn
         v-if="showButtons"
+        v-tooltip="'Execute the mission that is stored in the vehicle.'"
         class="absolute mb-3 ml-1 bottom-button left-32 bg-slate-50"
         elevation="2"
         style="z-index: 1002; border-radius: 0px"

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -1,57 +1,78 @@
 <template>
   <div ref="mapBase" class="page-base" :class="widgetStore.editingMode ? 'pointer-events-none' : 'pointer-events-auto'">
     <div :id="mapId" ref="map" class="map">
-      <v-btn
-        v-if="showButtons"
-        v-tooltip="home ? 'Center map on home position.' : 'Home position is currently undefined.'"
-        class="absolute left-0 m-3 bottom-button bg-slate-50"
-        :class="!home ? 'active-events-on-disabled' : ''"
-        :color="followerTarget == WhoToFollow.HOME ? 'red' : ''"
-        elevation="2"
-        style="z-index: 1002; border-radius: 0px"
-        icon="mdi-home-map-marker"
-        size="x-small"
-        :disabled="!home"
-        @click.stop="targetFollower.goToTarget(WhoToFollow.HOME, true)"
-        @dblclick.stop="targetFollower.follow(WhoToFollow.HOME)"
-      />
+      <v-tooltip
+        location="top"
+        :text="home ? 'Center map on home position.' : 'Cannot center map on home (home position undefined).'"
+      >
+        <template #activator="{ props: tooltipProps }">
+          <v-btn
+            v-if="showButtons"
+            v-bind="tooltipProps"
+            class="absolute left-0 m-3 bottom-button bg-slate-50"
+            :class="!home ? 'active-events-on-disabled' : ''"
+            :color="followerTarget == WhoToFollow.HOME ? 'red' : ''"
+            elevation="2"
+            style="z-index: 1002; border-radius: 0px"
+            icon="mdi-home-map-marker"
+            size="x-small"
+            :disabled="!home"
+            @click.stop="targetFollower.goToTarget(WhoToFollow.HOME, true)"
+            @dblclick.stop="targetFollower.follow(WhoToFollow.HOME)"
+          />
+        </template>
+      </v-tooltip>
 
-      <v-btn
-        v-if="showButtons"
-        v-tooltip="vehiclePosition ? 'Center map on vehicle position.' : 'Vehicle position is currently undefined.'"
-        class="absolute m-3 bottom-button left-10 bg-slate-50"
-        :class="!vehiclePosition ? 'active-events-on-disabled' : ''"
-        :color="followerTarget == WhoToFollow.VEHICLE ? 'red' : ''"
-        elevation="2"
-        style="z-index: 1002; border-radius: 0px"
-        icon="mdi-airplane-marker"
-        size="x-small"
-        :disabled="!vehiclePosition"
-        @click.stop="targetFollower.goToTarget(WhoToFollow.VEHICLE, true)"
-        @dblclick.stop="targetFollower.follow(WhoToFollow.VEHICLE)"
-      />
+      <v-tooltip
+        location="top"
+        :text="vehiclePosition ? 'Center map on vehicle position.' : 'Cannot center map on vehicle (vehicle offline).'"
+      >
+        <template #activator="{ props: tooltipProps }">
+          <v-btn
+            v-if="showButtons"
+            v-bind="tooltipProps"
+            class="absolute m-3 bottom-button left-10 bg-slate-50"
+            :class="!vehiclePosition ? 'active-events-on-disabled' : ''"
+            :color="followerTarget == WhoToFollow.VEHICLE ? 'red' : ''"
+            elevation="2"
+            style="z-index: 1002; border-radius: 0px"
+            icon="mdi-airplane-marker"
+            size="x-small"
+            :disabled="!vehiclePosition"
+            @click.stop="targetFollower.goToTarget(WhoToFollow.VEHICLE, true)"
+            @dblclick.stop="targetFollower.follow(WhoToFollow.VEHICLE)"
+          />
+        </template>
+      </v-tooltip>
 
-      <v-btn
-        v-if="showButtons"
-        v-tooltip="'Download the mission that is stored in the vehicle.'"
-        class="absolute m-3 bottom-button left-20 bg-slate-50"
-        elevation="2"
-        style="z-index: 1002; border-radius: 0px"
-        icon="mdi-download"
-        size="x-small"
-        @click.stop="downloadMissionFromVehicle"
-      />
-
-      <v-btn
-        v-if="showButtons"
-        v-tooltip="'Execute the mission that is stored in the vehicle.'"
-        class="absolute mb-3 ml-1 bottom-button left-32 bg-slate-50"
-        elevation="2"
-        style="z-index: 1002; border-radius: 0px"
-        icon="mdi-play"
-        size="x-small"
-        @click.stop="executeMissionOnVehicle"
-      />
+      <v-tooltip location="top" text="Download the mission that is stored in the vehicle.">
+        <template #activator="{ props: tooltipProps }">
+          <v-btn
+            v-if="showButtons"
+            v-bind="tooltipProps"
+            class="absolute m-3 bottom-button left-20 bg-slate-50"
+            elevation="2"
+            style="z-index: 1002; border-radius: 0px"
+            icon="mdi-download"
+            size="x-small"
+            @click.stop="downloadMissionFromVehicle"
+          />
+        </template>
+      </v-tooltip>
+      <v-tooltip location="top" text="Execute the mission that is stored in the vehicle.">
+        <template #activator="{ props: tooltipProps }">
+          <v-btn
+            v-if="showButtons"
+            v-bind="tooltipProps"
+            class="absolute mb-3 ml-1 bottom-button left-32 bg-slate-50"
+            elevation="2"
+            style="z-index: 1002; border-radius: 0px"
+            icon="mdi-play"
+            size="x-small"
+            @click.stop="executeMissionOnVehicle"
+          />
+        </template>
+      </v-tooltip>
     </div>
   </div>
 

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -45,12 +45,14 @@
         </template>
       </v-tooltip>
 
-      <v-tooltip location="top" text="Download the mission that is stored in the vehicle.">
+      <v-tooltip location="top" :text="vehicleDownloadMissionButtonTooltipText">
         <template #activator="{ props: tooltipProps }">
           <v-btn
             v-if="showButtons"
             v-bind="tooltipProps"
             class="absolute m-3 bottom-button left-20 bg-slate-50"
+            :class="!vehicleStore.isVehicleOnline ? 'active-events-on-disabled' : ''"
+            :disabled="!vehicleStore.isVehicleOnline"
             elevation="2"
             style="z-index: 1002; border-radius: 0px"
             icon="mdi-download"
@@ -59,12 +61,14 @@
           />
         </template>
       </v-tooltip>
-      <v-tooltip location="top" text="Execute the mission that is stored in the vehicle.">
+      <v-tooltip location="top" :text="vehicleExecuteMissionButtonTooltipText">
         <template #activator="{ props: tooltipProps }">
           <v-btn
             v-if="showButtons"
             v-bind="tooltipProps"
             class="absolute mb-3 ml-1 bottom-button left-32 bg-slate-50"
+            :class="!vehicleStore.isVehicleOnline ? 'active-events-on-disabled' : ''"
+            :disabled="!vehicleStore.isVehicleOnline"
             elevation="2"
             style="z-index: 1002; border-radius: 0px"
             icon="mdi-play"
@@ -615,6 +619,18 @@ const bottomButtonsDisplacement = computed(() => {
 
 const topProgressBarDisplacement = computed(() => {
   return `${Math.max(-widgetStore.widgetClearanceForVisibleArea(widget.value).top, 0)}px`
+})
+
+const vehicleDownloadMissionButtonTooltipText = computed(() => {
+  return vehicleStore.isVehicleOnline
+    ? 'Download the mission that is stored in the vehicle.'
+    : 'Vehicle offline (cannot download mission).'
+})
+
+const vehicleExecuteMissionButtonTooltipText = computed(() => {
+  return vehicleStore.isVehicleOnline
+    ? 'Execute the mission that is stored in the vehicle.'
+    : 'Vehicle offline (cannot execute mission).'
 })
 </script>
 

--- a/src/libs/utils-map.ts
+++ b/src/libs/utils-map.ts
@@ -161,6 +161,14 @@ export class TargetFollower {
     this.target = undefined
     this.onTargetChange(this.target)
   }
+
+  /**
+   * Returns the current target ref to follow.
+   * @returns {WhoToFollow | undefined} The current target ref to follow.
+   */
+  public getCurrentTarget(): WhoToFollow | undefined {
+    return this.target
+  }
 }
 
 /**

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -219,7 +219,7 @@
         </button>
       </div>
     </div>
-    <v-tooltip location="top center" text="Home position is currently undefined" :disabled="Boolean(home)">
+    <v-tooltip location="top center" :text="centerHomeButtonTooltipText">
       <template #activator="{ props: tooltipProps }">
         <v-btn
           class="absolute m-3 rounded-sm shadow-sm bottom-14 bg-slate-50"
@@ -234,11 +234,7 @@
         />
       </template>
     </v-tooltip>
-    <v-tooltip
-      location="top center"
-      text="Vehicle position is currently undefined"
-      :disabled="Boolean(vehiclePosition)"
-    >
+    <v-tooltip location="top center" :text="centerVehicleButtonTooltipText">
       <template #activator="{ props: tooltipProps }">
         <v-btn
           class="absolute m-3 rounded-sm shadow-sm bottom-14 bg-slate-50"
@@ -1853,6 +1849,18 @@ watch([home, planningMap], async () => {
   if (home.value === mapCenter.value || !planningMap.value || !mapNotYetCenteredInHome) return
   await goHome()
   mapNotYetCenteredInHome = false
+})
+
+const centerHomeButtonTooltipText = computed(() => {
+  if (home.value === undefined) return 'Home position is currently undefined'
+  if (targetFollower.getCurrentTarget() === WhoToFollow.HOME) return 'Tracking home position'
+  return 'Click once to center on home or twice to track it'
+})
+
+const centerVehicleButtonTooltipText = computed(() => {
+  if (vehiclePosition.value === undefined) return 'Vehicle position is currently undefined'
+  if (targetFollower.getCurrentTarget() === WhoToFollow.VEHICLE) return 'Tracking vehicle position'
+  return 'Click once to center on vehicle or twice to track it'
 })
 </script>
 


### PR DESCRIPTION
Added tooltips for all possible situations.

<img width="384" alt="image" src="https://github.com/user-attachments/assets/645dae97-94bb-43cb-ad52-f392a6b0a26a" />
<img width="228" alt="image" src="https://github.com/user-attachments/assets/5420318e-722e-43c6-8e29-aa4b808b1615" />
<img width="398" alt="image" src="https://github.com/user-attachments/assets/c7896825-a918-4f34-9cbc-b8c3e994892f" />


Fix #1736 