### PR TITLE
Ardupilot: make sure mission altitudes are numerical values

### DIFF
--- a/src/libs/vehicle/ardupilot/types.ts
+++ b/src/libs/vehicle/ardupilot/types.ts
@@ -55,7 +55,7 @@ export const convertCockpitWaypointsToMavlink = (
       param4: 999,
       x: round(cockpitWaypoint.coordinates[0] * Math.pow(10, 7)),
       y: round(cockpitWaypoint.coordinates[1] * Math.pow(10, 7)),
-      z: cockpitWaypoint.altitude,
+      z: Number(cockpitWaypoint.altitude),
       mission_type: { type: MavMissionType.MAV_MISSION_TYPE_MISSION },
     }
   })


### PR DESCRIPTION
before this patch I could not upload missions with negative altitude:

```
"header":{
      "system_id":255,
      "component_id":240,
      "sequence":0
   },
   "message":{
      "target_system":1,
      "target_component":1,
      "type":"MISSION_ITEM_INT",
      "seq":2,
      "frame":{
         "type":"MAV_FRAME_GLOBAL_RELATIVE_ALT_INT"
      },
      "command":{
         "type":"MAV_CMD_NAV_WAYPOINT"
      },
      "current":0,
      "autocontinue":1,
      "param1":0,
      "param2":5,
      "param3":0,
      "param4":999,
      "x":-274905443,
      "y":-485299512,
      "z":"-0.1",
      "mission_type":{
         "type":"MAV_MISSION_TYPE_MISSION"
      }
   }
}
```