### PR TITLE
electron: Make local storage persistent between sessions (on macOS)

### DIFF
--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -14,6 +14,11 @@ import { setupWorkspaceService } from './services/workspace'
 // Setup the logger service as soon as possible to avoid different behaviors across runtime
 setupElectronLogService()
 
+// Ensure consistent userData directory for localStorage persistence
+if (process.env.NODE_ENV === 'development') {
+  app.setPath('userData', join(app.getPath('userData'), 'dev'))
+}
+
 export const ROOT_PATH = {
   dist: join(__dirname, '..'),
 }
@@ -30,6 +35,8 @@ function createWindow(): void {
       preload: join(ROOT_PATH.dist, 'electron/preload.js'),
       contextIsolation: true,
       nodeIntegration: false,
+      // Add partition to ensure localStorage persistence
+      partition: 'persist:cockpit',
     },
     autoHideMenuBar: true,
     width: store.get('windowBounds')?.width ?? screen.getPrimaryDisplay().workAreaSize.width,


### PR DESCRIPTION
This bug was confirmed on macOS. ~It's not yet clear if it happens on other OSs as well.~ @ArturoManzoli confirmed the bug is not present on Linux, so it makes more sense that it wasn't reported yet.

## Steps to reproduce

1. Open current master of Cockpit
2. Open the dev tools
3. Run `window.localStorage.setItem('coco', 'xixi')` in the console
4. Run `window.localStorage.getItem('coco') in the console. You should see"xixi" there.
5. Close Cockpit
6. Open Cockpit and run `window.localStorage.getItem('coco')` again in the console. You should see `null` there.
7. Perform steps 1-6 with the version from this PR. You should see "xixi" on step 6.

Fix #2010.