### PR TITLE
joystick: Fix support for generic SDL joysticks

### DIFF
--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -1,6 +1,6 @@
 import { contextBridge, ipcRenderer } from 'electron'
 
-import type { ElectronSDLControllerStateEventData } from '@/types/joystick'
+import type { ElectronSDLJoystickControllerStateEventData } from '@/types/joystick'
 
 contextBridge.exposeInMainWorld('electronAPI', {
   getInfoOnSubnets: () => ipcRenderer.invoke('get-info-on-subnets'),
@@ -14,8 +14,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('update-not-available', (_event, info) => callback(info)),
   onDownloadProgress: (callback: (info: any) => void) =>
     ipcRenderer.on('download-progress', (_event, info) => callback(info)),
-  onElectronSDLControllerStateChange: (callback: (data: ElectronSDLControllerStateEventData) => void) =>
-    ipcRenderer.on('sdl-controller-state', (_event, data) => callback(data)),
+  onElectronSDLControllerJoystickStateChange: (callback: (data: ElectronSDLJoystickControllerStateEventData) => void) =>
+    ipcRenderer.on('sdl-controller-joystick-state', (_event, data) => callback(data)),
   checkSDLStatus: () => ipcRenderer.invoke('check-sdl-status'),
   downloadUpdate: () => ipcRenderer.send('download-update'),
   installUpdate: () => ipcRenderer.send('install-update'),

--- a/src/libs/cosmos.ts
+++ b/src/libs/cosmos.ts
@@ -1,7 +1,7 @@
 import { isBrowser } from 'browser-or-node'
 
 import { ElectronStorageDB } from '@/types/general'
-import type { ElectronSDLControllerStateEventData } from '@/types/joystick'
+import type { ElectronSDLJoystickControllerStateEventData } from '@/types/joystick'
 import { NetworkInfo } from '@/types/network'
 import { SDLStatus } from '@/types/sdl'
 
@@ -255,7 +255,9 @@ declare global {
       /**
        * Register callback for joystick state updates
        */
-      onElectronSDLControllerStateChange: (callback: (data: ElectronSDLControllerStateEventData) => void) => void
+      onElectronSDLControllerJoystickStateChange: (
+        callback: (data: ElectronSDLJoystickControllerStateEventData) => void
+      ) => void
       /**
        * Check if SDL was loaded successfully
        * @returns Promise with SDL load status

--- a/src/types/joystick.ts
+++ b/src/types/joystick.ts
@@ -1,6 +1,6 @@
 import { JoystickModel } from '@/libs/joystick/manager'
 
-import { SDLControllerState } from './sdl'
+import { SDLControllerState, SDLJoystickState } from './sdl'
 
 /**
  * Available joystick protocols.
@@ -392,7 +392,7 @@ export type JoystickCalibrationOptions = {
 /**
  * Data for the event of a new state of a joystick on the Electron side
  */
-export interface ElectronSDLControllerStateEventData {
+export interface ElectronSDLJoystickControllerStateEventBase {
   /**
    * Joystick device id
    */
@@ -410,10 +410,41 @@ export interface ElectronSDLControllerStateEventData {
    */
   vendorId: string
   /**
-   * Joystick state
+   * Joystick type
+   */
+  type: 'joystick' | 'controller'
+}
+
+/**
+ * Data for the event of a new state of a joystick on the Electron side
+ */
+export interface ElectronSDLControllerStateEventData extends ElectronSDLJoystickControllerStateEventBase {
+  /**
+   * Controller type
+   */
+  type: 'controller'
+  /**
+   * Controller state
    */
   state: SDLControllerState
 }
+
+/**
+ * Data for the event of a new state of a joystick on the Electron side
+ */
+export interface ElectronSDLJoystickStateEventData extends ElectronSDLJoystickControllerStateEventBase {
+  /**
+   * Joystick type
+   */
+  type: 'joystick'
+  /**
+   * Joystick state
+   */
+  state: SDLJoystickState
+}
+
+// eslint-disable-next-line prettier/prettier
+export type ElectronSDLJoystickControllerStateEventData = ElectronSDLControllerStateEventData | ElectronSDLJoystickStateEventData
 
 export type JoystickSdlStandardToGamepadStandard = {
   /**
@@ -480,5 +511,17 @@ export const convertSDLControllerStateToGamepadState = (sdlState: SDLControllerS
       sdlState.axes.leftTrigger,
       sdlState.axes.rightTrigger,
     ],
+  }
+}
+
+/**
+ * Convert SDL joystick state to Gamepad state, using the default mapping for both
+ * @param {SDLJoystickState} sdlState - SDL joystick state
+ * @returns {JoystickState} Gamepad state
+ */
+export const convertSDLJoystickStateToGamepadState = (sdlState: SDLJoystickState): JoystickState => {
+  return {
+    buttons: sdlState.buttons.map((button) => (button ? 1 : 0)),
+    axes: sdlState.axes,
   }
 }

--- a/src/types/sdl.ts
+++ b/src/types/sdl.ts
@@ -1,5 +1,10 @@
 /* eslint-disable jsdoc/require-jsdoc */
 
+export interface SDLJoystickState {
+  buttons: boolean[]
+  axes: number[]
+}
+
 /**
  * SDL joystick instance type
  */
@@ -7,11 +12,18 @@ export interface SDLJoystickInstance {
   /**
    * State of the joystick buttons
    */
-  buttons: number[]
+  buttons: boolean[]
   /**
    * State of the joystick axes
    */
   axes: number[]
+  /**
+   * State of the joystick hats
+   */
+  hats: string[]
+  /**
+   * Number of axes
+   */
   /**
    * Whether the joystick is disabled or not
    */
@@ -209,6 +221,19 @@ export interface SDLStatus {
       deviceId: number
       /**
        * The name of the controller
+       */
+      deviceName: string
+    }
+  >
+  connectedJoysticks: Map<
+    number,
+    {
+      /**
+       * The ID of the joystick
+       */
+      deviceId: number
+      /**
+       * The name of the joystick
        */
       deviceName: string
     }


### PR DESCRIPTION
The changes made here fix the reconnection problems that users on Windows were having with generic joysticks.

It also adds support for ["hats"](https://wiki.libsdl.org/SDL2/SDL_JoystickGetHat) of SDL joysticks, having them appearing as 5 buttons (centered, up, down, left and right).

Opening as draft as I'm waiting for the approval of [the fix](https://github.com/kmamal/node-sdl/pull/79) in the `node-sdl` library, which fixes the problem of not being even able to connect those generic joysticks on macOS (and maybe Linux?).