### PR TITLE
Add support for dynamically located Points of Interest

### DIFF
--- a/src/components/MainMenu.vue
+++ b/src/components/MainMenu.vue
@@ -213,6 +213,7 @@ import ConfigurationUIView from '@/views/ConfigurationUIView.vue'
 import ConfigurationVideoView from '@/views/ConfigurationVideoView.vue'
 import ToolsDataLakeView from '@/views/ToolsDataLakeView.vue'
 import ToolsLogsView from '@/views/ToolsLogsView.vue'
+import ToolsMapView from '@/views/ToolsMapView.vue'
 import ToolsMAVLinkView from '@/views/ToolsMAVLinkView.vue'
 
 const route = useRoute()
@@ -424,6 +425,12 @@ const toolsMenu = computed(() => {
       title: 'Data Logs',
       componentName: SubMenuComponentName.ToolsLogs,
       component: markRaw(ToolsLogsView) as SubMenuComponent,
+    },
+    {
+      icon: 'mdi-map-marker-radius',
+      title: 'Map',
+      componentName: SubMenuComponentName.ToolsMap,
+      component: markRaw(ToolsMapView) as SubMenuComponent,
     },
   ]
 

--- a/src/components/poi/PoiActionPopup.vue
+++ b/src/components/poi/PoiActionPopup.vue
@@ -104,11 +104,11 @@ import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { openSnackbar } from '@/composables/snackbar'
+import { usePointsOfInterest } from '@/composables/usePointsOfInterest'
 import { copyToClipboard } from '@/libs/utils'
 import { useAppInterfaceStore } from '@/stores/appInterface'
-import { useMissionStore } from '@/stores/mission'
 import { type DialogActions } from '@/types/general'
-import type { PointOfInterest } from '@/types/mission'
+import type { ResolvedPointOfInterest } from '@/types/mission'
 
 const props = withDefaults(
   defineProps<{
@@ -125,23 +125,23 @@ const emit = defineEmits<{
   /**
    * Emitted when the user requests a GoTo to the selected PoI.
    */
-  (event: 'goto', poi: PointOfInterest): void
+  (event: 'goto', poi: ResolvedPointOfInterest): void
   /**
    * Emitted when the user cancels the active GoTo for the selected PoI.
    */
-  (event: 'cancelGoto', poi: PointOfInterest): void
+  (event: 'cancelGoto', poi: ResolvedPointOfInterest): void
   /**
    * Emitted when the user requests to edit the selected PoI.
    */
-  (event: 'edit', poi: PointOfInterest): void
+  (event: 'edit', poi: ResolvedPointOfInterest): void
   /**
    * Emitted after the user confirms deletion of the selected PoI.
    */
-  (event: 'delete', poi: PointOfInterest): void
+  (event: 'delete', poi: ResolvedPointOfInterest): void
 }>()
 
 const interfaceStore = useAppInterfaceStore()
-const missionStore = useMissionStore()
+const { resolvedPointsOfInterest } = usePointsOfInterest()
 const { showDialog, closeDialog } = useInteractionDialog()
 
 const POI_POPUP_WIDTH = 221
@@ -153,11 +153,11 @@ const visible = ref(false)
 const position = ref({ x: 0, y: 0 })
 const selectedId = ref<string | null>(null)
 const selectedPoi = computed(() =>
-  selectedId.value === null ? null : missionStore.pointsOfInterest.find((p) => p.id === selectedId.value) ?? null
+  selectedId.value === null ? null : resolvedPointsOfInterest.value.find((p) => p.id === selectedId.value) ?? null
 )
 const isGotoTarget = computed(() => selectedId.value !== null && selectedId.value === props.gotoTargetId)
 
-const open = (poi: PointOfInterest, event: MouseEvent): void => {
+const open = (poi: ResolvedPointOfInterest, event: MouseEvent): void => {
   const margin = 8
   let x = event.clientX
   let y = event.clientY

--- a/src/components/poi/PoiManager.vue
+++ b/src/components/poi/PoiManager.vue
@@ -13,18 +13,101 @@
         </v-btn>
       </div>
       <div class="p-3">
-        <v-text-field v-model="newPoiName" label="Name" variant="outlined"></v-text-field>
+        <v-text-field v-model="newPoiName" label="Name" variant="outlined" class="mb-2"></v-text-field>
+        <div class="flex items-start mb-2">
+          <v-text-field
+            v-model="newPoiId"
+            label="ID"
+            variant="outlined"
+            :disabled="!!editingPoiId || !isManualIdEnabled"
+            :error-messages="idError"
+            class="flex-1"
+          />
+          <v-tooltip location="top" :text="editingPoiId ? `A POI's ID can't be changed after creation` : 'Edit ID'">
+            <template #activator="{ props }">
+              <v-btn
+                v-bind="props"
+                class="mt-2"
+                variant="text"
+                icon="mdi-pencil"
+                :color="isManualIdEnabled ? 'white' : 'grey'"
+                :disabled="!!editingPoiId"
+                @click="toggleManualIdEditing"
+              />
+            </template>
+          </v-tooltip>
+        </div>
         <v-text-field v-model="newPoiDescription" label="Description" variant="outlined"></v-text-field>
 
-        <div class="grid grid-cols-2 gap-x-4">
-          <v-text-field v-model.number="newPoiLat" label="Latitude" variant="outlined" type="number" step="0.0000001" />
-          <v-text-field
-            v-model.number="newPoiLng"
-            label="Longitude"
-            variant="outlined"
-            type="number"
-            step="0.0000001"
-          />
+        <div class="flex flex-col mb-2">
+          <fieldset class="poi-field mb-5">
+            <legend class="poi-field-legend">
+              <span>Latitude</span>
+              <v-tooltip location="top">
+                <template #activator="{ props }">
+                  <v-icon v-bind="props" size="14" color="grey">mdi-help-circle-outline</v-icon>
+                </template>
+                <div class="max-w-xs">
+                  <p class="text-sm mb-2">
+                    Enter a fixed coordinate, or an expression that follows live data and updates on the map.
+                  </p>
+                  <p class="text-sm">
+                    Click the field to pick a data-lake variable, or wrap variables in &#123;&#123; &#125;&#125; — e.g.
+                    &#123;&#123; mavlink/buoy/latitude &#125;&#125; + 0.0001.
+                  </p>
+                </div>
+              </v-tooltip>
+            </legend>
+            <div class="poi-expression-wrapper">
+              <div ref="latEditorContainer" class="poi-expression-editor" />
+              <div v-if="activeField === 'lat'" class="poi-var-dropdown">
+                <div
+                  v-for="item in filteredVariables"
+                  :key="item.id"
+                  class="poi-var-option"
+                  @mousedown.prevent="insertVariable('lat', item.id)"
+                >
+                  <span class="poi-var-name">{{ item.name }}</span>
+                  <span class="poi-var-id">{{ item.id }}</span>
+                </div>
+                <div v-if="filteredVariables.length === 0" class="poi-var-empty">No matching variables</div>
+              </div>
+            </div>
+          </fieldset>
+          <fieldset class="poi-field mb-4">
+            <legend class="poi-field-legend">
+              <span>Longitude</span>
+              <v-tooltip location="top">
+                <template #activator="{ props }">
+                  <v-icon v-bind="props" size="14" color="grey">mdi-help-circle-outline</v-icon>
+                </template>
+                <div class="max-w-xs">
+                  <p class="text-sm mb-2">
+                    Enter a fixed coordinate, or an expression that follows live data and updates on the map.
+                  </p>
+                  <p class="text-sm">
+                    Click the field to pick a data-lake variable, or wrap variables in &#123;&#123; &#125;&#125; — e.g.
+                    &#123;&#123; mavlink/buoy/longitude &#125;&#125; + 0.0001.
+                  </p>
+                </div>
+              </v-tooltip>
+            </legend>
+            <div class="poi-expression-wrapper">
+              <div ref="lngEditorContainer" class="poi-expression-editor" />
+              <div v-if="activeField === 'lng'" class="poi-var-dropdown">
+                <div
+                  v-for="item in filteredVariables"
+                  :key="item.id"
+                  class="poi-var-option"
+                  @mousedown.prevent="insertVariable('lng', item.id)"
+                >
+                  <span class="poi-var-name">{{ item.name }}</span>
+                  <span class="poi-var-id">{{ item.id }}</span>
+                </div>
+                <div v-if="filteredVariables.length === 0" class="poi-var-empty">No matching variables</div>
+              </div>
+            </div>
+          </fieldset>
         </div>
 
         <div class="mb-4">
@@ -90,16 +173,227 @@
 </template>
 
 <script setup lang="ts">
-import { v4 as uuid } from 'uuid'
-import { defineExpose, ref, watch } from 'vue'
+import { computed, defineExpose, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 
 import InteractionDialog from '@/components/InteractionDialog.vue'
 import { useInteractionDialog } from '@/composables/interactionDialog'
-import { useMissionStore } from '@/stores/mission'
-import type { PointOfInterest, PointOfInterestCoordinates } from '@/types/mission'
+import { generatePointOfInterestId, usePointsOfInterest } from '@/composables/usePointsOfInterest'
+import {
+  getAllDataLakeVariablesInfo,
+  listenToDataLakeVariablesInfoChanges,
+  unlistenToDataLakeVariablesInfoChanges,
+} from '@/libs/actions/data-lake'
+import { createMonacoEditor, monaco } from '@/libs/monaco-manager'
+import { machinizeString } from '@/libs/utils'
+import type { PoiCoordinateSource, PointOfInterest, PointOfInterestCoordinates } from '@/types/mission'
 
-const missionStore = useMissionStore()
+const { pointsOfInterest, addPointOfInterest, updatePointOfInterest, removePointOfInterest } = usePointsOfInterest()
 const { showDialog } = useInteractionDialog()
+
+// Number-typed data-lake variables offered in the coordinate dropdowns. POIs' own backing
+// variables are excluded to avoid clutter and self-reference.
+const availableVariables = ref<
+  {
+    /** Data-lake variable id */
+    id: string
+    /** Human-readable variable name */
+    name: string
+  }[]
+>([])
+
+const refreshAvailableVariables = (): void => {
+  availableVariables.value = Object.values(getAllDataLakeVariablesInfo())
+    .filter((variable) => variable.type === 'number' && !variable.id.startsWith('cockpit/pois/'))
+    .map((variable) => ({ id: variable.id, name: variable.name || variable.id }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+}
+
+let variablesInfoListenerId: string | undefined
+onMounted(() => {
+  refreshAvailableVariables()
+  variablesInfoListenerId = listenToDataLakeVariablesInfoChanges(refreshAvailableVariables)
+})
+
+// Latitude/longitude expressions are edited in compact Monaco editors. Clicking an editor opens a
+// dropdown of every available variable; typing in the editor filters it (by the token under the
+// cursor) and picking one inserts a `{{ variable }}` reference at the cursor.
+const latEditorContainer = ref<HTMLElement | null>(null)
+const lngEditorContainer = ref<HTMLElement | null>(null)
+let latEditor: monaco.editor.IStandaloneCodeEditor | null = null
+let lngEditor: monaco.editor.IStandaloneCodeEditor | null = null
+
+type CoordinateField = 'lat' | 'lng'
+
+// Which editor's variable dropdown is open, and the term used to filter it.
+const activeField = ref<CoordinateField | null>(null)
+const variableFilter = ref('')
+
+// Set right after inserting a variable, so the programmatic re-focus does not immediately reopen the dropdown.
+let suppressReopen = false
+
+// Whether each field still shows its initial value (dialog just opened, not yet edited). While
+// pristine, clicking the field shows the full variable list instead of filtering by the pre-filled
+// number (which would otherwise match nothing).
+const pristine: Record<CoordinateField, boolean> = { lat: true, lng: true }
+
+const filteredVariables = computed(() => {
+  const term = variableFilter.value.toLowerCase()
+  if (!term) return availableVariables.value
+  return availableVariables.value.filter(
+    (variable) => variable.id.toLowerCase().includes(term) || variable.name.toLowerCase().includes(term)
+  )
+})
+
+const editorForField = (field: CoordinateField): monaco.editor.IStandaloneCodeEditor | null =>
+  field === 'lat' ? latEditor : lngEditor
+
+const textUntilCursor = (editor: monaco.editor.IStandaloneCodeEditor): string => {
+  const model = editor.getModel()
+  const position = editor.getPosition()
+  if (!model || !position) return ''
+  return model.getValueInRange({
+    startLineNumber: position.lineNumber,
+    startColumn: 1,
+    endLineNumber: position.lineNumber,
+    endColumn: position.column,
+  })
+}
+
+// The text the dropdown filters by: the partial name inside an open `{{ ... ` or, failing that, the
+// variable-like token immediately before the cursor.
+const filterTermAtCursor = (editor: monaco.editor.IStandaloneCodeEditor): string => {
+  const text = textUntilCursor(editor)
+  const lastOpen = text.lastIndexOf('{{')
+  if (lastOpen !== -1 && !text.includes('}}', lastOpen)) return text.slice(lastOpen + 2).trim()
+  return text.match(/[\w/.-]*$/)?.[0] ?? ''
+}
+
+const isPlainNumber = (value: string): boolean => value.trim() !== '' && Number.isFinite(Number(value))
+
+// The dropdown shows the full list while the field is pristine or holds a plain number (filtering by
+// a number matches nothing); otherwise it filters by the token under the cursor.
+const dropdownFilterTerm = (editor: monaco.editor.IStandaloneCodeEditor, field: CoordinateField): string => {
+  if (pristine[field] || isPlainNumber(editor.getValue())) return ''
+  return filterTermAtCursor(editor)
+}
+
+const insertVariable = (field: CoordinateField, variableId: string): void => {
+  const editor = editorForField(field)
+  const position = editor?.getPosition()
+  if (!editor || !position) return
+
+  const text = textUntilCursor(editor)
+  const lastOpen = text.lastIndexOf('{{')
+
+  // Replace an open `{{ ...` (or the trailing token) so picking from the dropdown never nests braces.
+  const startColumn =
+    lastOpen !== -1 && !text.includes('}}', lastOpen)
+      ? lastOpen + 1
+      : position.column - (text.match(/[\w/.-]*$/)?.[0].length ?? 0)
+
+  const range = new monaco.Range(position.lineNumber, startColumn, position.lineNumber, position.column)
+  editor.executeEdits('insert-data-lake-variable', [{ range, text: `{{ ${variableId} }}`, forceMoveMarkers: true }])
+  activeField.value = null
+  suppressReopen = true
+  editor.focus()
+}
+
+const createCoordinateEditor = (
+  field: CoordinateField,
+  container: HTMLElement,
+  value: string,
+  onChange: (value: string) => void
+): monaco.editor.IStandaloneCodeEditor => {
+  const editor = createMonacoEditor(container, {
+    language: 'plaintext',
+    value,
+    editorOverrides: {
+      lineNumbers: 'off',
+      glyphMargin: false,
+      folding: false,
+      lineDecorationsWidth: 8,
+      lineNumbersMinChars: 0,
+      fontSize: 13,
+      padding: { top: 8, bottom: 8 },
+      renderLineHighlight: 'none',
+      overviewRulerLanes: 0,
+      minimap: { enabled: false },
+      wordWrap: 'on',
+      scrollBeyondLastLine: false,
+      scrollbar: { vertical: 'hidden', horizontal: 'hidden' },
+      quickSuggestions: false,
+      wordBasedSuggestions: 'off',
+      suggestOnTriggerCharacters: false,
+      autoClosingBrackets: 'never',
+    },
+  })
+
+  // Grow the editor to fit its content so a wrapped long expression spans multiple lines instead of
+  // being clipped at a fixed height.
+  const applyAutoHeight = (): void => {
+    const contentHeight = editor.getContentHeight()
+    container.style.height = `${contentHeight}px`
+    editor.layout({ width: container.clientWidth, height: contentHeight })
+  }
+  editor.onDidContentSizeChange(applyAutoHeight)
+  applyAutoHeight()
+
+  pristine[field] = true
+
+  const openDropdown = (): void => {
+    activeField.value = field
+    variableFilter.value = dropdownFilterTerm(editor, field)
+  }
+
+  editor.onDidChangeModelContent(() => {
+    pristine[field] = false
+    onChange(editor.getValue().trim())
+    if (activeField.value === field) variableFilter.value = dropdownFilterTerm(editor, field)
+  })
+  editor.onMouseDown(openDropdown)
+  editor.onDidFocusEditorText(() => {
+    if (suppressReopen) {
+      suppressReopen = false
+      return
+    }
+    openDropdown()
+  })
+  editor.onDidChangeCursorPosition(() => {
+    if (activeField.value === field) variableFilter.value = dropdownFilterTerm(editor, field)
+  })
+  // Delay so a dropdown item's mousedown can run before blur closes the dropdown.
+  editor.onDidBlurEditorText(() =>
+    setTimeout(() => {
+      if (activeField.value === field) activeField.value = null
+    }, 150)
+  )
+  editor.onKeyDown((event) => {
+    if (event.keyCode === monaco.KeyCode.Escape) activeField.value = null
+  })
+
+  return editor
+}
+
+const initCoordinateEditors = (): void => {
+  if (latEditorContainer.value && !latEditor) {
+    latEditor = createCoordinateEditor('lat', latEditorContainer.value, newPoiLatExpression.value, (value) => {
+      newPoiLatExpression.value = value
+    })
+  }
+  if (lngEditorContainer.value && !lngEditor) {
+    lngEditor = createCoordinateEditor('lng', lngEditorContainer.value, newPoiLngExpression.value, (value) => {
+      newPoiLngExpression.value = value
+    })
+  }
+}
+
+const disposeCoordinateEditors = (): void => {
+  latEditor?.dispose()
+  lngEditor?.dispose()
+  latEditor = null
+  lngEditor = null
+  activeField.value = null
+}
 
 const poiDialogVisible = ref(false)
 const newPoiName = ref('')
@@ -107,30 +401,62 @@ const newPoiDescription = ref('')
 const newPoiIcon = ref('mdi-map-marker')
 const newPoiColor = ref('#FF0000')
 const editingPoiId = ref<string | null>(null)
-const newPoiLat = ref<number | null>(null)
-const newPoiLng = ref<number | null>(null)
+const newPoiId = ref('')
+const isManualIdEnabled = ref(false)
+const newPoiLatExpression = ref('')
+const newPoiLngExpression = ref('')
 const isIconPickerOpen = ref(false)
 const iconSearchQuery = ref('')
 const isColorPickerOpen = ref(false)
 
-// Store original values for reverting changes if user cancels
-const originalPoiValues = ref<{
-  /** Original POI name */
-  name: string
-  /** Original POI description */
-  description: string
-  /** Original POI latitude */
-  lat: number
-  /** Original POI longitude */
-  lng: number
-  /** Original POI icon */
-  icon: string
-  /** Original POI color */
-  color: string
-} | null>(null)
+// Spin the expression editors up while the dialog is open, and tear them down on close so Monaco
+// instances are not leaked across opens.
+watch(poiDialogVisible, (visible) => {
+  if (visible) {
+    nextTick(initCoordinateEditors)
+  } else {
+    disposeCoordinateEditors()
+  }
+})
+
+onUnmounted(() => {
+  disposeCoordinateEditors()
+  if (variablesInfoListenerId) unlistenToDataLakeVariablesInfoChanges(variablesInfoListenerId)
+})
+
+// Snapshot of the POI as it was when the dialog opened, used to revert unsaved live-preview edits.
+const originalPoi = ref<PointOfInterest | null>(null)
 
 // Flag to prevent watcher from firing during dialog initialization
 const isInitializingDialog = ref(false)
+
+// Ids of all other POIs, used to keep the edited POI's id unique.
+const otherPoiIds = (): string[] =>
+  pointsOfInterest.value.filter((poi) => poi.id !== editingPoiId.value).map((poi) => poi.id)
+
+// Validation message for the id field (only editable while creating a POI).
+const idError = computed(() => {
+  if (editingPoiId.value) return ''
+  const id = newPoiId.value.trim()
+  if (!id) return 'ID is required'
+  if (machinizeString(id) !== id) return 'Only lowercase letters, numbers and dashes are allowed'
+  if (otherPoiIds().includes(id)) return 'This ID is already in use'
+  return ''
+})
+
+const toggleManualIdEditing = (): void => {
+  if (editingPoiId.value) return
+  isManualIdEnabled.value = !isManualIdEnabled.value
+  logUserAction(
+    isManualIdEnabled.value ? 'Enabled manual editing of the POI ID' : 'Disabled manual editing of the POI ID'
+  )
+}
+
+// Auto-derive the id from the name while creating a POI, unless the user is editing it manually.
+watch(newPoiName, (name) => {
+  if (isManualIdEnabled.value || editingPoiId.value) return
+  newPoiId.value = name.trim() ? generatePointOfInterestId(name, otherPoiIds()) : ''
+})
 
 // This ref will store the coordinates passed when opening the dialog for a NEW POI.
 // It's needed because props.initialCoordinates might change if the user clicks elsewhere on the map
@@ -227,40 +553,54 @@ const searchIcons = (): void => {
   )
 }
 
-// Live preview functionality - update POI in store when form values change
+// A coordinate field holding a plain number is stored as a number; anything else is kept as a
+// data-lake expression string. Both are backed by a transforming function in the data lake.
+const toCoordinateSource = (raw: string): PoiCoordinateSource => {
+  const numeric = Number(raw)
+  return Number.isFinite(numeric) ? numeric : raw
+}
+
+/**
+ * Builds the coordinate fields of a POI from the current form state. The fallback location is the
+ * literal coordinates when both fields are numbers, otherwise the POI's map placement point.
+ * @returns {Pick<PointOfInterest, 'latitude' | 'longitude' | 'fallbackCoordinates'> | null} The
+ * coordinate fields, or null when the form does not hold valid coordinates.
+ */
+const buildCoordinateFields = (): Pick<PointOfInterest, 'latitude' | 'longitude' | 'fallbackCoordinates'> | null => {
+  // Coerce defensively before trimming, as the bound value may be empty or unset.
+  const latRaw = (newPoiLatExpression.value ?? '').toString().trim()
+  const lngRaw = (newPoiLngExpression.value ?? '').toString().trim()
+  if (latRaw === '' || lngRaw === '') return null
+
+  const latitude = toCoordinateSource(latRaw)
+  const longitude = toCoordinateSource(lngRaw)
+
+  const existingFallback = pointsOfInterest.value.find((poi) => poi.id === editingPoiId.value)?.fallbackCoordinates
+  const fallbackCoordinates: PointOfInterestCoordinates =
+    typeof latitude === 'number' && typeof longitude === 'number'
+      ? [latitude, longitude]
+      : dialogInitialCoordinates.value ?? existingFallback ?? [0, 0]
+
+  return { latitude, longitude, fallbackCoordinates }
+}
+
+// Live preview - reflect form edits on the map while editing an existing POI.
 watch(
-  [newPoiName, newPoiDescription, newPoiLat, newPoiLng, newPoiIcon, newPoiColor],
-  (newValues, oldValues) => {
-    // Only apply live preview for existing POIs being edited and not during initialization
+  [newPoiName, newPoiDescription, newPoiLatExpression, newPoiLngExpression, newPoiIcon, newPoiColor],
+  () => {
     if (!editingPoiId.value || isInitializingDialog.value) return
 
-    // Get the current POI from store to preserve unchanged values
-    const currentPoi = missionStore.pointsOfInterest.find((poi) => poi.id === editingPoiId.value)
-    if (!currentPoi) return
-
-    const [newName, newDesc, newLat, newLng, newIcon, newColor] = newValues
-    const [oldName, oldDesc, oldLat, oldLng, oldIcon, oldColor] = oldValues || []
-
-    // Build update object with only changed fields
-    const updatedPoi: Partial<PointOfInterest> = {
-      timestamp: Date.now(),
+    const update: Partial<PointOfInterest> = {
+      name: newPoiName.value,
+      description: newPoiDescription.value,
+      icon: newPoiIcon.value,
+      color: newPoiColor.value,
     }
 
-    // Only update coordinates if they actually changed in the form
-    if (newLat !== oldLat || newLng !== oldLng) {
-      updatedPoi.coordinates = [newLat ?? 0, newLng ?? 0] as PointOfInterestCoordinates
-    }
+    const coordinateFields = buildCoordinateFields()
+    if (coordinateFields) Object.assign(update, coordinateFields)
 
-    // Update other fields if they changed
-    if (newName !== oldName) updatedPoi.name = newName
-    if (newDesc !== oldDesc) updatedPoi.description = newDesc
-    if (newIcon !== oldIcon) updatedPoi.icon = newIcon
-    if (newColor !== oldColor) updatedPoi.color = newColor
-
-    // Only update if there are actual changes (besides timestamp)
-    if (Object.keys(updatedPoi).length > 1) {
-      missionStore.updatePointOfInterest(editingPoiId.value, updatedPoi)
-    }
+    updatePointOfInterest(editingPoiId.value, update)
   },
   { deep: true }
 )
@@ -279,94 +619,93 @@ const openDialog = (coordinates?: PointOfInterestCoordinates | null, poiToEdit?:
   isColorPickerOpen.value = false
   iconSearchQuery.value = ''
   filteredIcons.value = availableIcons.value
+  isManualIdEnabled.value = false
+  newPoiId.value = ''
 
   if (poiToEdit) {
-    // Get fresh POI data from store instead of using potentially stale passed data
-    const freshPoi = missionStore.pointsOfInterest.find((poi) => poi.id === poiToEdit.id)
+    // Get fresh POI data from the store instead of using potentially stale passed data
+    const freshPoi = pointsOfInterest.value.find((poi) => poi.id === poiToEdit.id)
     if (!freshPoi) {
       showDialog({
         variant: 'error',
         title: 'Error',
-        message: 'POI not found in store.',
+        message: 'POI not found.',
       })
-      console.error('POI not found in store:', poiToEdit.id)
       isInitializingDialog.value = false
       return
     }
 
     editingPoiId.value = freshPoi.id
 
-    // Store original values for potential reversion (use current store values, not form values)
-    originalPoiValues.value = {
-      name: freshPoi.name,
-      description: freshPoi.description,
-      lat: Number(freshPoi.coordinates[0].toFixed(7)),
-      lng: Number(freshPoi.coordinates[1].toFixed(7)),
-      icon: freshPoi.icon,
-      color: freshPoi.color,
-    }
+    // Snapshot the original POI so unsaved live-preview edits can be reverted on cancel
+    originalPoi.value = { ...freshPoi }
 
-    // Set form values using fresh data from store
     newPoiName.value = freshPoi.name
     newPoiDescription.value = freshPoi.description
-    newPoiLat.value = Number(freshPoi.coordinates[0].toFixed(7))
-    newPoiLng.value = Number(freshPoi.coordinates[1].toFixed(7))
+    newPoiLatExpression.value = freshPoi.latitude.toString()
+    newPoiLngExpression.value = freshPoi.longitude.toString()
     newPoiIcon.value = freshPoi.icon
     newPoiColor.value = freshPoi.color
-    dialogInitialCoordinates.value = null // Not needed for editing, and clear it
+    newPoiId.value = freshPoi.id
+    dialogInitialCoordinates.value = null
   } else if (coordinates) {
+    // Creating a new POI at the specified coordinates
     editingPoiId.value = null
-    originalPoiValues.value = null // Clear for new POIs
+    originalPoi.value = null
+
     newPoiName.value = ''
     newPoiDescription.value = ''
     newPoiIcon.value = getRandomIcon()
     newPoiColor.value = getRandomColor()
-    newPoiLat.value = coordinates[0] // Still useful to pre-fill for potential direct edit
-    newPoiLng.value = coordinates[1] // Still useful to pre-fill for potential direct edit
-    dialogInitialCoordinates.value = [...coordinates] // Store for saving a new POI
+    newPoiLatExpression.value = coordinates[0].toString()
+    newPoiLngExpression.value = coordinates[1].toString()
+    dialogInitialCoordinates.value = [...coordinates]
   } else {
-    showDialog({
-      variant: 'error',
-      title: 'Error',
-      message: 'Cannot open POI dialog without coordinates for a new POI or POI data for editing.',
-    })
-    console.error('POI Dialog: Insufficient data to open.')
-    isInitializingDialog.value = false
-    return
+    // Creating a new POI without coordinates (shouldn't happen in normal flow)
+    editingPoiId.value = null
+    originalPoi.value = null
+
+    newPoiName.value = ''
+    newPoiDescription.value = ''
+    newPoiLatExpression.value = ''
+    newPoiLngExpression.value = ''
+    newPoiIcon.value = getRandomIcon()
+    newPoiColor.value = getRandomColor()
+    dialogInitialCoordinates.value = null
   }
 
-  poiDialogVisible.value = true
-
-  // Clear initialization flag after a short delay to allow form to settle
+  // Clear initialization flag after a short delay to allow Vue to process the changes
   setTimeout(() => {
     isInitializingDialog.value = false
-  }, 50)
+  }, 100)
+
+  logUserAction(
+    editingPoiId.value
+      ? `Opened the "${newPoiName.value}" point of interest for editing`
+      : 'Opened the dialog to add a new point of interest'
+  )
+  poiDialogVisible.value = true
 }
 
 const closeDialog = (): void => {
+  logUserAction('Closed the point-of-interest dialog')
   // Revert changes if user was editing an existing POI and cancels without saving
-  if (editingPoiId.value && originalPoiValues.value) {
-    const revertedPoi: Partial<PointOfInterest> = {
-      name: originalPoiValues.value.name,
-      description: originalPoiValues.value.description,
-      coordinates: [originalPoiValues.value.lat, originalPoiValues.value.lng] as PointOfInterestCoordinates,
-      icon: originalPoiValues.value.icon,
-      color: originalPoiValues.value.color,
-      timestamp: Date.now(),
-    }
-    missionStore.updatePointOfInterest(editingPoiId.value, revertedPoi)
+  if (editingPoiId.value && originalPoi.value) {
+    updatePointOfInterest(editingPoiId.value, originalPoi.value)
   }
 
   poiDialogVisible.value = false
   editingPoiId.value = null
-  originalPoiValues.value = null
+  originalPoi.value = null
   dialogInitialCoordinates.value = null
   isInitializingDialog.value = false
   // Reset form fields to ensure clean state next time
+  newPoiId.value = ''
+  isManualIdEnabled.value = false
   newPoiName.value = ''
   newPoiDescription.value = ''
-  newPoiLat.value = null
-  newPoiLng.value = null
+  newPoiLatExpression.value = ''
+  newPoiLngExpression.value = ''
   newPoiIcon.value = getRandomIcon()
   newPoiColor.value = getRandomColor()
   isIconPickerOpen.value = false
@@ -379,78 +718,54 @@ const savePoi = (): void => {
     return
   }
 
-  if (newPoiLat.value === null || newPoiLng.value === null || isNaN(newPoiLat.value) || isNaN(newPoiLng.value)) {
+  const coordinateFields = buildCoordinateFields()
+  if (!coordinateFields) {
     showDialog({
       title: 'Invalid Coordinates',
-      message: 'Latitude and Longitude must be valid numbers.',
+      message: 'Latitude and Longitude must be provided.',
       variant: 'error',
     })
     return
   }
 
-  if (editingPoiId.value) {
-    // Get the current POI from store to preserve current coordinates
-    const currentPoi = missionStore.pointsOfInterest.find((poi) => poi.id === editingPoiId.value)
-    if (!currentPoi) {
-      showDialog({ variant: 'error', title: 'Error', message: 'POI not found in store.' })
-      return
-    }
-
-    // Check if coordinates were actually changed in the form by comparing with original values
-    const coordinatesChanged = originalPoiValues.value
-      ? newPoiLat.value !== originalPoiValues.value.lat || newPoiLng.value !== originalPoiValues.value.lng
-      : false
-
-    // Clear original values since we're saving the changes
-    originalPoiValues.value = null
-
-    const poiUpdate: Partial<PointOfInterest> = {
-      name: newPoiName.value,
-      description: newPoiDescription.value,
-      // Use current store coordinates unless user specifically changed them in the form
-      coordinates: coordinatesChanged
-        ? ([newPoiLat.value, newPoiLng.value] as PointOfInterestCoordinates)
-        : currentPoi.coordinates,
-      icon: newPoiIcon.value,
-      color: newPoiColor.value,
-      timestamp: Date.now(),
-    }
-    missionStore.updatePointOfInterest(editingPoiId.value, poiUpdate)
-  } else {
-    // For new POIs, prioritize dialogInitialCoordinates if they exist (meaning they were passed on openDialog)
-    // Otherwise, use the (potentially user-modified) coordinates from the form.
-    const coordinatesToSave =
-      dialogInitialCoordinates.value ?? ([newPoiLat.value, newPoiLng.value] as PointOfInterestCoordinates)
-
-    if (!coordinatesToSave) {
-      // This case should ideally not be reached if openDialog is called correctly with coordinates for new POIs.
-      showDialog({ variant: 'error', title: 'Error', message: 'Cannot save Point of Interest without coordinates.' })
-      console.error(
-        'Cannot save new POI: coordinatesToSave is null. dialogInitialCoordinates:',
-        dialogInitialCoordinates.value,
-        'currentFormCoordinates:',
-        [newPoiLat.value, newPoiLng.value]
-      )
-      return
-    }
-
-    const newPoi: PointOfInterest = {
-      id: uuid(),
-      name: newPoiName.value,
-      description: newPoiDescription.value,
-      coordinates: coordinatesToSave,
-      icon: newPoiIcon.value,
-      color: newPoiColor.value,
-      timestamp: Date.now(),
-    }
-    missionStore.addPointOfInterest(newPoi)
+  if (!editingPoiId.value && idError.value) {
+    showDialog({ title: 'Invalid ID', message: idError.value, variant: 'error' })
+    return
   }
+
+  if (editingPoiId.value) {
+    // Editing existing POI - prevent revert on close since we're committing the changes
+    originalPoi.value = null
+
+    logUserAction(`Saved changes to the "${newPoiName.value}" point of interest`)
+    updatePointOfInterest(editingPoiId.value, {
+      name: newPoiName.value,
+      description: newPoiDescription.value,
+      icon: newPoiIcon.value,
+      color: newPoiColor.value,
+      ...coordinateFields,
+    })
+  } else {
+    const newPoi: PointOfInterest = {
+      id: newPoiId.value.trim(),
+      name: newPoiName.value,
+      description: newPoiDescription.value,
+      icon: newPoiIcon.value,
+      color: newPoiColor.value,
+      timestamp: Date.now(),
+      ...coordinateFields,
+    }
+    logUserAction(`Added the "${newPoiName.value}" point of interest`)
+    addPointOfInterest(newPoi)
+  }
+
   closeDialog()
 }
 
 const deletePoi = (): void => {
   if (editingPoiId.value) {
-    missionStore.removePointOfInterest(editingPoiId.value)
+    logUserAction(`Deleted the "${newPoiName.value}" point of interest`)
+    removePointOfInterest(editingPoiId.value)
     closeDialog()
   } else {
     // This case should ideally not be reached if the delete button is only visible when editingPoiId is set.
@@ -459,7 +774,6 @@ const deletePoi = (): void => {
       title: 'Error',
       message: 'No Point of Interest selected for deletion.',
     })
-    console.error('Delete POI: editingPoiId is null.')
   }
 }
 
@@ -482,6 +796,95 @@ defineExpose({
 .poi-dialog-text-fields .v-select .v-field__input {
   padding-top: 4px;
   padding-bottom: 4px;
+}
+
+/* Outlined field with a notched label (the legend cuts the top border, like a v-text-field). */
+.poi-field {
+  min-inline-size: 0;
+  margin: 0;
+  padding: 2px 8px 6px;
+  border: 1px solid rgba(255, 255, 255, 0.38);
+  border-radius: 4px;
+}
+
+.poi-field-legend {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: 4px;
+  padding: 0 4px;
+  font-size: 12px;
+  line-height: 1;
+  color: #ffffffb3;
+}
+
+.poi-expression-wrapper {
+  position: relative;
+}
+
+.poi-expression-editor {
+  min-height: 36px;
+  width: 100%;
+  overflow: visible;
+}
+
+.poi-expression-editor .monaco-editor,
+.poi-expression-editor .monaco-editor .margin,
+.poi-expression-editor .monaco-editor-background {
+  background-color: transparent !important;
+}
+
+.poi-expression-editor .monaco-editor,
+.poi-expression-editor .monaco-editor.focused,
+.poi-expression-editor .monaco-editor .inputarea {
+  outline: none !important;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+.poi-expression-editor .monaco-editor .overflow-guard {
+  border-radius: 4px;
+}
+
+.poi-var-dropdown {
+  position: absolute;
+  top: calc(100% + 2px);
+  left: 0;
+  right: 0;
+  z-index: 30;
+  max-height: 220px;
+  overflow-y: auto;
+  background-color: #1e1e1e;
+  border: 1px solid #ffffff33;
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+.poi-var-option {
+  display: flex;
+  flex-direction: column;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+
+.poi-var-option:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.poi-var-name {
+  font-size: 13px;
+  color: #ffffffde;
+}
+
+.poi-var-id {
+  font-size: 11px;
+  color: #ffffff80;
+}
+
+.poi-var-empty {
+  padding: 8px 10px;
+  font-size: 12px;
+  color: #ffffff80;
 }
 
 .poi-color-picker {

--- a/src/components/poi/PoiMapArrows.vue
+++ b/src/components/poi/PoiMapArrows.vue
@@ -63,9 +63,9 @@ import L, { type LatLngTuple } from 'leaflet'
 import { computed, onBeforeUnmount, ref, watch } from 'vue'
 
 import { useMapContext } from '@/composables/map/useMapContext'
+import { usePointsOfInterest } from '@/composables/usePointsOfInterest'
 import { TargetFollower, WhoToFollow } from '@/libs/map/utils-map'
 import { calculateHaversineDistance } from '@/libs/mission/general-estimates'
-import { useMissionStore } from '@/stores/mission'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
 import type { Edge, EdgeIntersection, PoiEdgeArrow, TargetEdgeArrow, WaypointCoordinates } from '@/types/mission'
 import type { Widget } from '@/types/widgets'
@@ -123,7 +123,7 @@ interface Props {
 
 const props = defineProps<Props>()
 
-const missionStore = useMissionStore()
+const { resolvedPointsOfInterest } = usePointsOfInterest()
 const widgetStore = useWidgetManagerStore()
 
 // Get map instance from composable
@@ -410,7 +410,7 @@ const calculatePoiEdgeArrows = (): void => {
   const cornerThreshold = 40
   const arrows: PoiEdgeArrow[] = []
 
-  missionStore.pointsOfInterest.forEach((poi) => {
+  resolvedPointsOfInterest.value.forEach((poi) => {
     const poiLatLng = L.latLng(poi.coordinates[0], poi.coordinates[1])
     if (!map.value) return
 
@@ -517,7 +517,7 @@ const throttledUpdateVehicleAndHomeArrows = useThrottleFn(calculateVehicleAndHom
 const centerMapOnPoi = (poiId: string): void => {
   if (!map.value) return
 
-  const poi = missionStore.pointsOfInterest.find((p) => p.id === poiId)
+  const poi = resolvedPointsOfInterest.value.find((p) => p.id === poiId)
   if (!poi) return
 
   map.value.setView(poi.coordinates as LatLngTuple, map.value.getZoom(), { animate: true })
@@ -542,9 +542,9 @@ watch(
   { immediate: true }
 )
 
-// Watch for map changes and POI changes
+// Watch for map view changes (debounced to avoid spamming during pan/zoom)
 watch(
-  [() => props.mapCenter, () => props.zoom, () => missionStore.pointsOfInterest],
+  [() => props.mapCenter, () => props.zoom],
   () => {
     if (props.mapReady && map.value && map.value instanceof L.Map) {
       debouncedUpdateArrows()
@@ -552,6 +552,17 @@ watch(
     }
   },
   { immediate: true }
+)
+
+// Watch for POI changes. Throttled (not debounced) so continuously-moving live-tracked POIs keep
+// their edge arrows updated, instead of perpetually resetting the debounce timer.
+watch(
+  () => resolvedPointsOfInterest.value,
+  () => {
+    if (props.mapReady && map.value && map.value instanceof L.Map) {
+      throttledUpdateArrows()
+    }
+  }
 )
 
 watch(

--- a/src/components/widgets/CompassHUD.vue
+++ b/src/components/widgets/CompassHUD.vue
@@ -146,6 +146,7 @@ import { colord } from 'colord'
 import gsap from 'gsap'
 import { computed, onBeforeMount, onBeforeUnmount, onMounted, reactive, ref, toRefs, watch } from 'vue'
 
+import { usePointsOfInterest } from '@/composables/usePointsOfInterest'
 import { calculateHaversineDistance } from '@/libs/mission/general-estimates'
 import { datalogger, DatalogVariable } from '@/libs/sensors-logging'
 import { degrees, radians, resetCanvas } from '@/libs/utils'
@@ -157,14 +158,16 @@ import type {
   HighlightedPoiMarker,
   HighlightedPoiMarkerDisplay,
   PoiMarker,
-  PointOfInterest,
+  PointOfInterestCoordinates,
   ReachedPoiMarker,
+  ResolvedPointOfInterest,
 } from '@/types/mission'
 import type { Widget } from '@/types/widgets'
 
 const widgetStore = useWidgetManagerStore()
 const interfaceStore = useAppInterfaceStore()
 const missionStore = useMissionStore()
+const { resolvedPointsOfInterest } = usePointsOfInterest()
 
 datalogger.registerUsage(DatalogVariable.heading)
 const store = useMainVehicleStore()
@@ -292,7 +295,7 @@ const calculateBearing = (vehicleLat: number, vehicleLng: number, poiLat: number
 const poiData = computed(() => {
   if (!store.coordinates.latitude || !store.coordinates.longitude) return []
 
-  return missionStore.pointsOfInterest.map((poi) => {
+  return resolvedPointsOfInterest.value.map((poi) => {
     const distance = calculateHaversineDistance(
       [store.coordinates.latitude!, store.coordinates.longitude!],
       poi.coordinates
@@ -315,11 +318,32 @@ const poiData = computed(() => {
 const homeCoordinates = computed(() => missionStore.homeMarkerPosition)
 const homeMarkerId = '__home__'
 
+// Home is rendered as a synthetic pseudo-POI (not a real data-lake-backed one): its position comes
+// from `coordinates`, never the data lake. Build it through this helper so the required variable-id
+// fields carry clearly-invalid sentinels instead of empty strings that could be mistaken for real
+// backing variables.
+const buildHomeHudPoi = (coords: PointOfInterestCoordinates): ResolvedPointOfInterest => ({
+  id: homeMarkerId,
+  name: 'Home',
+  description: '',
+  latitude: coords[0],
+  longitude: coords[1],
+  fallbackCoordinates: coords,
+  coordinates: coords,
+  isLiveTracked: false,
+  hasValidPosition: true,
+  latitudeVariableId: `${homeMarkerId}/latitude`,
+  longitudeVariableId: `${homeMarkerId}/longitude`,
+  icon: 'mdi-home',
+  color: '#1E88E5',
+  timestamp: 0,
+})
+
 type HudMarkerEntry = {
   /**
    * Point of interest data
    */
-  poi: PointOfInterest
+  poi: ResolvedPointOfInterest
   /**
    * Distance to the POI
    */
@@ -348,15 +372,7 @@ const hudMarkerData = computed((): HudMarkerEntry[] => {
   if (widget.value.options.showHomeOnHUD && homeCoordinates.value) {
     const coords = homeCoordinates.value
     entries.push({
-      poi: {
-        id: homeMarkerId,
-        name: 'Home',
-        description: '',
-        coordinates: coords,
-        icon: 'mdi-home',
-        color: '#1E88E5',
-        timestamp: 0,
-      },
+      poi: buildHomeHudPoi(coords),
       distance: calculateHaversineDistance([store.coordinates.latitude!, store.coordinates.longitude!], coords),
       bearing: calculateBearing(store.coordinates.latitude!, store.coordinates.longitude!, coords[0], coords[1]),
       markerSize: 12,

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -308,6 +308,7 @@ import { useMapTileLayers } from '@/composables/map/useMapTileLayers'
 import { useMapTileLayerSelection } from '@/composables/map/useMapTileLayerSelection'
 import { openSnackbar } from '@/composables/snackbar'
 import { useOfflineTiles } from '@/composables/useOfflineTiles'
+import { usePointsOfInterest } from '@/composables/usePointsOfInterest'
 import { MavCmd, MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import type { NoiseTileOptions } from '@/libs/map/map-tile-fallback'
 import { attachTileNoiseFallback, refreshNoiseFallbackTiles } from '@/libs/map/map-tile-fallback'
@@ -325,7 +326,13 @@ import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useMissionStore } from '@/stores/mission'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
-import type { IconDimensions, MarkerSizes, PointOfInterest, Waypoint, WaypointCoordinates } from '@/types/mission'
+import type {
+  IconDimensions,
+  MarkerSizes,
+  ResolvedPointOfInterest,
+  Waypoint,
+  WaypointCoordinates,
+} from '@/types/mission'
 import type { Widget } from '@/types/widgets'
 
 import ContextMenu from '../ContextMenu.vue'
@@ -350,6 +357,8 @@ const vehicleStore = useMainVehicleStore()
 const missionStore = useMissionStore()
 const widgetStore = useWidgetManagerStore()
 const router = useRouter()
+
+const { removePointOfInterest } = usePointsOfInterest()
 
 const mapContext = provideMapContext()
 
@@ -588,7 +597,7 @@ const updateGotoTarget = (coordinates: WaypointCoordinates): Promise<void> =>
 
 const poiGoTo = useMapPoiGoTo(poiMarkers, { issueGoto, updateGotoTarget })
 
-const onPoiEdit = (poi: PointOfInterest): void => {
+const onPoiEdit = (poi: ResolvedPointOfInterest): void => {
   if (!poiManagerMapWidgetRef.value) {
     openSnackbar({ message: 'POI Manager (map widget) is not available.', variant: 'error' })
     return
@@ -596,11 +605,11 @@ const onPoiEdit = (poi: PointOfInterest): void => {
   poiManagerMapWidgetRef.value.openDialog(undefined, poi)
 }
 
-const onPoiDelete = async (poi: PointOfInterest): Promise<void> => {
+const onPoiDelete = async (poi: ResolvedPointOfInterest): Promise<void> => {
   if (poiMarkers.gotoTargetId.value === poi.id) {
     await poiGoTo.onPoiCancelGoTo()
   }
-  missionStore.removePointOfInterest(poi.id)
+  removePointOfInterest(poi.id)
 }
 
 // Register the usage of the coordinate variables for logging

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -957,6 +957,15 @@ watch(
   () => clearMapDrawing()
 )
 
+// React to "center on coordinates" requests (e.g. from the Map tools menu).
+watch(
+  () => missionStore.mapCenterOnRequest,
+  (request) => {
+    if (!request || !map.value) return
+    map.value.setView(request.coordinates as LatLngTuple, map.value.getZoom(), { animate: true })
+  }
+)
+
 watch(
   () => missionStore.mapDownloadRequestRevision,
   () => {

--- a/src/composables/map/useMapPoiGoTo.ts
+++ b/src/composables/map/useMapPoiGoTo.ts
@@ -2,10 +2,10 @@ import { useThrottleFn } from '@vueuse/core'
 import { onBeforeUnmount, ref, watch } from 'vue'
 
 import { openSnackbar } from '@/composables/snackbar'
+import { usePointsOfInterest } from '@/composables/usePointsOfInterest'
 import { distanceInMeters } from '@/libs/map/utils-map'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
-import { useMissionStore } from '@/stores/mission'
-import type { PointOfInterest, WaypointCoordinates } from '@/types/mission'
+import type { ResolvedPointOfInterest, WaypointCoordinates } from '@/types/mission'
 
 import type { UseMapPoiMarkersReturn } from './useMapPoiMarkers'
 
@@ -45,10 +45,10 @@ export interface UseMapPoiGoToReturn {
   /**
    * Issues a GoTo to the given PoI and flags it as the active target until it's reached, cancelled, or
    * the vehicle leaves the GoTo state on its own (disarm or flight mode change).
-   * @param {PointOfInterest} poi - The PoI to send the vehicle to.
+   * @param {ResolvedPointOfInterest} poi - The PoI to send the vehicle to.
    * @returns {Promise<void>} Resolves once the GoTo command has been issued.
    */
-  onPoiGoTo: (poi: PointOfInterest) => Promise<void>
+  onPoiGoTo: (poi: ResolvedPointOfInterest) => Promise<void>
   /**
    * Cancels the active PoI GoTo by switching the vehicle to its position-hold flight mode.
    * @returns {Promise<void>} Resolves once the cancel command has been issued (or failed and been reported).
@@ -75,7 +75,7 @@ export const useMapPoiGoTo = (
   options: UseMapPoiGoToOptions
 ): UseMapPoiGoToReturn => {
   const vehicleStore = useMainVehicleStore()
-  const missionStore = useMissionStore()
+  const { resolvedPointsOfInterest } = usePointsOfInterest()
 
   // Vehicle state an active PoI GoTo expects, used to drop the highlight when the user disarms or
   // changes flight mode outside of the GoTo flow. Mode tracking only starts once the arm + GUIDED
@@ -105,7 +105,7 @@ export const useMapPoiGoTo = (
     openSnackbar({ message, variant: 'info' })
   }
 
-  const onPoiGoTo = async (poi: PointOfInterest): Promise<void> => {
+  const onPoiGoTo = async (poi: ResolvedPointOfInterest): Promise<void> => {
     poiMarkers.setGotoTarget(poi.id)
     resetPoiGotoTracking()
     lastIssuedCoordinates = poi.coordinates
@@ -134,7 +134,7 @@ export const useMapPoiGoTo = (
   )
 
   watch(
-    () => missionStore.pointsOfInterest.find((poi) => poi.id === poiMarkers.gotoTargetId.value)?.coordinates,
+    () => resolvedPointsOfInterest.value.find((poi) => poi.id === poiMarkers.gotoTargetId.value)?.coordinates,
     (coordinates) => {
       if (!coordinates || !lastIssuedCoordinates) return
       if (distanceInMeters(lastIssuedCoordinates, coordinates) < followMinDistanceMeters) return

--- a/src/composables/map/useMapPoiMarkers.ts
+++ b/src/composables/map/useMapPoiMarkers.ts
@@ -1,8 +1,9 @@
 import L, { type LatLngTuple, type LeafletEvent, type LeafletMouseEvent, type Map, type Marker } from 'leaflet'
 import { type Ref, type ShallowRef, nextTick, onBeforeUnmount, ref, shallowRef, watch } from 'vue'
 
-import { useMissionStore } from '@/stores/mission'
-import type { PointOfInterest } from '@/types/mission'
+import { usePointsOfInterest } from '@/composables/usePointsOfInterest'
+import { getPoiIconSignature, getPoiMarkerColor, getPoiMarkerOpacity, getPoiTooltipHtml } from '@/libs/utils-poi'
+import type { ResolvedPointOfInterest } from '@/types/mission'
 
 /**
  * Rendering classes and interaction callbacks for the PoI markers of a single map.
@@ -17,17 +18,18 @@ export interface UseMapPoiMarkersOptions {
    */
   tooltipClassName: string
   /**
-   * Whether markers can be dragged to move the underlying PoI. Defaults to true.
+   * Whether markers can be dragged to move the underlying PoI. Defaults to true. Live-tracked PoIs are
+   * never draggable regardless of this flag, since their position is owned by the data lake.
    */
   draggable?: boolean
   /**
-   * Called when a marker is left-clicked, with the up-to-date PoI from the store and the originating event.
+   * Called when a marker is left-clicked, with the up-to-date PoI and the originating event.
    */
-  onClick?: (poi: PointOfInterest, event: MouseEvent) => void
+  onClick?: (poi: ResolvedPointOfInterest, event: MouseEvent) => void
   /**
-   * Called when a marker is right-clicked, with the up-to-date PoI from the store and the originating event.
+   * Called when a marker is right-clicked, with the up-to-date PoI and the originating event.
    */
-  onContextMenu?: (poi: PointOfInterest, event: MouseEvent) => void
+  onContextMenu?: (poi: ResolvedPointOfInterest, event: MouseEvent) => void
 }
 
 /**
@@ -51,9 +53,10 @@ export interface UseMapPoiMarkersReturn {
 }
 
 /**
- * Mirrors the mission store's points of interest as draggable Leaflet markers on the given map, keeping them
- * in sync as PoIs are added, edited, moved or removed, and exposing GoTo-target highlighting. Markers are torn
- * down automatically when the owning component unmounts.
+ * Mirrors the resolved points of interest as Leaflet markers on the given map, keeping them in sync as PoIs
+ * are added, edited, moved or removed, and exposing GoTo-target highlighting. Coordinates come from the data
+ * lake (see {@link usePointsOfInterest}), so live-tracked PoIs follow their source and are not draggable.
+ * Markers are torn down automatically when the owning component unmounts.
  * @param {ShallowRef<Map | undefined>} map - The Leaflet map to draw on; markers (re)draw once it becomes available.
  * @param {UseMapPoiMarkersOptions} options - Rendering classes and interaction callbacks.
  * @returns {UseMapPoiMarkersReturn} The reactive marker registry and GoTo-target controls.
@@ -62,41 +65,48 @@ export const useMapPoiMarkers = (
   map: ShallowRef<Map | undefined>,
   options: UseMapPoiMarkersOptions
 ): UseMapPoiMarkersReturn => {
-  const missionStore = useMissionStore()
+  const { resolvedPointsOfInterest, movePointOfInterest } = usePointsOfInterest()
   const markers = shallowRef<Record<string, Marker>>({})
   const gotoTargetId = ref<string | null>(null)
   const draggable = options.draggable ?? true
 
-  // Snapshot of the fields each marker was last rendered with, keyed by PoI id. Lets syncMarkers skip
+  // Snapshot of the rendering inputs each marker was last drawn with, keyed by PoI id. Lets syncMarkers skip
   // markers whose data hasn't changed, instead of rebuilding every marker's icon (and Leaflet Draggable
-  // instance) whenever any single PoI in the store is edited or dragged. A plain record (rather than an
-  // ES Map) to avoid shadowing the Leaflet `Map` type already imported in this file.
+  // instance) whenever any single PoI in the list is edited or moved. A plain record (rather than an ES Map)
+  // to avoid shadowing the Leaflet `Map` type already imported in this file.
   const lastRenderedSignatures: Record<string, string> = {}
-  const poiSignature = (poi: PointOfInterest): string =>
-    JSON.stringify([poi.coordinates, poi.icon, poi.color, poi.name, poi.description])
+  // Icon-only signature per PoI, so a live-tracked PoI merely moving doesn't rebuild its icon (and DOM
+  // element), which would cancel in-progress clicks on frequently-updated markers.
+  const iconSignatures: Record<string, string> = {}
+  const poiSignature = (poi: ResolvedPointOfInterest): string =>
+    JSON.stringify([
+      poi.coordinates,
+      getPoiMarkerColor(poi),
+      getPoiMarkerOpacity(poi),
+      poi.icon,
+      poi.name,
+      poi.description,
+      poi.isLiveTracked,
+    ])
 
   // The map ref can momentarily hold a template-ref DOM element before the Leaflet instance is
   // assigned (consumers reuse the same ref name for the container and the map), so guard on the API.
   const isMapReady = (instance: Map | undefined): instance is Map =>
     !!instance && typeof instance.getContainer === 'function' && !!instance.getContainer()
 
-  const poiIconConfig = (poi: PointOfInterest): L.DivIconOptions => ({
+  const poiIconConfig = (poi: ResolvedPointOfInterest): L.DivIconOptions => ({
     html: `
     <div class="poi-marker-container">
-      <div class="poi-marker-background" style="background-color: ${poi.color}80;"></div>
-      <i class="v-icon notranslate mdi ${poi.icon}" style="color: rgba(255, 255, 255, 0.7); position: relative; z-index: 2;"></i>
+      <div class="poi-marker-background" style="background-color: ${getPoiMarkerColor(poi)}80;"></div>
+      <i class="v-icon notranslate mdi ${
+        poi.icon
+      }" style="color: rgba(255, 255, 255, 0.7); position: relative; z-index: 2;"></i>
     </div>
   `,
     className: options.iconClassName,
     iconSize: [32, 32],
-    iconAnchor: [16, 32],
+    iconAnchor: [16, 16],
   })
-
-  const tooltipContent = (poi: PointOfInterest, coordinates: LatLngTuple): string => `
-    <strong>${poi.name}</strong><br>
-    ${poi.description ? poi.description + '<br>' : ''}
-    Lat: ${coordinates[0].toFixed(8)}, Lng: ${coordinates[1].toFixed(8)}
-  `
 
   const applyGotoTargetStyle = (poiId: string, active: boolean): void => {
     const bg = markers.value[poiId]?.getElement()?.querySelector('.poi-marker-background') as HTMLElement | null
@@ -112,36 +122,37 @@ export const useMapPoiMarkers = (
     if (newId) applyGotoTargetStyle(newId, true)
   })
 
-  const addMarker = (poi: PointOfInterest): void => {
+  const addMarker = (poi: ResolvedPointOfInterest): void => {
     if (!isMapReady(map.value)) return
 
     const marker = L.marker(poi.coordinates as LatLngTuple, {
       icon: L.divIcon(poiIconConfig(poi)),
-      draggable,
+      draggable: draggable && !poi.isLiveTracked,
+      opacity: getPoiMarkerOpacity(poi),
     }).addTo(map.value)
 
-    marker.bindTooltip(tooltipContent(poi, poi.coordinates as LatLngTuple), {
+    marker.bindTooltip(getPoiTooltipHtml(poi, poi.coordinates), {
       permanent: false,
       direction: 'top',
-      offset: [0, -40],
+      offset: [0, -20],
       className: options.tooltipClassName,
     })
 
     marker.on('drag', (event: LeafletEvent) => {
       const coords = event.target.getLatLng()
-      marker.getTooltip()?.setContent(tooltipContent(poi, [coords.lat, coords.lng]))
+      marker.getTooltip()?.setContent(getPoiTooltipHtml(poi, [coords.lat, coords.lng]))
     })
 
     marker.on('dragend', (event: LeafletEvent) => {
       const coords = event.target.getLatLng()
-      missionStore.movePointOfInterest(poi.id, [coords.lat, coords.lng])
+      movePointOfInterest(poi.id, [coords.lat, coords.lng])
     })
 
     marker.on('click', (event: LeafletMouseEvent) => {
       L.DomEvent.stopPropagation(event)
-      const freshPoi = missionStore.pointsOfInterest.find((p) => p.id === poi.id)
+      const freshPoi = resolvedPointsOfInterest.value.find((p) => p.id === poi.id)
       if (!freshPoi) {
-        console.warn('POI not found in store:', poi.id)
+        console.warn('POI not found:', poi.id)
         return
       }
       options.onClick?.(freshPoi, event.originalEvent)
@@ -151,9 +162,9 @@ export const useMapPoiMarkers = (
       L.DomEvent.stopPropagation(event)
       event.originalEvent.stopPropagation()
       event.originalEvent.preventDefault()
-      const freshPoi = missionStore.pointsOfInterest.find((p) => p.id === poi.id)
+      const freshPoi = resolvedPointsOfInterest.value.find((p) => p.id === poi.id)
       if (!freshPoi) {
-        console.warn('POI not found in store:', poi.id)
+        console.warn('POI not found:', poi.id)
         return
       }
       options.onContextMenu?.(freshPoi, event.originalEvent)
@@ -161,27 +172,40 @@ export const useMapPoiMarkers = (
 
     markers.value[poi.id] = marker
     lastRenderedSignatures[poi.id] = poiSignature(poi)
+    iconSignatures[poi.id] = getPoiIconSignature(poi)
 
     if (gotoTargetId.value === poi.id) applyGotoTargetStyle(poi.id, true)
   }
 
-  const updateMarker = (poi: PointOfInterest): void => {
+  const updateMarker = (poi: ResolvedPointOfInterest): void => {
     const marker = markers.value[poi.id]
     if (!isMapReady(map.value) || !marker) return
 
-    // Skip markers whose data hasn't changed since last render, so editing or dragging one PoI doesn't
+    // Skip markers whose data hasn't changed since last render, so editing or moving one PoI doesn't
     // rebuild every other marker's icon and tear down its Leaflet Draggable instance mid-interaction.
     const signature = poiSignature(poi)
     if (lastRenderedSignatures[poi.id] === signature) return
     lastRenderedSignatures[poi.id] = signature
 
     marker.setLatLng(poi.coordinates as LatLngTuple)
-    marker.setIcon(L.divIcon(poiIconConfig(poi)))
 
-    // setIcon replaces the marker's DOM element, so the goto-target class needs to be re-applied.
-    if (gotoTargetId.value === poi.id) applyGotoTargetStyle(poi.id, true)
+    // Keep draggability in sync: a PoI edited into a live expression must stop being draggable (and
+    // vice-versa), since dragging would overwrite its coordinates with a static position.
+    if (draggable && !poi.isLiveTracked) marker.dragging?.enable()
+    else marker.dragging?.disable()
 
-    marker.getTooltip()?.setContent(tooltipContent(poi, poi.coordinates as LatLngTuple))
+    marker.setOpacity(getPoiMarkerOpacity(poi))
+
+    // Only rebuild the icon when its appearance changes. setIcon replaces the marker's DOM element,
+    // so both the goto-target class and any in-progress click would otherwise be lost.
+    const iconSignature = getPoiIconSignature(poi)
+    if (iconSignatures[poi.id] !== iconSignature) {
+      marker.setIcon(L.divIcon(poiIconConfig(poi)))
+      iconSignatures[poi.id] = iconSignature
+      if (gotoTargetId.value === poi.id) applyGotoTargetStyle(poi.id, true)
+    }
+
+    marker.getTooltip()?.setContent(getPoiTooltipHtml(poi, poi.coordinates))
   }
 
   const removeMarker = (poiId: string): void => {
@@ -189,10 +213,11 @@ export const useMapPoiMarkers = (
     markers.value[poiId].remove()
     delete markers.value[poiId]
     delete lastRenderedSignatures[poiId]
+    delete iconSignatures[poiId]
     if (gotoTargetId.value === poiId) gotoTargetId.value = null
   }
 
-  const syncMarkers = (pois: PointOfInterest[]): void => {
+  const syncMarkers = (pois: ResolvedPointOfInterest[]): void => {
     const liveIds = new Set(pois.map((p) => p.id))
     Object.keys(markers.value).forEach((id) => {
       if (!liveIds.has(id)) removeMarker(id)
@@ -201,7 +226,7 @@ export const useMapPoiMarkers = (
   }
 
   watch(
-    () => missionStore.pointsOfInterest,
+    resolvedPointsOfInterest,
     async (pois) => {
       if (!isMapReady(map.value)) {
         await nextTick()
@@ -216,7 +241,7 @@ export const useMapPoiMarkers = (
   watch(
     map,
     (instance) => {
-      if (isMapReady(instance)) syncMarkers(missionStore.pointsOfInterest)
+      if (isMapReady(instance)) syncMarkers(resolvedPointsOfInterest.value)
     },
     { immediate: true }
   )
@@ -225,6 +250,7 @@ export const useMapPoiMarkers = (
     Object.values(markers.value).forEach((marker) => marker.remove())
     markers.value = {}
     Object.keys(lastRenderedSignatures).forEach((id) => delete lastRenderedSignatures[id])
+    Object.keys(iconSignatures).forEach((id) => delete iconSignatures[id])
   })
 
   return { markers, gotoTargetId, setGotoTarget }

--- a/src/composables/usePointsOfInterest.ts
+++ b/src/composables/usePointsOfInterest.ts
@@ -1,0 +1,250 @@
+import { type ComputedRef, type Ref, computed, reactive, watch } from 'vue'
+
+import { useBlueOsStorage } from '@/composables/settingsSyncer'
+import { getDataLakeVariableData, listenDataLakeVariable, unlistenDataLakeVariable } from '@/libs/actions/data-lake'
+import { poiLatitudeVariableId, poiLongitudeVariableId, syncPoiCoordinateVariables } from '@/libs/poi/poi-data-lake'
+import { machinizeString } from '@/libs/utils'
+import type {
+  PointOfInterest,
+  PointOfInterestColor,
+  PointOfInterestCoordinates,
+  PointOfInterestIcon,
+  ResolvedPointOfInterest,
+} from '@/types/mission'
+
+const pointsOfInterestKey = 'cockpit-points-of-interest'
+
+/**
+ * Builds a human-friendly POI id from its name, ensuring it is unique among the given ids.
+ * @param {string} name - The POI name to derive the id from
+ * @param {string[]} existingIds - Ids already in use, which the result must not collide with
+ * @returns {string} A machinized, unique id (falls back to `poi` when the name has no usable characters)
+ */
+export const generatePointOfInterestId = (name: string, existingIds: string[]): string => {
+  const base = machinizeString(name) || 'poi'
+  if (!existingIds.includes(base)) return base
+  let suffix = 2
+  while (existingIds.includes(`${base}-${suffix}`)) suffix++
+  return `${base}-${suffix}`
+}
+
+/**
+ * Legacy POI shapes that may exist in persisted storage and need migrating to the current model.
+ */
+interface LegacyPointOfInterest {
+  /** Unique id */
+  id: string
+  /** Name */
+  name: string
+  /** Description */
+  description: string
+  /** Legacy fixed coordinates */
+  coordinates?: PointOfInterestCoordinates
+  /** Current-model latitude source */
+  latitude?: number | string
+  /** Current-model longitude source */
+  longitude?: number | string
+  /** Current-model fallback coordinates */
+  fallbackCoordinates?: PointOfInterestCoordinates
+  /** Experimental latitude expression from an older iteration */
+  latitudeExpression?: number | string
+  /** Experimental longitude expression from an older iteration */
+  longitudeExpression?: number | string
+  /** Experimental last known coordinates from an older iteration */
+  lastKnownCoordinates?: PointOfInterestCoordinates
+  /** Icon */
+  icon: PointOfInterestIcon
+  /** Color */
+  color: PointOfInterestColor
+  /** Timestamp */
+  timestamp?: number
+}
+
+const migratePointOfInterest = (poi: LegacyPointOfInterest): PointOfInterest => {
+  const legacyCoordinates = poi.coordinates ?? poi.lastKnownCoordinates ?? [0, 0]
+  const latitude = poi.latitude ?? poi.latitudeExpression ?? legacyCoordinates[0]
+  const longitude = poi.longitude ?? poi.longitudeExpression ?? legacyCoordinates[1]
+  const fallbackCoordinates = poi.fallbackCoordinates ?? poi.lastKnownCoordinates ?? legacyCoordinates
+
+  return {
+    id: poi.id,
+    name: poi.name,
+    description: poi.description,
+    latitude,
+    longitude,
+    fallbackCoordinates,
+    icon: poi.icon,
+    color: poi.color,
+    timestamp: poi.timestamp ?? Date.now(),
+  }
+}
+
+/**
+ * Shared reactive state and actions for managing points of interest.
+ */
+interface PointsOfInterestState {
+  /** Persisted POI definitions */
+  pointsOfInterest: Ref<PointOfInterest[]>
+  /** POIs with coordinates resolved from the data lake (consumed by the UI) */
+  resolvedPointsOfInterest: ComputedRef<ResolvedPointOfInterest[]>
+  /** Adds a new POI */
+  addPointOfInterest: (poi: PointOfInterest) => void
+  /** Updates an existing POI */
+  updatePointOfInterest: (id: string, update: Partial<PointOfInterest>) => void
+  /** Removes a POI */
+  removePointOfInterest: (id: string) => void
+  /** Moves a POI to a static position (used for drag interactions) */
+  movePointOfInterest: (id: string, newCoordinates: PointOfInterestCoordinates) => void
+}
+
+let state: PointsOfInterestState | undefined
+
+const createState = (): PointsOfInterestState => {
+  const pointsOfInterest = useBlueOsStorage<PointOfInterest[]>(pointsOfInterestKey, [])
+
+  // Migrate any legacy POIs to the current model (coordinates split into data-lake-backed sources).
+  // POIs created before this feature lack `fallbackCoordinates`; those get a fresh human-friendly id
+  // derived from their name (de-duplicated). POIs already in the current model keep their id.
+  const rawPois = pointsOfInterest.value as unknown as LegacyPointOfInterest[]
+  const usedIds = rawPois.filter((poi) => poi.fallbackCoordinates !== undefined).map((poi) => poi.id)
+  const migrated = rawPois.map((raw) => {
+    const poi = migratePointOfInterest(raw)
+    if (raw.fallbackCoordinates !== undefined) return poi
+    const id = generatePointOfInterestId(poi.name, usedIds)
+    usedIds.push(id)
+    return { ...poi, id }
+  })
+
+  if (JSON.stringify(migrated) !== JSON.stringify(pointsOfInterest.value)) {
+    pointsOfInterest.value = migrated
+  }
+
+  // Live coordinate values mirrored from the data lake, keyed by variable id.
+  const liveCoordinateValues = reactive<Record<string, number | undefined>>({})
+
+  // Listeners this composable holds on each POI's own coordinate variables.
+  const outputListeners: Record<
+    string,
+    {
+      /** Id of the POI coordinate variable being listened to */
+      variableId: string
+      /** Listener handle returned by `listenDataLakeVariable` */
+      listenerId: string
+    }[]
+  > = {}
+
+  const mirrorLiveValue = (variableId: string): void => {
+    const value = getDataLakeVariableData(variableId)
+    liveCoordinateValues[variableId] = typeof value === 'number' ? value : undefined
+  }
+
+  const syncOutputListeners = (pois: PointOfInterest[]): void => {
+    const presentIds = new Set(pois.map((poi) => poi.id))
+
+    Object.keys(outputListeners).forEach((poiId) => {
+      if (presentIds.has(poiId)) return
+      outputListeners[poiId].forEach(({ variableId, listenerId }) => unlistenDataLakeVariable(variableId, listenerId))
+      delete outputListeners[poiId]
+      delete liveCoordinateValues[poiLatitudeVariableId(poiId)]
+      delete liveCoordinateValues[poiLongitudeVariableId(poiId)]
+    })
+
+    pois.forEach((poi) => {
+      if (outputListeners[poi.id]) return
+      const latitudeVariableId = poiLatitudeVariableId(poi.id)
+      const longitudeVariableId = poiLongitudeVariableId(poi.id)
+      mirrorLiveValue(latitudeVariableId)
+      mirrorLiveValue(longitudeVariableId)
+      outputListeners[poi.id] = [
+        {
+          variableId: latitudeVariableId,
+          listenerId: listenDataLakeVariable(latitudeVariableId, () => mirrorLiveValue(latitudeVariableId)),
+        },
+        {
+          variableId: longitudeVariableId,
+          listenerId: listenDataLakeVariable(longitudeVariableId, () => mirrorLiveValue(longitudeVariableId)),
+        },
+      ]
+    })
+  }
+
+  // Fixed (number) coordinates are reflected into the reactive mirror immediately, so dragging or
+  // editing a POI moves its marker without waiting on the transforming function's delayed re-eval.
+  const seedLiteralCoordinateValues = (pois: PointOfInterest[]): void => {
+    pois.forEach((poi) => {
+      if (typeof poi.latitude === 'number') liveCoordinateValues[poiLatitudeVariableId(poi.id)] = poi.latitude
+      if (typeof poi.longitude === 'number') liveCoordinateValues[poiLongitudeVariableId(poi.id)] = poi.longitude
+    })
+  }
+
+  watch(
+    pointsOfInterest,
+    (pois) => {
+      syncPoiCoordinateVariables(pois)
+      syncOutputListeners(pois)
+      seedLiteralCoordinateValues(pois)
+    },
+    { deep: true, immediate: true }
+  )
+
+  const resolvedPointsOfInterest = computed<ResolvedPointOfInterest[]>(() =>
+    pointsOfInterest.value.map((poi) => {
+      const latitudeVariableId = poiLatitudeVariableId(poi.id)
+      const longitudeVariableId = poiLongitudeVariableId(poi.id)
+      // Every POI follows its data-lake-backed coordinates. A fixed number is just an expression that
+      // resolves to itself; a string is a live data-lake expression that may track another variable.
+      const isLiveTracked = typeof poi.latitude === 'string' || typeof poi.longitude === 'string'
+
+      const latitude = liveCoordinateValues[latitudeVariableId]
+      const longitude = liveCoordinateValues[longitudeVariableId]
+      const hasValidPosition = typeof latitude === 'number' && typeof longitude === 'number'
+      const coordinates: PointOfInterestCoordinates = hasValidPosition
+        ? [latitude as number, longitude as number]
+        : poi.fallbackCoordinates
+
+      return { ...poi, coordinates, isLiveTracked, hasValidPosition, latitudeVariableId, longitudeVariableId }
+    })
+  )
+
+  const addPointOfInterest = (poi: PointOfInterest): void => {
+    pointsOfInterest.value.push(poi)
+  }
+
+  const updatePointOfInterest = (id: string, update: Partial<PointOfInterest>): void => {
+    const index = pointsOfInterest.value.findIndex((poi) => poi.id === id)
+    if (index === -1) return
+    pointsOfInterest.value[index] = { ...pointsOfInterest.value[index], ...update, timestamp: Date.now() }
+  }
+
+  const removePointOfInterest = (id: string): void => {
+    const index = pointsOfInterest.value.findIndex((poi) => poi.id === id)
+    if (index !== -1) pointsOfInterest.value.splice(index, 1)
+  }
+
+  const movePointOfInterest = (id: string, newCoordinates: PointOfInterestCoordinates): void => {
+    updatePointOfInterest(id, {
+      latitude: newCoordinates[0],
+      longitude: newCoordinates[1],
+      fallbackCoordinates: newCoordinates,
+    })
+  }
+
+  return {
+    pointsOfInterest,
+    resolvedPointsOfInterest,
+    addPointOfInterest,
+    updatePointOfInterest,
+    removePointOfInterest,
+    movePointOfInterest,
+  }
+}
+
+/**
+ * Reactive access to the points of interest, with coordinates backed by the data lake.
+ * State is created once and shared across all callers.
+ * @returns {PointsOfInterestState} The shared points-of-interest state and actions
+ */
+export const usePointsOfInterest = (): PointsOfInterestState => {
+  if (!state) state = createState()
+  return state
+}

--- a/src/libs/actions/data-lake-transformations.ts
+++ b/src/libs/actions/data-lake-transformations.ts
@@ -33,8 +33,14 @@ const saveTransformingFunctions = (): void => {
   updateTransformingFunctionListeners()
 }
 
-const getExpressionValue = (func: TransformingFunction): string | number | boolean => {
-  const expressionWithValues = replaceDataLakeInputsInString(func.expression)
+/**
+ * Evaluates a data-lake expression, replacing `{{ variable }}` inputs with their current values and
+ * running the result as a JavaScript expression (so arithmetic like "{{ x }} * 10" works).
+ * @param {string} expression - The expression to evaluate
+ * @returns {string | number | boolean} The evaluated value
+ */
+export const evaluateDataLakeExpression = (expression: string): string | number | boolean => {
+  const expressionWithValues = replaceDataLakeInputsInString(expression)
 
   // Inputs whose variables have no value yet are left as literal '{{ ... }}' placeholders by the replacement.
   // Bail out with a clear error instead of letting eval fail with a cryptic "Unexpected token '{'" SyntaxError.
@@ -44,7 +50,7 @@ const getExpressionValue = (func: TransformingFunction): string | number | boole
   }
 
   // If the expression contains a return statement, we can just evaluate it directly
-  if (func.expression.includes('return')) {
+  if (expression.includes('return')) {
     return eval(`(function() { ${expressionWithValues} })()`)
   }
 
@@ -74,6 +80,10 @@ const getExpressionValue = (func: TransformingFunction): string | number | boole
   }
 
   throw new Error('Function has no return statement and has comments on all lines.')
+}
+
+const getExpressionValue = (func: TransformingFunction): string | number | boolean => {
+  return evaluateDataLakeExpression(func.expression)
 }
 
 const variablesListeners: Record<string, Record<string, string[]>> = {}

--- a/src/libs/actions/data-lake-transformations.ts
+++ b/src/libs/actions/data-lake-transformations.ts
@@ -148,6 +148,13 @@ const setupTransformingFunctionsListeners = (): void => {
 }
 
 const deleteAllTransformingFunctionsListeners = (): void => {
+  // Cancel any pending initial evaluations. Without this, a rebuild leaves stale timeouts that hold
+  // an outdated function reference and later write an old value back (e.g. reverting one coordinate
+  // of a just-dragged POI, since updating a function replaces its object and triggers a rebuild).
+  Object.keys(initialEvaluationTimeouts).forEach((funcId) => {
+    clearTimeout(initialEvaluationTimeouts[funcId])
+    delete initialEvaluationTimeouts[funcId]
+  })
   Object.keys(nextDelayToEvaluateFaillingTransformingFunction).forEach((funcId) => {
     delete nextDelayToEvaluateFaillingTransformingFunction[funcId]
     delete lastTimeTriedToEvaluateFaillingTransformingFunction[funcId]

--- a/src/libs/poi/poi-data-lake.ts
+++ b/src/libs/poi/poi-data-lake.ts
@@ -1,0 +1,95 @@
+import {
+  createTransformingFunction,
+  deleteTransformingFunction,
+  getAllTransformingFunctions,
+  updateTransformingFunction,
+} from '@/libs/actions/data-lake-transformations'
+import type { PoiCoordinateSource } from '@/types/mission'
+
+/**
+ * Builds the data-lake variable id holding a POI's latitude.
+ * @param {string} poiId - The POI id
+ * @returns {string} The latitude variable id
+ */
+export const poiLatitudeVariableId = (poiId: string): string => `cockpit/pois/${poiId}/latitude`
+
+/**
+ * Builds the data-lake variable id holding a POI's longitude.
+ * @param {string} poiId - The POI id
+ * @returns {string} The longitude variable id
+ */
+export const poiLongitudeVariableId = (poiId: string): string => `cockpit/pois/${poiId}/longitude`
+
+// Prefix shared by every POI-backing data-lake variable, used to find and prune orphaned ones.
+const poiVariablePrefix = 'cockpit/pois/'
+
+/**
+ * A POI coordinate definition, used to keep the backing data-lake variables in sync.
+ */
+export interface PoiCoordinateDefinition {
+  /** The POI id */
+  id: string
+  /** The POI name, used to label the backing transforming functions */
+  name: string
+  /** Latitude source: a fixed number or a data-lake expression */
+  latitude: PoiCoordinateSource
+  /** Longitude source: a fixed number or a data-lake expression */
+  longitude: PoiCoordinateSource
+}
+
+// Every POI coordinate is backed by a transforming function: a fixed number resolves to itself, an
+// expression (e.g. "{{ mavlink/buoy/latitude }} + 0.0001") is evaluated and tracks its dependencies.
+const coordinateExpression = (source: PoiCoordinateSource): string =>
+  typeof source === 'number' ? String(source) : source
+
+const ensureCoordinateFunction = (variableId: string, name: string, source: PoiCoordinateSource): void => {
+  const expression = coordinateExpression(source)
+  const existing = getAllTransformingFunctions().find((func) => func.id === variableId)
+
+  if (existing) {
+    if (existing.expression !== expression || existing.name !== name) {
+      updateTransformingFunction({ ...existing, name, type: 'number', expression })
+    }
+    return
+  }
+
+  createTransformingFunction(variableId, name, 'number', expression)
+}
+
+const deleteCoordinateFunction = (variableId: string): void => {
+  const existing = getAllTransformingFunctions().find((func) => func.id === variableId)
+  if (existing) deleteTransformingFunction(existing)
+}
+
+/**
+ * Removes the transforming functions backing a POI's coordinates.
+ * @param {string} poiId - The POI id
+ */
+export const unregisterPoiCoordinateVariables = (poiId: string): void => {
+  deleteCoordinateFunction(poiLatitudeVariableId(poiId))
+  deleteCoordinateFunction(poiLongitudeVariableId(poiId))
+}
+
+/**
+ * Keeps the transforming functions backing every POI's coordinates in sync with the given
+ * definitions. Creates/updates a function for each current coordinate and prunes those of POIs that
+ * no longer exist. Safe to call repeatedly; functions whose expression is unchanged are left as-is.
+ * @param {PoiCoordinateDefinition[]} pois - The current POI coordinate definitions
+ */
+export const syncPoiCoordinateVariables = (pois: PoiCoordinateDefinition[]): void => {
+  const presentIds = new Set<string>()
+
+  pois.forEach((poi) => {
+    const latitudeVariableId = poiLatitudeVariableId(poi.id)
+    const longitudeVariableId = poiLongitudeVariableId(poi.id)
+    ensureCoordinateFunction(latitudeVariableId, `${poi.name} latitude`, poi.latitude)
+    ensureCoordinateFunction(longitudeVariableId, `${poi.name} longitude`, poi.longitude)
+    presentIds.add(latitudeVariableId)
+    presentIds.add(longitudeVariableId)
+  })
+
+  // Prune transforming functions for POIs (or coordinates) that no longer exist.
+  getAllTransformingFunctions()
+    .filter((func) => func.id.startsWith(poiVariablePrefix) && !presentIds.has(func.id))
+    .forEach(deleteTransformingFunction)
+}

--- a/src/libs/utils-poi.ts
+++ b/src/libs/utils-poi.ts
@@ -1,0 +1,85 @@
+import type { PointOfInterestCoordinates, ResolvedPointOfInterest } from '@/types/mission'
+
+// Marker color used for live-tracked POIs that currently have no valid position data.
+const stalePoiMarkerColor = '#808080'
+
+// Marker opacity used for live-tracked POIs sitting on their fallback coordinates.
+const stalePoiMarkerOpacity = 0.4
+
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+
+/**
+ * Whether a live-tracked POI is currently positioned on its fallback coordinates (no live data).
+ * @param {ResolvedPointOfInterest} poi The resolved POI
+ * @returns {boolean} True when the POI is live-tracked but has no valid position
+ */
+export const isPoiOnFallbackCoordinates = (poi: ResolvedPointOfInterest): boolean =>
+  poi.isLiveTracked && !poi.hasValidPosition
+
+/**
+ * Gets the status text to display in a POI tooltip.
+ * @param {ResolvedPointOfInterest} poi The resolved POI
+ * @returns {string} Status text, or an empty string for static POIs
+ */
+export const getPoiStatusText = (poi: ResolvedPointOfInterest): string => {
+  if (!poi.isLiveTracked) return ''
+  return poi.hasValidPosition ? 'Live tracking' : 'Coordinates unknown'
+}
+
+/**
+ * Gets the marker color for a POI, graying out live-tracked POIs without valid position data.
+ * @param {ResolvedPointOfInterest} poi The resolved POI
+ * @returns {string} The color to use for the marker
+ */
+export const getPoiMarkerColor = (poi: ResolvedPointOfInterest): string => {
+  if (!isPoiOnFallbackCoordinates(poi)) return poi.color
+  return stalePoiMarkerColor
+}
+
+/**
+ * Gets the marker opacity for a POI, dimming live-tracked POIs without valid position data.
+ * @param {ResolvedPointOfInterest} poi The resolved POI
+ * @returns {number} The opacity to use for the marker
+ */
+export const getPoiMarkerOpacity = (poi: ResolvedPointOfInterest): number =>
+  isPoiOnFallbackCoordinates(poi) ? stalePoiMarkerOpacity : 1
+
+/**
+ * Builds a signature describing a POI marker's icon appearance. Used to avoid rebuilding the
+ * Leaflet icon (which recreates its DOM element and breaks in-progress clicks) on every position
+ * update of a live-tracked POI.
+ * @param {ResolvedPointOfInterest} poi The resolved POI
+ * @returns {string} A signature that changes only when the icon appearance changes
+ */
+export const getPoiIconSignature = (poi: ResolvedPointOfInterest): string => `${getPoiMarkerColor(poi)}|${poi.icon}`
+
+/**
+ * Builds the tooltip HTML for a POI marker. When a live-tracked POI has no valid position, the
+ * coordinates line is replaced with an "unknown" notice instead of showing the fallback location.
+ * @param {ResolvedPointOfInterest} poi The resolved POI
+ * @param {PointOfInterestCoordinates} coordinates The coordinates to display (e.g. while dragging)
+ * @returns {string} The tooltip HTML
+ */
+export const getPoiTooltipHtml = (poi: ResolvedPointOfInterest, coordinates: PointOfInterestCoordinates): string => {
+  // POI names/descriptions are user-controlled, so escape them before embedding in tooltip HTML.
+  const name = escapeHtml(poi.name)
+  const description = poi.description ? `${escapeHtml(poi.description)}<br>` : ''
+  const header = `<strong>${name}</strong><br>${description}`
+
+  if (isPoiOnFallbackCoordinates(poi)) {
+    return `${header}<em>Coordinates unknown</em>`
+  }
+
+  const statusText = getPoiStatusText(poi)
+  return `
+    ${header}
+    ${statusText ? `<em>${statusText}</em><br>` : ''}
+    Lat: ${coordinates[0].toFixed(8)}, Lng: ${coordinates[1].toFixed(8)}
+  `
+}

--- a/src/stores/appInterface.ts
+++ b/src/stores/appInterface.ts
@@ -35,6 +35,7 @@ export enum SubMenuComponentName {
   ToolsMAVLink = 'tools-mavlink',
   ToolsDataLake = 'tools-datalake',
   ToolsLogs = 'tools-logs',
+  ToolsMap = 'tools-map',
 }
 
 export const useAppInterfaceStore = defineStore('responsive', {

--- a/src/stores/mission.ts
+++ b/src/stores/mission.ts
@@ -20,8 +20,6 @@ import {
   MapTileProviderPreference,
   MissionCommand,
   MissionEstimatesSnapshot,
-  PointOfInterest,
-  PointOfInterestCoordinates,
   SavedMission,
   Survey,
   Waypoint,
@@ -106,8 +104,6 @@ export const useMissionStore = defineStore('mission', () => {
   const { showDialog } = useInteractionDialog()
 
   const mainVehicleStore = useMainVehicleStore()
-
-  const pointsOfInterest = useBlueOsStorage<PointOfInterest[]>('cockpit-points-of-interest', [])
 
   // Metadata for user-loaded GeoTIFF overlays. The raster bytes live in the overlay storage
   // (IndexedDB), keyed by each entry's `id`.
@@ -281,32 +277,6 @@ export const useMissionStore = defineStore('mission', () => {
       currentPlanningWaypoints,
       currentPlanningWaypoints.map((w) => (w.id === id ? { ...w, ...newWaypoint } : w))
     )
-  }
-
-  const addPointOfInterest = (poi: PointOfInterest): void => {
-    pointsOfInterest.value.push(poi)
-  }
-
-  const updatePointOfInterest = (id: string, poiUpdate: Partial<PointOfInterest>): void => {
-    const index = pointsOfInterest.value.findIndex((p) => p.id === id)
-    if (index !== -1) {
-      pointsOfInterest.value[index] = { ...pointsOfInterest.value[index], ...poiUpdate, timestamp: Date.now() }
-    }
-  }
-
-  const removePointOfInterest = (id: string): void => {
-    const index = pointsOfInterest.value.findIndex((p) => p.id === id)
-    if (index !== -1) {
-      pointsOfInterest.value.splice(index, 1)
-    }
-  }
-
-  const movePointOfInterest = (id: string, newCoordinates: PointOfInterestCoordinates): void => {
-    const poi = pointsOfInterest.value.find((p) => p.id === id)
-    if (poi === undefined) {
-      throw Error(`Could not move Point of Interest. No POI with id ${id} was found.`)
-    }
-    updatePointOfInterest(id, { coordinates: newCoordinates })
   }
 
   const clearMission = (): void => {
@@ -779,11 +749,6 @@ export const useMissionStore = defineStore('mission', () => {
     saveLastMapPosition,
     setDefaultMapPosition,
     getWaypointNumber,
-    pointsOfInterest,
-    addPointOfInterest,
-    updatePointOfInterest,
-    removePointOfInterest,
-    movePointOfInterest,
     mapOverlays,
     addMapOverlay,
     removeMapOverlay,

--- a/src/stores/mission.ts
+++ b/src/stores/mission.ts
@@ -93,6 +93,13 @@ export const useMissionStore = defineStore('mission', () => {
   const mapClearRequestRevision = ref(0)
   const mapDownloadRequestRevision = ref(0)
   const homeMarkerPosition = ref<WaypointCoordinates | undefined>(undefined)
+  // Request for any active map to center on given coordinates. Replaced (new object) on each request.
+  const mapCenterOnRequest = ref<{
+    /** Coordinates the map should center on */
+    coordinates: WaypointCoordinates
+    /** Incremented on each request so repeated centerings on the same coordinates still trigger */
+    revision: number
+  } | null>(null)
 
   // Fallback vehicle type used by vehicle-specific planning features when no vehicle is connected.
   const plannedVehicleType = useBlueOsStorage<MavType | undefined>('cockpit-planned-vehicle-type', undefined)
@@ -578,6 +585,10 @@ export const useMissionStore = defineStore('mission', () => {
     mapClearRequestRevision.value += 1
   }
 
+  const requestMapCenterOn = (coordinates: WaypointCoordinates): void => {
+    mapCenterOnRequest.value = { coordinates, revision: (mapCenterOnRequest.value?.revision ?? 0) + 1 }
+  }
+
   const requestMapMissionDownload = (): void => {
     mapDownloadRequestRevision.value += 1
   }
@@ -789,6 +800,8 @@ export const useMissionStore = defineStore('mission', () => {
     canSkipToNextWp,
     currentWaypointOnMission,
     mapClearRequestRevision,
+    mapCenterOnRequest,
+    requestMapCenterOn,
     mapDownloadRequestRevision,
     requestMapClear,
     requestMapMissionDownload,

--- a/src/types/mission.ts
+++ b/src/types/mission.ts
@@ -322,7 +322,16 @@ export type PointOfInterestIcon = string
 export type PointOfInterestColor = string
 
 /**
- * Interface representing a Point of Interest (POI) on the map.
+ * Source for one of a POI's coordinates.
+ * A `number` is a fixed/static value. A `string` is a data-lake expression (e.g.
+ * "{{ mavlink/buoy/latitude }}") that is resolved live into the data lake.
+ */
+export type PoiCoordinateSource = number | string
+
+/**
+ * Interface representing a Point of Interest (POI) definition.
+ * This is the persisted shape. The actual coordinates always live in the data lake (see
+ * `poiLatitudeVariableId`/`poiLongitudeVariableId`); UI components consume `ResolvedPointOfInterest`.
  */
 export interface PointOfInterest {
   /**
@@ -338,9 +347,18 @@ export interface PointOfInterest {
    */
   description: string
   /**
-   * Geographical coordinates of the POI.
+   * Source for the POI latitude: a static number or a data-lake expression.
    */
-  coordinates: PointOfInterestCoordinates
+  latitude: PoiCoordinateSource
+  /**
+   * Source for the POI longitude: a static number or a data-lake expression.
+   */
+  longitude: PoiCoordinateSource
+  /**
+   * Location shown before the live coordinates resolve, or when live data is unavailable.
+   * For static POIs this matches the fixed coordinates.
+   */
+  fallbackCoordinates: PointOfInterestCoordinates
   /**
    * Icon representing the POI.
    */
@@ -351,6 +369,33 @@ export interface PointOfInterest {
   color: PointOfInterestColor
   /** Timestamp of creation or last update */
   timestamp: number
+}
+
+/**
+ * A POI with its coordinates resolved from the data lake. This is what UI components render.
+ */
+export interface ResolvedPointOfInterest extends PointOfInterest {
+  /**
+   * Current coordinates, read from the data lake. Falls back to `fallbackCoordinates` when the
+   * live value is not available.
+   */
+  coordinates: PointOfInterestCoordinates
+  /**
+   * Whether any coordinate is driven by a live data-lake expression.
+   */
+  isLiveTracked: boolean
+  /**
+   * Whether live coordinates are currently available (always true for static POIs).
+   */
+  hasValidPosition: boolean
+  /**
+   * Id of the data-lake variable holding the POI's latitude.
+   */
+  latitudeVariableId: string
+  /**
+   * Id of the data-lake variable holding the POI's longitude.
+   */
+  longitudeVariableId: string
 }
 
 /**

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -4531,6 +4531,14 @@ const openPoiDialog = (): void => {
   }
   hideContextMenu()
 }
+// React to "center on coordinates" requests (e.g. from the Map tools menu).
+watch(
+  () => missionStore.mapCenterOnRequest,
+  (request) => {
+    if (!request || !planningMap.value) return
+    planningMap.value.setView(request.coordinates as LatLngTuple, planningMap.value.getZoom(), { animate: true })
+  }
+)
 </script>
 
 <style>

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -814,6 +814,7 @@ const widgetStore = useWidgetManagerStore()
 const missionEstimates = useMissionEstimates()
 const angleOverlay = useVertexAngleOverlay()
 const dragMeasureOverlay = useDragMeasureOverlay(angleOverlay)
+
 const { height: windowHeight } = useWindowSize()
 
 const { showDialog, closeDialog } = useInteractionDialog()

--- a/src/views/ToolsMapView.vue
+++ b/src/views/ToolsMapView.vue
@@ -1,0 +1,229 @@
+<template>
+  <BaseConfigurationView>
+    <template #title>Map</template>
+    <template #content>
+      <div class="flex-col h-full overflow-y-auto ml-[10px] pr-3 -mr-[10px] -mb-[10px]">
+        <ExpansiblePanel no-top-divider no-bottom-divider :is-expanded="!interfaceStore.isOnPhoneScreen">
+          <template #title>Points of Interest</template>
+          <template #info>
+            <li>View, edit and remove the points of interest shown on the map.</li>
+            <li>Static POIs have fixed coordinates, while live POIs follow data-lake variables.</li>
+          </template>
+          <template #content>
+            <div class="flex justify-center flex-col ml-2 pr-4 mb-8 mt-2 w-full">
+              <v-data-table
+                :items="pois"
+                items-per-page="10"
+                class="elevation-1 bg-transparent rounded-lg mb-8"
+                theme="dark"
+                :headers="headers"
+                :style="interfaceStore.globalGlassMenuStyles"
+              >
+                <template #item="{ item }">
+                  <tr>
+                    <td>
+                      <div class="flex items-center gap-3 mx-1 w-[240px]">
+                        <div class="poi-marker-container" :style="{ opacity: getPoiMarkerOpacity(item) }">
+                          <div
+                            class="poi-marker-background"
+                            :style="{ backgroundColor: `${getPoiMarkerColor(item)}80` }"
+                          />
+                          <v-icon :icon="item.icon" size="18" class="poi-marker-glyph" />
+                        </div>
+                        <div class="flex flex-col min-w-0">
+                          <p class="whitespace-nowrap overflow-hidden truncate">{{ item.name }}</p>
+                          <p
+                            v-if="item.description"
+                            class="text-xs opacity-60 whitespace-nowrap overflow-hidden truncate"
+                          >
+                            {{ item.description }}
+                          </p>
+                        </div>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="flex items-center justify-center mx-1 w-[110px]">
+                        <v-chip
+                          size="small"
+                          :color="poiStatusColor(item)"
+                          variant="flat"
+                          label
+                          class="text-white text-xs font-medium"
+                        >
+                          {{ poiStatusLabel(item) }}
+                        </v-chip>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="flex items-center justify-center mx-1 w-[200px]">
+                        <p class="whitespace-nowrap overflow-hidden truncate font-mono text-xs">
+                          {{ poiCoordinatesText(item) }}
+                        </p>
+                      </div>
+                    </td>
+                    <td class="w-[160px] text-right">
+                      <div class="flex items-center justify-center">
+                        <v-btn
+                          variant="outlined"
+                          class="rounded-full mx-1"
+                          icon="mdi-crosshairs-gps"
+                          size="x-small"
+                          @click="centerOnPoi(item)"
+                        />
+                        <v-btn
+                          variant="outlined"
+                          class="rounded-full mx-1"
+                          icon="mdi-pencil"
+                          size="x-small"
+                          @click="editPoi(item)"
+                        />
+                        <v-btn
+                          variant="outlined"
+                          class="rounded-full mx-1"
+                          icon="mdi-trash-can-outline"
+                          size="x-small"
+                          @click="removePoi(item)"
+                        />
+                      </div>
+                    </td>
+                  </tr>
+                </template>
+                <template #bottom>
+                  <tr class="w-full">
+                    <td colspan="4" class="text-center flex items-center justify-center h-[50px] mb-3 w-full gap-2">
+                      <v-btn variant="outlined" class="rounded-lg" @click="openNewPoiDialog">
+                        <v-icon start>mdi-plus</v-icon>
+                        Add point of interest
+                      </v-btn>
+                    </td>
+                  </tr>
+                </template>
+                <template #no-data>
+                  <tr>
+                    <td colspan="4" class="text-center flex items-center justify-center h-[50px] w-full">
+                      <p class="text-[16px] w-full">No points of interest found</p>
+                    </td>
+                  </tr>
+                </template>
+              </v-data-table>
+            </div>
+          </template>
+        </ExpansiblePanel>
+      </div>
+    </template>
+  </BaseConfigurationView>
+
+  <PoiManager ref="poiManagerRef" />
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+import ExpansiblePanel from '@/components/ExpansiblePanel.vue'
+import PoiManager from '@/components/poi/PoiManager.vue'
+import { useInteractionDialog } from '@/composables/interactionDialog'
+import { usePointsOfInterest } from '@/composables/usePointsOfInterest'
+import { getPoiMarkerColor, getPoiMarkerOpacity } from '@/libs/utils-poi'
+import { useAppInterfaceStore } from '@/stores/appInterface'
+import { useMissionStore } from '@/stores/mission'
+import type { ResolvedPointOfInterest } from '@/types/mission'
+
+import BaseConfigurationView from './BaseConfigurationView.vue'
+
+const interfaceStore = useAppInterfaceStore()
+const missionStore = useMissionStore()
+const { showDialog, closeDialog } = useInteractionDialog()
+const { resolvedPointsOfInterest: pois, removePointOfInterest } = usePointsOfInterest()
+
+const poiManagerRef = ref<InstanceType<typeof PoiManager> | null>(null)
+
+const headers = [
+  { title: 'Name', key: 'name', align: 'start', sortable: true },
+  { title: 'Status', key: 'status', align: 'center', sortable: false },
+  { title: 'Coordinates', key: 'coordinates', align: 'center', sortable: false },
+  { title: 'Actions', key: 'actions', align: 'end', sortable: false },
+] as const
+
+const poiStatusLabel = (poi: ResolvedPointOfInterest): string => {
+  if (!poi.isLiveTracked) return 'Static'
+  return poi.hasValidPosition ? 'Live' : 'No data'
+}
+
+const poiStatusColor = (poi: ResolvedPointOfInterest): string => {
+  if (!poi.isLiveTracked) return '#607d8b'
+  return poi.hasValidPosition ? '#4caf50' : '#ff9800'
+}
+
+const poiCoordinatesText = (poi: ResolvedPointOfInterest): string => {
+  if (poi.isLiveTracked && !poi.hasValidPosition) return 'Coordinates unknown'
+  return `${poi.coordinates[0].toFixed(7)}, ${poi.coordinates[1].toFixed(7)}`
+}
+
+const centerOnPoi = (poi: ResolvedPointOfInterest): void => {
+  logUserAction(`Centered the map on the "${poi.name}" point of interest`)
+  missionStore.requestMapCenterOn(poi.coordinates)
+  // Close the submenu panel so the centered map is visible, but keep the main menu drawer open.
+  interfaceStore.configModalVisibility = false
+  interfaceStore.currentSubMenuComponentName = null
+}
+
+const editPoi = (poi: ResolvedPointOfInterest): void => {
+  poiManagerRef.value?.openDialog(undefined, poi)
+}
+
+const removePoi = (poi: ResolvedPointOfInterest): void => {
+  showDialog({
+    variant: 'warning',
+    title: 'Remove point of interest?',
+    message: `Remove "${poi.name}"? This deletes it and its backing data-lake variables.`,
+    actions: [
+      { text: 'Cancel', size: 'small', action: closeDialog },
+      {
+        text: 'Remove',
+        size: 'small',
+        action: () => {
+          closeDialog()
+          logUserAction(`Removed the "${poi.name}" point of interest`)
+          removePointOfInterest(poi.id)
+        },
+      },
+    ],
+  })
+}
+
+const openNewPoiDialog = (): void => {
+  poiManagerRef.value?.openDialog()
+}
+</script>
+
+<style scoped>
+.v-data-table :deep(tbody tr:hover) {
+  background-color: rgba(0, 0, 0, 0.1) !important;
+}
+
+.poi-marker-container {
+  position: relative;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.poi-marker-background {
+  position: absolute;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  z-index: 1;
+}
+
+.poi-marker-glyph {
+  color: rgba(255, 255, 255, 0.7);
+  position: relative;
+  z-index: 2;
+}
+</style>


### PR DESCRIPTION
# Live-tracked Points of Interest


https://github.com/user-attachments/assets/f49a4a2c-3b0f-4261-911a-d65f23567500



## What this introduces

Points of Interest (POIs) can now follow a moving target instead of being pinned to a fixed spot.

- **Static or live coordinates** — a POI's latitude/longitude can be a fixed number (as before) or a data-lake expression such as `{{ mavlink/buoy/latitude }}`. Live POIs move on the map as their underlying values update.
- **POI manager** — a static/live toggle, plus a combobox to pick any number-typed data-lake variable (or type a custom expression). Live POIs that have no valid value yet are shown dimmed with a "Coordinates unknown" tooltip.
- **Tools → Map menu** — lists every POI with its live/static status and lets you center, edit or delete each one.
- **Center-on dial** — the map's "center on" speed dial now includes POIs: single-click to center, double-click to keep tracking. Home/vehicle/mission tracking is unchanged.
- **Map widget, mission map, HUD and edge arrows** all render the resolved POI positions and update live.

## Key design choices

- POI logic lives in a `usePointsOfInterest` composable plus small plain-`.ts` modules, instead of the mission Pinia store.
- A clean split between the **persisted definition** (name, icon, color, coordinate source, fallback) and the **resolved runtime POI** (current coordinates + live status) that the UI consumes. No runtime/derived state is ever written back into the persisted object.
- Display concerns (marker color, opacity, tooltip, status text) are centralized in `libs/utils-poi.ts` and shared by every consumer, removing the duplicated marker/tooltip code that previously lived in both map components.

## How POIs relate to the data lake

Every POI exposes its position through the data lake as two variables:

```
cockpit/pois/<id>/latitude
cockpit/pois/<id>/longitude
```

These are the single source of truth for a POI's *live* position, which keeps POIs consistent with Cockpit's broader move toward sourcing widget data from the data lake.

- **Static coordinate** — the fixed number is written into the backing variable once.
- **Live coordinate** — the expression is evaluated (via `evaluateDataLakeExpression`, so arithmetic like `{{ x }} * 10` works), and the result is re-written whenever any referenced variable changes. Each backing variable subscribes only to the variables its expression actually references, so updates are pushed, not polled.

The composable mirrors those backing variables back into reactive state and produces `resolvedPointsOfInterest`. When a live expression has no value yet (e.g. the source hasn't published), the POI falls back to its stored `fallbackCoordinates` and is flagged as having no valid position (driving the dimmed marker + tooltip).

Static POIs resolve their render position straight from their persisted definition rather than reading it back through the data lake, so edits like dragging apply immediately without a round-trip lag.
