### PR TITLE
src: types: genericIndicator.ts: fix incorrect tether turns tracking

### DIFF
--- a/src/types/genericIndicator.ts
+++ b/src/types/genericIndicator.ts
@@ -51,7 +51,7 @@ export const veryGenericIndicatorPresets: VeryGenericIndicatorPreset[] = [
     variableName: 'TetherTrn',
     iconName: 'mdi-horizontal-rotate-clockwise',
     variableUnit: 'x',
-    variableMultiplier: 100,
+    variableMultiplier: 1,
   },
   {
     displayName: 'Lights (1)',


### PR DESCRIPTION
Unit is `x`, not `%` - no multiplier needed.