### PR TITLE
blueos: Add `usage` and `frequency` of each CPU core (and averages) to the data-lake

### DIFF
--- a/src/libs/blueos.ts
+++ b/src/libs/blueos.ts
@@ -4,6 +4,7 @@ import { getDataLakeVariableData } from '@/libs/actions/data-lake'
 import { type ActionConfig } from '@/libs/joystick/protocols/cockpit-actions'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useMissionStore } from '@/stores/mission'
+import { type RawCpuLoadInfo, type RawCpuTempInfo } from '@/types/blueos'
 import { ExternalWidgetSetupInfo } from '@/types/widgets'
 
 /**
@@ -278,9 +279,6 @@ export const getVehicleName = async (vehicleAddress: string): Promise<Response> 
   }
 }
 
-// eslint-disable-next-line jsdoc/require-jsdoc
-type RawCpuTempInfo = { name: string; temperature: number; maximum_temperature: number; critical_temperature: number }
-
 export const getCpuTempCelsius = async (vehicleAddress: string): Promise<number> => {
   try {
     const url = `${protocol}//${vehicleAddress}/system-information/system/temperature`
@@ -288,6 +286,16 @@ export const getCpuTempCelsius = async (vehicleAddress: string): Promise<number>
     return cpuTempRawInfo[0].temperature
   } catch (error) {
     throw new Error(`Could not get temperature of the BlueOS CPU. ${error}`)
+  }
+}
+
+export const getCpusInfo = async (vehicleAddress: string): Promise<RawCpuLoadInfo[]> => {
+  try {
+    const url = `${protocol}//${vehicleAddress}/system-information/system/cpu`
+    const cpuLoadRawInfo: RawCpuLoadInfo[] = await ky.get(url, { timeout: defaultTimeout }).json()
+    return cpuLoadRawInfo
+  } catch (error) {
+    throw new Error(`Could not get load of the BlueOS CPU. ${error}`)
   }
 }
 

--- a/src/types/blueos.ts
+++ b/src/types/blueos.ts
@@ -1,0 +1,20 @@
+/* eslint-disable jsdoc/require-jsdoc  */
+
+/**
+ * Information about the temperature of the BlueOS CPU
+ */
+export type RawCpuTempInfo = {
+  name: string
+  temperature: number
+  maximum_temperature: number
+  critical_temperature: number
+}
+
+/**
+ * Information about each CPU core in BlueOS
+ */
+export type RawCpuLoadInfo = {
+  name: string
+  usage: number
+  frequency: number
+}


### PR DESCRIPTION
<img width="545" height="610" alt="image" src="https://github.com/user-attachments/assets/8dc4e25b-de07-4b28-a749-1abd1dd0dbd5" />
