### PR TITLE
data-flattener: support bitfields on mavlink data

### DIFF
--- a/src/libs/vehicle/ardupilot/data-flattener.ts
+++ b/src/libs/vehicle/ardupilot/data-flattener.ts
@@ -82,6 +82,15 @@ export function flattenData(data: Record<string, unknown>): FlattenedPair[] {
           },
         ]
       }
+      if (typeof value === 'object' && value !== null && 'bits' in value) {
+        return [
+          {
+            path: `${messageName}/${key}`,
+            type: typeof (value as any).bits as 'number',
+            value: (value as any).bits,
+          },
+        ]
+      }
       if (Array.isArray(value)) {
         if (value.length === 0) return []
         if (isNumberArray(value)) {


### PR DESCRIPTION
![Screenshot 2025-06-19 at 11 40 55](https://github.com/user-attachments/assets/503a8266-08b1-4600-9cd4-ab32904f4d78)
