### PR TITLE
data-lake table: treat non-persistent user vars correctly

### DIFF
--- a/src/views/ToolsDataLakeView.vue
+++ b/src/views/ToolsDataLakeView.vue
@@ -382,7 +382,7 @@ const isCompoundVariable = (id: string): boolean => {
 }
 
 const isUserDefinedVariable = (id: string): boolean => {
-  return availableDataLakeVariables.value.find((v) => v.id === id)?.persistent ?? false
+  return availableDataLakeVariables.value.find((v) => v.id === id)?.persistent != null
 }
 
 const editCompoundVariable = (id: string): void => {


### PR DESCRIPTION
Considers variables with the persistent field defined to be "User variables", which allows editing their definition and deleting them. The previous approach used null-coalescing, which meant a false value for persistence was spuriously treated as an internal variable instead of a user-defined one.

Fixes #1975