### PR TITLE
Allow data-lake variables to be populated by joystick axes

### DIFF
--- a/src/libs/joystick/protocols.ts
+++ b/src/libs/joystick/protocols.ts
@@ -9,7 +9,11 @@ import {
 import { modifierKeyActions, otherAvailableActions } from './protocols/other'
 
 export const allAvailableAxes = (): ProtocolAction[] => {
-  return [...Object.values(mavlinkManualControlAxes), otherAvailableActions.no_function]
+  return [
+    ...Object.values(mavlinkManualControlAxes),
+    ...Object.values(availableDataLakeActions()),
+    otherAvailableActions.no_function,
+  ]
 }
 
 export const allAvailableButtons = (): ProtocolAction[] => {

--- a/src/libs/joystick/protocols/data-lake.ts
+++ b/src/libs/joystick/protocols/data-lake.ts
@@ -4,6 +4,7 @@ import { useControllerStore } from '@/stores/controller'
 import { type ProtocolAction, CockpitModifierKeyOption, JoystickProtocol } from '@/types/joystick'
 
 import { modifierKeyActions } from './other'
+import { scale } from '@/libs/utils'
 
 /**
  * An action to set a data lake variable
@@ -42,7 +43,7 @@ export const availableDataLakeActions = (): Record<string, DataLakeVariableActio
   return actions
 }
 
-// Update data lake variables when joystick buttons are pressed
+// Update data lake variables when joystick buttons or axes are used
 setupPostPiniaConnection(() => {
   const controllerStore = useControllerStore()
   controllerStore.registerControllerUpdateCallback((joystickState, actionsMapping, activeActions) => {
@@ -50,6 +51,7 @@ setupPostPiniaConnection(() => {
 
     const useShift = activeActions.map((a) => a.id).includes(modifierKeyActions.shift.id)
 
+    // Handle button mappings
     joystickState.buttons
       .map((btnState, idx) => ({ id: idx, value: btnState }))
       .forEach((btn) => {
@@ -67,6 +69,22 @@ setupPostPiniaConnection(() => {
         if (shiftMapping?.action?.protocol === JoystickProtocol.DataLakeVariable) {
           const shouldBeActive = btn.value && useShift
           setDataLakeVariableData(shiftMapping.action.id, shouldBeActive ? Number(btn.value) : 0)
+        }
+      })
+
+    // Handle axes mappings
+    joystickState.axes
+      .map((axisState, idx) => ({ id: idx, value: axisState }))
+      .forEach((axis) => {
+        if (axis.value === undefined) return
+
+        const axisMapping = actionsMapping.axesCorrespondencies[axis.id]
+
+        // Handle axis mapped to data lake variable
+        if (axisMapping?.action?.protocol === JoystickProtocol.DataLakeVariable) {
+          // Scale the axis value from [-1, 1] to the configured [min, max] range
+          const scaledValue = scale(axis.value, -1, 1, axisMapping.min, axisMapping.max)
+          setDataLakeVariableData(axisMapping.action.id, scaledValue)
         }
       })
   })

--- a/src/views/ConfigurationJoystickView.vue
+++ b/src/views/ConfigurationJoystickView.vue
@@ -293,7 +293,7 @@
                             v-if="item.type === 'axis'"
                             v-model="controllerStore
                               .protocolMapping.axesCorrespondencies[item.id as JoystickAxis].action"
-                            :items="controllerStore.availableAxesActions"
+                            :items="filteredAndSortedAxisActions"
                             item-title="name"
                             hide-details
                             class="mb-2"
@@ -566,7 +566,7 @@
             />
             <v-select
               v-model="controllerStore.protocolMapping.axesCorrespondencies[input.id].action"
-              :items="controllerStore.availableAxesActions"
+              :items="filteredAndSortedAxisActions"
               item-title="name"
               hide-details
               density="compact"
@@ -757,6 +757,14 @@ const filteredAndSortedJoystickActions = computed((): JoystickAction[] => {
     })
     .filter((action: JoystickAction) => !idsExcludedJoystickActions.includes(action.id))
     .sort((a: JoystickAction, b: JoystickAction) => a.name.localeCompare(b.name))
+})
+
+const filteredAndSortedAxisActions = computed((): JoystickAction[] => {
+  return controllerStore.availableAxesActions.filter((action: JoystickAction) => {
+    const dataLakeVariableInfo = getDataLakeVariableInfo(action.id)
+    if (!dataLakeVariableInfo) return true
+    return dataLakeVariableInfo.allowUserToChangeValue && dataLakeVariableInfo.type !== 'string'
+  })
 })
 
 const headers = ref([


### PR DESCRIPTION
## Steps to reproduce

1. Create a data-lake variable of `number` type
2. Select it from the joystick axis mapping
3. Take a look at the variable value being changed with the axis movement.


https://github.com/user-attachments/assets/7e737f51-94db-4ed7-95b7-fee8e7ffe353

Fix #1658.
