### PR TITLE
underlying-fallback: Fix stop routine on the console capture

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,18 +51,22 @@
     <link rel="stylesheet" href="/src/styles/global.css">
 
     <script>
+        // Start console capture
+        const {
+            backupSettings,
+            importSettings,
+            downloadLogs,
+            resetSettings,
+        } = import('./src/libs/index-utils.js');
+
         document.addEventListener("DOMContentLoaded", async function() {
-            // Import utility functions (console capture starts automatically)
+            // Import utility functions
             const {
                 backupSettings,
                 importSettings,
                 downloadLogs,
                 resetSettings,
-                monitorElementAndStopCapture
             } = await import('./src/libs/index-utils.js');
-
-            // Start monitoring the fallback element to stop capture when app loads
-            monitorElementAndStopCapture('underlying-fallback');
 
             const overlay = document.getElementById('browser-overlay')
             const content = document.getElementById('app')

--- a/src/libs/index-utils.js
+++ b/src/libs/index-utils.js
@@ -41,6 +41,13 @@ const originalConsole = {
           })
           .join(' '),
       })
+    } else {
+      // Restore original console methods
+      console.log = originalConsole.log
+      console.warn = originalConsole.warn
+      console.error = originalConsole.error
+      console.info = originalConsole.info
+      console.debug = originalConsole.debug
     }
 
     // Always call original console method to display in console
@@ -70,17 +77,13 @@ window.addEventListener('unhandledrejection', function (event) {
   }
 })
 
-// Test that console capture is working
-console.log('Cockpit index-utils loaded - console capture active')
-
-/**
- * Stop console capture and restore original console methods
- * @returns {void}
- */
-export function stopConsoleCapture() {
+window.addEventListener('cockpit-app-loaded', function () {
   isCapturing = false
   console.log('Console capture stopped - app loaded successfully')
-}
+})
+
+// Test that console capture is working
+console.log('Cockpit index-utils loaded - console capture active')
 
 /**
  * Check if console capture is currently active
@@ -88,50 +91,6 @@ export function stopConsoleCapture() {
  */
 export function isConsoleCaptureActive() {
   return isCapturing
-}
-
-/**
- * Monitor element visibility and stop capture when hidden
- * @param {string} elementId - ID of element to monitor
- * @returns {void}
- */
-export function monitorElementAndStopCapture(elementId) {
-  const element = document.getElementById(elementId)
-  if (!element) {
-    console.warn(`Element with ID "${elementId}" not found`)
-    return
-  }
-
-  // Create a MutationObserver to watch for style changes
-  const observer = new MutationObserver(() => {
-    if (isCapturing && element.style.display === 'none') {
-      stopConsoleCapture()
-      observer.disconnect() // Stop observing once we've stopped capture
-    }
-  })
-
-  // Start observing the element for attribute changes (style changes)
-  observer.observe(element, {
-    attributes: true,
-    attributeFilter: ['style'],
-  })
-
-  // Also check computed style in case CSS classes change visibility
-  const styleObserver = new MutationObserver(() => {
-    if (isCapturing) {
-      const computedStyle = window.getComputedStyle(element)
-      if (computedStyle.display === 'none' || computedStyle.visibility === 'hidden') {
-        stopConsoleCapture()
-        styleObserver.disconnect()
-      }
-    }
-  })
-
-  styleObserver.observe(document.body, {
-    subtree: true,
-    attributes: true,
-    attributeFilter: ['class', 'style'],
-  })
 }
 
 /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -72,3 +72,6 @@ setupPredefinedLakeAndActionResources()
 
 // Initialize auto-run for actions
 initializeActionAutoRun()
+
+// If the app has successfully loaded, announce that so the console capture can be stopped
+window.dispatchEvent(new CustomEvent('cockpit-app-loaded'))


### PR DESCRIPTION
It was not stopping the capture when the underlying fallback was hidden, thus adding a performance overhead and masking the console calls.