### PR TITLE
electron: Fix protocol used to make requests on BlueOS

### DIFF
--- a/src/libs/blueos.ts
+++ b/src/libs/blueos.ts
@@ -66,7 +66,7 @@ const defaultTimeout = 10000
 const quickStatusTimeout = 3000
 const beaconTimeout = 5000
 
-const protocol = window.location.protocol
+const protocol = window.location.protocol.includes('file') ? 'http' : window.location.protocol
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export const getBagOfHoldingFromVehicle = async (


### PR DESCRIPTION
On the built version of Electron, the protocol is `file:`, so it fails to fetch any info from BlueOS. This includes setting sync, for example.

The way I wrote the solution limits the usage of the electron version to `http` backends (as it was before), but as it's a critical fix, I'm pushing it the simplest way possible so we can fix users problems and release a new Beta today.