### PR TITLE
Remind user to record stream on vehicle arming

### DIFF
--- a/src/assets/defaults.ts
+++ b/src/assets/defaults.ts
@@ -919,3 +919,11 @@ export const defaultJoystickCalibration: JoystickCalibration = {
     },
   },
 }
+
+export const defaultAutoRecordingOptions = {
+  autoRecordMode: undefined,
+  showReminder: false,
+  reminderDelay: 0,
+  selectedStreams: [],
+  stopRecordingOnDisarm: false,
+}

--- a/src/components/AutoRecordVideoDialog.vue
+++ b/src/components/AutoRecordVideoDialog.vue
@@ -1,0 +1,173 @@
+<template>
+  <InteractionDialog v-model:visible="visible" variant="text-only" width="600">
+    <template #title>
+      <div class="flex justify-between mt-2">
+        <div class="w-full text-center -mr-10">Auto record video streams</div>
+        <v-btn icon="mdi-close" size="medium" variant="text" @click="handleCloseModal" />
+      </div>
+    </template>
+    <template #content>
+      <v-card-text class="flex flex-col">
+        <v-radio-group v-model="autoRecordMode" class="flex flex-col">
+          <v-radio class="mb-2" label="Start recording all streams when the vehicle is armed" value="all" />
+          <div>
+            <v-radio
+              class="mb-2"
+              label="Automatically start recording only the following streams:"
+              value="selected"
+              @click="showReminder = false"
+            />
+            <div class="ml-6 mb-4">
+              <v-combobox
+                v-model="selectedStreams"
+                :items="availableStreams"
+                multiple
+                hide-details
+                chips
+                label="Available streams"
+                theme="dark"
+                class="w-4/5"
+                density="compact"
+                :close-on-content-click="false"
+                return-object
+                :item-title="(stream: VideoStreamCorrespondency) => stream.name"
+                :item-value="(stream: VideoStreamCorrespondency) => stream"
+                @update:model-value="handleComboBoxUpdate"
+              >
+                <template #item="{ item, props }">
+                  <v-list-item v-bind="props">
+                    {{ (item as unknown as VideoStreamCorrespondency).name }}
+                  </v-list-item>
+                </template>
+                <template #selection="{ item, index }">
+                  <v-chip :key="index" close @click:close="removeSelectedStream(index)">
+                    {{ (item as unknown as VideoStreamCorrespondency).name }}
+                  </v-chip>
+                </template>
+              </v-combobox>
+            </div>
+          </div>
+          <v-radio class="mb-2" label="Do not auto record streams when vehicle is armed" value="none" />
+        </v-radio-group>
+        <v-checkbox
+          v-model="showReminder"
+          hide-details
+          label="Show recording reminder when the vehicle is armed"
+          class="-mb-2"
+        />
+        <div class="flex w-auto justify-items-start items-center ml-10 opacity-70">
+          <p>Delay:</p>
+          <input
+            v-model="reminderDelay"
+            type="number"
+            min="0"
+            max="9999"
+            step="1"
+            class="bg-[#FFFFFF11] w-[80px] mx-1"
+          />
+          <p>{{ reminderDelay > 1 ? 'seconds' : 'second' }}</p>
+        </div>
+        <v-checkbox
+          v-model="stopRecordingOnDisarm"
+          hide-details
+          label="Stop recording when the vehicle is disarmed"
+          class="-mb-2"
+        />
+      </v-card-text>
+    </template>
+    <template #actions>
+      <div class="flex justify-between items-center w-full">
+        <v-checkbox
+          v-model="rememberChoice"
+          density="comfortable"
+          hide-details
+          label="Remember my choice"
+          class="ml-2"
+        />
+        <v-btn color="#FFFFFF" @click="handleCloseModal">
+          {{ rememberChoice ? 'Save and apply' : 'Apply' }}
+        </v-btn>
+      </div>
+    </template>
+  </InteractionDialog>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+
+import { useVideoStore } from '@/stores/video'
+import { VideoStreamCorrespondency } from '@/types/video'
+
+import InteractionDialog from './InteractionDialog.vue'
+
+const videoStore = useVideoStore()
+const emit = defineEmits(['close'])
+const visible = ref(false)
+const rememberChoice = ref(true)
+
+const autoRecordMode = computed({
+  get: () => videoStore.momentaryAutoRecordOptions.autoRecordMode || 'none',
+  set: (value: 'none' | 'all' | 'selected') => {
+    videoStore.momentaryAutoRecordOptions.autoRecordMode = value
+  },
+})
+
+const stopRecordingOnDisarm = computed({
+  get: () => videoStore.momentaryAutoRecordOptions.stopRecordingOnDisarm ?? false,
+  set: (value: boolean) => {
+    videoStore.momentaryAutoRecordOptions.stopRecordingOnDisarm = value
+  },
+})
+
+const showReminder = computed({
+  get: () => videoStore.momentaryAutoRecordOptions.showReminder ?? true,
+  set: (value: boolean) => {
+    videoStore.momentaryAutoRecordOptions.showReminder = value
+  },
+})
+
+const reminderDelay = computed({
+  get: () => videoStore.momentaryAutoRecordOptions.reminderDelay ?? 1,
+  set: (value: number) => {
+    videoStore.momentaryAutoRecordOptions.reminderDelay = value
+  },
+})
+
+const selectedStreams = computed<VideoStreamCorrespondency[]>({
+  get: () => videoStore.momentaryAutoRecordOptions.selectedStreams || [],
+  set: (value: VideoStreamCorrespondency[]) => {
+    videoStore.momentaryAutoRecordOptions.selectedStreams = value
+  },
+})
+
+const availableStreams = computed(() => videoStore.streamsCorrespondency)
+
+const removeSelectedStream = (index: number): void => {
+  const updated = [...selectedStreams.value]
+  updated.splice(index, 1)
+  selectedStreams.value = updated
+}
+
+const handleComboBoxUpdate = (): void => {
+  if (selectedStreams.value.length > 0) {
+    autoRecordMode.value = 'selected'
+    showReminder.value = false
+  }
+}
+
+const handleCloseModal = (): void => {
+  if (rememberChoice.value) {
+    Object.assign(videoStore.persistentAutoRecordOptions, videoStore.momentaryAutoRecordOptions)
+  }
+  visible.value = false
+  emit('close')
+}
+
+watch(autoRecordMode, (value) => {
+  if (value === 'none') {
+    showReminder.value = true
+  } else if (value === 'all') {
+    showReminder.value = false
+  }
+})
+</script>

--- a/src/components/RecordingReminder.vue
+++ b/src/components/RecordingReminder.vue
@@ -1,0 +1,101 @@
+<template>
+  <div class="fixed bottom-[48px] right-0 m-4">
+    <div
+      v-if="showReminder"
+      :class="[animationStage, bgColor, fading ? 'opacity-0' : 'opacity-100']"
+      class="flex items-center justify-center overflow-hidden text-white transition-all duration-500 ease-in-out elevation-4"
+      :style="{ borderRadius: borderRadius + 'px' }"
+    >
+      <template v-if="animationStage === 'rectangle'">
+        <v-icon icon="mdi-video-check" color="white" class="text-[28px]" />
+        <div class="flex justify-between items-center p-4">
+          <p class="text-white -mr-4">Don't forget to record your activity!</p>
+        </div>
+      </template>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+
+const emit = defineEmits(['close'])
+
+const showReminder = ref(true)
+const fading = ref(false)
+const animationStage = ref('circle')
+const bgColor = ref('bg-red-500')
+const borderRadius = ref(25)
+
+const initialDelay = 100
+const transitionToRectDelay = 1500
+const fadingDelay = 5000
+const closeDelay = 5500
+const startBorderAnimation = 1000
+const borderAnimationDelay = 20
+const borderRadiusStart = 25
+const borderRadiusEnd = 8
+
+const animateBorderRadius = (): void => {
+  borderRadius.value = borderRadiusStart
+  const interval = setInterval(() => {
+    if (borderRadius.value > borderRadiusEnd) {
+      borderRadius.value--
+    } else {
+      clearInterval(interval)
+    }
+  }, borderAnimationDelay)
+}
+
+onMounted(() => {
+  setTimeout(() => {
+    animationStage.value = 'circle-grow'
+  }, initialDelay)
+
+  setTimeout(() => {
+    animateBorderRadius()
+  }, startBorderAnimation)
+
+  setTimeout(() => {
+    animationStage.value = 'rectangle'
+    bgColor.value = 'bg-orange-600'
+  }, transitionToRectDelay)
+
+  setTimeout(() => {
+    fading.value = true
+  }, fadingDelay)
+
+  setTimeout(() => {
+    showReminder.value = false
+    emit('close')
+  }, closeDelay)
+})
+</script>
+
+<style scoped>
+.circle {
+  width: 0;
+  height: 0;
+  border-radius: 50%;
+}
+
+.circle-grow {
+  animation: growWobble 0.6s cubic-bezier(0.68, -0.55, 0.265, 1.55) forwards;
+}
+
+.rectangle {
+  width: 350px;
+  height: 50px;
+}
+
+@keyframes growWobble {
+  0% {
+    width: 0;
+    height: 0;
+  }
+  100% {
+    width: 50px;
+    height: 50px;
+  }
+}
+</style>

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -182,3 +182,11 @@ export type VideoStreamCorrespondency = {
   name: string
   externalId: string
 }
+
+export type AutoRecordVideoStreams = {
+  autoRecordMode: 'all' | 'none' | 'selected' | undefined
+  stopRecordingOnDisarm: boolean
+  showReminder: boolean
+  reminderDelay: number
+  selectedStreams: VideoStreamCorrespondency[]
+}

--- a/src/views/ConfigurationVideoView.vue
+++ b/src/views/ConfigurationVideoView.vue
@@ -5,7 +5,7 @@
     <template #content>
       <div class="flex-col h-full ml-[1vw] max-w-[540px] max-h-[85vh] overflow-y-auto pr-3">
         <ExpansiblePanel no-top-divider :is-expanded="!interfaceStore.isOnPhoneScreen">
-          <template #title>Streams mapping</template>
+          <template #title>Streams setup</template>
           <template #info>
             Here you can map your external video streams to internal names. This allows you to easily switch between
             different video sources in Cockpit, without having to reconfigure every widget that uses the video stream.
@@ -13,7 +13,7 @@
             internal name, so if you need to change the external one, you only need to do it here.
           </template>
           <template #content>
-            <div class="flex justify-center flex-col w-[90%] ml-2 mb-8 mt-2">
+            <div class="flex justify-center flex-col w-[90%] ml-2 mb-4 mt-2">
               <v-data-table
                 :items="videoStore.streamsCorrespondency"
                 items-per-page="10"
@@ -87,10 +87,19 @@
                 <template #bottom></template>
               </v-data-table>
             </div>
+            <div class="flex w-full justify-end pr-[42px] pb-4">
+              <v-btn
+                class="bg-[#FFFFFF11] elevation-1"
+                prepend-icon="mdi-video-check"
+                @click="showAutoStreamRecordingDialog = true"
+              >
+                Auto record video streams
+              </v-btn>
+            </div>
           </template>
         </ExpansiblePanel>
         <ExpansiblePanel no-top-divider :is-expanded="!interfaceStore.isOnPhoneScreen">
-          <template #title>Allowed WebRTC remote IP Addresses</template>
+          <template #title>Allowed WebRTC remote IP addresses</template>
           <template #info>
             Select the IP addresses to allow connecting to for WebRTC video streaming. For best performance it is
             recommended to only use the most reliable interfaces - e.g. avoid wireless interfaces if there is a
@@ -226,12 +235,17 @@
       </div>
     </template>
   </BaseConfigurationView>
+  <AutoRecordVideoDialog
+    v-model:showDialog="showAutoStreamRecordingDialog"
+    @close="showAutoStreamRecordingDialog = false"
+  />
 </template>
 
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
 import { onMounted, ref } from 'vue'
 
+import AutoRecordVideoDialog from '@/components/AutoRecordVideoDialog.vue'
 import ExpansiblePanel from '@/components/ExpansiblePanel.vue'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useVideoStore } from '@/stores/video'
@@ -250,6 +264,7 @@ const interfaceStore = useAppInterfaceStore()
 const editingStreamId = ref<string | null>(null)
 const editingStreamName = ref('')
 const hoveredStreamId = ref<string | null>(null)
+const showAutoStreamRecordingDialog = ref(false)
 
 const editStreamName = (item: VideoStreamCorrespondency): void => {
   editingStreamId.value = item.externalId


### PR DESCRIPTION
- On first time arming the vehicle there will be a popup asking the user to configure the auto recording parameters;
- Later, the user can find this settings at the Video Configurations menu;
- Persistent and non persistent settings can be applied. If `remember my choice` checkbox is marked, settings will persist.

https://github.com/user-attachments/assets/4e525f14-5a75-4925-81c1-725ae34c6c54

Closes #947 