### PR TITLE
defaults: Fix gamepad-to-cockpit-standard mapping for the Xbox One joysticks

### DIFF
--- a/src/assets/joystick-profiles.ts
+++ b/src/assets/joystick-profiles.ts
@@ -231,6 +231,11 @@ export const availableGamepadToCockpitMaps: { [key in JoystickModel]: GamepadToC
     axes: [0, 1, 2, 3],
     buttons: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
   },
+  [JoystickModel.XboxOne_Wired]: {
+    name: 'Xbox One (wired)',
+    axes: [0, 1, 2, 3],
+    buttons: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+  },
   [JoystickModel.XboxOneS_Bluetooth]: {
     name: 'Xbox One S (bluetooth)',
     axes: [0, 1, 2, 3],

--- a/src/assets/joystick-profiles.ts
+++ b/src/assets/joystick-profiles.ts
@@ -227,14 +227,14 @@ export const availableGamepadToCockpitMaps: { [key in JoystickModel]: GamepadToC
     buttons: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17],
   },
   [JoystickModel.XboxOne_Wireless]: {
-    name: 'Xbox One S',
+    name: 'Xbox One Wireless',
     axes: [0, 1, 2, 3],
-    buttons: [0, 1, 2, 3, 4, 11, 6, 7, 8, 9, 5, 11, 12, 13, 14, 15, 16, 17],
+    buttons: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
   },
   [JoystickModel.XboxOneS_Bluetooth]: {
-    name: 'Xbox One S',
+    name: 'Xbox One S (bluetooth)',
     axes: [0, 1, 2, 3],
-    buttons: [0, 1, 2, 3, 4, 11, 6, 7, 8, 9, 5, 11, 12, 13, 14, 15, 16, 17],
+    buttons: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
   },
   [JoystickModel.XboxController_Bluetooth]: {
     name: 'Xbox Controller (bluetooth)',

--- a/src/libs/joystick/manager.ts
+++ b/src/libs/joystick/manager.ts
@@ -31,6 +31,7 @@ export enum JoystickModel {
   DualSense = 'DualSense (PS5)',
   DualShock4 = 'DualShock (PS4)',
   XboxOne_Wireless = 'Xbox One Wireless Controller',
+  XboxOne_Wired = 'Xbox One Wired Controller',
   XboxOneS_Bluetooth = 'Xbox One S (bluetooth)',
   XboxController_Bluetooth = 'Xbox controller (bluetooth)',
   XboxController_Wired = 'Xbox controller (wired)',
@@ -46,6 +47,7 @@ const JoystickMapVidPid: Map<string, JoystickModel> = new Map([
   // Sony
   ['054c:0ce6', JoystickModel.DualSense],
   ['054c:09cc', JoystickModel.DualShock4],
+  ['045e:02ea', JoystickModel.XboxOne_Wired],
   ['045e:02e0', JoystickModel.XboxOne_Wireless],
   ['045e:02fd', JoystickModel.XboxOneS_Bluetooth],
   ['045e:0b13', JoystickModel.XboxController_Bluetooth],


### PR DESCRIPTION
I just want to say that the whole xbox wireless controller thing [is a f nightmare](https://www.pcgamingwiki.com/wiki/Controller:Xbox_Wireless_Controller#Technical_information).