### PR TITLE
flatpak: Add missing filesystem permissions to fix video persistence and access

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
         "--device=all",
         "--socket=pulseaudio",
         "--filesystem=/run/udev:ro",
+        "--filesystem=~/Cockpit:create",
         "--share=network",
         "--talk-name=org.freedesktop.Notifications"
       ],


### PR DESCRIPTION
## Bug fix
This patch adds the missing permissions for Cockpit to access the filesystem on Flatpak builds.
It specifically adds permission to access the `~/Cockpit` folder, which is is the only one that we use, so we don't have broadly unnecessary filesystem access.

## Tests Required to Merge (by dev and/or testers)
- [x] Install the Flatpak binary on a Linux machine
- [x] Record a video
- [x] Click to open the video folder. The folder should open and the video should be there
- [x] This PR should be tested on Steam Deck, as its a known issue there.

Fixes #1891.