### PR TITLE
Merge Electron logs with Cockpit internal ones

### DIFF
--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -14,6 +14,9 @@ import { setupWorkspaceService } from './services/workspace'
 // If the app is packaged, push logs to the system instead of the console
 if (app.isPackaged) {
   Object.assign(console, logger.functions)
+
+  // Log Electron low-level events
+  logger.eventLogger.startLogging()
 }
 
 export const ROOT_PATH = {

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -4,6 +4,7 @@ import { join } from 'path'
 
 import { setupAutoUpdater } from './services/auto-update'
 import store from './services/config-store'
+import { setupElectronLogService } from './services/electron-log'
 import { setupJoystickMonitoring } from './services/joystick'
 import { setupNetworkService } from './services/network'
 import { setupResourceMonitoringService } from './services/resource-monitoring'
@@ -87,6 +88,7 @@ setupNetworkService()
 setupResourceMonitoringService()
 setupWorkspaceService()
 setupJoystickMonitoring()
+setupElectronLogService()
 
 app.whenReady().then(async () => {
   console.log('Electron app is ready.')

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -1,5 +1,4 @@
 import { app, BrowserWindow, protocol, screen } from 'electron'
-import logger from 'electron-log'
 import { join } from 'path'
 
 import { setupAutoUpdater } from './services/auto-update'
@@ -12,13 +11,8 @@ import { serialService } from './services/serial'
 import { setupFilesystemStorage } from './services/storage'
 import { setupWorkspaceService } from './services/workspace'
 
-// If the app is packaged, push logs to the system instead of the console
-if (app.isPackaged) {
-  Object.assign(console, logger.functions)
-
-  // Log Electron low-level events
-  logger.eventLogger.startLogging()
-}
+// Setup the logger service as soon as possible to avoid different behaviors across runtime
+setupElectronLogService()
 
 export const ROOT_PATH = {
   dist: join(__dirname, '..'),
@@ -88,7 +82,6 @@ setupNetworkService()
 setupResourceMonitoringService()
 setupWorkspaceService()
 setupJoystickMonitoring()
-setupElectronLogService()
 
 app.whenReady().then(async () => {
   console.log('Electron app is ready.')

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -50,4 +50,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('serial-data', (_event, data) => callback(data))
   },
   systemLog: (level: string, message: string) => ipcRenderer.send('system-log', { level, message }),
+  getElectronLogs: () => ipcRenderer.invoke('get-electron-logs'),
+  getElectronLogContent: (logName: string) => ipcRenderer.invoke('get-electron-log-content', logName),
+  deleteElectronLog: (logName: string) => ipcRenderer.invoke('delete-electron-log', logName),
+  deleteOldElectronLogs: () => ipcRenderer.invoke('delete-old-electron-logs'),
 })

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -49,4 +49,5 @@ contextBridge.exposeInMainWorld('electronAPI', {
   onSerialData: (callback: (data: { path: string; data: number[] }) => void) => {
     ipcRenderer.on('serial-data', (_event, data) => callback(data))
   },
+  systemLog: (level: string, message: string) => ipcRenderer.send('system-log', { level, message }),
 })

--- a/src/electron/services/electron-log.ts
+++ b/src/electron/services/electron-log.ts
@@ -1,0 +1,32 @@
+import { ipcMain } from 'electron'
+import logger from 'electron-log'
+
+/**
+ * Setup electron-log service for system logging
+ */
+export const setupElectronLogService = (): void => {
+  // Set up system logging IPC handler
+  ipcMain.on('system-log', (_event, { level, message }) => {
+    switch (level) {
+      case 'error':
+        logger.error(message)
+        break
+      case 'warn':
+        logger.warn(message)
+        break
+      case 'info':
+        logger.info(message)
+        break
+      case 'debug':
+        logger.debug(message)
+        break
+      case 'trace':
+        logger.verbose(message) // electron-log uses verbose instead of trace
+        break
+      case 'log':
+      default:
+        logger.log(message)
+        break
+    }
+  })
+}

--- a/src/electron/services/electron-log.ts
+++ b/src/electron/services/electron-log.ts
@@ -1,6 +1,34 @@
 import { format } from 'date-fns'
-import { ipcMain } from 'electron'
+import { app, ipcMain } from 'electron'
 import logger from 'electron-log'
+import { readdir, readFile, stat, unlink } from 'fs/promises'
+import { join } from 'path'
+
+import { type ElectronLog } from '@/types/electron-general'
+
+// Import the same date format used in system-logging.ts
+const systemLogDateFormat = 'LLL dd, yyyy'
+const systemLogTimeFormat = 'HH꞉mm꞉ss O'
+const systemLogDateTimeFormat = `${systemLogDateFormat} - ${systemLogTimeFormat}`
+
+/**
+ * Get the electron log file path based on the platform
+ * @returns {string} The path to the electron log file
+ */
+const getElectronLogsPath = (): string => {
+  const appName = app.getName()
+
+  switch (process.platform) {
+    case 'win32':
+      return join(app.getPath('appData'), appName, 'logs')
+    case 'darwin':
+      return join(app.getPath('logs'))
+    case 'linux':
+      return join(app.getPath('logs'))
+    default:
+      return join(app.getPath('logs'))
+  }
+}
 
 /**
  * Setup electron-log service for system logging
@@ -11,6 +39,90 @@ export const setupElectronLogService = (): void => {
   logger.transports.file.format = '[{y}-{m}-{d} {h}:{i}:{s}.{ms}] [{level}] {text}'
   logger.transports.file.maxSize = 10 * 1024 * 1024 // 10MB max file size
   logger.transports.file.archiveLog = (file) => file + '.old' // Archive old logs
+
+  // Get all electron logs
+  ipcMain.handle('get-electron-logs', async (): Promise<ElectronLog[]> => {
+    try {
+      const logFiles = await readdir(getElectronLogsPath())
+      const syslogFiles = logFiles.filter((file) => file.endsWith('.syslog') || file.endsWith('.syslog.old'))
+
+      return await Promise.all(
+        syslogFiles.map(async (logFile) => {
+          const logContent = await readFile(join(getElectronLogsPath(), logFile), 'utf-8')
+
+          // Extract date and time from filename
+          const match = logFile.match(/Cockpit \((.+?)\)\.syslog/)
+          let initialDate = format(new Date(), systemLogDateFormat)
+          let initialTime = format(new Date(), systemLogTimeFormat)
+          if (match) {
+            const dateTimeString = match[1]
+            const parts = dateTimeString.split(' - ')
+            if (parts.length >= 2) {
+              initialDate = parts[0]
+              initialTime = parts[1]
+            }
+          }
+
+          return {
+            content: logContent,
+            path: logFile,
+            initialTime,
+            initialDate,
+          }
+        })
+      )
+    } catch (error) {
+      throw new Error(`Failed to read electron logs. ${error}`)
+    }
+  })
+
+  // Get specific electron log content
+  ipcMain.handle('get-electron-log-content', async (_event, logName: string): Promise<string> => {
+    try {
+      const logPath = join(getElectronLogsPath(), logName)
+      return await readFile(logPath, 'utf-8')
+    } catch (error) {
+      throw new Error(`Failed to read electron log ${logName}. ${error}`)
+    }
+  })
+
+  // Delete specific electron log
+  ipcMain.handle('delete-electron-log', async (_event, logName: string): Promise<boolean> => {
+    try {
+      const logPath = join(getElectronLogsPath(), logName)
+      await unlink(logPath)
+      return true
+    } catch (error) {
+      throw new Error(`Failed to delete electron log ${logName}. ${error}`)
+    }
+  })
+
+  // Delete old electron logs
+  ipcMain.handle('delete-old-electron-logs', async (): Promise<string[]> => {
+    try {
+      const logFiles = await readdir(getElectronLogsPath())
+      const syslogFiles = logFiles.filter((file) => file.endsWith('.syslog') || file.endsWith('.syslog.old'))
+
+      const yesterday = new Date()
+      yesterday.setDate(yesterday.getDate() - 1)
+
+      const deletedFiles: string[] = []
+
+      for (const file of syslogFiles) {
+        const filePath = join(getElectronLogsPath(), file)
+        const stats = await stat(filePath)
+
+        if (stats.mtime < yesterday) {
+          await unlink(filePath)
+          deletedFiles.push(file)
+        }
+      }
+
+      return deletedFiles
+    } catch (error) {
+      throw new Error(`Failed to delete old electron logs. ${error}`)
+    }
+  })
 
   // Set up system logging IPC handler
   ipcMain.on('system-log', (_event, { level, message }) => {

--- a/src/electron/services/electron-log.ts
+++ b/src/electron/services/electron-log.ts
@@ -1,3 +1,4 @@
+import { format } from 'date-fns'
 import { ipcMain } from 'electron'
 import logger from 'electron-log'
 
@@ -5,6 +6,12 @@ import logger from 'electron-log'
  * Setup electron-log service for system logging
  */
 export const setupElectronLogService = (): void => {
+  // Configure file transport to create a new log file for each session
+  logger.transports.file.fileName = `Cockpit (${format(new Date(), systemLogDateTimeFormat)}).syslog`
+  logger.transports.file.format = '[{y}-{m}-{d} {h}:{i}:{s}.{ms}] [{level}] {text}'
+  logger.transports.file.maxSize = 10 * 1024 * 1024 // 10MB max file size
+  logger.transports.file.archiveLog = (file) => file + '.old' // Archive old logs
+
   // Set up system logging IPC handler
   ipcMain.on('system-log', (_event, { level, message }) => {
     switch (level) {

--- a/src/electron/services/electron-log.ts
+++ b/src/electron/services/electron-log.ts
@@ -59,16 +59,11 @@ export const setupElectronLogService = (): void => {
     debug: (...args: any[]) => originalLoggerFunctions.debug(tagLog(...args)),
   }
 
-  // If the app is packaged, push logs to the system instead of the console
-  if (app.isPackaged) {
-    Object.assign(console, taggedLoggerFunctions)
+  // Override console functions to add [Main] tag for native Electron logs
+  Object.assign(console, taggedLoggerFunctions)
 
-    // Log Electron low-level events
-    logger.eventLogger.startLogging()
-  } else {
-    // In development, still redirect console to logger for consistent tagging
-    Object.assign(console, logger.functions)
-  }
+  // Log Electron low-level events
+  logger.eventLogger.startLogging()
 
   // Get all electron logs
   ipcMain.handle('get-electron-logs', async (): Promise<ElectronLog[]> => {

--- a/src/libs/cosmos.ts
+++ b/src/libs/cosmos.ts
@@ -300,6 +300,12 @@ declare global {
        * Register callback for serial data events
        */
       onSerialData: (callback: (data: SerialData) => void) => void
+      /**
+       * Send a log message to electron-log
+       * @param level - The log level (error, warn, info, debug, trace, log)
+       * @param message - The message to log
+       */
+      systemLog: (level: string, message: string) => void
     }
   }
 }

--- a/src/libs/cosmos.ts
+++ b/src/libs/cosmos.ts
@@ -1,5 +1,6 @@
 import { isBrowser } from 'browser-or-node'
 
+import { type ElectronLog } from '@/types/electron-general'
 import { ElectronStorageDB } from '@/types/general'
 import type { ElectronSDLJoystickControllerStateEventData } from '@/types/joystick'
 import { NetworkInfo } from '@/types/network'
@@ -306,6 +307,24 @@ declare global {
        * @param message - The message to log
        */
       systemLog: (level: string, message: string) => void
+      /**
+       * Get a list of all electron logs
+       */
+      getElectronLogs: () => Promise<ElectronLog[]>
+      /**
+       * Get specific electron log content
+       * @param logName - The name of the log file
+       */
+      getElectronLogContent: (logName: string) => Promise<string>
+      /**
+       * Delete a specific electron log
+       * @param logName - The name of the log file to delete
+       */
+      deleteElectronLog: (logName: string) => Promise<boolean>
+      /**
+       * Delete old electron logs (older than 1 day)
+       */
+      deleteOldElectronLogs: () => Promise<string[]>
     }
   }
 }

--- a/src/libs/system-logging.ts
+++ b/src/libs/system-logging.ts
@@ -87,7 +87,11 @@ if (enableSystemLogging === 'true') {
       o.forEach((m) => {
         let msg = m
         try {
-          msg = m.toString()
+          if (typeof m === 'object' && m !== null) {
+            msg = JSON.stringify(m)
+          } else {
+            msg = m.toString()
+          }
         } catch {
           msg = ''
         }

--- a/src/types/electron-general.ts
+++ b/src/types/electron-general.ts
@@ -1,0 +1,21 @@
+/**
+ * Interface for the electron log
+ */
+export interface ElectronLog {
+  /**
+   * The log file content
+   */
+  content: string
+  /**
+   * The path to the log file
+   */
+  path: string
+  /**
+   * The initial time when logging started
+   */
+  initialTime: string
+  /**
+   * The initial date when logging started
+   */
+  initialDate: string
+}


### PR DESCRIPTION
I'm opening this one in favor of #1967. I saw that the whole "electron log" vs "cockpit internal log" was causing a lot of confusion, so I decided to go for a more long-term solution.

## Behavior change
This patch merges the Cockpit Internal logs with the Electron logs into a single file, using the same naming as the former Cockpit ones, and uses the same table as we have today to allow the user to download or delete those.

## Tests Required to Merge (by dev and/or testers)
- [x] Install one of the binary artifacts generated on this PR (it's needed since the logs files are only generated in production)
- [ ] Open Cockpit and wait some seconds or perform any actions
- [ ] Open the Dev menu
- [ ] Download one of the logs there
- [ ] Reopen Cockpit and delete the previous log

Fixes #1891.

