### PR TITLE
Add snapshot tool mini widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "localforage": "^1.10.0",
     "mathjs": "^13.0.3",
     "monaco-editor": "^0.52.0",
+    "piexifjs": "^1.0.6",
     "pinia": "^2.0.13",
     "posthog-js": "^1.194.3",
     "roboto-fontface": "*",

--- a/src/components/mini-widgets/MiniVideoRecorder.vue
+++ b/src/components/mini-widgets/MiniVideoRecorder.vue
@@ -132,6 +132,7 @@ const selectedExternalId = ref<string | undefined>()
 const externalStreamId = computed(() => selectedExternalId.value)
 
 const openVideoLibraryModal = (): void => {
+  interfaceStore.videoLibraryMode = 'videos'
   interfaceStore.videoLibraryVisibility = true
 }
 

--- a/src/components/mini-widgets/SnapshotTool.vue
+++ b/src/components/mini-widgets/SnapshotTool.vue
@@ -1,0 +1,320 @@
+<template>
+  <div
+    ref="recorderWidget"
+    class="flex justify-around pl-1 pr-[3px] py-1 text-center text-white rounded-lg w-[70px] h-9 align-center bg-slate-800/60"
+    :class="{ 'pointer-events-none': widgetStore.editingMode }"
+  >
+    <v-menu v-model="isSnapshotMenuOpen" offset="4" transition="fade-transition">
+      <template #activator="{ props: templateProps }">
+        <div v-bind="templateProps" class="flex flex-col items-center justify-around pl-1 pr-2">
+          <v-icon icon="mdi-menu-up" class="text-[22px] -mr-3 -ml-2 -mb-1 opacity-80 cursor-pointer" size="22" />
+          <v-icon :icon="snapshotTypeIcon" class="text-[22px] -mr-3 -ml-2 mb-1 cursor-pointer opacity-60" size="14" />
+        </div>
+      </template>
+      <v-list density="compact" class="pa-0 text-white rounded-md" :style="interfaceStore.globalGlassMenuStyles">
+        <v-list-item
+          class="bg-[#FFFFFF11] hover:bg-[#FFFFFF22] cursor-pointer text-sm"
+          @click="handleOpenSnapshotLibrary"
+          ><template #title>
+            <span class="text-white text-[16px] font-bold">Open snapshot library</span>
+          </template>
+        </v-list-item>
+        <v-divider />
+        <v-list-item title="Single capture" @click="handleSelectSnapshotTriggerType('single')">
+          <template #append>
+            <v-icon size="22" icon="mdi-video-image" />
+          </template>
+        </v-list-item>
+        <v-divider />
+        <v-divider />
+        <v-list-item title="Timed multi-capture" @click="handleSelectSnapshotTriggerType('timed')">
+          <template #append> <v-icon size="20" icon="mdi-timer-outline" /> </template>
+        </v-list-item>
+      </v-list>
+    </v-menu>
+    <v-divider v-if="!isTakingTimedSnapshot" vertical />
+    <div
+      v-else
+      class="bottom-0 left-0 w-[2px] bg-red-500 opacity-40"
+      :style="{ height: `${timerProgress}%` }"
+      color="green"
+      value="90"
+    />
+    <v-icon icon="mdi-camera" class="mb-[-2px]" size="32" @click="handleTakeSnapshot" />
+    <v-icon
+      v-if="snapshotTriggerType === 'timed'"
+      :icon="isTakingTimedSnapshot ? 'mdi-stop' : 'mdi-play'"
+      class="mb-[-2px] cursor-pointer mr-1 bg-[#FFFFFFff] rounded-full"
+      :class="{
+        'text-red-500 -ml-[32px]': isTakingTimedSnapshot,
+        'text-green-500 -ml-[33px]': !isTakingTimedSnapshot,
+      }"
+      size="22"
+      @click="isTakingTimedSnapshot = !isTakingTimedSnapshot"
+    />
+  </div>
+  <v-dialog v-model="widgetStore.miniWidgetManagerVars(miniWidget.hash).configMenuOpen" width="450">
+    <div
+      class="flex flex-col items-center p-2 px-4 pt-1 m-5 rounded-md gap-y-4"
+      :style="interfaceStore.globalGlassMenuStyles"
+    >
+      <p class="text-xl font-semibold mt-2 mb-4">Snapshot settings</p>
+      <div class="absolute top-0 right-0">
+        <v-tooltip
+          location="bottom"
+          open-on-click
+          :persistent="false"
+          :open-on-hover="false"
+          :open-on-focus="false"
+          close-on-content-click
+        >
+          <template #activator="{ props: iconProps }">
+            <v-icon
+              v-bind="iconProps"
+              icon="mdi-information-outline"
+              class="absolute top-2 right-2 cursor-pointer text-white"
+              size="18"
+            />
+          </template>
+
+          <span> Some features like “Capturing Cockpit work area” are only available in the Electron version. </span>
+        </v-tooltip>
+      </div>
+      <v-select
+        v-model="miniWidget.options.selectedStreams"
+        :items="videoStore.namesAvailableStreams || []"
+        density="compact"
+        multiple
+        clearable
+        label="Streams to capture"
+        variant="outlined"
+        no-data-text="No streams available."
+        hide-details
+        theme="dark"
+        class="w-[90%]"
+      />
+      <div class="flex items-center justify-start w-[90%] -mt-3 mb-2">
+        <v-checkbox
+          v-model="miniWidget.options.captureWorkspace"
+          :disabled="!isElectronEnv"
+          :class="{ 'opacity-20 pointer-events-none': !isElectronEnv }"
+          density="compact"
+          variant="outlined"
+          hide-details
+          theme="dark"
+          @update:model-value="(val) => (miniWidget.options.captureWorkspace = val)"
+        />
+        <p class="ml-[4px] -mb-[2px] text-sm" :class="{ 'opacity-20 pointer-events-none': !isElectronEnv }">
+          Capture Cockpit work area (Electron only)
+        </p>
+      </div>
+      <v-text-field
+        v-model.number="timedSnapshotInterval"
+        label="Timed snapshot interval (seconds)"
+        type="number"
+        density="compact"
+        variant="outlined"
+        hide-details
+        theme="dark"
+        class="w-[90%] mt-2"
+        :min="1"
+        step="1"
+        @update:model-value="(val) => (timedSnapshotInterval = parseInt(val))"
+      />
+      <div class="flex w-[90%] justify-end items-center mt-4 border-t-[1px] border-t-[#FFFFFF11]">
+        <v-btn
+          class="w-auto text-uppercase mt-2 -mr-6"
+          variant="text"
+          @click="widgetStore.miniWidgetManagerVars(miniWidget.hash).configMenuOpen = false"
+        >
+          Close
+        </v-btn>
+      </div>
+    </div>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+import { onBeforeMount, onMounted, ref, toRefs, watch } from 'vue'
+
+import { useInteractionDialog } from '@/composables/interactionDialog'
+import { useBlueOsStorage } from '@/composables/settingsSyncer'
+import { openSnackbar } from '@/composables/snackbar'
+import { isElectron } from '@/libs/utils'
+import { useAppInterfaceStore } from '@/stores/appInterface'
+import { useSnapshotStore } from '@/stores/snapshot'
+import { useVideoStore } from '@/stores/video'
+import { useWidgetManagerStore } from '@/stores/widgetManager'
+import type { MiniWidget } from '@/types/widgets'
+
+const { showDialog } = useInteractionDialog()
+const snapshotStore = useSnapshotStore()
+const interfaceStore = useAppInterfaceStore()
+const widgetStore = useWidgetManagerStore()
+const videoStore = useVideoStore()
+
+const props = defineProps<{
+  /**
+   * Configuration of the widget
+   */
+  miniWidget: MiniWidget
+}>()
+const miniWidget = toRefs(props).miniWidget
+const isElectronEnv = isElectron()
+
+const recorderWidget = ref()
+const snapshotTypeIcon = ref<'mdi-video-image' | 'mdi-timer-outline'>('mdi-video-image')
+const snapshotTriggerType = ref<'single' | 'timed'>('single')
+const isSnapshotMenuOpen = ref<boolean>(false)
+const timedSnapshotInterval = useBlueOsStorage('cockpit-snapshotTimedInterval', 5)
+const isTakingTimedSnapshot = ref<boolean>(false)
+const timerProgress = ref<number>(50)
+
+const flashEffect = async (): Promise<void> => {
+  const flashOverlay = document.createElement('div')
+  flashOverlay.style.position = 'fixed'
+  flashOverlay.style.top = '0'
+  flashOverlay.style.left = '0'
+  flashOverlay.style.width = '100%'
+  flashOverlay.style.height = '100%'
+  flashOverlay.style.backgroundColor = 'black'
+  flashOverlay.style.opacity = '0'
+  flashOverlay.style.transition = 'opacity 0.1s ease'
+  flashOverlay.style.zIndex = '9999'
+
+  document.body.appendChild(flashOverlay)
+
+  void flashOverlay.offsetWidth
+
+  flashOverlay.style.opacity = '0.4'
+  await new Promise((resolve) => setTimeout(resolve, 50))
+
+  flashOverlay.style.opacity = '0'
+  await new Promise((resolve) => setTimeout(resolve, 100))
+
+  document.body.removeChild(flashOverlay)
+}
+
+const handleTakeSnapshot = async (): Promise<void> => {
+  if (!areSelectedStreamsAreAvailable()) return
+  isSnapshotMenuOpen.value = false
+
+  try {
+    if (snapshotTriggerType.value !== 'timed') {
+      await snapshotStore.takeSnapshot(
+        miniWidget.value.options.nameSelectedStreams,
+        miniWidget.value.options.captureWorkspace
+      )
+
+      flashEffect()
+      openSnackbar({
+        message: 'Snapshot recorded successfully.',
+        variant: 'success',
+        duration: 2000,
+      })
+    }
+  } catch (error) {
+    showDialog({
+      title: 'Error taking snapshot',
+      message: `Make sure the streams have finished loading.`,
+      variant: 'error',
+      persistent: false,
+      maxWidth: '550px',
+    })
+  }
+}
+
+const handleOpenSnapshotLibrary = (): void => {
+  isSnapshotMenuOpen.value = false
+  interfaceStore.videoLibraryMode = 'snapshots'
+  interfaceStore.videoLibraryVisibility = true
+}
+
+const handleSelectSnapshotTriggerType = (type: 'single' | 'timed'): void => {
+  if (type === 'single') {
+    snapshotTriggerType.value = 'single'
+    snapshotTypeIcon.value = 'mdi-video-image'
+  } else if (type === 'timed') {
+    snapshotTriggerType.value = 'timed'
+    snapshotTypeIcon.value = 'mdi-timer-outline'
+  }
+  isSnapshotMenuOpen.value = false
+}
+
+let progressInterval: ReturnType<typeof setInterval> | null = null
+let shotInterval: ReturnType<typeof setInterval> | null = null
+
+watch(isTakingTimedSnapshot, (newValue) => {
+  if (newValue) {
+    // Capture a initial snapshot
+    snapshotStore.takeSnapshot(miniWidget.value.options.nameSelectedStreams, miniWidget.value.options.captureWorkspace)
+    flashEffect()
+    openSnackbar({
+      message: `Timed snapshot started. This will capture the selected interfaces every ${timedSnapshotInterval.value} seconds until you press the camera button again.`,
+      variant: 'info',
+      duration: 4000,
+    })
+
+    // Capture subsequent timed snapshots
+    shotInterval = setInterval(async () => {
+      await snapshotStore.takeSnapshot(
+        miniWidget.value.options.nameSelectedStreams,
+        miniWidget.value.options.captureWorkspace
+      )
+      timerProgress.value = 0
+    }, timedSnapshotInterval.value * 1000)
+
+    // Update the progress bar
+    const PROGRESS_TICK = 50
+    const step = (100 * PROGRESS_TICK) / (timedSnapshotInterval.value * 1000)
+    timerProgress.value = 0
+    progressInterval = setInterval(() => {
+      timerProgress.value = Math.min(timerProgress.value + step, 100)
+    }, PROGRESS_TICK)
+    return
+  }
+  openSnackbar({ message: 'Timed snapshot stopped.', variant: 'info', duration: 2000 })
+  if (shotInterval) {
+    clearInterval(shotInterval)
+    shotInterval = null
+  }
+  if (progressInterval) {
+    clearInterval(progressInterval)
+    progressInterval = null
+  }
+  timerProgress.value = 0
+})
+
+const areSelectedStreamsAreAvailable = (): boolean => {
+  if (
+    miniWidget.value.options.selectedStreams.every((stream: string) =>
+      videoStore.namesAvailableStreams.includes(stream)
+    )
+  ) {
+    miniWidget.value.options.nameSelectedStreams = miniWidget.value.options.selectedStreams
+    return true
+  }
+
+  showDialog({
+    message: 'Selected streams are not available anymore. Please check the currently available options.',
+    variant: 'warning',
+  })
+  return false
+}
+
+onBeforeMount(async () => {
+  // Set initial widget options if they don't exist
+  if (Object.keys(miniWidget.value.options).length === 0) {
+    miniWidget.value.options = {
+      selectedStreams: undefined as string[] | undefined,
+      captureWorkspace: false,
+    }
+  }
+})
+
+onMounted(() => {
+  if (!isElectronEnv) {
+    miniWidget.value.options.captureWorkspace = false
+  }
+})
+</script>

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -8,6 +8,7 @@ import { setupJoystickMonitoring } from './services/joystick'
 import { setupMemoryService } from './services/memory'
 import { setupNetworkService } from './services/network'
 import { setupFilesystemStorage } from './services/storage'
+import { setupWorkspaceService } from './services/workspace'
 
 // If the app is packaged, push logs to the system instead of the console
 if (app.isPackaged) {
@@ -78,6 +79,7 @@ protocol.registerSchemesAsPrivileged([
 setupFilesystemStorage()
 setupNetworkService()
 setupMemoryService()
+setupWorkspaceService()
 setupJoystickMonitoring()
 
 app.whenReady().then(async () => {

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -39,4 +39,5 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   openCockpitFolder: () => ipcRenderer.invoke('open-cockpit-folder'),
   openVideoFolder: () => ipcRenderer.invoke('open-video-folder'),
+  captureWorkspace: (rect?: Electron.Rectangle) => ipcRenderer.invoke('capture-workspace', rect),
 })

--- a/src/electron/services/workspace.ts
+++ b/src/electron/services/workspace.ts
@@ -1,0 +1,14 @@
+import { BrowserWindow, ipcMain } from 'electron'
+
+/**
+ * Setup workspace service
+ * Exposes Electron IPC handler for capturing the workspace
+ */
+export const setupWorkspaceService = (): void => {
+  ipcMain.handle('capture-workspace', async (event, rect) => {
+    const win = BrowserWindow.fromWebContents(event.sender)
+    if (!win) throw new Error('No window')
+    const image = await win.capturePage(rect)
+    return image.toPNG()
+  })
+}

--- a/src/libs/cosmos.ts
+++ b/src/libs/cosmos.ts
@@ -253,6 +253,10 @@ declare global {
        * Open video folder
        */
       openVideoFolder: () => void
+      /**
+       * Capture the workspace area of the application
+       */
+      captureWorkspace(rect?: Electron.Rectangle): Promise<Uint8Array>
     }
   }
 }

--- a/src/libs/videoStorage.ts
+++ b/src/libs/videoStorage.ts
@@ -120,8 +120,17 @@ const videoStoringIndexedDB: StorageDB = new LocalForageStorage(
   'Cockpit video recordings and their corresponding telemetry subtitles.'
 )
 
+const snapshotsIndexedDB: StorageDB = new LocalForageStorage(
+  'Cockpit - Snapshots',
+  'cockpit-snapshots-db',
+  1.0,
+  'Cockpit snapshots taken from video streams or workspace.'
+)
+
 const electronVideoStorage = new ElectronStorage(['videos'])
 const temporaryElectronVideoStorage = new ElectronStorage(['videos', 'temporary-video-chunks'])
+const electronSnapshotStorage = new ElectronStorage(['snapshots'])
 
 export const videoStorage = isElectron() ? electronVideoStorage : videoStoringIndexedDB
 export const tempVideoStorage = isElectron() ? temporaryElectronVideoStorage : tempVideoChunksIndexdedDB
+export const snapshotStorage = isElectron() ? electronSnapshotStorage : snapshotsIndexedDB

--- a/src/stores/appInterface.ts
+++ b/src/stores/appInterface.ts
@@ -43,6 +43,7 @@ export const useAppInterfaceStore = defineStore('responsive', {
     height: windowHeight.value,
     configModalVisibility: false,
     videoLibraryVisibility: false,
+    videoLibraryMode: 'video',
     UIGlassEffect: useBlueOsStorage('cockpit-ui-glass-effect', {
       opacity: 0.9,
       bgColor: '#63636354',

--- a/src/stores/snapshot.ts
+++ b/src/stores/snapshot.ts
@@ -1,0 +1,252 @@
+import { BlobReader, BlobWriter, ZipWriter } from '@zip.js/zip.js'
+import { format } from 'date-fns'
+import saveAs from 'file-saver'
+import piexif from 'piexifjs'
+import { defineStore } from 'pinia'
+
+import { useInteractionDialog } from '@/composables/interactionDialog'
+import { useBlueOsStorage } from '@/composables/settingsSyncer'
+import { app_version } from '@/libs/cosmos'
+import { isElectron } from '@/libs/utils'
+import { snapshotStorage } from '@/libs/videoStorage'
+import { StorageDB } from '@/types/general'
+import { EIXFType, SnapshotExif, SnapshotFileDescriptor } from '@/types/snapshot'
+import { DownloadProgressCallback, FileDescriptor } from '@/types/video'
+
+import { useMainVehicleStore } from './mainVehicle'
+import { useVideoStore } from './video'
+
+export const useSnapshotStore = defineStore('snapshot', () => {
+  const videoStore = useVideoStore()
+  const vehicleStore = useMainVehicleStore()
+  const { showDialog } = useInteractionDialog()
+
+  const zipMultipleFiles = useBlueOsStorage('cockpit-zip-multiple-video-files', false)
+
+  const blobToDataURL = (blob: Blob): Promise<string> =>
+    new Promise((res) => {
+      const r = new FileReader()
+      r.onload = () => res(r.result as string)
+      r.readAsDataURL(blob)
+    })
+
+  const dataURLToBlob = (dataURL: string): Blob => {
+    const [meta, b64] = dataURL.split(',')
+    const bin = atob(b64)
+    const arr = new Uint8Array(bin.length)
+    for (let i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i)
+    const mime = /data:(.*);base64/.exec(meta)?.[1] ?? 'image/jpeg'
+    return new Blob([arr], { type: mime })
+  }
+
+  const toDMS = (deg: number): [number, number][] => {
+    const d = Math.floor(Math.abs(deg))
+    const mFloat = (Math.abs(deg) - d) * 60
+    const m = Math.floor(mFloat)
+    const s = Math.round((mFloat - m) * 6000)
+    return [
+      [d, 1],
+      [m, 1],
+      [s, 100],
+    ]
+  }
+
+  const buildExif = (opts: EIXFType): SnapshotExif => {
+    const { latitude, longitude, yaw, pitch, roll, width, height } = opts
+    return {
+      '0th': {
+        [piexif.ImageIFD.Software]: `Cockpit ${app_version.version} - Blue Robotics`,
+      },
+      'Exif': {
+        [piexif.ExifIFD.UserComment]: `Vehicle attitude: {yaw: ${yaw?.toFixed(2) ?? 0}, pitch: ${
+          pitch?.toFixed(2) ?? 0
+        }, roll: ${roll?.toFixed(2) ?? 0}}`,
+        [piexif.ExifIFD.PixelXDimension]: width,
+        [piexif.ExifIFD.PixelYDimension]: height,
+      },
+      'GPS': {
+        [piexif.GPSIFD.GPSLatitudeRef]: latitude >= 0 ? 'N' : 'S',
+        [piexif.GPSIFD.GPSLongitudeRef]: longitude >= 0 ? 'E' : 'W',
+        [piexif.GPSIFD.GPSLatitude]: toDMS(Math.abs(latitude)),
+        [piexif.GPSIFD.GPSLongitude]: toDMS(Math.abs(longitude)),
+      },
+    }
+  }
+
+  const embedExif = async (blob: Blob, exifObj: piexif.Ifd): Promise<Blob> => {
+    const dataURL = await blobToDataURL(blob)
+    const exifStr = piexif.dump(exifObj)
+    const updated = piexif.insert(exifStr, dataURL)
+    return dataURLToBlob(updated)
+  }
+
+  const maybeEmbedExif = async (b: Blob, exif: piexif.Ifd): Promise<Blob> => {
+    if (b.type !== 'image/jpeg') return b
+    try {
+      return await embedExif(b, exif)
+    } catch (err) {
+      console.error('EXIF embed failed – storing image without metadata', err)
+      return b
+    }
+  }
+
+  const captureStreamFrame = async (streamName: string): Promise<Blob> => {
+    if (!streamName) {
+      return Promise.reject(new Error('Stream name is required to capture a snapshot.'))
+    }
+    const mediaStream = videoStore.getMediaStream(streamName)
+    if (!mediaStream) return Promise.reject(new Error(`Media stream not found for stream name: ${streamName}`))
+
+    const video = document.createElement('video')
+    video.srcObject = mediaStream
+    video.playsInline = true
+    video.muted = true
+    video.style.display = 'none'
+    document.body.appendChild(video)
+
+    await video.play()
+    const track = mediaStream.getVideoTracks()[0]
+    const { width = video.videoWidth, height = video.videoHeight } = track.getSettings()
+    video.width = width
+    video.height = height
+
+    const canvas = document.createElement('canvas')
+    canvas.width = width
+    canvas.height = height
+    const ctx = canvas.getContext('2d')
+    if (!ctx) throw new Error('Could not get 2D context')
+    ctx.drawImage(video, 0, 0, width, height)
+
+    video.pause()
+    document.body.removeChild(video)
+
+    return new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob((blob) => (blob ? resolve(blob) : reject(new Error('Canvas toBlob failed'))), 'image/jpeg', 0.9)
+    })
+  }
+
+  const captureWorkspaceElectron = async (): Promise<Blob> => {
+    const workArea = document.querySelector<HTMLElement>('#app')
+    if (!workArea) throw new Error('Work area element not found')
+    const { x, y, width, height } = workArea.getBoundingClientRect()
+    const rect: Electron.Rectangle = {
+      x: Math.floor(x),
+      y: Math.floor(y),
+      width: Math.floor(width),
+      height: Math.floor(height),
+    }
+    // @ts-ignore: ignore TypeScript error on next line
+    const pngBuffer = await window.electronAPI!.captureWorkspace(rect)
+    return new Blob([pngBuffer], { type: 'image/png' })
+  }
+
+  const snapshotFilename = (streamName: string): string => {
+    const timestamp = format(new Date(), 'LLL dd, yyyy - HH꞉mm꞉ss O')
+    return `(${timestamp})_Cockpit_${streamName}.jpeg`
+  }
+
+  const takeSnapshot = async (streamNames: string[], captureWorkspace?: boolean): Promise<void> => {
+    const { yaw, pitch, roll } = vehicleStore.attitude
+    const { latitude, longitude } = vehicleStore.coordinates
+
+    if (captureWorkspace) {
+      if (isElectron() && window.electronAPI) {
+        try {
+          let wsBlob = await captureWorkspaceElectron()
+          const wsExif = buildExif({
+            latitude,
+            longitude,
+            yaw,
+            pitch,
+            roll,
+            width: window.innerWidth,
+            height: window.innerHeight,
+          })
+          wsBlob = await maybeEmbedExif(wsBlob, wsExif)
+          await snapshotStorage.setItem(snapshotFilename('workspace'), wsBlob)
+        } catch (err) {
+          throw err as Error
+        }
+      } else {
+        throw new Error('Workspace capture requires Electron')
+      }
+    }
+
+    if (streamNames.length > 0) {
+      for (const streamName of streamNames) {
+        try {
+          let stBlob = await captureStreamFrame(streamName)
+          const { width, height } = videoStore.getMediaStream(streamName)?.getVideoTracks()[0].getSettings() || {}
+          const stExif = buildExif({ latitude, longitude, yaw, pitch, roll, width, height })
+          stBlob = await maybeEmbedExif(stBlob, stExif)
+          await snapshotStorage.setItem(snapshotFilename(streamName || 'workspace'), stBlob)
+        } catch (err) {
+          throw err as Error
+        }
+      }
+    }
+  }
+
+  const createZipAndDownload = async (
+    files: FileDescriptor[],
+    zipFilename: string,
+    progressCallback?: DownloadProgressCallback
+  ): Promise<void> => {
+    const zipWriter = new ZipWriter(new BlobWriter('application/zip'), { level: 0 })
+    const zipAddingPromises = files.map(({ filename, blob }) =>
+      zipWriter.add(filename, new BlobReader(blob), { onprogress: progressCallback })
+    )
+    await Promise.all(zipAddingPromises)
+    const blob = await zipWriter.close()
+    saveAs(blob, zipFilename)
+  }
+
+  const downloadFiles = async (
+    db: StorageDB | LocalForage,
+    keys: string[],
+    shouldZip = false,
+    zipFilenamePrefix = 'Cockpit-Snapshot-Files',
+    progressCallback?: DownloadProgressCallback
+  ): Promise<void> => {
+    const maybeFiles = await Promise.all(
+      keys.map(async (key) => {
+        try {
+          return { blob: await db.getItem(key), filename: key }
+        } catch (err) {
+          console.error(`Snapshot download: failed to read "${key}"`, err)
+          return { blob: undefined, filename: key }
+        }
+      })
+    )
+
+    const files = maybeFiles.filter((file): file is SnapshotFileDescriptor => file.blob instanceof Blob)
+    if (files.length === 0) {
+      showDialog({ message: 'No files found.', variant: 'error' })
+      return
+    }
+    if (shouldZip) {
+      await createZipAndDownload(files, `${zipFilenamePrefix}.zip`, progressCallback)
+    } else {
+      files.forEach(({ blob, filename }) => saveAs(blob, filename))
+    }
+  }
+
+  const downloadFilesFromSnapshotDB = async (
+    fileNames: string[],
+    progressCallback?: DownloadProgressCallback
+  ): Promise<void> => {
+    console.debug(`Downloading files from the snapshot database: ${fileNames.join(', ')}`)
+    if (fileNames.length > 1 && zipMultipleFiles.value) {
+      const ZipFilename = fileNames.length > 1 ? 'Cockpit-Snapshot-Capturing' : 'Cockpit-Snapshot-Capturing'
+      await downloadFiles(snapshotStorage, fileNames, true, ZipFilename, progressCallback)
+    } else {
+      await downloadFiles(snapshotStorage, fileNames)
+    }
+  }
+
+  const deleteSnapshotFiles = async (fileNames: string[]): Promise<void> => {
+    await Promise.all(fileNames.map((fileName) => snapshotStorage.removeItem(fileName)))
+  }
+
+  return { snapshotStorage, downloadFilesFromSnapshotDB, snapshotFilename, takeSnapshot, deleteSnapshotFiles }
+})

--- a/src/types/shims.d.ts
+++ b/src/types/shims.d.ts
@@ -5,6 +5,7 @@ declare module 'vuetify'
 declare module 'vuetify/lib/components'
 declare module 'vuetify/lib/directives'
 declare module '@peermetrics/webrtc-stats'
+declare module 'piexifjs'
 declare module '@kmamal/sdl'
 
 declare module 'vue-virtual-scroller' {
@@ -31,4 +32,27 @@ declare module 'vue-draggable-resizable' {
   import { DefineComponent } from 'vue'
   const component: DefineComponent<Record<string, never>>
   export default component
+}
+
+declare module 'piexifjs' {
+  export interface Ifd {
+    '0th': Record<number, string | number | number[][] | undefined>
+    'Exif'?: Record<number, string | number | number[][] | undefined>
+    'GPS'?: Record<number, string | number | number[][] | undefined>
+    'Interop'?: Record<number, any>
+    '1st'?: Record<number, any>
+    'thumbnail'?: string
+  }
+
+  const piexif: {
+    ImageIFD: Record<string, number>
+    ExifIFD: Record<string, number>
+    GPSIFD: Record<string, number>
+    dump(exif: Ifd): string
+    insert(exifStr: string, jpegDataUrl: string): string
+    load(jpegDataUrl: string): Ifd
+    remove(jpegDataUrl: string): string
+  }
+
+  export default piexif
 }

--- a/src/types/snapshot.ts
+++ b/src/types/snapshot.ts
@@ -1,0 +1,103 @@
+/**
+ * Snapshot File descriptor
+ */
+export interface SnapshotFileDescriptor {
+  /**
+   * Snapshot content
+   */
+  blob: Blob
+  /**
+   * Filename of the snapshot
+   */
+  filename: string
+}
+
+/**
+ * Snapshot file descriptor for library
+ */
+export interface SnapshotLibraryFile extends SnapshotFileDescriptor {
+  /**
+   * Name of the stream or workspace from which the snapshot was taken
+   */
+  streamName: string
+  /**
+   * Date when the snapshot was taken
+   */
+  date: Date
+  /**
+   * URL to access the snapshot file
+   */
+  url: string
+}
+
+/**
+ * EXIF data type for snapshots
+ */
+export interface EIXFType {
+  /**
+   * Latitude of the snapshot location
+   */
+  latitude: number
+  /**
+   * Longitude of the snapshot location
+   */
+  longitude: number
+  /**
+   * Yaw angle of the vehicle during the snapshot
+   */
+  yaw?: number
+  /**
+   * Pitch angle of the vehicle during the snapshot
+   */
+  pitch?: number
+  /**
+   * Roll angle of the vehicle during the snapshot
+   */
+  roll?: number
+  /**
+   * Width of the image
+   */
+  width?: number
+  /**
+   * Height of the image
+   */
+  height?: number
+}
+
+type ExifBlock = Record<number, string | number | number[][] | undefined>
+
+/**
+ * Snapshot EXIF data structure
+ */
+export interface SnapshotExif {
+  /**
+   * Camera version
+   */
+  '0th': ExifBlock
+  /**
+   * Image description
+   */
+  'Exif': ExifBlock
+  /**
+   * GPS data
+   */
+  'GPS': ExifBlock
+}
+
+/**
+ *
+ */
+export interface Thumb {
+  /**
+   * Thumb filename
+   */
+  filename: string
+  /**
+   * Thumb blob
+   */
+  blob?: Blob // raw *only if it exists*
+  /**
+   * URL to the thumb
+   */
+  url?: string // object-url cached here
+}

--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -88,6 +88,7 @@ export enum MiniWidgetType {
   EkfStateIndicator = 'EkfStateIndicator',
   SatelliteIndicator = 'SatelliteIndicator',
   ViewSelector = 'ViewSelector',
+  SnapshotTool = 'SnapshotTool',
 }
 
 /**
@@ -851,6 +852,7 @@ export const isMiniWidgetConfigurable: Record<MiniWidgetType, boolean> = {
   [MiniWidgetType.ModeSelector]: false,
   [MiniWidgetType.SatelliteIndicator]: false,
   [MiniWidgetType.ViewSelector]: false,
+  [MiniWidgetType.SnapshotTool]: true,
 }
 
 export const widgetHasOwnContextMenu: Record<WidgetType, boolean> = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7616,6 +7616,11 @@ picomatch@^4.0.2:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.2.tgz#77c742931e8f3b8820946c76cd0c1f13730d1dab"
   integrity sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==
 
+piexifjs@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/piexifjs/-/piexifjs-1.0.6.tgz#883811d73f447218d0d06e9ed7866d04533e59e0"
+  integrity sha512-0wVyH0cKohzBQ5Gi2V1BuxYpxWfxF3cSqfFXfPIpl5tl9XLS5z4ogqhUCD20AbHi0h9aJkqXNJnkVev6gwh2ag==
+
 pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -8502,8 +8507,16 @@ stop-iteration-iterator@^1.1.0:
     es-errors "^1.3.0"
     internal-slot "^1.1.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  name string-width-cjs
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8588,8 +8601,14 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  name strip-ansi-cjs
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -9685,8 +9704,16 @@ workbox-window@7.3.0, workbox-window@^7.0.0:
     "@types/trusted-types" "^2.0.2"
     workbox-core "7.3.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
-  name wrap-ansi-cjs
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
Add a mini widget to control Cockpit snapshot capture (1). 

* Provides single and timed capture from multiple sources.
* In Electron, also provides Cockpit workspace capture.
* Add EIXF info to the image files (2)

(1)

https://github.com/user-attachments/assets/ea5ef160-9350-43df-882d-954de3df3e86

(2)
![image](https://github.com/user-attachments/assets/0174ff71-aa51-4dd6-85d7-3825a8bf3ea2)


