### PR TITLE
custom-actions: Change icon and color of the delete button

### DIFF
--- a/src/views/ConfigurationActionsView.vue
+++ b/src/views/ConfigurationActionsView.vue
@@ -87,8 +87,7 @@
                         <v-btn
                           variant="outlined"
                           class="rounded-full mx-1"
-                          color="error"
-                          icon="mdi-delete"
+                          icon="mdi-trash-can-outline"
                           size="x-small"
                           @click="deleteAction(item)"
                         />


### PR DESCRIPTION
Replace the delete button icon from MDI's delete to MDI's trash-can-outline, and change its color to white, as the other buttons.

Those changes make it more clear that it's a trash button, and not a "stop" one, specially in low resolution screens.

Before:
<img width="1085" alt="image" src="https://github.com/user-attachments/assets/e7987cf0-d968-4088-bbef-29afcc046332" />

After:
<img width="1084" alt="image" src="https://github.com/user-attachments/assets/5409671a-66a4-44c3-8e1c-f3f309cff5f0" />

Fix #1831 