### PR TITLE
Fix telemetry capture on PostHog

### DIFF
--- a/src/libs/external-telemetry/event-tracking.ts
+++ b/src/libs/external-telemetry/event-tracking.ts
@@ -99,11 +99,11 @@ class EventTracker {
           api_key: EventTracker.postHogApiKey,
           event: eventPayload.eventName,
           properties: eventPayload.properties,
-          timestamp: eventPayload.timestamp,
+          timestamp: new Date(eventPayload.timestamp).toISOString(),
           distinct_id: EventTracker.posthog?.get_distinct_id(),
         }
 
-        await ky.post(`${EventTracker.postHogApiUrl}/capture/`, { json: body, mode: 'no-cors', throwHttpErrors: false })
+        await ky.post(`${EventTracker.postHogApiUrl}/i/v0/e`, { json: body, timeout: 5000 })
         successfullySentEventsKeys.push(eventId)
         console.log('Event sent successfully:', eventId)
       } catch (error) {

--- a/src/libs/external-telemetry/event-tracking.ts
+++ b/src/libs/external-telemetry/event-tracking.ts
@@ -27,7 +27,7 @@ class EventTracker {
   static postHogApiUrl = 'https://us.i.posthog.com'
   static postHogApiKey = 'phc_SfqVeZcpYHmhUn9NRizThxFxiI9fKqvjRjmBDB8ToRs'
   static posthog: ReturnType<typeof posthog.init> | undefined = undefined
-  eventTrackingQueue: LocalForage
+  eventTrackingQueue: LocalForage | undefined = undefined
 
   /**
    * Initialize the event tracking system
@@ -69,7 +69,7 @@ class EventTracker {
    * @param {Record<string, unknown>} eventProperties - The properties of the event
    */
   async capture(eventName: string, eventProperties?: Record<string, unknown>): Promise<void> {
-    if (!EventTracker.enableEventTracking) return
+    if (!EventTracker.enableEventTracking || !this.eventTrackingQueue) return
 
     const eventId = `${eventName}-${Date.now()}`
     const eventPayload: EventPayload = {
@@ -85,6 +85,8 @@ class EventTracker {
    * Send all events in the queue to the event tracking system
    */
   async sendEvents(): Promise<void> {
+    if (!this.eventTrackingQueue) return
+
     const queuedEventsKeys = await this.eventTrackingQueue.keys()
     const successfullySentEventsKeys: string[] = []
 


### PR DESCRIPTION
PostHog has made some changes on their capture endpoint, so for the last week our application was not capturing telemetry data.

This PR fixes it, and also improves the event-sending loop, so it doesn't lose any events and keeps sending even when some fail.