### PR TITLE
video: Fix 4K video processing

### DIFF
--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -397,22 +397,6 @@ export const useVideoStore = defineStore('video', () => {
       updatedInfo.dateLastRecordingUpdate = new Date()
       unprocessedVideos.value = { ...unprocessedVideos.value, ...{ [recordingHash]: updatedInfo } }
 
-      // Gets the thumbnail from the first chunk
-      if (chunksCount === 0) {
-        try {
-          const videoChunk = await tempVideoStorage.getItem(chunkName)
-          if (videoChunk) {
-            const firstChunkBlob = new Blob([videoChunk as Blob])
-            const thumbnail = await extractThumbnailFromVideo(firstChunkBlob)
-            // Save thumbnail in the storage
-            await tempVideoStorage.setItem(videoThumbnailFilename(recordingHash), thumbnail)
-            unprocessedVideos.value = { ...unprocessedVideos.value, ...{ [recordingHash]: updatedInfo } }
-          }
-        } catch (error) {
-          console.error('Failed to extract thumbnail:', error)
-        }
-      }
-
       // If the chunk was saved, remove it from the unsaved list
       clearTimeout(unsavedChunkAlerts[chunkName])
       delete unsavedChunkAlerts[chunkName]


### PR DESCRIPTION
They way that the processing pipeline works right now, we have 3 main things happening:
1. Video is processed (chunks merged and duration fixed)
2. Video thumbnail is generated
3. Video subtitles (telemetry) is generated

The problem that is happening is that the current video thumbnail extraction, for some reason that is still not clear, is not working for 4K videos, like the ones generated by Radcam. Those videos are also not playable in the embeded video player that we have in the video library modal.

The video is correctly processed, but as the thumbnail is failing to be generated, it is breaking the processing pipeline, causing the subtitles not to be generated, and the user to receive an error message saying the processing failed.

My solution does the following:
1. Puts the thumbnail extraction inside a try/catch block, so if it fails, it generates a placeholder thumbnail
2. Puts a message on the embedded video player saying a video cannot by played (if it cannot be played) and saying it should instead be downloaded

Fix #1761 