### PR TITLE
Deprecate generic-variables system and migrate everything to the data-lake

### DIFF
--- a/src/components/widgets/Plotter.vue
+++ b/src/components/widgets/Plotter.vue
@@ -19,9 +19,22 @@
         <v-col cols="12">
           <div class="text-subtitle-1 font-weight-medium mb-4">Data Source</div>
           <div class="ml-2">
+            <v-text-field
+              v-model="searchTerm"
+              density="compact"
+              variant="filled"
+              theme="dark"
+              type="text"
+              placeholder="Search variables..."
+              class="mb-4"
+              clearable
+              @update:model-value="menuOpen = true"
+              @click:clear="menuOpen = false"
+              @update:focused="(isFocused: boolean) => (menuOpen = isFocused)"
+            />
             <v-select
               v-model="widget.options.dataLakeVariableId"
-              :items="availableDataLakeNumberVariables"
+              :items="filteredDataLakeNumberVariables"
               item-title="name"
               item-value="id"
               label="Data Lake variable"
@@ -29,6 +42,8 @@
               persistent-hint
               variant="outlined"
               density="comfortable"
+              :menu-props="{ modelValue: menuOpen }"
+              @click="menuOpen = !menuOpen"
             />
           </div>
         </v-col>
@@ -192,6 +207,19 @@ onUnmounted(() => {
 
 const availableDataLakeNumberVariables = computed(() => {
   return availableDataLakeVariables.value.filter((variable) => variable.type === 'number')
+})
+
+const searchTerm = ref('')
+const menuOpen = ref(false)
+
+watch(
+  () => widget.value.options.dataLakeVariableId,
+  () => (menuOpen.value = false)
+)
+
+const filteredDataLakeNumberVariables = computed(() => {
+  const search = (searchTerm.value || '').toLowerCase()
+  return availableDataLakeNumberVariables.value.filter((variable) => variable.name.toLowerCase().includes(search))
 })
 
 // Remove the oldest sample if the number of samples is greater than the max samples

--- a/src/libs/actions/data-lake.ts
+++ b/src/libs/actions/data-lake.ts
@@ -1,6 +1,11 @@
 import { v4 as uuid } from 'uuid'
 
 /**
+ * The type of a variable in the data lake
+ */
+export type DataLakeVariableType = 'string' | 'number' | 'boolean'
+
+/**
  * A variable to be used on a Cockpit action
  * @param { string } id - The id of the variable
  * @param { string } name - The name of the variable
@@ -12,7 +17,7 @@ import { v4 as uuid } from 'uuid'
 export class DataLakeVariable {
   id: string
   name: string
-  type: 'string' | 'number' | 'boolean'
+  type: DataLakeVariableType
   description?: string
   persistent: boolean
   persistValue: boolean
@@ -20,7 +25,7 @@ export class DataLakeVariable {
   constructor(
     id: string,
     name: string,
-    type: 'string' | 'number' | 'boolean',
+    type: DataLakeVariableType,
     description?: string,
     persistent = false,
     persistValue = false

--- a/src/libs/vehicle/vehicle.ts
+++ b/src/libs/vehicle/vehicle.ts
@@ -66,10 +66,6 @@ export abstract class AbstractVehicle<Modes> {
   _cockpitRegistrationUUID: string
   _funnyName: string
 
-  // Used to store generic data that does not belong to any specific subclass
-  // Usually used for development purposes (e.g.: test the implementation of new sensors)
-  _genericVariables: Record<string, unknown> = {}
-
   // Signals
   onArm = new Signal<boolean>()
   onAttitude = new Signal<Attitude>()
@@ -77,7 +73,6 @@ export abstract class AbstractVehicle<Modes> {
   onBatteries = new Signal<Battery[]>()
   onCpuLoad = new Signal<number>()
   onCommandAck = new Signal<CommandAck>()
-  onGenericVariables = new Signal<Record<string, unknown>>()
   onMode = new Signal<Modes>()
   onPosition = new Signal<Coordinates>()
   onPowerSupply = new Signal<PowerSupply>()
@@ -113,7 +108,6 @@ export abstract class AbstractVehicle<Modes> {
     this.onAttitude.register_caller(() => this.attitude())
     this.onBatteries.register_caller(() => this.batteries())
     this.onCpuLoad.register_caller(() => this.cpuLoad())
-    this.onGenericVariables.register_caller(() => this.genericVariables())
     this.onMode.register_caller(() => this.mode())
     this.onPosition.register_caller(() => this.position())
     this.onPowerSupply.register_caller(() => this.powerSupply())
@@ -138,14 +132,6 @@ export abstract class AbstractVehicle<Modes> {
    */
   type(): Type {
     return this._type
-  }
-
-  /**
-   * Return the generic variables hashmap of the vehicle
-   * @returns {Record<string, unknown>}
-   */
-  genericVariables(): Record<string, unknown> {
-    return this._genericVariables
   }
 
   /**


### PR DESCRIPTION
With that patch, we remove the entire generic-variables system and migrate all related functionality to the data-lake system.

This means the VGI is now integrated with the data-lake system, so people can consume anything from there, as well as create their own variables (through the compound-variables/mixer system).

Main changes to watch for and test in this PR:
- Old VGIs should keep working (special attention to `NAMED_VALUE_X` stuff)
- Logging system should keep working