### PR TITLE
diy-widget: Allow inheriting from the Cockpit interface styles

### DIFF
--- a/src/components/widgets/DoItYourself.vue
+++ b/src/components/widgets/DoItYourself.vue
@@ -19,7 +19,7 @@
         <v-icon class="absolute top-[12px] right-[12px] cursor-pointer" @click="showHelp = !showHelp">
           mdi-help-circle-outline
         </v-icon>
-        <v-card-title class="w-full text-center mt-2 mb-2">DIY widget configuration</v-card-title>
+        <v-card-title class="w-full text-center mt-2">DIY widget configuration</v-card-title>
         <v-card-text class="mx-2 flex flex-col gap-y-3">
           <v-expand-transition>
             <div v-if="showHelp" class="help-panel mb-4 p-4 rounded bg-white/5">
@@ -42,21 +42,21 @@
 
           <v-expansion-panels v-model="expandedPanel" class="editors-container" multiple>
             <v-expansion-panel value="html">
-              <v-expansion-panel-title static height="36px" class="text-white/60"> HTML </v-expansion-panel-title>
+              <v-expansion-panel-title static height="30px" class="text-white/60"> HTML </v-expansion-panel-title>
               <v-expansion-panel-text eager>
                 <div ref="htmlEditorContainer" class="editor-container" :style="{ height: editorHeight }" />
               </v-expansion-panel-text>
             </v-expansion-panel>
 
             <v-expansion-panel value="js">
-              <v-expansion-panel-title static height="36px" class="text-white/60"> JS </v-expansion-panel-title>
+              <v-expansion-panel-title static height="30px" class="text-white/60"> JS </v-expansion-panel-title>
               <v-expansion-panel-text eager>
                 <div ref="jsEditorContainer" class="editor-container" :style="{ height: editorHeight }" />
               </v-expansion-panel-text>
             </v-expansion-panel>
 
             <v-expansion-panel value="css">
-              <v-expansion-panel-title static height="36px" class="text-white/60"> CSS </v-expansion-panel-title>
+              <v-expansion-panel-title static height="30px" class="text-white/60"> CSS </v-expansion-panel-title>
               <v-expansion-panel-text eager>
                 <div ref="cssEditorContainer" class="editor-container" :style="{ height: editorHeight }" />
               </v-expansion-panel-text>
@@ -65,8 +65,9 @@
           <v-checkbox
             v-model="widget.options.inheritCockpitStyles"
             label="Inherit Cockpit interface styles"
-            class="mt-2"
             density="compact"
+            class="-mb-2"
+            hide-details
           />
         </v-card-text>
         <v-card-actions>

--- a/src/components/widgets/DoItYourself.vue
+++ b/src/components/widgets/DoItYourself.vue
@@ -1,7 +1,11 @@
 <!-- eslint-disable vue/no-v-html -->
 <template>
   <div class="main">
-    <div class="w-full h-full" v-html="compiledCode" />
+    <div
+      class="w-full h-full"
+      :style="widget.options.inheritCockpitStyles ? interfaceStore.globalGlassMenuStyles : {}"
+      v-html="compiledCode"
+    />
   </div>
   <v-dialog
     v-model="widgetStore.widgetManagerVars(widget.hash).configMenuOpen"
@@ -58,6 +62,12 @@
               </v-expansion-panel-text>
             </v-expansion-panel>
           </v-expansion-panels>
+          <v-checkbox
+            v-model="widget.options.inheritCockpitStyles"
+            label="Inherit Cockpit interface styles"
+            class="mt-2"
+            density="compact"
+          />
         </v-card-text>
         <v-card-actions>
           <div class="flex justify-between items-center px-4 w-full h-full">
@@ -143,7 +153,6 @@ const defaultOptions = {
   width: 100%;
   height: 100%;
   padding: 1rem;
-  background-color: white;
   border-radius: 10px;
   display: flex;
   align-items: center;
@@ -157,6 +166,7 @@ const defaultOptions = {
 document.addEventListener('DOMContentLoaded', () => {
   // Your code here
 });`,
+  inheritCockpitStyles: true,
 }
 
 /* eslint-disable no-useless-escape */
@@ -291,6 +301,7 @@ const exportConfig = (): void => {
     html: htmlEditor.getValue(),
     css: cssEditor.getValue(),
     js: jsEditor.getValue(),
+    inheritCockpitStyles: widget.value.options.inheritCockpitStyles || false,
   }
 
   // Create file content as JSON string
@@ -342,6 +353,9 @@ const importConfig = (): void => {
         if (htmlEditor) htmlEditor.setValue(config.html)
         if (cssEditor) cssEditor.setValue(config.css)
         if (jsEditor) jsEditor.setValue(config.js)
+
+        // Update the inheritCockpitStyles option if present (defaults to false for backwards compatibility)
+        widget.value.options.inheritCockpitStyles = config.inheritCockpitStyles || false
 
         // Apply changes
         applyChanges()


### PR DESCRIPTION
Idea came from [a question in our discord channel](https://discord.com/channels/1135646343776456765/1136408531122274344/1402294749620338839).

With this, the user can have it's DIY widget in the same style as the rest of the application.
 
https://github.com/user-attachments/assets/75e4b927-f49a-42c9-af31-1301324b98c6

