### PR TITLE
Add initial support for command waypoints

### DIFF
--- a/src/components/mission-planning/CommandInputForm.vue
+++ b/src/components/mission-planning/CommandInputForm.vue
@@ -1,0 +1,273 @@
+<template>
+  <div class="command-form">
+    <div class="flex flex-col px-3 my-2 bg-[#EEEEEE22] text-white rounded-md">
+      <!-- Command Type Selection -->
+      <div class="flex flex-col w-full justify-between items-center text-[12px] border-b border-white/10 py-2">
+        <p class="w-full text-center">Type</p>
+        <v-select
+          v-model="selectedCommandType"
+          :items="commandTypeOptions"
+          item-title="name"
+          item-value="value"
+          hide-details
+          class="spaced-number w-full"
+          density="compact"
+          theme="dark"
+          variant="plain"
+          @update:model-value="onCommandTypeChange"
+        ></v-select>
+      </div>
+
+      <!-- MAVLink Command Selection -->
+      <div v-if="selectedCommandType" class="flex flex-col w-full justify-between items-center text-[12px] py-2">
+        <p class="w-full text-center">Command</p>
+        <v-select
+          v-model="selectedMavCommand"
+          :items="availableMavCommands"
+          item-title="name"
+          item-value="value"
+          hide-details
+          class="spaced-number w-full"
+          density="compact"
+          theme="dark"
+          variant="plain"
+          @update:model-value="onMavCommandChange"
+        ></v-select>
+      </div>
+
+      <!-- Parameter Inputs -->
+      <div v-if="selectedMavCommand" class="flex flex-col">
+        <v-divider class="border-black w-full" />
+        <div class="text-[11px] font-semibold text-center py-2">Parameters</div>
+
+        <!-- Nav Command Parameters (4 params) -->
+        <template v-if="selectedCommandType === MissionCommandType.MAVLINK_NAV_COMMAND">
+          <div
+            v-for="paramNum in 4"
+            :key="paramNum"
+            class="flex w-full gap-x-4 justify-between items-center text-[11px]"
+            :class="{ 'border-b border-white/10': paramNum < 4 }"
+          >
+            <p class="w-[80px] text-start opacity-75">Param {{ paramNum }}:</p>
+            <div class="flex w-full pr-2 h-[28px] items-center">
+              <v-text-field
+                v-model.number="commandParams[`param${paramNum}`]"
+                type="number"
+                step="any"
+                density="compact"
+                variant="plain"
+                hide-details
+                class="spaced-number right-aligned-input w-[100px] text-right -mr-3"
+              ></v-text-field>
+            </div>
+          </div>
+        </template>
+
+        <!-- Non-Nav Command Parameters (7 params) -->
+        <template v-if="selectedCommandType === MissionCommandType.MAVLINK_NON_NAV_COMMAND">
+          <div
+            v-for="paramNum in 7"
+            :key="paramNum"
+            class="flex w-full gap-x-4 justify-between items-center text-[11px] py-1"
+            :class="{ 'border-b border-white/10': paramNum < 7 }"
+          >
+            <p class="w-[120px] text-start opacity-75">
+              Param {{ paramNum }} {{ paramNum === 5 ? '(x)' : paramNum === 6 ? '(y)' : paramNum === 7 ? '(z)' : '' }}:
+            </p>
+            <div class="flex w-full pr-2 h-[28px] items-center">
+              <v-text-field
+                v-model.number="
+                  commandParams[paramNum <= 4 ? `param${paramNum}` : paramNum === 5 ? 'x' : paramNum === 6 ? 'y' : 'z']
+                "
+                type="number"
+                step="any"
+                density="compact"
+                variant="plain"
+                hide-details
+                class="spaced-number right-aligned-input w-[100px] text-right -mr-3"
+              ></v-text-field>
+            </div>
+          </div>
+        </template>
+      </div>
+
+      <!-- Action Buttons -->
+      <div class="flex w-full justify-between py-2">
+        <v-btn size="small" variant="outlined" @click="cancelCommand"> Cancel </v-btn>
+        <v-btn v-if="selectedMavCommand" size="small" variant="outlined" @click="addCommand">
+          {{ isEditing ? 'Update' : 'Add' }}
+        </v-btn>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, ref, watch } from 'vue'
+
+import { MavCmd } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
+import { MissionCommand, MissionCommandType } from '@/types/mission'
+
+const props = defineProps<{
+  /**
+   * Existing command to edit (optional)
+   */
+  existingCommand?: MissionCommand
+  /**
+   * Whether this is an edit operation
+   */
+  isEditing?: boolean
+}>()
+
+const emit = defineEmits<{
+  (event: 'commandReady', command: MissionCommand): void
+  (event: 'cancel'): void
+}>()
+
+const selectedCommandType = ref<MissionCommandType | null>(null)
+const selectedMavCommand = ref<MavCmd | null>(null)
+
+const commandParams = reactive<Record<string, number>>({
+  param1: 0,
+  param2: 0,
+  param3: 0,
+  param4: 0,
+  x: 0,
+  y: 0,
+  z: 0,
+})
+
+const commandTypeOptions = [
+  { name: 'MAVLink Navigation Command', value: MissionCommandType.MAVLINK_NAV_COMMAND },
+  { name: 'MAVLink Non-Navigation Command', value: MissionCommandType.MAVLINK_NON_NAV_COMMAND },
+]
+
+// Helper function to convert MAV_CMD enum to display name
+const formatCommandName = (command: string): string => {
+  return command.replace('MAV_CMD_', '').replace('NAV_', ' ')
+}
+
+// Generate command options from MavCmd enum
+const allNavCommands = computed(() => {
+  return Object.values(MavCmd)
+    .filter((cmd) => cmd.startsWith('MAV_CMD_NAV_'))
+    .map((cmd) => ({
+      name: formatCommandName(cmd),
+      value: cmd,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+})
+
+const allNonNavCommands = computed(() => {
+  return Object.values(MavCmd)
+    .filter((cmd) => cmd.startsWith('MAV_CMD_') && !cmd.startsWith('MAV_CMD_NAV_'))
+    .map((cmd) => ({
+      name: formatCommandName(cmd),
+      value: cmd,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+})
+
+const availableMavCommands = computed(() => {
+  if (selectedCommandType.value === MissionCommandType.MAVLINK_NAV_COMMAND) {
+    return allNavCommands.value
+  } else if (selectedCommandType.value === MissionCommandType.MAVLINK_NON_NAV_COMMAND) {
+    return allNonNavCommands.value
+  }
+  return []
+})
+
+const onCommandTypeChange = (): void => {
+  selectedMavCommand.value = null
+  resetParams()
+}
+
+const onMavCommandChange = (): void => {
+  resetParams()
+}
+
+const resetParams = (): void => {
+  Object.keys(commandParams).forEach((key) => {
+    commandParams[key] = 0
+  })
+}
+
+const addCommand = (): void => {
+  if (!selectedCommandType.value || !selectedMavCommand.value) return
+
+  const command: MissionCommand =
+    selectedCommandType.value === MissionCommandType.MAVLINK_NAV_COMMAND
+      ? {
+          type: MissionCommandType.MAVLINK_NAV_COMMAND,
+          command: selectedMavCommand.value,
+          param1: commandParams.param1,
+          param2: commandParams.param2,
+          param3: commandParams.param3,
+          param4: commandParams.param4,
+        }
+      : {
+          type: MissionCommandType.MAVLINK_NON_NAV_COMMAND,
+          command: selectedMavCommand.value,
+          param1: commandParams.param1,
+          param2: commandParams.param2,
+          param3: commandParams.param3,
+          param4: commandParams.param4,
+          x: commandParams.x,
+          y: commandParams.y,
+          z: commandParams.z,
+        }
+
+  emit('commandReady', command)
+  resetForm()
+}
+
+const cancelCommand = (): void => {
+  emit('cancel')
+  resetForm()
+}
+
+const resetForm = (): void => {
+  selectedCommandType.value = null
+  selectedMavCommand.value = null
+  resetParams()
+}
+
+// Initialize form with existing command if editing
+watch(
+  () => props.existingCommand,
+  (command) => {
+    if (command && props.isEditing) {
+      selectedCommandType.value = command.type
+      selectedMavCommand.value = command.command
+      commandParams.param1 = command.param1
+      commandParams.param2 = command.param2
+      commandParams.param3 = command.param3
+      commandParams.param4 = command.param4
+
+      if (command.type === MissionCommandType.MAVLINK_NON_NAV_COMMAND) {
+        commandParams.x = command.x
+        commandParams.y = command.y
+        commandParams.z = command.z
+      }
+    }
+  },
+  { immediate: true }
+)
+</script>
+
+<style scoped>
+.right-aligned-input input {
+  text-align: right !important;
+  padding-right: 10px !important;
+  font-size: 12px !important;
+}
+
+.v-field {
+  font-size: 14px !important;
+  text-align: right !important;
+}
+
+.spaced-number input[type='number']::-webkit-inner-spin-button {
+  margin-left: 6px;
+}
+</style>

--- a/src/components/mission-planning/WaypointConfigPanel.vue
+++ b/src/components/mission-planning/WaypointConfigPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="main-panel flex flex-col h-full" :style="interfaceStore.globalGlassMenuStyles">
+  <div class="flex flex-col h-full w-full justify-start" :style="interfaceStore.globalGlassMenuStyles">
     <ExpansiblePanel
       mark-expanded
       compact
@@ -10,19 +10,14 @@
       :is-expanded="true"
     >
       <template #title>
-        <p class="ml-4 text-center text-[13px] font-normal">
-          {{
-            selectedWaypoint.id === 'home'
-              ? 'Home'
-              : `Waypoint  ${missionStore.getWaypointNumber(selectedWaypoint?.id as string)}
-          parameters`
-          }}
+        <p class="ml-10 text-center text-[13px] font-normal">
+          {{ selectedWaypoint.id === 'home' ? 'Home' : `Waypoint  parameters` }}
         </p>
       </template>
       <template #content>
         <div
           v-if="waypointOnMissionStore?.coordinates"
-          class="flex flex-col justify-center w-full items-center py-1 px-2 mb-2 bg-[#EEEEEE22] text-white rounded-bl-md rounded-br-md"
+          class="flex flex-col justify-center w-full items-center py-1 px-2 my-2 bg-[#EEEEEE22] text-white rounded-bl-md rounded-br-md"
         >
           <div class="flex w-full gap-x-4 my-[4px] justify-between text-[12px] text-center mb-[2px]">
             <p class="w-[50px] text-start">Latitude:</p>
@@ -68,7 +63,7 @@
               item-value="value"
               hide-details
               attach
-              class="mb-2 spaced-number right-aligned-input"
+              class="spaced-number right-aligned-input"
               density="compact"
               theme="dark"
               variant="plain"
@@ -77,24 +72,122 @@
         </div>
       </template>
     </ExpansiblePanel>
-    <v-btn
-      class="absolute bg-[#00000066] text-white bottom-2 right-2"
-      variant="plain"
-      size="small"
-      prepend-icon="mdi-delete"
-      @click="handleRemoveWaypoint(selectedWaypoint)"
+
+    <!-- Commands Section -->
+    <ExpansiblePanel
+      mark-expanded
+      compact
+      elevation-effect
+      no-bottom-divider
+      darken-content
+      invert-chevron
+      :is-expanded="true"
+      class="flex-1 min-h-0"
     >
-      Delete
-    </v-btn>
+      <template #title>
+        <p class="ml-4 text-center text-[13px] font-normal">
+          Waypoint Commands ({{ waypointOnMissionStore?.commands?.length || 0 }})
+        </p>
+      </template>
+      <template #content>
+        <div class="flex flex-col h-full -mr-2 pr-1 overflow-y-scroll">
+          <!-- Existing Commands -->
+          <div v-if="waypointOnMissionStore?.commands?.length" class="flex flex-col gap-2 my-2">
+            <div
+              v-for="(command, index) in waypointOnMissionStore.commands"
+              :key="index"
+              class="flex flex-col p-2 bg-[#EEEEEE22] text-white rounded-md"
+            >
+              <div class="flex justify-between items-center">
+                <div class="flex flex-col gap-1 max-w-[80%]">
+                  <p class="text-[11px] font-semibold overflow-hidden text-ellipsis whitespace-nowrap">
+                    {{ command.command }}
+                  </p>
+                  <p class="text-[10px] opacity-75 overflow-hidden text-ellipsis whitespace-nowrap">
+                    {{ command.type }}
+                  </p>
+                  <div class="text-[10px] grid grid-cols-2 gap-1">
+                    <span v-if="command.type === MissionCommandType.MAVLINK_NAV_COMMAND">
+                      P1: {{ command.param1 }} | P2: {{ command.param2 }}<br />
+                      P3: {{ command.param3 }} | P4: {{ command.param4 }}
+                    </span>
+                    <span v-else-if="command.type === MissionCommandType.MAVLINK_NON_NAV_COMMAND">
+                      P1: {{ command.param1 }} | P2: {{ command.param2 }} | P3: {{ command.param3 }}<br />
+                      P4: {{ command.param4 }} | P5: {{ command.x }} | P6: {{ command.y }} | P7: {{ command.z }}
+                    </span>
+                  </div>
+                </div>
+                <div class="flex flex-col gap-3">
+                  <v-btn
+                    size="x-small"
+                    variant="outlined"
+                    icon="mdi-pencil"
+                    class="!h-[24px] !w-[24px] !min-w-[24px]"
+                    @click="editCommand(index)"
+                  />
+                  <v-btn
+                    size="x-small"
+                    variant="outlined"
+                    icon="mdi-delete"
+                    class="!h-[24px] !w-[24px] !min-w-[24px]"
+                    @click="removeCommand(index)"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Add New Command Button -->
+          <v-btn
+            v-if="!showCommandForm"
+            class="w-full mb-2 bg-[#62626266] text-white"
+            variant="plain"
+            size="small"
+            prepend-icon="mdi-plus"
+            @click="showCommandForm = true"
+          >
+            Append New Command
+          </v-btn>
+
+          <!-- Command Input Form -->
+          <CommandInputForm
+            v-if="showCommandForm"
+            :existing-command="editingCommand"
+            :is-editing="editingCommandIndex !== -1"
+            @command-ready="handleCommandReady"
+            @cancel="handleCommandCancel"
+          />
+        </div>
+      </template>
+    </ExpansiblePanel>
+
+    <div class="flex flex-col mt-auto">
+      <v-btn
+        class="bg-[#00000066] text-white mt-2 mb-1 mx-1"
+        variant="plain"
+        size="small"
+        prepend-icon="mdi-delete"
+        @click="handleRemoveWaypoint(selectedWaypoint)"
+      >
+        Delete waypoint
+      </v-btn>
+    </div>
   </div>
 </template>
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 
 import ExpansiblePanel from '@/components/ExpansiblePanel.vue'
+import CommandInputForm from '@/components/mission-planning/CommandInputForm.vue'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMissionStore } from '@/stores/mission'
-import { AltitudeReferenceType, Waypoint, WaypointCoordinates } from '@/types/mission'
+import {
+  AltitudeReferenceType,
+  MissionCommand,
+  MissionCommandType,
+  Waypoint,
+  WaypointCoordinates,
+} from '@/types/mission'
 
 const interfaceStore = useAppInterfaceStore()
 const missionStore = useMissionStore()
@@ -108,6 +201,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (event: 'removeWaypoint', waypoint: Waypoint): void
+  (event: 'shouldUpdateWaypoints'): void
 }>()
 
 const selectedWaypoint = ref(props.selectedWaypoint)
@@ -122,6 +216,11 @@ const editableAltitudeRefType = ref<AltitudeReferenceType>(
   waypointOnMissionStore.value?.altitudeReferenceType || AltitudeReferenceType.RELATIVE_TO_HOME
 )
 
+// Command management variables
+const showCommandForm = ref(false)
+const editingCommand = ref<MissionCommand | undefined>()
+const editingCommandIndex = ref(-1)
+
 watch(editableAltitudeRefType, (newType) => {
   if (waypointOnMissionStore.value) {
     waypointOnMissionStore.value.altitudeReferenceType = newType
@@ -130,6 +229,7 @@ watch(editableAltitudeRefType, (newType) => {
 
 const handleRemoveWaypoint = (waypoint: Waypoint): void => {
   emit('removeWaypoint', waypoint)
+  emit('shouldUpdateWaypoints')
 }
 
 const availableFrames = Object.values(AltitudeReferenceType).map((value: AltitudeReferenceType) => ({
@@ -165,6 +265,7 @@ watch(
     selectedWaypoint.value = newWaypoint
     editableLat.value = newWaypoint.coordinates[0].toString()
     editableLng.value = newWaypoint.coordinates[1].toString()
+    handleCommandCancel()
   }
 )
 
@@ -178,6 +279,35 @@ watch(
     }
   }
 )
+
+const handleCommandReady = (command: MissionCommand): void => {
+  if (editingCommandIndex.value >= 0) {
+    // Update existing command
+    missionStore.updateWaypointCommand(props.selectedWaypoint.id, editingCommandIndex.value, command)
+  } else {
+    // Add new command
+    missionStore.addCommandToWaypoint(props.selectedWaypoint.id, command)
+  }
+  handleCommandCancel()
+}
+
+const handleCommandCancel = (): void => {
+  showCommandForm.value = false
+  editingCommand.value = undefined
+  editingCommandIndex.value = -1
+  emit('shouldUpdateWaypoints')
+}
+
+const editCommand = (index: number): void => {
+  if (!waypointOnMissionStore.value?.commands) return
+  editingCommand.value = waypointOnMissionStore.value.commands[index]
+  editingCommandIndex.value = index
+  showCommandForm.value = true
+}
+
+const removeCommand = (index: number): void => {
+  missionStore.removeCommandFromWaypoint(props.selectedWaypoint.id, index)
+}
 </script>
 <style>
 v-menu__content {

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -1084,6 +1084,11 @@ watch(
   border: 1rem;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   color: black;
+  z-index: 100;
+}
+
+.vehicle-marker {
+  z-index: 200 !important;
 }
 
 .leaflet-control-zoom {

--- a/src/libs/vehicle/mavlink/types.ts
+++ b/src/libs/vehicle/mavlink/types.ts
@@ -4,15 +4,9 @@ import type { MavParamType } from '@/libs/connection/m2r/dialects/ardupilotmega/
 import { type Message } from '@/libs/connection/m2r/messages/mavlink2rest-message'
 import { round } from '@/libs/utils'
 import { AlertLevel } from '@/types/alert'
-import { type Waypoint, AltitudeReferenceType, WaypointType } from '@/types/mission'
+import { type Waypoint, AltitudeReferenceType, MissionCommandType } from '@/types/mission'
 
-import {
-  MavCmd,
-  MavFrame,
-  MAVLinkType,
-  MavMissionType,
-  MavSeverity,
-} from '../../connection/m2r/messages/mavlink2rest-enum'
+import { MavFrame, MAVLinkType, MavMissionType, MavSeverity } from '../../connection/m2r/messages/mavlink2rest-enum'
 import type { VehicleConfigurationSettings } from '../types'
 
 const cockpitMavlinkFrameCorrespondency: [MavFrame, AltitudeReferenceType][] = [
@@ -35,43 +29,92 @@ export const convertCockpitWaypointsToMavlink = (
   cockpitWaypoints: Waypoint[],
   system_id: number
 ): Message.MissionItemInt[] => {
-  return cockpitWaypoints.map((cockpitWaypoint, i) => {
-    return {
-      target_system: system_id,
-      target_component: 1,
-      type: MAVLinkType.MISSION_ITEM_INT,
-      seq: i,
-      frame: {
-        type:
+  const mavlinkWaypoints: Message.MissionItemInt[] = []
+  cockpitWaypoints.forEach((cockpitWaypoint) => {
+    cockpitWaypoint.commands.forEach((waypointCommand) => {
+      if (
+        [MissionCommandType.MAVLINK_NAV_COMMAND, MissionCommandType.MAVLINK_NON_NAV_COMMAND].includes(
+          waypointCommand.type
+        )
+      ) {
+        const frameType =
           mavlinkFrameFromCockpitAltRef(cockpitWaypoint.altitudeReferenceType) ||
-          MavFrame.MAV_FRAME_GLOBAL_RELATIVE_ALT_INT,
-      },
-      command: { type: MavCmd.MAV_CMD_NAV_WAYPOINT },
-      current: 0,
-      autocontinue: 1,
-      param1: 0,
-      param2: 5,
-      param3: 0,
-      param4: 999,
-      x: round(cockpitWaypoint.coordinates[0] * Math.pow(10, 7)),
-      y: round(cockpitWaypoint.coordinates[1] * Math.pow(10, 7)),
-      z: Number(cockpitWaypoint.altitude),
-      mission_type: { type: MavMissionType.MAV_MISSION_TYPE_MISSION },
-    }
+          MavFrame.MAV_FRAME_GLOBAL_RELATIVE_ALT_INT
+        const x =
+          waypointCommand.type === MissionCommandType.MAVLINK_NAV_COMMAND
+            ? round(cockpitWaypoint.coordinates[0] * Math.pow(10, 7))
+            : waypointCommand.x
+        const y =
+          waypointCommand.type === MissionCommandType.MAVLINK_NAV_COMMAND
+            ? round(cockpitWaypoint.coordinates[1] * Math.pow(10, 7))
+            : waypointCommand.y
+        const z =
+          waypointCommand.type === MissionCommandType.MAVLINK_NAV_COMMAND
+            ? Number(cockpitWaypoint.altitude)
+            : waypointCommand.z
+        mavlinkWaypoints.push({
+          target_system: system_id,
+          target_component: 1,
+          type: MAVLinkType.MISSION_ITEM_INT,
+          seq: mavlinkWaypoints.length,
+          frame: { type: frameType },
+          command: { type: waypointCommand.command },
+          current: 0,
+          autocontinue: 1,
+          param1: waypointCommand.param1,
+          param2: waypointCommand.param2,
+          param3: waypointCommand.param3,
+          param4: waypointCommand.param4,
+          x,
+          y,
+          z,
+          mission_type: { type: MavMissionType.MAV_MISSION_TYPE_MISSION },
+        })
+      }
+    })
   })
+
+  return mavlinkWaypoints
 }
 
 export const convertMavlinkWaypointsToCockpit = (mavlinkWaypoints: Message.MissionItemInt[]): Waypoint[] => {
-  return mavlinkWaypoints.map((mavlinkWaypoint) => {
-    return {
-      id: uuid(),
-      coordinates: [mavlinkWaypoint.x / Math.pow(10, 7), mavlinkWaypoint.y / Math.pow(10, 7)],
-      altitude: mavlinkWaypoint.z,
-      altitudeReferenceType:
-        cockpitAltRefFromMavlinkFrame(mavlinkWaypoint.frame.type) || AltitudeReferenceType.RELATIVE_TO_HOME,
-      type: WaypointType.PASS_BY,
+  const cockpitWaypoints: Waypoint[] = []
+  mavlinkWaypoints.forEach((mavlinkWaypoint) => {
+    if (mavlinkWaypoint.command.type.includes('MAV_CMD_NAV')) {
+      const altitudeReferenceType =
+        cockpitAltRefFromMavlinkFrame(mavlinkWaypoint.frame.type) || AltitudeReferenceType.RELATIVE_TO_HOME
+      cockpitWaypoints.push({
+        id: uuid(),
+        coordinates: [mavlinkWaypoint.x / Math.pow(10, 7), mavlinkWaypoint.y / Math.pow(10, 7)],
+        altitude: mavlinkWaypoint.z,
+        altitudeReferenceType,
+        commands: [
+          {
+            type: MissionCommandType.MAVLINK_NAV_COMMAND,
+            command: mavlinkWaypoint.command.type,
+            param1: mavlinkWaypoint.param1,
+            param2: mavlinkWaypoint.param2,
+            param3: mavlinkWaypoint.param3,
+            param4: mavlinkWaypoint.param4,
+          },
+        ],
+      })
+    } else if (cockpitWaypoints.length > 0) {
+      cockpitWaypoints[cockpitWaypoints.length - 1].commands.push({
+        type: MissionCommandType.MAVLINK_NON_NAV_COMMAND,
+        command: mavlinkWaypoint.command.type,
+        param1: mavlinkWaypoint.param1,
+        param2: mavlinkWaypoint.param2,
+        param3: mavlinkWaypoint.param3,
+        param4: mavlinkWaypoint.param4,
+        x: mavlinkWaypoint.x,
+        y: mavlinkWaypoint.y,
+        z: mavlinkWaypoint.z,
+      })
     }
   })
+
+  return cockpitWaypoints
 }
 
 export const alertLevelFromMavSeverity = {

--- a/src/libs/vehicle/mavlink/vehicle.ts
+++ b/src/libs/vehicle/mavlink/vehicle.ts
@@ -1174,7 +1174,13 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
    * Clear mission that is on the vehicle
    */
   async clearMissions(): Promise<void> {
-    await this.uploadMission([])
+    const message: Message.MissionClearAll = {
+      type: MAVLinkType.MISSION_CLEAR_ALL,
+      target_system: this.currentSystemId,
+      target_component: 1,
+      mission_type: { type: MavMissionType.MAV_MISSION_TYPE_MISSION },
+    }
+    sendMavlinkMessage(message)
   }
 
   /**

--- a/src/types/mission.ts
+++ b/src/types/mission.ts
@@ -117,6 +117,10 @@ export type SurveyPolygon = {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const instanceOfCockpitMission = (maybeMission: any): maybeMission is CockpitMission => {
+  if (!maybeMission || typeof maybeMission !== 'object') {
+    return false
+  }
+
   const requiredKeys = ['version', 'settings', 'waypoints']
   const requiredSettingsKeys = [
     'mapCenter',

--- a/src/types/mission.ts
+++ b/src/types/mission.ts
@@ -1,9 +1,80 @@
+import { MavCmd } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
+
 /**
- * Possible types for waypoints. Usually used to decide what function should the waypoint perform.
+ * Possible types for mission commands.
  */
-export enum WaypointType {
-  PASS_BY = 'Pass by',
+export enum MissionCommandType {
+  MAVLINK_NAV_COMMAND = 'MAVLINK_NAV_COMMAND',
+  MAVLINK_NON_NAV_COMMAND = 'MAVLINK_NON_NAV_COMMAND',
 }
+
+export type MavlinkNavCommand = {
+  /**
+   * MAVLink navigation command type.
+   */
+  type: MissionCommandType.MAVLINK_NAV_COMMAND
+  /**
+   * The command to be executed by the mission.
+   */
+  command: MavCmd
+  /**
+   * The first parameter of the mission command.
+   */
+  param1: number
+  /**
+   * The second parameter of the mission command.
+   */
+  param2: number
+  /**
+   * The third parameter of the mission command.
+   */
+  param3: number
+  /**
+   * The fourth parameter of the mission command.
+   */
+  param4: number
+}
+
+export type MavlinkNonNavCommand = {
+  /**
+   * MAVLink non-navigation command type.
+   */
+  type: MissionCommandType.MAVLINK_NON_NAV_COMMAND
+  /**
+   * MAVLink non-navigation command.
+   */
+  command: MavCmd
+  /**
+   * The first parameter of the non-navigation command.
+   */
+  param1: number
+  /**
+   * The second parameter of the non-navigation command.
+   */
+  param2: number
+  /**
+   * The third parameter of the non-navigation command.
+   */
+  param3: number
+  /**
+   * The fourth parameter of the non-navigation command.
+   */
+  param4: number
+  /**
+   * The x parameter of the non-navigation command.
+   */
+  x: number
+  /**
+   * The y parameter of the non-navigation command.
+   */
+  y: number
+  /**
+   * The z parameter of the non-navigation command.
+   */
+  z: number
+}
+
+export type MissionCommand = MavlinkNavCommand | MavlinkNonNavCommand
 
 /**
  * Possible types for waypoints. Usually used to decide what function should the waypoint perform.
@@ -36,9 +107,9 @@ export type Waypoint = {
    */
   altitudeReferenceType: AltitudeReferenceType
   /**
-   * The type of the waypoint. Usually used to decide what function should the waypoint perform.
+   * The commands to be executed by the waypoint, in sequence.
    */
-  type: WaypointType
+  commands: MissionCommand[]
 }
 
 export type CockpitMission = {
@@ -58,10 +129,6 @@ export type CockpitMission = {
      * The zoom of the map when the user saved the file
      */
     zoom: number
-    /**
-     * The type to be used for the next placed waypoint
-     */
-    currentWaypointType: WaypointType
     /**
      * The altitude to be used for the next placed waypoint
      */
@@ -125,7 +192,6 @@ export const instanceOfCockpitMission = (maybeMission: any): maybeMission is Coc
   const requiredSettingsKeys = [
     'mapCenter',
     'zoom',
-    'currentWaypointType',
     'currentWaypointAltitude',
     'currentWaypointAltitudeRefType',
     'defaultCruiseSpeed',

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -189,15 +189,6 @@
         </div>
         <v-divider v-if="isCreatingSurvey" class="my-2" />
         <div v-if="isCreatingSurvey || isCreatingSimplePath" class="flex flex-col w-full h-full p-2">
-          <p class="text-sm text-slate-200">Waypoint type</p>
-          <select
-            v-model="WaypointType.PASS_BY"
-            class="h-auto py-2 px-2 my-2 mx-5 font-medium text-sm rounded-sm bg-[#FFFFFF33] hover:bg-[#FFFFFF44] transition-colors duration-200"
-          >
-            <option :value="WaypointType.PASS_BY">Pass-by</option>
-          </select>
-
-          <v-divider class="my-2" />
           <p class="overflow-visible my-1 text-sm text-slate-200">Altitude (m)</p>
           <input v-model="currentWaypointAltitude" class="px-2 py-1 m-1 mx-5 rounded-sm bg-[#FFFFFF22]" />
           <p class="overflow-visible mt-2 text-sm text-slate-200">Altitude type:</p>
@@ -1162,6 +1153,9 @@ watch(
   [surveyPolygonVertexesPositions, isCreatingSurvey],
   () => {
     updateConfirmButtonPosition()
+    if (isCreatingSurvey.value) {
+      currentWaypointType.value = WaypointType.PASS_BY
+    }
   },
   { immediate: true, deep: true }
 )

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -400,6 +400,7 @@ import 'leaflet/dist/leaflet.css'
 
 import { useWindowSize } from '@vueuse/core'
 import { formatDistanceToNow } from 'date-fns'
+import { format } from 'date-fns'
 import { saveAs } from 'file-saver'
 import L, { type LatLngTuple, LeafletMouseEvent, Map, Marker, Polygon } from 'leaflet'
 import { v4 as uuid } from 'uuid'
@@ -1298,7 +1299,8 @@ const saveMissionToFile = async (): Promise<void> => {
   const blob = new Blob([JSON.stringify(cockpitMissionFile, null, 2)], {
     type: 'application/json',
   })
-  saveAs(blob, 'mission_plan.cmp')
+  const date = format(new Date(), 'LLL_dd_yyyy_HH_mm_ss')
+  saveAs(blob, `cockpit_mission_plan_${date}.cmp`)
 }
 
 const loadMissionFromFile = async (e: Event): Promise<void> => {


### PR DESCRIPTION
Allows someone to choose one of their waypoints and change it from "Pass by" to "MAVLink Generic Waypoint". When this is done 5 new fields appear to allow the user to explicitly set the "MAV_CMD" as well as the 4 parameters.

Conversion from the vehicle to Cockpit also takes those into account (any waypoint that is not a `MAV_CMD_NAV_WAYPOINT` is casted to a "MAVLink Generic Waypoint".

In the video it can be seen that two waypoints were modified to use a MAV_CMD_DO_JUMP and skip waypoints 4 and 7 from the mission, going directly to 5 and 2, respectively.

https://github.com/user-attachments/assets/727ab4d0-c9af-44e7-893b-2f04d18bd29b

~Opening as draft as I didn't test it yet and also because I'm not completely sure about the implementation (I'm thinking about deprecating the "Pass by" and directly using the MAVLink ones, but specifying the protocol (MAVLink).~ Tested and it's working fine. We can go with it for now.

Fix #1737 