### PR TITLE
map: Improve tooltips on home and position buttons

### DIFF
--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -1,10 +1,7 @@
 <template>
   <div ref="mapBase" class="page-base" :class="widgetStore.editingMode ? 'pointer-events-none' : 'pointer-events-auto'">
     <div :id="mapId" ref="map" class="map">
-      <v-tooltip
-        location="top"
-        :text="home ? 'Center map on home position.' : 'Cannot center map on home (home position undefined).'"
-      >
+      <v-tooltip location="top" :text="centerHomeButtonTooltipText">
         <template #activator="{ props: tooltipProps }">
           <v-btn
             v-if="showButtons"
@@ -23,10 +20,7 @@
         </template>
       </v-tooltip>
 
-      <v-tooltip
-        location="top"
-        :text="vehiclePosition ? 'Center map on vehicle position.' : 'Cannot center map on vehicle (vehicle offline).'"
-      >
+      <v-tooltip location="top" :text="centerVehicleButtonTooltipText">
         <template #activator="{ props: tooltipProps }">
           <v-btn
             v-if="showButtons"
@@ -624,13 +618,36 @@ const topProgressBarDisplacement = computed(() => {
 const vehicleDownloadMissionButtonTooltipText = computed(() => {
   return vehicleStore.isVehicleOnline
     ? 'Download the mission that is stored in the vehicle.'
-    : 'Vehicle offline (cannot download mission).'
+    : 'Cannot download mission (vehicle offline).'
 })
 
 const vehicleExecuteMissionButtonTooltipText = computed(() => {
   return vehicleStore.isVehicleOnline
     ? 'Execute the mission that is stored in the vehicle.'
-    : 'Vehicle offline (cannot execute mission).'
+    : 'Cannot execute mission (vehicle offline).'
+})
+
+const centerHomeButtonTooltipText = computed(() => {
+  if (home.value === undefined) {
+    return 'Cannot center map on home (home position undefined).'
+  }
+  if (followerTarget.value === WhoToFollow.HOME) {
+    return 'Tracking home position. Click to stop tracking.'
+  }
+  return 'Click once to center on home or twice to track it.'
+})
+
+const centerVehicleButtonTooltipText = computed(() => {
+  if (!vehicleStore.isVehicleOnline) {
+    return 'Cannot center map on vehicle (vehicle offline).'
+  }
+  if (vehiclePosition.value === undefined) {
+    return 'Cannot center map on vehicle (vehicle position undefined).'
+  }
+  if (followerTarget.value === WhoToFollow.VEHICLE) {
+    return 'Tracking vehicle position. Click to stop tracking.'
+  }
+  return 'Click once to center on vehicle or twice to track it.'
 })
 </script>
 

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -1852,15 +1852,26 @@ watch([home, planningMap], async () => {
 })
 
 const centerHomeButtonTooltipText = computed(() => {
-  if (home.value === undefined) return 'Home position is currently undefined'
-  if (targetFollower.getCurrentTarget() === WhoToFollow.HOME) return 'Tracking home position'
-  return 'Click once to center on home or twice to track it'
+  if (home.value === undefined) {
+    return 'Cannot center map on home (home position undefined).'
+  }
+  if (followerTarget.value === WhoToFollow.HOME) {
+    return 'Tracking home position. Click to stop tracking.'
+  }
+  return 'Click once to center on home or twice to track it.'
 })
 
 const centerVehicleButtonTooltipText = computed(() => {
-  if (vehiclePosition.value === undefined) return 'Vehicle position is currently undefined'
-  if (targetFollower.getCurrentTarget() === WhoToFollow.VEHICLE) return 'Tracking vehicle position'
-  return 'Click once to center on vehicle or twice to track it'
+  if (!vehicleStore.isVehicleOnline) {
+    return 'Cannot center map on vehicle (vehicle offline).'
+  }
+  if (vehiclePosition.value === undefined) {
+    return 'Cannot center map on vehicle (vehicle position undefined).'
+  }
+  if (followerTarget.value === WhoToFollow.VEHICLE) {
+    return 'Tracking vehicle position. Click to stop tracking.'
+  }
+  return 'Click once to center on vehicle or twice to track it.'
 })
 </script>
 


### PR DESCRIPTION
- Differentiate between offline vehicle and online vehicle without position.
- Use the same logic on both the map widget and the mission planning page