### PR TITLE
components: MiniVideoRecorder: Do not show badge if there is no video

### DIFF
--- a/src/components/mini-widgets/MiniVideoRecorder.vue
+++ b/src/components/mini-widgets/MiniVideoRecorder.vue
@@ -34,14 +34,18 @@
     <div class="flex justify-center w-6">
       <v-divider vertical class="h-6 ml-1" />
       <v-badge
+        v-if="numberOfVideosOnDB > 0"
         color="info"
         :content="numberOfVideosOnDB"
         :dot="isOutside || isVideoLibraryDialogOpen"
         class="cursor-pointer"
         @click="openVideoLibraryModal"
       >
-        <v-icon class="w-6 h-6 ml-1 text-slate-100" @click="openVideoLibraryModal"> mdi-video-box </v-icon></v-badge
-      >
+        <v-icon class="w-6 h-6 ml-1 text-slate-100" @click="openVideoLibraryModal"> mdi-video-box </v-icon>
+      </v-badge>
+      <v-icon v-else class="w-6 h-6 ml-1 text-slate-100 cursor-pointer" @click="openVideoLibraryModal">
+        mdi-video-box
+      </v-icon>
     </div>
   </div>
   <v-dialog v-model="widgetStore.miniWidgetManagerVars(miniWidget.hash).configMenuOpen" width="auto">


### PR DESCRIPTION
Having a notification dot there when there is no video does not make sense, it appears that there is something and when the mouse is over it says zero. 

![image](https://github.com/user-attachments/assets/95c1ca6f-73ca-4289-b5ce-91460185eefa)
