### PR TITLE
src: components: About.vue: update old docs link

### DIFF
--- a/src/components/About.vue
+++ b/src/components/About.vue
@@ -53,7 +53,7 @@
               icon="mdi-file-document-outline"
               size="xs"
               target="_blank"
-              href="https://docs.bluerobotics.com/ardusub-zola/software/control-station/Cockpit-1.0/overview"
+              href="https://blueos.cloud/cockpit/docs"
             />
           </div>
         </div>


### PR DESCRIPTION
Redirects work, but it's preferable to not have too many if it's avoidable.