### PR TITLE
username-dialog: Show save button when there are no users registered

### DIFF
--- a/src/components/UserNameInputDialog.vue
+++ b/src/components/UserNameInputDialog.vue
@@ -4,7 +4,7 @@
     persistent
     :show-dialog="showUserDialog"
     :title="`Manage users on: ${currentVehicleName}`"
-    :actions="showNewUsernamePrompt ? inputDialogActions : regularDialogActions"
+    :actions="showNewUsernamePrompt || isUsernamesEmpty ? inputDialogActions : regularDialogActions"
     :max-width="700"
   >
     <template #content>


### PR DESCRIPTION
Before:
<img width="813" height="425" alt="image" src="https://github.com/user-attachments/assets/c51ddb8c-7d6a-4070-8c83-f93cfc747856" />


After:
<img width="789" height="437" alt="image" src="https://github.com/user-attachments/assets/ed3c5a0e-0f34-41d8-9f8e-27793ede70a0" />

Fix #2012 