### PR TITLE
custom-actions: fix MAVLink Message Action independence

### DIFF
--- a/src/components/configuration/MavlinkMessageActionConfig.vue
+++ b/src/components/configuration/MavlinkMessageActionConfig.vue
@@ -144,7 +144,8 @@ const resetActionConfig = (messageType: MAVLinkType = defaultMessageType): void 
 }
 
 const resetNewAction = (): void => {
-  newActionConfig.value = { ...defaultActionConfig }
+  // Deep copy, to avoid sharing config between Actions
+  newActionConfig.value = structuredClone(defaultActionConfig)
 }
 
 const createActionConfig = (): void => {


### PR DESCRIPTION
Moved to a deep copy, to avoid maintaining configuration between Action definitions.

I'm slightly sad about this, because it loses the current convenience of the last adjustment of the message type being maintained during the session (which is nice when defining multiple similar Actions), but maintaining that behaviour in a non-broken way requires a lot of nuance and detailed copying, which would be much harder to understand and maintain than a straight deep copy of the defaults for the reset.

Fixes #2042, and the "reset" button functionality when creating a custom MAVLink message Action.