### PR TITLE
migration: Stop renaming old components in the profiles

### DIFF
--- a/src/utils/migrations.ts
+++ b/src/utils/migrations.ts
@@ -1,7 +1,3 @@
-import { v4 as uuid4 } from 'uuid'
-
-import { Profile, WidgetType } from '@/types/widgets'
-
 /**
  * Migrate old localStorage keys to new ones
  */
@@ -21,38 +17,8 @@ const migrateRenameOfLocalStorageKeys = (): void => {
 }
 
 /**
- * Migrate old widget component names to new ones
- */
-const migrateRenameWidgetTypeOnProfiles = (): void => {
-  const mappingWidgetComponentName = {
-    CustomWidgetBase: 'CollapsibleContainer',
-  }
-  const profiles: Profile[] = JSON.parse(localStorage.getItem('cockpit-saved-profiles-v8')!)
-  if (!profiles) return
-
-  profiles.forEach((profile) => {
-    profile.views.forEach((view) => {
-      view.widgets.forEach((widget) => {
-        Object.entries(mappingWidgetComponentName).forEach(([oldName, newName]) => {
-          if (widget.component === oldName) {
-            widget.component = newName as WidgetType
-          }
-          if (widget.name === oldName) {
-            widget.name = newName as WidgetType
-          }
-          widget.hash = uuid4()
-        })
-      })
-    })
-  })
-
-  localStorage.setItem('cockpit-saved-profiles-v8', JSON.stringify(profiles))
-}
-
-/**
  * Run all migrations
  */
 export function runMigrations(): void {
   migrateRenameOfLocalStorageKeys()
-  migrateRenameWidgetTypeOnProfiles()
 }

--- a/src/views/WidgetsView.vue
+++ b/src/views/WidgetsView.vue
@@ -14,7 +14,7 @@
       <SnappingGrid v-if="store.snapToGrid && store.editingMode" :grid-interval="store.gridInterval" />
       <template v-for="widget in view.widgets.slice().reverse()" :key="widget.hash">
         <WidgetHugger
-          v-if="Object.values(WidgetType).includes(widget.component)"
+          v-if="componentExists(widget.component)"
           :widget="widget"
           :allow-moving="store.widgetManagerVars(widget.hash).allowMoving"
           :allow-resizing="store.editingMode"
@@ -37,14 +37,28 @@ import WidgetHugger from '../components/WidgetHugger.vue'
 
 const store = useWidgetManagerStore()
 
+// TODO: Remove this non-migration implementation once we have a better solution that doesn't cause sync conflicts
+const mappedComponentType = (componentName: string): WidgetType => {
+  const mappingWidgetComponentName = {
+    CustomWidgetBase: 'CollapsibleContainer',
+  }
+  return (mappingWidgetComponentName[componentName] || componentName) as WidgetType
+}
+
 const componentCache: Record<string, AsyncComponentLoader> = {}
 
-const componentFromType = (componentType: WidgetType): AsyncComponentLoader => {
+const componentFromType = (componentName: string): AsyncComponentLoader => {
+  const componentType = mappedComponentType(componentName)
+
   if (componentCache[componentType] === undefined) {
     componentCache[componentType] = defineAsyncComponent(() => import(`../components/widgets/${componentType}.vue`))
   }
 
   return componentCache[componentType]
+}
+
+const componentExists = (componentName: string): boolean => {
+  return Object.values(WidgetType).includes(mappedComponentType(componentName))
 }
 </script>
 


### PR DESCRIPTION
This was causing infinite restart loops if the user tried to keep the BlueOS profiles on sync conflicts.

This solution keeps the old names in the profiles and just map them to the new names on runtime.