### PR TITLE
electron: Allow monitoring CPU usage and GPU memory

### DIFF
--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -5,8 +5,8 @@ import { join } from 'path'
 import { setupAutoUpdater } from './services/auto-update'
 import store from './services/config-store'
 import { setupJoystickMonitoring } from './services/joystick'
-import { setupMemoryService } from './services/memory'
 import { setupNetworkService } from './services/network'
+import { setupResourceMonitoringService } from './services/resource-monitoring'
 import { setupFilesystemStorage } from './services/storage'
 import { setupWorkspaceService } from './services/workspace'
 
@@ -78,7 +78,7 @@ protocol.registerSchemesAsPrivileged([
 
 setupFilesystemStorage()
 setupNetworkService()
-setupMemoryService()
+setupResourceMonitoringService()
 setupWorkspaceService()
 setupJoystickMonitoring()
 

--- a/src/electron/services/memory.ts
+++ b/src/electron/services/memory.ts
@@ -1,4 +1,5 @@
 import { app, ipcMain } from 'electron'
+import * as os from 'os'
 
 /**
  * Setup memory usage monitoring
@@ -9,18 +10,66 @@ export const setupMemoryService = (): void => {
     try {
       const memoryInfo = await app.getAppMetrics()
 
-      // Sum all process memory
+      // Separate memory by process type
+      let mainMemory = 0
+      let renderersMemory = 0
+      let gpuMemory = 0
+
+      memoryInfo.forEach((metric) => {
+        const memory = metric.memory?.workingSetSize || 0
+
+        switch (metric.type) {
+          case 'Browser':
+            mainMemory += memory
+            break
+          case 'Tab':
+          case 'Utility':
+            renderersMemory += memory
+            break
+          case 'GPU':
+            gpuMemory += memory
+            break
+          default:
+            // For any other process types, add to main
+            mainMemory += memory
+            break
+        }
+      })
+
+      // Sum all process memory for backward compatibility
       const totalMemory = memoryInfo.reduce((total, metric) => {
         return total + (metric.memory?.workingSetSize || 0)
       }, 0)
 
+      // Get CPU usage
+      const cpus = os.cpus()
+      let totalIdle = 0
+      let totalTick = 0
+
+      cpus.forEach((cpu) => {
+        Object.entries(cpu.times).forEach(([, time]) => {
+          totalTick += time
+        })
+        totalIdle += cpu.times.idle
+      })
+
+      const cpuUsagePercent = Math.max(0, Math.min(100, 100 - (totalIdle / totalTick) * 100))
+
       return {
-        totalMemoryMB: totalMemory / 1024, // Convert from KiloBytes to MegaBytes
+        totalMemoryMB: totalMemory / 1024, // Convert from KiloBytes to MegaBytes (backward compatibility)
+        mainMemoryMB: mainMemory / 1024, // Main process memory in MB
+        renderersMemoryMB: renderersMemory / 1024, // Total renderer processes memory in MB
+        gpuMemoryMB: gpuMemory / 1024, // GPU process memory in MB
+        cpuUsagePercent: cpuUsagePercent, // CPU usage percentage
       }
     } catch (error) {
-      console.error('Failed to get memory usage:', error)
+      console.error('Failed to get resource usage:', error)
       return {
         totalMemoryMB: 0,
+        mainMemoryMB: 0,
+        renderersMemoryMB: 0,
+        gpuMemoryMB: 0,
+        cpuUsagePercent: 0,
       }
     }
   })

--- a/src/electron/services/resource-monitoring.ts
+++ b/src/electron/services/resource-monitoring.ts
@@ -5,7 +5,7 @@ import * as os from 'os'
  * Setup memory usage monitoring
  * Exposes IPC handler for getting real-time memory usage information
  */
-export const setupMemoryService = (): void => {
+export const setupResourceMonitoringService = (): void => {
   ipcMain.handle('get-resource-usage', async () => {
     try {
       const memoryInfo = await app.getAppMetrics()

--- a/src/libs/cosmos.ts
+++ b/src/libs/cosmos.ts
@@ -203,6 +203,22 @@ declare global {
          * The total memory usage of the application in MB
          */
         totalMemoryMB: number
+        /**
+         * The main process memory usage in MB
+         */
+        mainMemoryMB: number
+        /**
+         * The total renderer processes memory usage in MB
+         */
+        renderersMemoryMB: number
+        /**
+         * The GPU process memory usage in MB
+         */
+        gpuMemoryMB: number
+        /**
+         * The CPU usage percentage
+         */
+        cpuUsagePercent: number
       }>
       /**
        * Register callback for update available event


### PR DESCRIPTION
## New feature
This patch adds three new data-lake variables related to resource usage on the standalone/Electron app:
- CPU usage (percentage)
- GPU memory usage (MB)
- Renderers memory usage (MB)

With them, debugging application performance becomes significantly easier.

## Tests Required to Merge (by dev and/or testers)
- [x] Open Cockpit
- [x] Add Plotter widgets for the new variables
- [x] See if the values make sense

https://github.com/user-attachments/assets/ed652c7c-d4cc-4e34-b5f2-3e5351d77f17

