### PR TITLE
widgets: video-player: Rotate background as well

### DIFF
--- a/src/components/widgets/VideoPlayer.vue
+++ b/src/components/widgets/VideoPlayer.vue
@@ -265,6 +265,7 @@ const streamStatus = computed(() => {
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  transform: v-bind('transformStyle');
 }
 video {
   height: 100%;
@@ -273,7 +274,6 @@ video {
   top: 0;
   left: 0;
   object-fit: v-bind('widget.options.videoFitStyle');
-  transform: v-bind('transformStyle');
 }
 .no-video-alert {
   width: 100%;


### PR DESCRIPTION
Before/after:
![image](https://github.com/user-attachments/assets/bef97636-b624-47d3-a0f0-82ba77ce57b7)
![image](https://github.com/user-attachments/assets/7fcd27b2-9ccf-45e5-bd9d-7a7b324ec0e8)


Partially solves #1937.