### PR TITLE
arm-safety-menu: Make options more clear and make it easy canceling the action

### DIFF
--- a/src/components/ArmSafetyDialog.vue
+++ b/src/components/ArmSafetyDialog.vue
@@ -1,0 +1,94 @@
+<template>
+  <InteractionDialog v-model="show" title="Be careful" variant="text-only" max-width="780px" :persistent="false">
+    <template #content>
+      <div class="flex gap-x-2 absolute top-0 right-0 py-2 pr-3">
+        <slot name="help-icon"></slot>
+        <v-btn icon :width="34" :height="34" variant="text" class="bg-transparent" @click="cancelOpeningMainMenu">
+          <v-icon :size="22">mdi-close</v-icon>
+        </v-btn>
+      </div>
+
+      <div class="flex items-center justify-center mb-6">
+        <v-icon class="text-yellow text-[60px] mx-8">mdi-alert-rhombus</v-icon>
+        <p class="w-[560px] text-balance">
+          The vehicle is currently armed and the main-menu contains configurations and tools that can cause unsafe
+          situations. Take care if you still decide to proceed, by choosing one of the options below.
+        </p>
+      </div>
+    </template>
+    <template #actions>
+      <div class="flex items-center justify-between gap-8 w-full text-md">
+        <button class="option-button" @click="continueAnyway">Continue anyway</button>
+        <button class="option-button" @click="doNotAskAgainInThisSession">
+          Continue and don't warn again during this session
+        </button>
+        <button class="option-button" @click="neverAskAgain">Continue and never warn again</button>
+        <button class="option-button" @click="disarmVehicle">Disarm vehicle and continue</button>
+      </div>
+    </template>
+  </InteractionDialog>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+import InteractionDialog from '@/components/InteractionDialog.vue'
+import { useSnackbar } from '@/composables/snackbar'
+import { useAlertStore } from '@/stores/alert'
+import { useAppInterfaceStore } from '@/stores/appInterface'
+import { useMainVehicleStore } from '@/stores/mainVehicle'
+
+const vehicleStore = useMainVehicleStore()
+const alertStore = useAlertStore()
+const interfaceStore = useAppInterfaceStore()
+const { openSnackbar } = useSnackbar()
+
+const show = ref(true)
+
+const cancelOpeningMainMenu = (): void => {
+  show.value = false
+}
+
+const continueAnyway = (): void => {
+  interfaceStore.isMainMenuVisible = true
+  show.value = false
+}
+
+const doNotAskAgainInThisSession = (): void => {
+  alertStore.skipArmedMenuWarningThisSession = true
+  continueAnyway()
+}
+
+const neverAskAgain = (): void => {
+  alertStore.neverShowArmedMenuWarning = true
+  continueAnyway()
+
+  openSnackbar({
+    message: 'Armed menu warning disabled. You can re-enable it in the Settings > Alerts menu.',
+    variant: 'info',
+    duration: 10000,
+    closeButton: true,
+  })
+}
+
+const disarmVehicle = (): void => {
+  vehicleStore.disarm()
+  interfaceStore.isMainMenuVisible = true
+  show.value = false
+}
+</script>
+
+<style scoped>
+.option-button {
+  font-weight: 500;
+  margin: 0.25rem;
+  padding: 0.5rem;
+  max-width: 13rem;
+  border-radius: 0.35rem;
+  text-wrap: balance;
+}
+
+.option-button:hover {
+  background-color: rgba(88, 94, 103, 0.2);
+}
+</style>

--- a/src/composables/armSafetyDialog.ts
+++ b/src/composables/armSafetyDialog.ts
@@ -1,0 +1,47 @@
+import { v4 as uuid } from 'uuid'
+import { createApp } from 'vue'
+
+import ArmSafetyDialog from '@/components/ArmSafetyDialog.vue'
+import vuetify from '@/plugins/vuetify'
+import { useAlertStore } from '@/stores/alert'
+import { useAppInterfaceStore } from '@/stores/appInterface'
+import { useMainVehicleStore } from '@/stores/mainVehicle'
+
+import { useSnackbar } from './snackbar'
+
+export const openMainMenuIfSafeOrDesired = (): void => {
+  const vehicleStore = useMainVehicleStore()
+  const alertStore = useAlertStore()
+  const interfaceStore = useAppInterfaceStore()
+  const { openSnackbar } = useSnackbar()
+
+  // If the vehicle is not armed, its safe to open the main menu
+  if (!vehicleStore.isArmed) {
+    interfaceStore.isMainMenuVisible = true
+    return
+  }
+
+  // Skip warning if user has chosen to never show it again or skip for this session
+  if (alertStore.neverShowArmedMenuWarning || alertStore.skipArmedMenuWarningThisSession) {
+    // Show a snackbar warning instead
+    openSnackbar({ message: 'Take care, your vehicle is armed', variant: 'warning' })
+    interfaceStore.isMainMenuVisible = true
+    return
+  }
+
+  const mountPoint = document.createElement('div')
+  mountPoint.id = `arm-safety-dialog-${uuid()}`
+  document.body.appendChild(mountPoint)
+  const dialogApp = createApp(ArmSafetyDialog, {
+    onConfirmed: () => {
+      dialogApp.unmount()
+      mountPoint.remove()
+    },
+    onDismissed: () => {
+      dialogApp.unmount()
+      mountPoint.remove()
+    },
+  })
+  dialogApp.use(vuetify)
+  dialogApp.mount(mountPoint)
+}

--- a/src/stores/alert.ts
+++ b/src/stores/alert.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { computed, reactive, watch } from 'vue'
+import { computed, reactive, ref, watch } from 'vue'
 
 import { useBlueOsStorage } from '@/composables/settingsSyncer'
 
@@ -9,6 +9,7 @@ export const useAlertStore = defineStore('alert', () => {
   const alerts = reactive([new Alert(AlertLevel.Success, 'Cockpit started')])
   const enableVoiceAlerts = useBlueOsStorage('cockpit-enable-voice-alerts', true)
   const neverShowArmedMenuWarning = useBlueOsStorage('cockpit-never-show-armed-menu-warning', false)
+  const skipArmedMenuWarningThisSession = ref(false)
   // eslint-disable-next-line jsdoc/require-jsdoc
   const availableAlertSpeechVoices = reactive<SpeechSynthesisVoice[]>([])
   const selectedAlertSpeechVoiceName = useBlueOsStorage<string | undefined>(
@@ -161,5 +162,6 @@ export const useAlertStore = defineStore('alert', () => {
     pushWarningAlert,
     pushCriticalAlert,
     neverShowArmedMenuWarning,
+    skipArmedMenuWarningThisSession,
   }
 })


### PR DESCRIPTION
Added a close button as well as the ability to close the dialog it by clicking the ESC key or outside it (made it non-persistent).

Also changed the layout and texts to take less horizontal space and make it more clear what each option is going to do.

![image](https://github.com/user-attachments/assets/80539172-d0a3-4178-aea3-a8f951db3fee)

Change requested by @NickNothom.
