### PR TITLE
setting-syncer: Stop opening success snackbars on startup

### DIFF
--- a/src/composables/settingsSyncer.ts
+++ b/src/composables/settingsSyncer.ts
@@ -136,8 +136,11 @@ export function useBlueOsStorage<T>(key: string, defaultValue: MaybeRef<T>): Rem
       try {
         await setKeyDataOnCockpitVehicleStorage(vehicleAddress, `settings/${username}/${key}`, newValue)
         const message = `Success updating '${key}' on BlueOS.`
-        openSnackbar({ message, duration: 3000, variant: 'success', closeButton: true })
-        console.info(message)
+        if (finishedInitialFetch.value) {
+          openSnackbar({ message, duration: 3000, variant: 'success', closeButton: true })
+        } else {
+          console.info(message)
+        }
       } catch (fetchError) {
         const message = `Failed updating '${key}' on BlueOS. Will keep trying.`
         openSnackbar({ message, duration: 3000, variant: 'error', closeButton: true })
@@ -192,7 +195,7 @@ export function useBlueOsStorage<T>(key: string, defaultValue: MaybeRef<T>): Rem
       if (useBlueOsValue) {
         currentValue.value = valueOnBlueOS as T
         const message = `Fetched remote value of key ${key} from the vehicle.`
-        openSnackbar({ message, duration: 3000, variant: 'success' })
+        console.info(message)
 
         // TODO: This is a workaround to make the profiles work after an import.
         // We need to find a better way to handle this, without reloading.
@@ -210,7 +213,7 @@ export function useBlueOsStorage<T>(key: string, defaultValue: MaybeRef<T>): Rem
       } else {
         await updateValueOnBlueOS(currentValue.value)
         const message = `Pushed local value of key ${key} to the vehicle.`
-        openSnackbar({ message, duration: 3000, variant: 'success' })
+        console.info(message)
       }
 
       console.info(`Success syncing '${key}' with BlueOS.`)


### PR DESCRIPTION
If an action is done behind the scenes, automatically (without user interaction), and this action is a success, we don't need to inform the user about it, we should just do it silently. 

We should only inform the user if the action is done interactively or if it fails (thus needing user attention and manual intervention).