### PR TITLE
ardupilot: Add system ID to the data-lake

### DIFF
--- a/src/libs/actions/mavlink-message-actions-message-definitions.ts
+++ b/src/libs/actions/mavlink-message-actions-message-definitions.ts
@@ -15,7 +15,7 @@ interface MessageField {
 export const messageFieldDefinitions: Partial<Record<MAVLinkType, Record<string, MessageField>>> = {
   [MAVLinkType.COMMAND_LONG]: {
     target_system: {
-      value: 1,
+      value: '{{ardupilotSystemId}}',
       type: MessageFieldType.NUMBER,
       description: 'System ID of target system',
       required: true,
@@ -83,7 +83,7 @@ export const messageFieldDefinitions: Partial<Record<MAVLinkType, Record<string,
   },
   [MAVLinkType.COMMAND_INT]: {
     target_system: {
-      value: 1,
+      value: '{{ardupilotSystemId}}',
       type: MessageFieldType.NUMBER,
       description: 'System ID of target system',
       required: true,

--- a/src/libs/joystick/protocols/predefined-resources.ts
+++ b/src/libs/joystick/protocols/predefined-resources.ts
@@ -65,7 +65,7 @@ export const setupMavlinkCameraResources = (): void => {
     name: 'Camera Zoom (MAVLink)',
     messageType: MAVLinkType.COMMAND_LONG,
     messageConfig: {
-      target_system: { value: 1, type: MessageFieldType.NUMBER },
+      target_system: { value: '{{ardupilotSystemId}}', type: MessageFieldType.NUMBER },
       target_component: { value: 1, type: MessageFieldType.NUMBER },
       command: { value: MavCmd.MAV_CMD_SET_CAMERA_ZOOM, type: MessageFieldType.TYPE_STRUCT_ENUM },
       confirmation: { value: 0, type: MessageFieldType.NUMBER },
@@ -92,7 +92,7 @@ export const setupMavlinkCameraResources = (): void => {
     name: 'Camera Focus (MAVLink)',
     messageType: MAVLinkType.COMMAND_LONG,
     messageConfig: {
-      target_system: { value: 1, type: MessageFieldType.NUMBER },
+      target_system: { value: '{{ardupilotSystemId}}', type: MessageFieldType.NUMBER },
       target_component: { value: 1, type: MessageFieldType.NUMBER },
       command: { value: MavCmd.MAV_CMD_SET_CAMERA_FOCUS, type: MessageFieldType.TYPE_STRUCT_ENUM },
       confirmation: { value: 0, type: MessageFieldType.NUMBER },

--- a/src/libs/vehicle/ardupilot/ardupilot.ts
+++ b/src/libs/vehicle/ardupilot/ardupilot.ts
@@ -525,7 +525,7 @@ export abstract class ArduPilotVehicle<Modes> extends Vehicle.AbstractVehicle<Mo
     const gotoMessage: Message.SetPositionTargetLocalNed = {
       time_boot_ms: 0,
       type: MAVLinkType.SET_POSITION_TARGET_LOCAL_NED,
-      target_system: 1,
+      target_system: this.currentSystemId,
       target_component: 1,
       coordinate_frame: { type: MavFrame.MAV_FRAME_LOCAL_OFFSET_NED },
       type_mask: { bits: 0b0000111111111000 },
@@ -786,7 +786,7 @@ export abstract class ArduPilotVehicle<Modes> extends Vehicle.AbstractVehicle<Mo
   requestParametersList(): void {
     const paramRequestMessage: Message.ParamRequestList = {
       type: MAVLinkType.PARAM_REQUEST_LIST,
-      target_system: 0,
+      target_system: this.currentSystemId,
       target_component: 0,
     }
     sendMavlinkMessage(paramRequestMessage)
@@ -882,7 +882,7 @@ export abstract class ArduPilotVehicle<Modes> extends Vehicle.AbstractVehicle<Mo
   requestMissionItem(seq: number, missionType: MavMissionType): void {
     const message: Message.MissionRequestInt = {
       type: MAVLinkType.MISSION_REQUEST_INT,
-      target_system: 0,
+      target_system: this.currentSystemId,
       target_component: 0,
       seq: seq,
       mission_type: { type: missionType },
@@ -899,7 +899,7 @@ export abstract class ArduPilotVehicle<Modes> extends Vehicle.AbstractVehicle<Mo
   sendMissionAck(success: boolean, missionType: MavMissionType): void {
     const message: Message.MissionAck = {
       type: MAVLinkType.MISSION_ACK,
-      target_system: 0,
+      target_system: this.currentSystemId,
       target_component: 0,
       mavtype: { type: success ? MavMissionResult.MAV_MISSION_ACCEPTED : MavMissionResult.MAV_MISSION_DENIED },
       mission_type: { type: missionType },

--- a/src/libs/vehicle/ardupilot/ardupilot.ts
+++ b/src/libs/vehicle/ardupilot/ardupilot.ts
@@ -60,6 +60,7 @@ export type ArduPilot = ArduPilotVehicle<any>
 
 const preDefinedDataLakeVariables = {
   cameraTilt: { id: 'cameraTiltDeg', name: 'Camera Tilt Degrees', type: 'number' },
+  ardupilotSystemId: { id: 'ardupilotSystemId', name: 'ArduPilot System ID', type: 'number' },
 }
 
 /**
@@ -118,17 +119,20 @@ export abstract class ArduPilotVehicle<Modes> extends Vehicle.AbstractVehicle<Mo
   /**
    * Construct a new generic ArduPilot type
    * @param {Vehicle.Type} type
-   * @param {number} system_id
+   * @param {number} systemId
    */
-  constructor(type: Vehicle.Type, system_id: number) {
+  constructor(type: Vehicle.Type, systemId: number) {
     super(Vehicle.Firmware.ArduPilot, type)
-    this.currentSystemId = system_id
+    this.currentSystemId = systemId
 
     // Request vehicle to stream a pre-defined list of messages so the GCS can receive them
     this.requestDefaultMessages()
 
     // Create data-lake variables for the vehicle
     this.createPredefinedDataLakeVariables()
+
+    // Set the system ID in the data-lake
+    setDataLakeVariableData(preDefinedDataLakeVariables.ardupilotSystemId.id, systemId)
   }
 
   /**


### PR DESCRIPTION
This way it can be used, for example, on actions calls, without the user needing to know it in advance, or needing to replace when the vehicle is changed.

Requested by @Williangalvani based on some struggle he had configuring stuff on a mission day.