### PR TITLE
Simplify Main-menu responsiveness logic

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -11,7 +11,7 @@
         <div
           id="menu-trigger"
           class="menu-trigger border-4 flex items-center justify-center w-[30px] px-0 py-2 cursor-pointer overflow-hidden rounded-r-lg rounded-br-lg -ml-[1px]"
-          :class="[interfaceStore.isOnSmallScreen ? 'top-[30%]' : 'top-[50%]']"
+          :class="[interfaceStore.isOnSmallScreen ? 'top-[20%] scale-75 -ml-[3px]' : 'top-[50%]']"
           :style="
             interfaceStore.highlightedComponent === 'menu-trigger'
               ? interfaceStore.globalGlassMenuHighlightStyles

--- a/src/App.vue
+++ b/src/App.vue
@@ -22,195 +22,11 @@
           <v-icon class="text-white text-[46px] opacity-80">mdi-menu-right</v-icon>
         </div>
       </div>
-      <transition name="slide-in-left">
-        <div
-          v-if="interfaceStore.isMainMenuVisible"
-          ref="mainMenu"
-          class="left-menu slide-in"
-          :style="[
-            glassMenuStyles,
-            simplifiedMainMenu ? { width: '45px', borderRadius: '0 10px 10px 0' } : mainMenuWidth,
-          ]"
-        >
-          <v-window v-model="interfaceStore.mainMenuCurrentStep" class="h-full w-full">
-            <v-window-item :value="1" class="h-full">
-              <div
-                class="relative flex flex-col h-full justify-between align-center items-center select-none"
-                :class="
-                  interfaceStore.isOnSmallScreen
-                    ? 'gap-y-0 pt-2 pb-3 sm:sm:py-0 sm:-ml-[3px] xs:xs:py-0 xs:-ml-[3px]'
-                    : 'lg:gap-y-2 xl:gap-y-3 gap-y-4 py-4'
-                "
-              >
-                <GlassButton
-                  v-if="route.name === 'widgets-view'"
-                  :label="simplifiedMainMenu ? '' : 'Edit Interface'"
-                  :selected="widgetStore.editingMode"
-                  :label-class="[menuLabelSize, '-mb-0.5 mt-6']"
-                  :icon="simplifiedMainMenu ? 'mdi-pencil' : undefined"
-                  :icon-size="simplifiedMainMenu ? 25 : undefined"
-                  variant="uncontained"
-                  :tooltip="simplifiedMainMenu ? 'Edit Mode' : undefined"
-                  :width="buttonSize"
-                  @click="
-                    () => {
-                      widgetStore.editingMode = !widgetStore.editingMode
-                      closeMainMenu()
-                    }
-                  "
-                  ><img v-if="!simplifiedMainMenu" :src="EditModeIcon" alt="Edit Mode Icon" />
-                </GlassButton>
-                <GlassButton
-                  v-if="route.name !== 'widgets-view'"
-                  :label="simplifiedMainMenu ? '' : 'Flight'"
-                  :label-class="[menuLabelSize, '-mb-0.5 mt-6']"
-                  :icon="simplifiedMainMenu ? 'mdi-send' : undefined"
-                  :icon-size="simplifiedMainMenu ? 25 : undefined"
-                  variant="uncontained"
-                  :tooltip="simplifiedMainMenu ? 'Flight' : undefined"
-                  :width="buttonSize"
-                  :selected="$route.name === 'Flight'"
-                  @click="
-                    () => {
-                      $router.push('/')
-                      closeMainMenu()
-                    }
-                  "
-                  ><img v-if="!simplifiedMainMenu" :src="FlightIcon" alt="Flight Icon" />
-                </GlassButton>
-                <GlassButton
-                  v-if="route.name !== 'Mission planning'"
-                  :label="simplifiedMainMenu ? '' : 'Mission Planning'"
-                  :label-class="[menuLabelSize, '-mb-0.5 mt-6']"
-                  :icon="simplifiedMainMenu ? 'mdi-map-marker-radius-outline' : undefined"
-                  :icon-size="simplifiedMainMenu ? 25 : undefined"
-                  variant="uncontained"
-                  :tooltip="simplifiedMainMenu ? 'Mission Planning' : undefined"
-                  :width="buttonSize"
-                  :selected="$route.name === 'Mission planning'"
-                  @click="
-                    () => {
-                      $router.push('/mission-planning')
-                      closeMainMenu()
-                    }
-                  "
-                  ><img v-if="!simplifiedMainMenu" :src="MissionPlanningIcon" alt="MissionPlanning Icon"
-                /></GlassButton>
-                <GlassButton
-                  :label="simplifiedMainMenu ? '' : 'Settings'"
-                  :label-class="[menuLabelSize, '-mb-0.5 mt-6']"
-                  :icon="simplifiedMainMenu ? 'mdi-cog' : undefined"
-                  :icon-size="simplifiedMainMenu ? 25 : undefined"
-                  variant="uncontained"
-                  :tooltip="simplifiedMainMenu ? 'Configuration' : undefined"
-                  :width="buttonSize"
-                  :selected="showSubMenu"
-                  class="mb-1"
-                  :style="
-                    interfaceStore.highlightedComponent === 'settings-menu-item' && {
-                      animation: 'highlightBackground 0.5s alternate 20',
-                      borderRadius: '10px',
-                    }
-                  "
-                  @click="selectSubMenu(SubMenuName.settings)"
-                  ><img v-if="!simplifiedMainMenu" :src="SettingsIcon" alt="Settings Icon" />
-                </GlassButton>
-                <GlassButton
-                  :label="simplifiedMainMenu ? '' : 'Tools'"
-                  :label-class="[menuLabelSize, '-mb-0.5 mt-6']"
-                  :icon="simplifiedMainMenu ? 'mdi-tools' : undefined"
-                  :icon-size="simplifiedMainMenu ? 25 : undefined"
-                  variant="uncontained"
-                  :tooltip="simplifiedMainMenu ? 'Tools' : undefined"
-                  :width="buttonSize"
-                  :selected="showSubMenu"
-                  class="mb-1"
-                  @click="selectSubMenu(SubMenuName.tools)"
-                  ><img v-if="!simplifiedMainMenu" :src="ToolsIcon" alt="Tools Icon" />
-                </GlassButton>
-                <GlassButton
-                  :label="simplifiedMainMenu ? '' : isFullscreen ? 'Exit Fullscreen' : 'Enter Fullscreen'"
-                  :label-class="[menuLabelSize, '-mb-0.5 mt-6']"
-                  :icon="simplifiedMainMenu ? fullScreenToggleIcon : undefined"
-                  :icon-size="simplifiedMainMenu ? 25 : undefined"
-                  variant="uncontained"
-                  :tooltip="simplifiedMainMenu ? (isFullscreen ? 'Exit Fullscreen' : 'Enter Fullscreen') : undefined"
-                  :button-class="simplifiedMainMenu ? '-mb-2' : ''"
-                  :width="buttonSize"
-                  :selected="false"
-                  @click="
-                    () => {
-                      toggleFullscreen()
-                      closeMainMenu()
-                    }
-                  "
-                  ><img
-                    v-if="!simplifiedMainMenu"
-                    :src="isFullscreen ? ExitFullScreenIcon : FullScreenIcon"
-                    alt="Fullscreen Icon"
-                  />
-                </GlassButton>
-                <GlassButton
-                  :label="simplifiedMainMenu ? '' : 'About'"
-                  :label-class="[menuLabelSize, '-mb-0.5 mt-6']"
-                  :icon="simplifiedMainMenu ? 'mdi-information-outline' : undefined"
-                  :icon-size="simplifiedMainMenu ? 25 : undefined"
-                  variant="uncontained"
-                  :tooltip="simplifiedMainMenu ? 'About' : undefined"
-                  :button-class="!simplifiedMainMenu ? '-mt-[5px]' : undefined"
-                  :width="buttonSize"
-                  :selected="showSubMenu"
-                  @click="openAboutDialog"
-                  ><img v-if="!simplifiedMainMenu" :src="InfoIcon" alt="Info Icon" />
-                </GlassButton>
-              </div>
-            </v-window-item>
-            <v-window-item :value="2" class="h-full w-full">
-              <div class="flex flex-col w-full h-full justify-between">
-                <GlassButton
-                  v-for="menuitem in currentSubMenu"
-                  :key="menuitem.title"
-                  :label="simplifiedMainMenu ? undefined : menuitem.title"
-                  :label-class="menuLabelSize"
-                  :button-class="interfaceStore.isOnSmallScreen ? '-ml-[2px]' : ''"
-                  :icon="menuitem.icon"
-                  :selected="interfaceStore.currentSubMenuComponentName === menuitem.componentName"
-                  variant="uncontained"
-                  :height="buttonSize * 0.45"
-                  :icon-size="buttonSize * 0.5"
-                  :style="
-                    interfaceStore.highlightedComponent === menuitem.title && {
-                      animation: 'highlightBackground 0.5s alternate 50',
-                      borderRadius: '4px',
-                    }
-                  "
-                  @click="toggleSubMenuComponent(menuitem.component)"
-                  ><template #content
-                    ><div v-if="currentSubMenuComponent === menuitem.component" class="arrow-left"></div></template
-                ></GlassButton>
-                <div class="flex flex-col justify-center align-center pb-1">
-                  <v-divider width="70%" />
-                  <GlassButton
-                    :label-class="menuLabelSize"
-                    icon="mdi-arrow-left"
-                    :icon-class="interfaceStore.isOnSmallScreen ? '' : '-mb-[1px]'"
-                    :button-class="interfaceStore.isOnSmallScreen ? (simplifiedMainMenu ? '-mt-1' : 'mt-1') : undefined"
-                    variant="round"
-                    :width="buttonSize / 2.4"
-                    :selected="false"
-                    @click="
-                      () => {
-                        interfaceStore.mainMenuCurrentStep = 1
-                        currentSubMenuComponent = null
-                      }
-                    "
-                  />
-                </div>
-              </div>
-            </v-window-item>
-          </v-window>
-        </div>
-      </transition>
+      <MainMenu
+        v-model:currentSubMenuComponent="currentSubMenuComponent"
+        @close-main-menu="closeMainMenu"
+        @open-about-dialog="handleShowAboutDialog"
+      />
 
       <teleport to="body">
         <GlassModal
@@ -318,18 +134,9 @@
 </template>
 
 <script setup lang="ts">
-import { onClickOutside, useDebounceFn, useFullscreen, useStorage, useWindowSize } from '@vueuse/core'
-import { computed, markRaw, onBeforeUnmount, onMounted, ref, watch } from 'vue'
-import { useRoute } from 'vue-router'
+import { useDebounceFn, useStorage, useWindowSize } from '@vueuse/core'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 
-import EditModeIcon from '@/assets/icons/edit-mode.svg'
-import ExitFullScreenIcon from '@/assets/icons/exit-full-screen.svg'
-import FlightIcon from '@/assets/icons/flight.svg'
-import FullScreenIcon from '@/assets/icons/full-screen.svg'
-import InfoIcon from '@/assets/icons/info.svg'
-import MissionPlanningIcon from '@/assets/icons/mission-planning.svg'
-import SettingsIcon from '@/assets/icons/settings.svg'
-import ToolsIcon from '@/assets/icons/tools.svg'
 import GlassModal from '@/components/GlassModal.vue'
 import SnackbarContainer from '@/components/SnackbarContainer.vue'
 import Tutorial from '@/components/Tutorial.vue'
@@ -347,25 +154,15 @@ import { isElectron } from '@/libs/utils'
 import About from './components/About.vue'
 import AltitudeSlider from './components/AltitudeSlider.vue'
 import EditMenu from './components/EditMenu.vue'
-import GlassButton from './components/GlassButton.vue'
+import MainMenu from './components/MainMenu.vue'
 import MiniWidgetContainer from './components/MiniWidgetContainer.vue'
 import SlideToConfirm from './components/SlideToConfirm.vue'
 import { useSnackbar } from './composables/snackbar'
-import { SubMenuComponentName, SubMenuName, useAppInterfaceStore } from './stores/appInterface'
+import { useAppInterfaceStore } from './stores/appInterface'
 import { useMainVehicleStore } from './stores/mainVehicle'
 import { useWidgetManagerStore } from './stores/widgetManager'
 import { SubMenuComponent } from './types/general'
-import ConfigurationActionsView from './views/ConfigurationActionsView.vue'
-import ConfigurationAlertsView from './views/ConfigurationAlertsView.vue'
-import ConfigurationDevelopmentView from './views/ConfigurationDevelopmentView.vue'
-import ConfigurationGeneralView from './views/ConfigurationGeneralView.vue'
-import ConfigurationJoystickView from './views/ConfigurationJoystickView.vue'
-import ConfigurationTelemetryView from './views/ConfigurationLogsView.vue'
-import ConfigurationMissionView from './views/ConfigurationMissionView.vue'
-import ConfigurationUIView from './views/ConfigurationUIView.vue'
-import ConfigurationVideoView from './views/ConfigurationVideoView.vue'
-import ToolsDataLakeView from './views/ToolsDataLakeView.vue'
-import ToolsMAVLinkView from './views/ToolsMAVLinkView.vue'
+
 const { showDialog, closeDialog } = useInteractionDialog()
 const { openSnackbar } = useSnackbar()
 
@@ -374,125 +171,17 @@ const vehicleStore = useMainVehicleStore()
 const interfaceStore = useAppInterfaceStore()
 
 const showAboutDialog = ref(false)
-const showSubMenu = ref(false)
 const currentSubMenuComponent = ref<SubMenuComponent>(null)
-const mainMenu = ref()
+
+const handleShowAboutDialog = (): void => {
+  showAboutDialog.value = true
+}
 
 // Main menu
 const isMenuOpen = ref(false)
 const isSlidingOut = ref(false)
 
-const { width: windowWidth, height: windowHeight } = useWindowSize()
-
-const configMenu = [
-  {
-    icon: 'mdi-view-dashboard-variant',
-    title: 'General',
-    componentName: SubMenuComponentName.SettingsGeneral,
-    component: markRaw(ConfigurationGeneralView) as SubMenuComponent,
-  },
-  {
-    icon: 'mdi-monitor-cellphone',
-    title: 'Interface',
-    componentName: SubMenuComponentName.SettingsInterface,
-    component: markRaw(ConfigurationUIView) as SubMenuComponent,
-  },
-  {
-    icon: 'mdi-controller',
-    title: 'Joystick',
-    componentName: SubMenuComponentName.SettingsJoystick,
-    component: markRaw(ConfigurationJoystickView) as SubMenuComponent,
-  },
-  {
-    icon: 'mdi-video',
-    title: 'Video',
-    componentName: SubMenuComponentName.SettingsVideo,
-    component: markRaw(ConfigurationVideoView) as SubMenuComponent,
-  },
-  {
-    icon: 'mdi-subtitles-outline',
-    title: 'Telemetry',
-    componentName: SubMenuComponentName.SettingsTelemetry,
-    component: markRaw(ConfigurationTelemetryView) as SubMenuComponent,
-  },
-  {
-    icon: 'mdi-alert-rhombus-outline',
-    title: 'Alerts',
-    componentName: SubMenuComponentName.SettingsAlerts,
-    component: markRaw(ConfigurationAlertsView) as SubMenuComponent,
-  },
-  {
-    icon: 'mdi-dev-to',
-    title: 'Dev',
-    componentName: SubMenuComponentName.SettingsDev,
-    component: markRaw(ConfigurationDevelopmentView) as SubMenuComponent,
-  },
-  {
-    icon: 'mdi-map-marker-path',
-    title: 'Mission',
-    componentName: SubMenuComponentName.SettingsMission,
-    component: markRaw(ConfigurationMissionView) as SubMenuComponent,
-  },
-  {
-    icon: 'mdi-run-fast',
-    title: 'Actions',
-    componentName: SubMenuComponentName.SettingsActions,
-    component: markRaw(ConfigurationActionsView) as SubMenuComponent,
-  },
-]
-
-const toolsMenu = [
-  {
-    icon: 'mdi-protocol',
-    title: 'MAVLink',
-    componentName: SubMenuComponentName.ToolsMAVLink,
-    component: markRaw(ToolsMAVLinkView) as SubMenuComponent,
-  },
-  {
-    icon: 'mdi-database-outline',
-    title: 'Data-lake',
-    componentName: SubMenuComponentName.ToolsDataLake,
-    component: markRaw(ToolsDataLakeView) as SubMenuComponent,
-  },
-]
-
-const availableSubMenus = {
-  settings: configMenu,
-  tools: toolsMenu,
-}
-
-const currentSubMenu = computed(() => {
-  if (interfaceStore.currentSubMenuName === null) return []
-  return availableSubMenus[interfaceStore.currentSubMenuName]
-})
-
-watch(
-  () => interfaceStore.currentSubMenuComponentName,
-  (subMenuComponentName) => {
-    currentSubMenuComponent.value =
-      currentSubMenu.value.find((item) => item.componentName === subMenuComponentName)?.component || null
-  }
-)
-
-const selectSubMenu = (subMenuName: SubMenuName): void => {
-  interfaceStore.currentSubMenuName = subMenuName
-  interfaceStore.mainMenuCurrentStep = 2
-}
-
-const toggleSubMenuComponent = (component: SubMenuComponent): void => {
-  if (currentSubMenuComponent.value === null) {
-    currentSubMenuComponent.value = component
-    interfaceStore.configModalVisibility = true
-    return
-  }
-  if (currentSubMenuComponent.value === component) {
-    currentSubMenuComponent.value = null
-    interfaceStore.configModalVisibility = false
-    return
-  }
-  currentSubMenuComponent.value = component
-  interfaceStore.configModalVisibility = true
-}
+const { width: windowWidth } = useWindowSize()
 
 const isConfigModalVisible = computed(() => interfaceStore.isConfigModalVisible)
 
@@ -504,26 +193,6 @@ watch(isConfigModalVisible, (newVal) => {
 
 const topBottomBarScale = computed(() => {
   return windowWidth.value / originalBarWidth
-})
-
-const maxScreenHeightPixelsThatFitsLargeMenu = computed(() => {
-  const heightTopBar = widgetStore.currentTopBarHeightPixels * topBottomBarScale.value
-  const heightBottomBar = widgetStore.currentBottomBarHeightPixels * topBottomBarScale.value
-  const visibleAreaHeight = windowHeight.value - heightTopBar - heightBottomBar
-  return visibleAreaHeight
-})
-
-const simplifiedMainMenu = computed(() => {
-  const threshold = windowWidth.value > 1300 ? 860 : 680
-  return maxScreenHeightPixelsThatFitsLargeMenu.value < threshold
-})
-
-const mainMenuWidth = computed(() => {
-  const width =
-    interfaceStore.isOnSmallScreen && interfaceStore.mainMenuCurrentStep === 2
-      ? '60px'
-      : `${interfaceStore.mainMenuWidth}px`
-  return { width }
 })
 
 const toggleMainMenu = (): void => {
@@ -643,65 +312,7 @@ watch(
   }
 )
 
-const buttonSize = computed(() => {
-  if (interfaceStore.is2xl) return 72
-  if (interfaceStore.isXl) return 66
-  if (interfaceStore.isLg) return 60
-  if (interfaceStore.isMd) return 54
-  if (interfaceStore.isSm && windowHeight.value > 700) return 60
-  if (interfaceStore.isSm && windowHeight.value < 700) return 48
-  if (interfaceStore.isXs && windowHeight.value >= 700) return 60
-  return 48
-})
-
-const menuLabelSize = computed(() => {
-  if (interfaceStore.is2xl) return 'text-[15px]'
-  if (interfaceStore.isXl) return 'text-[14px]'
-  if (interfaceStore.isLg) return 'text-[13px]'
-  if (interfaceStore.isMd) return 'text-[12px]'
-  if (interfaceStore.isSm) return 'text-[10px]'
-  if (interfaceStore.isXs && windowHeight.value >= 700) return 'text-[12px]'
-  return 'text-[10px]'
-})
-
-onClickOutside(mainMenu, () => {
-  if (interfaceStore.mainMenuCurrentStep === 1 && !interfaceStore.isTutorialVisible) {
-    closeMainMenu()
-  }
-  if (
-    interfaceStore.mainMenuCurrentStep === 2 &&
-    currentSubMenuComponent.value === null &&
-    !interfaceStore.isTutorialVisible
-  ) {
-    closeMainMenu()
-  }
-})
-
-const glassMenuStyles = computed(() => ({
-  backgroundColor: interfaceStore.UIGlassEffect.bgColor,
-  color: interfaceStore.UIGlassEffect.fontColor,
-  backdropFilter: `blur(${interfaceStore.UIGlassEffect.blur}px)`,
-}))
-
-const openAboutDialog = (): void => {
-  showAboutDialog.value = true
-  closeMainMenu()
-}
-
-const route = useRoute()
 const routerSection = ref()
-
-// Full screen toggling
-const { isFullscreen, toggle: toggleFullscreen } = useFullscreen()
-
-const debouncedToggleFullScreen = useDebounceFn(() => toggleFullscreen(), 10)
-const fullScreenCallbackId = registerActionCallback(
-  availableCockpitActions.toggle_full_screen,
-  debouncedToggleFullScreen
-)
-onBeforeUnmount(() => unregisterActionCallback(fullScreenCallbackId))
-
-const fullScreenToggleIcon = computed(() => (isFullscreen.value ? 'mdi-fullscreen-exit' : 'mdi-overscan'))
 
 const currentSelectedViewName = computed(() => widgetStore.currentView.name)
 
@@ -789,47 +400,6 @@ body {
 
 body.hide-cursor {
   cursor: none;
-}
-
-.left-menu {
-  position: fixed;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  border-radius: 0 20px 20px 0;
-  border: 1px #cbcbcb22 solid;
-  border-left: none;
-  top: 50%;
-  left: 0;
-  transform: translateY(-50%);
-  box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.3), 0px 8px 12px 6px rgba(0, 0, 0, 0.15);
-  z-index: 1000;
-}
-
-@keyframes slideInLeft {
-  from {
-    transform: translateX(-100%) translateY(-50%);
-  }
-  to {
-    transform: translateX(0) translateY(-50%);
-  }
-}
-
-@keyframes slideOutLeft {
-  from {
-    transform: translateX(0) translateY(-50%);
-  }
-  to {
-    transform: translateX(-100%) translateY(-50%);
-  }
-}
-
-.slide-in-left-enter-active {
-  animation: slideInLeft 300ms ease forwards;
-}
-
-.slide-in-left-leave-active {
-  animation: slideOutLeft 300ms ease forwards;
 }
 
 .router-view {

--- a/src/components/MainMenu.vue
+++ b/src/components/MainMenu.vue
@@ -1,0 +1,491 @@
+<template>
+  <transition name="slide-in-left">
+    <div
+      v-if="interfaceStore.isMainMenuVisible"
+      ref="mainMenu"
+      class="left-menu slide-in"
+      :style="[glassMenuStyles, simplifiedMainMenu ? { width: '45px', borderRadius: '0 10px 10px 0' } : mainMenuWidth]"
+    >
+      <v-window v-model="interfaceStore.mainMenuCurrentStep" class="h-full w-full">
+        <v-window-item :value="1" class="h-full">
+          <div
+            class="relative flex flex-col h-full justify-between align-center items-center select-none"
+            :class="
+              interfaceStore.isOnSmallScreen
+                ? 'gap-y-0 pt-2 pb-3 sm:sm:py-0 sm:-ml-[3px] xs:xs:py-0 xs:-ml-[3px]'
+                : 'lg:gap-y-2 xl:gap-y-3 gap-y-4 py-4'
+            "
+          >
+            <GlassButton
+              v-if="route.name === 'widgets-view'"
+              :label="simplifiedMainMenu ? '' : 'Edit Interface'"
+              :selected="widgetStore.editingMode"
+              :label-class="[menuLabelSize, '-mb-0.5 mt-6']"
+              :icon="simplifiedMainMenu ? 'mdi-pencil' : undefined"
+              :icon-size="simplifiedMainMenu ? 25 : undefined"
+              variant="uncontained"
+              :tooltip="simplifiedMainMenu ? 'Edit Mode' : undefined"
+              :width="buttonSize"
+              @click="
+                () => {
+                  widgetStore.editingMode = !widgetStore.editingMode
+                  handleCloseMainMenu()
+                }
+              "
+              ><img v-if="!simplifiedMainMenu" :src="EditModeIcon" alt="Edit Mode Icon" />
+            </GlassButton>
+            <GlassButton
+              v-if="route.name !== 'widgets-view'"
+              :label="simplifiedMainMenu ? '' : 'Flight'"
+              :label-class="[menuLabelSize, '-mb-0.5 mt-6']"
+              :icon="simplifiedMainMenu ? 'mdi-send' : undefined"
+              :icon-size="simplifiedMainMenu ? 25 : undefined"
+              variant="uncontained"
+              :tooltip="simplifiedMainMenu ? 'Flight' : undefined"
+              :width="buttonSize"
+              :selected="$route.name === 'Flight'"
+              @click="
+                () => {
+                  $router.push('/')
+                  handleCloseMainMenu()
+                }
+              "
+              ><img v-if="!simplifiedMainMenu" :src="FlightIcon" alt="Flight Icon" />
+            </GlassButton>
+            <GlassButton
+              v-if="route.name !== 'Mission planning'"
+              :label="simplifiedMainMenu ? '' : 'Mission Planning'"
+              :label-class="[menuLabelSize, '-mb-0.5 mt-6']"
+              :icon="simplifiedMainMenu ? 'mdi-map-marker-radius-outline' : undefined"
+              :icon-size="simplifiedMainMenu ? 25 : undefined"
+              variant="uncontained"
+              :tooltip="simplifiedMainMenu ? 'Mission Planning' : undefined"
+              :width="buttonSize"
+              :selected="$route.name === 'Mission planning'"
+              @click="
+                () => {
+                  $router.push('/mission-planning')
+                  handleCloseMainMenu()
+                }
+              "
+              ><img v-if="!simplifiedMainMenu" :src="MissionPlanningIcon" alt="MissionPlanning Icon"
+            /></GlassButton>
+            <GlassButton
+              :label="simplifiedMainMenu ? '' : 'Settings'"
+              :label-class="[menuLabelSize, '-mb-0.5 mt-6']"
+              :icon="simplifiedMainMenu ? 'mdi-cog' : undefined"
+              :icon-size="simplifiedMainMenu ? 25 : undefined"
+              variant="uncontained"
+              :tooltip="simplifiedMainMenu ? 'Configuration' : undefined"
+              :width="buttonSize"
+              :selected="showSubMenu"
+              class="mb-1"
+              :style="
+                interfaceStore.highlightedComponent === 'settings-menu-item' && {
+                  animation: 'highlightBackground 0.5s alternate 20',
+                  borderRadius: '10px',
+                }
+              "
+              @click="selectSubMenu(SubMenuName.settings)"
+              ><img v-if="!simplifiedMainMenu" :src="SettingsIcon" alt="Settings Icon" />
+            </GlassButton>
+            <GlassButton
+              :label="simplifiedMainMenu ? '' : 'Tools'"
+              :label-class="[menuLabelSize, '-mb-0.5 mt-6']"
+              :icon="simplifiedMainMenu ? 'mdi-tools' : undefined"
+              :icon-size="simplifiedMainMenu ? 25 : undefined"
+              variant="uncontained"
+              :tooltip="simplifiedMainMenu ? 'Tools' : undefined"
+              :width="buttonSize"
+              :selected="showSubMenu"
+              class="mb-1"
+              @click="selectSubMenu(SubMenuName.tools)"
+              ><img v-if="!simplifiedMainMenu" :src="ToolsIcon" alt="Tools Icon" />
+            </GlassButton>
+            <GlassButton
+              :label="simplifiedMainMenu ? '' : isFullscreen ? 'Exit Fullscreen' : 'Enter Fullscreen'"
+              :label-class="[menuLabelSize, '-mb-0.5 mt-6']"
+              :icon="simplifiedMainMenu ? fullScreenToggleIcon : undefined"
+              :icon-size="simplifiedMainMenu ? 25 : undefined"
+              variant="uncontained"
+              :tooltip="simplifiedMainMenu ? (isFullscreen ? 'Exit Fullscreen' : 'Enter Fullscreen') : undefined"
+              :button-class="simplifiedMainMenu ? '-mb-2' : ''"
+              :width="buttonSize"
+              :selected="false"
+              @click="
+                () => {
+                  toggleFullscreen()
+                  handleCloseMainMenu()
+                }
+              "
+              ><img
+                v-if="!simplifiedMainMenu"
+                :src="isFullscreen ? ExitFullScreenIcon : FullScreenIcon"
+                alt="Fullscreen Icon"
+              />
+            </GlassButton>
+            <GlassButton
+              :label="simplifiedMainMenu ? '' : 'About'"
+              :label-class="[menuLabelSize, '-mb-0.5 mt-6']"
+              :icon="simplifiedMainMenu ? 'mdi-information-outline' : undefined"
+              :icon-size="simplifiedMainMenu ? 25 : undefined"
+              variant="uncontained"
+              :tooltip="simplifiedMainMenu ? 'About' : undefined"
+              :button-class="!simplifiedMainMenu ? '-mt-[5px]' : undefined"
+              :width="buttonSize"
+              :selected="showSubMenu"
+              @click="openAboutDialog"
+              ><img v-if="!simplifiedMainMenu" :src="InfoIcon" alt="Info Icon" />
+            </GlassButton>
+          </div>
+        </v-window-item>
+        <v-window-item :value="2" class="h-full w-full">
+          <div class="flex flex-col w-full h-full justify-between">
+            <GlassButton
+              v-for="menuitem in currentSubMenu"
+              :key="menuitem.title"
+              :label="simplifiedMainMenu ? undefined : menuitem.title"
+              :label-class="menuLabelSize"
+              :button-class="interfaceStore.isOnSmallScreen ? '-ml-[2px]' : ''"
+              :icon="menuitem.icon"
+              :selected="interfaceStore.currentSubMenuComponentName === menuitem.componentName"
+              variant="uncontained"
+              :height="buttonSize * 0.45"
+              :icon-size="buttonSize * 0.5"
+              :style="
+                interfaceStore.highlightedComponent === menuitem.title && {
+                  animation: 'highlightBackground 0.5s alternate 50',
+                  borderRadius: '4px',
+                }
+              "
+              @click="toggleSubMenuComponent(menuitem.component)"
+              ><template #content
+                ><div v-if="currentSubMenuComponent === menuitem.component" class="arrow-left"></div></template
+            ></GlassButton>
+            <div class="flex flex-col justify-center align-center pb-1">
+              <v-divider width="70%" />
+              <GlassButton
+                :label-class="menuLabelSize"
+                icon="mdi-arrow-left"
+                :icon-class="interfaceStore.isOnSmallScreen ? '' : '-mb-[1px]'"
+                :button-class="interfaceStore.isOnSmallScreen ? (simplifiedMainMenu ? '-mt-1' : 'mt-1') : undefined"
+                variant="round"
+                :width="buttonSize / 2.4"
+                :selected="false"
+                @click="
+                  () => {
+                    interfaceStore.mainMenuCurrentStep = 1
+                    currentSubMenuComponentRef = null
+                  }
+                "
+              />
+            </div>
+          </div>
+        </v-window-item>
+      </v-window>
+    </div>
+  </transition>
+</template>
+<script setup lang="ts">
+import { onClickOutside, useDebounceFn, useFullscreen, useWindowSize } from '@vueuse/core'
+import { computed, markRaw, onBeforeUnmount, ref, watch } from 'vue'
+import { useRoute } from 'vue-router'
+
+import EditModeIcon from '@/assets/icons/edit-mode.svg'
+import ExitFullScreenIcon from '@/assets/icons/exit-full-screen.svg'
+import FlightIcon from '@/assets/icons/flight.svg'
+import FullScreenIcon from '@/assets/icons/full-screen.svg'
+import InfoIcon from '@/assets/icons/info.svg'
+import MissionPlanningIcon from '@/assets/icons/mission-planning.svg'
+import SettingsIcon from '@/assets/icons/settings.svg'
+import ToolsIcon from '@/assets/icons/tools.svg'
+import GlassButton from '@/components/GlassButton.vue'
+import {
+  availableCockpitActions,
+  registerActionCallback,
+  unregisterActionCallback,
+} from '@/libs/joystick/protocols/cockpit-actions'
+import { SubMenuComponentName, SubMenuName, useAppInterfaceStore } from '@/stores/appInterface'
+import { useWidgetManagerStore } from '@/stores/widgetManager'
+import { SubMenuComponent } from '@/types/general'
+import ConfigurationActionsView from '@/views/ConfigurationActionsView.vue'
+import ConfigurationAlertsView from '@/views/ConfigurationAlertsView.vue'
+import ConfigurationDevelopmentView from '@/views/ConfigurationDevelopmentView.vue'
+import ConfigurationGeneralView from '@/views/ConfigurationGeneralView.vue'
+import ConfigurationJoystickView from '@/views/ConfigurationJoystickView.vue'
+import ConfigurationTelemetryView from '@/views/ConfigurationLogsView.vue'
+import ConfigurationMissionView from '@/views/ConfigurationMissionView.vue'
+import ConfigurationUIView from '@/views/ConfigurationUIView.vue'
+import ConfigurationVideoView from '@/views/ConfigurationVideoView.vue'
+import ToolsDataLakeView from '@/views/ToolsDataLakeView.vue'
+import ToolsMAVLinkView from '@/views/ToolsMAVLinkView.vue'
+
+const route = useRoute()
+const interfaceStore = useAppInterfaceStore()
+const widgetStore = useWidgetManagerStore()
+const { width: windowWidth, height: windowHeight } = useWindowSize()
+const { isFullscreen, toggle: toggleFullscreen } = useFullscreen()
+
+/**
+ *
+ */
+interface Props {
+  /**
+   *
+   */
+  currentSubMenuComponent: SubMenuComponent | null
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<{
+  (event: 'update:currentSubMenuComponent', value: SubMenuComponent | null): void
+  (event: 'closeMainMenu'): void
+  (event: 'openAboutDialog'): void
+}>()
+
+const currentSubMenuComponentRef = computed({
+  get: () => props.currentSubMenuComponent,
+  set: (val: SubMenuComponent | null) => emit('update:currentSubMenuComponent', val),
+})
+
+const showSubMenu = ref(false)
+const mainMenu = ref()
+
+const configMenu = [
+  {
+    icon: 'mdi-view-dashboard-variant',
+    title: 'General',
+    componentName: SubMenuComponentName.SettingsGeneral,
+    component: markRaw(ConfigurationGeneralView) as SubMenuComponent,
+  },
+  {
+    icon: 'mdi-monitor-cellphone',
+    title: 'Interface',
+    componentName: SubMenuComponentName.SettingsInterface,
+    component: markRaw(ConfigurationUIView) as SubMenuComponent,
+  },
+  {
+    icon: 'mdi-controller',
+    title: 'Joystick',
+    componentName: SubMenuComponentName.SettingsJoystick,
+    component: markRaw(ConfigurationJoystickView) as SubMenuComponent,
+  },
+  {
+    icon: 'mdi-video',
+    title: 'Video',
+    componentName: SubMenuComponentName.SettingsVideo,
+    component: markRaw(ConfigurationVideoView) as SubMenuComponent,
+  },
+  {
+    icon: 'mdi-subtitles-outline',
+    title: 'Telemetry',
+    componentName: SubMenuComponentName.SettingsTelemetry,
+    component: markRaw(ConfigurationTelemetryView) as SubMenuComponent,
+  },
+  {
+    icon: 'mdi-alert-rhombus-outline',
+    title: 'Alerts',
+    componentName: SubMenuComponentName.SettingsAlerts,
+    component: markRaw(ConfigurationAlertsView) as SubMenuComponent,
+  },
+  {
+    icon: 'mdi-dev-to',
+    title: 'Dev',
+    componentName: SubMenuComponentName.SettingsDev,
+    component: markRaw(ConfigurationDevelopmentView) as SubMenuComponent,
+  },
+  {
+    icon: 'mdi-map-marker-path',
+    title: 'Mission',
+    componentName: SubMenuComponentName.SettingsMission,
+    component: markRaw(ConfigurationMissionView) as SubMenuComponent,
+  },
+  {
+    icon: 'mdi-run-fast',
+    title: 'Actions',
+    componentName: SubMenuComponentName.SettingsActions,
+    component: markRaw(ConfigurationActionsView) as SubMenuComponent,
+  },
+]
+
+const toolsMenu = [
+  {
+    icon: 'mdi-protocol',
+    title: 'MAVLink',
+    componentName: SubMenuComponentName.ToolsMAVLink,
+    component: markRaw(ToolsMAVLinkView) as SubMenuComponent,
+  },
+  {
+    icon: 'mdi-database-outline',
+    title: 'Data-lake',
+    componentName: SubMenuComponentName.ToolsDataLake,
+    component: markRaw(ToolsDataLakeView) as SubMenuComponent,
+  },
+]
+
+const selectSubMenu = (subMenuName: SubMenuName): void => {
+  interfaceStore.currentSubMenuName = subMenuName
+  interfaceStore.mainMenuCurrentStep = 2
+}
+
+const toggleSubMenuComponent = (component: SubMenuComponent): void => {
+  if (currentSubMenuComponentRef.value === null) {
+    currentSubMenuComponentRef.value = component
+    interfaceStore.configModalVisibility = true
+    return
+  }
+  if (currentSubMenuComponentRef.value === component) {
+    currentSubMenuComponentRef.value = null
+    interfaceStore.configModalVisibility = false
+    return
+  }
+  currentSubMenuComponentRef.value = component
+  interfaceStore.configModalVisibility = true
+}
+
+const simplifiedMainMenu = computed(() => {
+  const threshold = windowWidth.value > 1300 ? 860 : 680
+  return maxScreenHeightPixelsThatFitsLargeMenu.value < threshold
+})
+
+const mainMenuWidth = computed(() => {
+  const width =
+    interfaceStore.isOnSmallScreen && interfaceStore.mainMenuCurrentStep === 2
+      ? '60px'
+      : `${interfaceStore.mainMenuWidth}px`
+  return { width }
+})
+
+const maxScreenHeightPixelsThatFitsLargeMenu = computed(() => {
+  const heightTopBar = widgetStore.currentTopBarHeightPixels * topBottomBarScale.value
+  const heightBottomBar = widgetStore.currentBottomBarHeightPixels * topBottomBarScale.value
+  const visibleAreaHeight = windowHeight.value - heightTopBar - heightBottomBar
+  return visibleAreaHeight
+})
+
+const buttonSize = computed(() => {
+  if (interfaceStore.is2xl) return 72
+  if (interfaceStore.isXl) return 66
+  if (interfaceStore.isLg) return 60
+  if (interfaceStore.isMd) return 54
+  if (interfaceStore.isSm && windowHeight.value > 700) return 60
+  if (interfaceStore.isSm && windowHeight.value < 700) return 48
+  if (interfaceStore.isXs && windowHeight.value >= 700) return 60
+  return 48
+})
+
+const menuLabelSize = computed(() => {
+  if (interfaceStore.is2xl) return 'text-[15px]'
+  if (interfaceStore.isXl) return 'text-[14px]'
+  if (interfaceStore.isLg) return 'text-[13px]'
+  if (interfaceStore.isMd) return 'text-[12px]'
+  if (interfaceStore.isSm) return 'text-[10px]'
+  if (interfaceStore.isXs && windowHeight.value >= 700) return 'text-[12px]'
+  return 'text-[10px]'
+})
+
+const glassMenuStyles = computed(() => ({
+  backgroundColor: interfaceStore.UIGlassEffect.bgColor,
+  color: interfaceStore.UIGlassEffect.fontColor,
+  backdropFilter: `blur(${interfaceStore.UIGlassEffect.blur}px)`,
+}))
+
+const handleCloseMainMenu = (): void => {
+  emit('closeMainMenu')
+}
+
+const openAboutDialog = (): void => {
+  emit('closeMainMenu')
+  emit('openAboutDialog')
+}
+
+const debouncedToggleFullScreen = useDebounceFn(() => toggleFullscreen(), 10)
+
+const fullScreenCallbackId = registerActionCallback(
+  availableCockpitActions.toggle_full_screen,
+  debouncedToggleFullScreen
+)
+
+const originalBarWidth = 1800
+
+const topBottomBarScale = computed(() => {
+  return windowWidth.value / originalBarWidth
+})
+
+const availableSubMenus = {
+  settings: configMenu,
+  tools: toolsMenu,
+}
+
+const currentSubMenu = computed(() => {
+  if (interfaceStore.currentSubMenuName === null) return []
+  return availableSubMenus[interfaceStore.currentSubMenuName]
+})
+
+onClickOutside(mainMenu, () => {
+  if (interfaceStore.mainMenuCurrentStep === 1 && !interfaceStore.isTutorialVisible) {
+    emit('closeMainMenu')
+  }
+  if (
+    interfaceStore.mainMenuCurrentStep === 2 &&
+    currentSubMenuComponentRef.value === null &&
+    !interfaceStore.isTutorialVisible
+  ) {
+    emit('closeMainMenu')
+  }
+})
+
+watch(
+  () => interfaceStore.currentSubMenuComponentName,
+  (subMenuComponentName) => {
+    currentSubMenuComponentRef.value =
+      currentSubMenu.value.find((item) => item.componentName === subMenuComponentName)?.component || null
+  }
+)
+
+onBeforeUnmount(() => unregisterActionCallback(fullScreenCallbackId))
+
+const fullScreenToggleIcon = computed(() => (isFullscreen.value ? 'mdi-fullscreen-exit' : 'mdi-overscan'))
+</script>
+<style scoped>
+.left-menu {
+  position: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border-radius: 0 20px 20px 0;
+  border: 1px #cbcbcb22 solid;
+  border-left: none;
+  top: 50%;
+  left: 0;
+  transform: translateY(-50%);
+  box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.3), 0px 8px 12px 6px rgba(0, 0, 0, 0.15);
+  z-index: 1000;
+}
+
+@keyframes slideInLeft {
+  from {
+    transform: translateX(-100%) translateY(-50%);
+  }
+  to {
+    transform: translateX(0) translateY(-50%);
+  }
+}
+
+@keyframes slideOutLeft {
+  from {
+    transform: translateX(0) translateY(-50%);
+  }
+  to {
+    transform: translateX(-100%) translateY(-50%);
+  }
+}
+
+.slide-in-left-enter-active {
+  animation: slideInLeft 300ms ease forwards;
+}
+
+.slide-in-left-leave-active {
+  animation: slideOutLeft 300ms ease forwards;
+}
+</style>

--- a/src/components/MainMenu.vue
+++ b/src/components/MainMenu.vue
@@ -6,10 +6,10 @@
       class="left-menu slide-in"
       :style="[glassMenuStyles, simplifiedMainMenu ? { width: '45px', borderRadius: '0 10px 10px 0' } : mainMenuWidth]"
     >
-      <v-window v-model="interfaceStore.mainMenuCurrentStep" class="h-full w-full">
+      <v-window v-model="interfaceStore.mainMenuCurrentStep" class="h-full w-full py-1">
         <v-window-item :value="1" class="h-full">
           <div
-            class="relative flex flex-col h-full justify-between align-center items-center select-none"
+            class="relative flex flex-col max-h-[95vh] justify-between align-center items-center select-none overflow-y-auto scrollbar-hide"
             :class="
               interfaceStore.isOnSmallScreen
                 ? 'gap-y-0 pt-2 pb-3 sm:sm:py-0 sm:-ml-[3px] xs:xs:py-0 xs:-ml-[3px]'
@@ -140,7 +140,7 @@
           </div>
         </v-window-item>
         <v-window-item :value="2" class="h-full w-full">
-          <div class="flex flex-col w-full h-full justify-between">
+          <div class="flex flex-col w-full max-h-[95vh] justify-between overflow-y-auto scrollbar-hide">
             <GlassButton
               v-for="menuitem in currentSubMenu"
               :key="menuitem.title"
@@ -223,15 +223,15 @@ import ToolsMAVLinkView from '@/views/ToolsMAVLinkView.vue'
 const route = useRoute()
 const interfaceStore = useAppInterfaceStore()
 const widgetStore = useWidgetManagerStore()
-const { width: windowWidth, height: windowHeight } = useWindowSize()
+const { height: windowHeight } = useWindowSize()
 const { isFullscreen, toggle: toggleFullscreen } = useFullscreen()
 
 /**
- *
+ * Props to control the current sub-menu
  */
 interface Props {
   /**
-   *
+   * The current sub-menu component
    */
   currentSubMenuComponent: SubMenuComponent | null
 }
@@ -344,23 +344,17 @@ const toggleSubMenuComponent = (component: SubMenuComponent): void => {
 }
 
 const simplifiedMainMenu = computed(() => {
-  const threshold = windowWidth.value > 1300 ? 860 : 680
-  return maxScreenHeightPixelsThatFitsLargeMenu.value < threshold
+  if (interfaceStore.isLg || interfaceStore.isMd) return true
+  if (interfaceStore.isXs || interfaceStore.isSm) return true
+  if (windowHeight.value < 700) return true
+  return false
 })
-
 const mainMenuWidth = computed(() => {
   const width =
     interfaceStore.isOnSmallScreen && interfaceStore.mainMenuCurrentStep === 2
       ? '60px'
       : `${interfaceStore.mainMenuWidth}px`
   return { width }
-})
-
-const maxScreenHeightPixelsThatFitsLargeMenu = computed(() => {
-  const heightTopBar = widgetStore.currentTopBarHeightPixels * topBottomBarScale.value
-  const heightBottomBar = widgetStore.currentBottomBarHeightPixels * topBottomBarScale.value
-  const visibleAreaHeight = windowHeight.value - heightTopBar - heightBottomBar
-  return visibleAreaHeight
 })
 
 const buttonSize = computed(() => {
@@ -405,12 +399,6 @@ const fullScreenCallbackId = registerActionCallback(
   availableCockpitActions.toggle_full_screen,
   debouncedToggleFullScreen
 )
-
-const originalBarWidth = 1800
-
-const topBottomBarScale = computed(() => {
-  return windowWidth.value / originalBarWidth
-})
 
 const availableSubMenus = {
   settings: configMenu,


### PR DESCRIPTION
- Main menu now is a separate component from the App, improving maintainability and code readability;
- Its logic now uses existent breakpoints from AppInterfaceStore;
- It will never overshoot the screen height, being now scrollable with hidden scrollbars (1);
- Now, main-menu is responsive to window width and height independently (2);

(1)

https://github.com/user-attachments/assets/79642916-4552-4785-95f5-4c92ac1d1a9a

(2)

https://github.com/user-attachments/assets/ec66a3e8-0188-49fa-8fd9-9cbc97269a67

