### PR TITLE
add autoSave functionality to form editor

### DIFF
--- a/src/components/widgets/DoItYourself.vue
+++ b/src/components/widgets/DoItYourself.vue
@@ -62,6 +62,14 @@
               </v-expansion-panel-text>
             </v-expansion-panel>
           </v-expansion-panels>
+          
+          <v-checkbox
+            v-model="autoSave"
+            label="Auto Save"
+            density="compact"
+            class="-mb-2"
+            hide-details
+          />
           <v-checkbox
             v-model="widget.options.inheritCockpitStyles"
             label="Inherit Cockpit interface styles"
@@ -104,6 +112,8 @@ import { computed, onBeforeMount, onBeforeUnmount, onMounted, ref, toRefs } from
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
 import type { Widget } from '@/types/widgets'
+
+const autoSave = ref(false)
 
 self.MonacoEnvironment = {
   getWorker(_, label) {
@@ -220,6 +230,12 @@ const addKeyboardShortcuts = (editor: monaco.editor.IStandaloneCodeEditor): void
   })
 }
 
+const addChangeListener = (editor: monaco.editor.IStandaloneCodeEditor): void => {
+  editor.onDidChangeModelContent(() => {
+    onAutoSave();
+  });
+}
+
 const initEditor = async (): Promise<void> => {
   if (htmlEditor || !htmlEditorContainer.value) return
   if (jsEditor || !jsEditorContainer.value) return
@@ -229,10 +245,25 @@ const initEditor = async (): Promise<void> => {
   jsEditor = createEditor(jsEditorContainer.value, 'javascript', widget.value.options.js || defaultOptions.js)
   cssEditor = createEditor(cssEditorContainer.value, 'css', widget.value.options.css || defaultOptions.css)
 
-  // Add keyboard shortcuts to all editors
-  if (htmlEditor) addKeyboardShortcuts(htmlEditor)
-  if (jsEditor) addKeyboardShortcuts(jsEditor)
-  if (cssEditor) addKeyboardShortcuts(cssEditor)
+  // Add keyboard shortcuts and change listener to all editors
+  if (htmlEditor) { 
+    addKeyboardShortcuts(htmlEditor)
+    addChangeListener(htmlEditor)
+  }
+  if (jsEditor) {
+    addKeyboardShortcuts(jsEditor)
+    addChangeListener(jsEditor)
+  }
+  if (cssEditor) { 
+    addKeyboardShortcuts(cssEditor)
+    addChangeListener(cssEditor)
+  }
+
+}
+
+const onAutoSave = () => {
+  if(!autoSave.value) return
+  applyChanges()
 }
 
 const handleDialogOpening = async (): Promise<void> => {
@@ -290,6 +321,8 @@ const finishEditor = (): void => {
 
 const closeDialog = (): void => {
   widgetStore.widgetManagerVars(widget.value.hash).configMenuOpen = false
+  if(autoSave.value)
+    applyChanges()
   finishEditor()
 }
 


### PR DESCRIPTION
### Summary
This PR introduces an `autoSave` feature to the "DoItYourself" widget's form editor. The feature automatically saves user changes in the background, reducing the risk of data loss and improving the overall user experience. Users can enable or disable this feature as needed, and data is saved even when closing the editor.

### Details
- Added `autoSave` logic to the existing HTML/CSS/JS form editor.
- Saves form data on field changes and when closing the editor.
- Users can toggle the `autoSave` feature on or off.

### Benefits
- Improves reliability and user experience.
- Reduces accidental data loss during form editing.
- Gives users control over auto-saving behavior.

### Notes
- Tested on Chrome browser for consistent behavior.


### Video 
https://github.com/user-attachments/assets/28bbebc3-0b66-4cb9-b2e0-b40d9a47291d

