### PR TITLE
Severely reduce the lag in the table tab of the joystick configuration page for constrained setups

### DIFF
--- a/src/types/joystick.ts
+++ b/src/types/joystick.ts
@@ -57,18 +57,23 @@ export class Joystick {
    * @returns {JoystickState}
    */
   get state(): JoystickState {
-    return {
-      buttons:
-        this.gamepadToCockpitMap?.buttons.map((idx) => {
-          if (idx === null || this.gamepad.buttons[idx] === undefined) return undefined
-          return this.gamepad.buttons[idx].value
-        }) || [],
-      axes:
-        this.gamepadToCockpitMap?.axes.map((idx) => {
-          if (idx === null || this.gamepad.axes[idx] === undefined) return undefined
-          return this.gamepad.axes[idx]
-        }) || [],
-    }
+    let buttons =
+      this.gamepadToCockpitMap?.buttons.map((idx) => {
+        if (idx === null || this.gamepad.buttons[idx] === undefined) return undefined
+        return this.gamepad.buttons[idx].value
+      }) || []
+
+    buttons = buttons.filter((button) => button !== undefined)
+
+    let axes =
+      this.gamepadToCockpitMap?.axes.map((idx) => {
+        if (idx === null || this.gamepad.axes[idx] === undefined) return undefined
+        return this.gamepad.axes[idx]
+      }) || []
+
+    axes = axes.filter((axis) => axis !== undefined)
+
+    return { buttons, axes }
   }
 }
 

--- a/src/views/ConfigurationJoystickView.vue
+++ b/src/views/ConfigurationJoystickView.vue
@@ -364,7 +364,7 @@
                           <div
                             class="flex items-center justify-center gap-x-4 rounded-xl"
                             :class="
-                                item.type === 'button' && (joystick.state.buttons[item.id as JoystickButton] ?? 0) > 0.5 ? 'bg-[#2c99ce]' : 'bg-transparent'
+                                item.type === 'button' && isButtonPressed(item.id as JoystickButton) ? 'bg-[#2c99ce]' : 'bg-transparent'
                               "
                           >
                             <p>{{ item.type }}</p>
@@ -670,6 +670,39 @@ const showJoystickLayout = ref(true)
 const currentTabVIew = ref('table')
 
 const protocols = Object.values(JoystickProtocol).filter((value) => typeof value === 'string')
+
+// Throttled button states implementation for performance optimization
+const throttledButtonStates = ref<Record<number, number | undefined>>({})
+const lastButtonUpdateTime = ref(0)
+const buttonUpdateThrottleMs = 30
+
+// Optimized shallow watcher instead of deep watcher
+let buttonUpdateScheduled = false
+watch(
+  () => currentJoystick.value?.state.buttons,
+  (newButtonStates) => {
+    if (!newButtonStates || buttonUpdateScheduled) return
+
+    buttonUpdateScheduled = true
+    requestAnimationFrame(() => {
+      const now = Date.now()
+      if (now - lastButtonUpdateTime.value > buttonUpdateThrottleMs) {
+        // Only update changed buttons instead of copying entire object
+        for (const [buttonId, value] of Object.entries(newButtonStates)) {
+          if (throttledButtonStates.value[Number(buttonId)] !== value) {
+            throttledButtonStates.value[Number(buttonId)] = value
+          }
+        }
+        lastButtonUpdateTime.value = now
+      }
+      buttonUpdateScheduled = false
+    })
+  }
+)
+
+const isButtonPressed = (buttonId: JoystickButton): boolean => {
+  return (throttledButtonStates.value[buttonId] ?? 0) > 0.5
+}
 
 const shiftFunction = {
   protocol: 'cockpit-modifier-key',

--- a/src/views/ConfigurationJoystickView.vue
+++ b/src/views/ConfigurationJoystickView.vue
@@ -503,7 +503,7 @@
                 />
                 <div class="h-[360px] p-1 overflow-y-auto">
                   <Button
-                    v-for="action in filteredAndSortedJoystickActions()"
+                    v-for="action in filteredAndSortedJoystickActions"
                     :key="action.name"
                     class="w-full my-1 text-sm hover:bg-slate-700 flex flex-col py-2 relative align-center"
                     :class="{ 'bg-slate-700': currentButtonActions[input.id].action.id == action.id }"
@@ -669,8 +669,6 @@ const availableModifierKeys: ProtocolAction[] = Object.values(modifierKeyActions
 const showJoystickLayout = ref(true)
 const currentTabVIew = ref('table')
 
-const protocols = Object.values(JoystickProtocol).filter((value) => typeof value === 'string')
-
 // Throttled button states implementation for performance optimization
 const throttledButtonStates = ref<Record<number, number | undefined>>({})
 const lastButtonUpdateTime = ref(0)
@@ -728,13 +726,6 @@ watch(
   }
 )
 
-const filteredProtocols = protocols.filter(
-  (protocol) =>
-    protocol === JoystickProtocol.MAVLinkManualControl ||
-    protocol === JoystickProtocol.CockpitAction ||
-    protocol === JoystickProtocol.DataLakeVariable
-)
-
 const warnIfJoystickDoesNotSupportExtendedManualControl = async (): Promise<void> => {
   try {
     const m2rVersion = await getMavlink2RestVersion(globalAddress)
@@ -749,10 +740,16 @@ const warnIfJoystickDoesNotSupportExtendedManualControl = async (): Promise<void
   }
 }
 
-const filteredAndSortedJoystickActions = (): JoystickAction[] => {
+const filteredAndSortedJoystickActions = computed((): JoystickAction[] => {
+  const allowedProtocols = [
+    JoystickProtocol.MAVLinkManualControl,
+    JoystickProtocol.CockpitAction,
+    JoystickProtocol.DataLakeVariable,
+  ]
+
   return buttonActionsToShow.value
     .filter((action: JoystickAction) => action.name.toLowerCase().includes(searchText.value.toLowerCase()))
-    .filter((action: JoystickAction) => filteredProtocols.includes(action.protocol))
+    .filter((action: JoystickAction) => allowedProtocols.includes(action.protocol as JoystickProtocol))
     .filter((action: JoystickAction) => {
       const dataLakeVariableInfo = getDataLakeVariableInfo(action.id)
       if (!dataLakeVariableInfo) return true
@@ -760,7 +757,7 @@ const filteredAndSortedJoystickActions = (): JoystickAction[] => {
     })
     .filter((action: JoystickAction) => !idsExcludedJoystickActions.includes(action.id))
     .sort((a: JoystickAction, b: JoystickAction) => a.name.localeCompare(b.name))
-}
+})
 
 const headers = ref([
   { text: 'Type', value: 'type' },

--- a/src/views/ConfigurationJoystickView.vue
+++ b/src/views/ConfigurationJoystickView.vue
@@ -773,13 +773,11 @@ const tableItems = computed(() => {
     return []
   }
 
-  const originalAxes = currentJoystick.value.gamepadToCockpitMap?.axes || []
-  const axesItems = originalAxes.slice(0, 31).map((axis) => ({ type: 'axis', id: axis }))
+  const originalAxes = currentJoystick.value.state.axes
+  const axesItems = originalAxes.slice(0, 31).map((_, index) => ({ type: 'axis', id: index }))
 
-  const originalButtons = currentJoystick.value.gamepadToCockpitMap?.buttons || []
-  const buttonItems = originalButtons
-    .map((button, index) => ({ type: 'button', id: button, index: index }))
-    .filter((button) => button.index >= 0 && button.index <= 31)
+  const originalButtons = currentJoystick.value.state.buttons
+  const buttonItems = originalButtons.slice(0, 31).map((_, index) => ({ type: 'button', id: index }))
 
   return [...axesItems, ...buttonItems]
 })


### PR DESCRIPTION
This was a performance issue that existed for a long time, but got more noticeable with the introduction of #1876 (not sure why). The application frame rate dropped a lot when entering the table tab, and for more constrained setups it got to the point of making the axis and buttons state updates to lag on several seconds.

This patch solves the problem by calculating all button states at the same time, once, every 100ms, instead of restyling the DOM for every button at the joystick rate.

## Modified Features
Besides the performance improvement, the user should see no difference.

## Tests Required to Merge (by dev and/or testers)
- [ ] Open Cockpit in current master
- [ ] Connect a joystick
- [ ] Open Chrome Dev tools, switch to the performance tab and throttle the CPU to 6x slowdown
- [ ] Open the joystick configuration page
- [ ] Switch to the table tab
- [ ] Verify that the button and axes states updates have a major lag
- [ ] Do all the steps again but with this PR. The major lag should be gone (there will be still some lag, as we are throttling down the CPU severely, not being a real scenario, but an exagerated one to see the problem)

Before (the drop from ~60fps to ~8fps was when entering the table tab):
<img width="598" alt="SCR-20250707-tsqe" src="https://github.com/user-attachments/assets/d3419563-6bde-42ee-99b1-859cd7bb785e" />

After (opening the table tab causes no drop in the framerate):
<img width="587" alt="SCR-20250708-kjzn" src="https://github.com/user-attachments/assets/5bc0cd59-ecf7-4994-9e0e-c6c9dcbd8128" />

Fix #1435 
