### PR TITLE
src: components: ArmSafetyDialog: improve text, reorder options

### DIFF
--- a/src/components/ArmSafetyDialog.vue
+++ b/src/components/ArmSafetyDialog.vue
@@ -11,18 +11,19 @@
       <div class="flex items-center justify-center mb-6">
         <v-icon class="text-yellow text-[60px] mx-8">mdi-alert-rhombus</v-icon>
         <p class="w-[560px] text-balance">
-          The vehicle is currently armed and the main-menu contains configurations and tools that can cause unsafe
-          situations. Take care if you still decide to proceed, by choosing one of the options below.
+          The vehicle is currently armed, and the main-menu contains configurations and tools that can cause unsafe
+          situations.
         </p>
+        <p class="w-[560px] text-balance">Come back later, or proceed carefully with one of the following options:</p>
       </div>
     </template>
     <template #actions>
       <div class="flex items-center justify-between gap-8 w-full text-md">
-        <button class="option-button" @click="continueAnyway">Continue anyway</button>
+        <button class="option-button" @click="neverAskAgain">Continue and never warn again</button>
         <button class="option-button" @click="doNotAskAgainInThisSession">
           Continue and don't warn again during this session
         </button>
-        <button class="option-button" @click="neverAskAgain">Continue and never warn again</button>
+        <button class="option-button" @click="continueAnyway">Continue anyway</button>
         <button class="option-button" @click="disarmVehicle">Disarm vehicle and continue</button>
       </div>
     </template>


### PR DESCRIPTION
I've been unwell, so missed out on reviewing #1898 before it got merged.

I think ideally there would just be one continue button, with the warning and disarming options presented as radio buttons and a checkbox respectively, e.g.:

```
⚫️ Warn me again next time                 [x] Disarm vehicle
O Don't warn me again this session
O Never warn me again                            [ CONTINUE ]
```

but I don't have the knowledge or time to do that right now, so for now I've just reordered the existing options in order of least to most "safe":

<img width="792" alt="Screenshot 2025-06-21 at 1 08 33 am" src="https://github.com/user-attachments/assets/7c53d84a-4507-4343-be90-d3c099ea7f57" />