### PR TITLE
Fix video library modal slowing cockpit down

### DIFF
--- a/src/libs/videoStorage.ts
+++ b/src/libs/videoStorage.ts
@@ -120,6 +120,13 @@ const videoStoringIndexedDB: StorageDB = new LocalForageStorage(
   'Cockpit video recordings and their corresponding telemetry subtitles.'
 )
 
+const snapshotThumbnailsIndexedDB: StorageDB = new LocalForageStorage(
+  'Cockpit - Snapshot Thumbnails',
+  'cockpit-snapshot-thumbnails-db',
+  1.0,
+  'Cockpit snapshot thumbnails.'
+)
+
 const snapshotsIndexedDB: StorageDB = new LocalForageStorage(
   'Cockpit - Snapshots',
   'cockpit-snapshots-db',
@@ -130,7 +137,9 @@ const snapshotsIndexedDB: StorageDB = new LocalForageStorage(
 const electronVideoStorage = new ElectronStorage(['videos'])
 const temporaryElectronVideoStorage = new ElectronStorage(['videos', 'temporary-video-chunks'])
 const electronSnapshotStorage = new ElectronStorage(['snapshots'])
+const snapshotThumbnailsStorage = new ElectronStorage(['snapshots', 'thumbs'])
 
 export const videoStorage = isElectron() ? electronVideoStorage : videoStoringIndexedDB
 export const tempVideoStorage = isElectron() ? temporaryElectronVideoStorage : tempVideoChunksIndexdedDB
 export const snapshotStorage = isElectron() ? electronSnapshotStorage : snapshotsIndexedDB
+export const snapshotThumbStorage = isElectron() ? snapshotThumbnailsStorage : snapshotThumbnailsIndexedDB

--- a/src/stores/snapshot.ts
+++ b/src/stores/snapshot.ts
@@ -211,8 +211,8 @@ export const useSnapshotStore = defineStore('snapshot', () => {
           const { width, height } = videoStore.getMediaStream(streamName)?.getVideoTracks()[0].getSettings() || {}
           const stExif = buildExif({ latitude, longitude, yaw, pitch, roll, width, height })
           stBlob = await maybeEmbedExif(stBlob, stExif)
-          const filename = snapshotFilename(streamName || 'workspace')
-          const thumbFilename = snapshotFilename(streamName || 'workspace') + '-thumb'
+          const filename = snapshotFilename(streamName.replace(/[\\/]/g, '_') || 'workspace')
+          const thumbFilename = snapshotFilename(streamName.replace(/[\\/]/g, '_') || 'workspace') + '-thumb'
 
           await snapshotStorage.setItem(filename, stBlob)
           await snapshotThumbStorage.setItem(thumbFilename, thumbBlob)

--- a/src/types/snapshot.ts
+++ b/src/types/snapshot.ts
@@ -28,6 +28,10 @@ export interface SnapshotLibraryFile extends SnapshotFileDescriptor {
    * URL to access the snapshot file
    */
   url: string
+  /**
+   * Thumbnail of the snapshot
+   */
+  thumbnail: Blob // optional, used for displaying in the library
 }
 
 /**


### PR DESCRIPTION
* Added a thumbnail folder inside ../cockpit/snapshots;
* Thumbnails are now loaded on the library, and full size pictures are lazy-loaded;

** time to open snapshot library with 1.800 pictures (1.000 in 4k): 3 seconds.

Closes #2002 