### PR TITLE
controller: Cast button values to the correct type before checking for press

### DIFF
--- a/src/stores/controller.ts
+++ b/src/stores/controller.ts
@@ -316,7 +316,7 @@ export const useControllerStore = defineStore('controller', () => {
 
     const activeActions = joystickState.buttons
       .map((btnState, idx) => ({ id: idx, value: btnState }))
-      .filter((btn) => btn.value ?? 0 > 0.5)
+      .filter((btn) => (btn.value ?? 0) > 0.5)
       .map((btn) => {
         const btnMapping = mapping.buttonsCorrespondencies[modifierKeyId as CockpitModifierKeyOption][btn.id]
         if (btnMapping && btnMapping.action) {


### PR DESCRIPTION
In some cases, with some joysticks, the left and right triggers are being parsed as `true` independently of their position.

With the default ROV profile that means one cannot control the camera tilt as both "Tilt up" and "Tilt down" are always pressed.

I could reproduce it more than once with the DualSense and [a user has reported the same with the Steam Deck in our forums](https://discuss.bluerobotics.com/t/cockpit-video-recording-on-steam-deck/20871/10).

After some investigation that was an easy fix: make it explicit in the comparison that the value to be compared is the result of the nullish coalescing operation, always.

## Steps to reproduce
1. Open Cockpit standalone
2. Connect your joystick
3. Connect Cockpit to a vehicle
4. Check Cockpit logs. There will be a "activeActions" list there, and the list should be empty
5. Checkout to the first commit of this branch ("[TEMP] Log the joystick actions that are being triggered"). You should see the same list being printed, but it will have two entries, with the names of the actions that are mapped to the L2 and R2 triggers of your joystick. They are being sent (on master) even if you don't press those triggers.

After the PR approval, I will remove the first commit so it doesn't pollute the versioning tree.