### PR TITLE
Stop spamming Cockpit Action calls (send only on the rising edge)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -318,7 +318,7 @@
 </template>
 
 <script setup lang="ts">
-import { onClickOutside, useDebounceFn, useFullscreen, useStorage, useWindowSize } from '@vueuse/core'
+import { onClickOutside, useFullscreen, useStorage, useWindowSize } from '@vueuse/core'
 import { computed, markRaw, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 
@@ -694,11 +694,7 @@ const routerSection = ref()
 // Full screen toggling
 const { isFullscreen, toggle: toggleFullscreen } = useFullscreen()
 
-const debouncedToggleFullScreen = useDebounceFn(() => toggleFullscreen(), 10)
-const fullScreenCallbackId = registerActionCallback(
-  availableCockpitActions.toggle_full_screen,
-  debouncedToggleFullScreen
-)
+const fullScreenCallbackId = registerActionCallback(availableCockpitActions.toggle_full_screen, toggleFullscreen)
 onBeforeUnmount(() => unregisterActionCallback(fullScreenCallbackId))
 
 const fullScreenToggleIcon = computed(() => (isFullscreen.value ? 'mdi-fullscreen-exit' : 'mdi-overscan'))
@@ -744,13 +740,14 @@ const showTopBarNow = ref(true)
 watch([() => widgetStore.currentView, () => widgetStore.currentView.showBottomBarOnBoot], () => {
   showBottomBarNow.value = widgetStore.currentView.showBottomBarOnBoot
 })
-const debouncedToggleBottomBar = useDebounceFn(() => (showBottomBarNow.value = !showBottomBarNow.value), 25)
 const bottomBarToggleCallbackId = registerActionCallback(
   availableCockpitActions.toggle_bottom_bar,
-  debouncedToggleBottomBar
+  () => (showBottomBarNow.value = !showBottomBarNow.value)
 )
-const debouncedToggleTopBar = useDebounceFn(() => (showTopBarNow.value = !showTopBarNow.value), 25)
-const topBarToggleCallbackId = registerActionCallback(availableCockpitActions.toggle_top_bar, debouncedToggleTopBar)
+const topBarToggleCallbackId = registerActionCallback(
+  availableCockpitActions.toggle_top_bar,
+  () => (showTopBarNow.value = !showTopBarNow.value)
+)
 onBeforeUnmount(() => {
   unregisterActionCallback(bottomBarToggleCallbackId)
   unregisterActionCallback(topBarToggleCallbackId)

--- a/src/stores/widgetManager.ts
+++ b/src/stores/widgetManager.ts
@@ -1,6 +1,6 @@
 import '@/libs/cosmos'
 
-import { useDebounceFn, useStorage, useWindowSize } from '@vueuse/core'
+import { useStorage, useWindowSize } from '@vueuse/core'
 import { saveAs } from 'file-saver'
 import { defineStore } from 'pinia'
 import { v4 as uuid4 } from 'uuid'
@@ -781,18 +781,10 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
     loadProfile(defaultProfile)
   }
 
-  const debouncedSelectNextView = useDebounceFn(() => selectNextView(), 10)
-  const selectNextViewCallbackId = registerActionCallback(
-    availableCockpitActions.go_to_next_view,
-    debouncedSelectNextView
-  )
+  const selectNextViewCallbackId = registerActionCallback(availableCockpitActions.go_to_next_view, selectNextView)
   onBeforeUnmount(() => unregisterActionCallback(selectNextViewCallbackId))
 
-  const debouncedSelectPreviousView = useDebounceFn(() => selectPreviousView(), 10)
-  const selectPrevViewCBId = registerActionCallback(
-    availableCockpitActions.go_to_previous_view,
-    debouncedSelectPreviousView
-  )
+  const selectPrevViewCBId = registerActionCallback(availableCockpitActions.go_to_previous_view, selectPreviousView)
   onBeforeUnmount(() => unregisterActionCallback(selectPrevViewCBId))
 
   // Profile migrations


### PR DESCRIPTION
This patch makes sure Cockpit Actions are only called on the rising edge, so we stop spamming calls that can lead to undesired behaviors.

Fix #1670 
Fix #545 