### PR TITLE
electron: Fix fetching of memory-usage

### DIFF
--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -4,6 +4,7 @@ import { join } from 'path'
 
 import { setupAutoUpdater } from './services/auto-update'
 import store from './services/config-store'
+import { setupMemoryService } from './services/memory'
 import { setupNetworkService } from './services/network'
 import { setupFilesystemStorage } from './services/storage'
 
@@ -75,6 +76,7 @@ protocol.registerSchemesAsPrivileged([
 
 setupFilesystemStorage()
 setupNetworkService()
+setupMemoryService()
 
 app.whenReady().then(async () => {
   console.log('Electron app is ready.')

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -2,6 +2,7 @@ import { contextBridge, ipcRenderer } from 'electron'
 
 contextBridge.exposeInMainWorld('electronAPI', {
   getInfoOnSubnets: () => ipcRenderer.invoke('get-info-on-subnets'),
+  getResourceUsage: () => ipcRenderer.invoke('get-resource-usage'),
   onUpdateAvailable: (callback: (info: any) => void) =>
     ipcRenderer.on('update-available', (_event, info) => callback(info)),
   onUpdateDownloaded: (callback: (info: any) => void) =>

--- a/src/electron/services/memory.ts
+++ b/src/electron/services/memory.ts
@@ -1,0 +1,27 @@
+import { app, ipcMain } from 'electron'
+
+/**
+ * Setup memory usage monitoring
+ * Exposes IPC handler for getting real-time memory usage information
+ */
+export const setupMemoryService = (): void => {
+  ipcMain.handle('get-resource-usage', async () => {
+    try {
+      const memoryInfo = await app.getAppMetrics()
+
+      // Sum all process memory
+      const totalMemory = memoryInfo.reduce((total, metric) => {
+        return total + (metric.memory?.workingSetSize || 0)
+      }, 0)
+
+      return {
+        totalMemoryMB: totalMemory / 1024, // Convert from KiloBytes to MegaBytes
+      }
+    } catch (error) {
+      console.error('Failed to get memory usage:', error)
+      return {
+        totalMemoryMB: 0,
+      }
+    }
+  })
+}

--- a/src/libs/cosmos.ts
+++ b/src/libs/cosmos.ts
@@ -193,6 +193,16 @@ declare global {
        */
       getInfoOnSubnets: () => Promise<NetworkInfo[]>
       /**
+       * Get memory usage information from the main process
+       * @returns Promise containing memory usage data
+       */
+      getResourceUsage: () => Promise<{
+        /**
+         * The total memory usage of the application in MB
+         */
+        totalMemoryMB: number
+      }>
+      /**
        * Register callback for update available event
        */
       onUpdateAvailable: (callback: (info: any) => void) => void


### PR DESCRIPTION
Electron does not expose resource-usage updates on the `window.performance.memory` object, but instead has its own way of fetching an presenting those. This patch implements it to fix the updating of the memory-usage variable on the standalone application.

Fix #1669.