### PR TITLE
Fix updates on macOS (arm64) 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,21 +209,6 @@ jobs:
           path: dist/Cockpit-${{ matrix.suffix }}-${{ matrix.arch }}-${{ env.VERSION }}.${{ matrix.extension }}
           if-no-files-found: error
 
-      - name: Upload diff artifact (mac-only)
-        if: matrix.os == 'macos-13' || matrix.os == 'macos-14'
-        uses: actions/upload-artifact@v4
-        with:
-          name: Cockpit-${{ matrix.suffix }}-${{ matrix.arch }}-${{ env.VERSION }}.zip
-          path: dist/Cockpit*.zip
-          if-no-files-found: error
-
-      - name: Upload latest metadata artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.latestMetadataName }}-${{ matrix.arch }}
-          path: dist/latest*.yml
-          if-no-files-found: error
-
       - name: Upload binary release
         uses: svenstaro/upload-release-action@v2
         if: startsWith(github.ref, 'refs/tags/') && success()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           suffix: mac
           arch: arm64
           extension: dmg
-          latestMetadataName: latest-mac.yml
+          latestMetadataName: latest-mac-arm64.yml
           deployCommand: deploy:electron:mac:arm64
 
         - os: ubuntu-latest
@@ -194,6 +194,13 @@ jobs:
         # No Apple specific env vars needed here as electron-builder ignores them on these platforms
         run: |
           yarn ${{ matrix.deployCommand }}
+
+      - name: Rename macOS arm64 latest metadata
+        if: matrix.os == 'macos-14'
+        run: |
+          # In some environments the file may already be generated with the arm64 suffix.
+          # Only rename if the generic name exists.
+          if [ -f dist/latest-mac.yml ]; then mv dist/latest-mac.yml dist/latest-mac-arm64.yml; fi
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The x64 and the arm64 versions were both generating an update metadata file with the same name ("latest-mac.yml"), and since the x64 CI takes more time to complete, it was overriding the arm64 version of the file.

This PR changes the filename for the arm64 version, to use the default pattern from `electron-updater`.

It can be seen [in my fork](https://github.com/rafaellehmkuhl/cockpit-public/releases/tag/v1.16.0-beta11) that the metadata segregation is working fine.

I also took the opportunity to remove unnecessary artifacts (diffs and update metadata files) from the pull-request CI.

Fix #1988