### PR TITLE
Remove non-functional options from the joystick axis function selection

### DIFF
--- a/src/libs/joystick/protocols.ts
+++ b/src/libs/joystick/protocols.ts
@@ -9,11 +9,7 @@ import {
 import { modifierKeyActions, otherAvailableActions } from './protocols/other'
 
 export const allAvailableAxes = (): ProtocolAction[] => {
-  return [
-    ...Object.values(mavlinkManualControlAxes),
-    ...Object.values(otherAvailableActions),
-    ...Object.values(availableDataLakeActions()),
-  ]
+  return [...Object.values(mavlinkManualControlAxes), otherAvailableActions.no_function]
 }
 
 export const allAvailableButtons = (): ProtocolAction[] => {


### PR DESCRIPTION
I reviewed it and actually there were several options there that simple don't make sense today.
Cockpit's joystick backend only have support today for `MANUAL_CONTROL` actions, so everything else was removed.

Fix #1900