### PR TITLE
data-lake: Warn instead of throwing on creation of already existing variable

### DIFF
--- a/src/libs/actions/data-lake.ts
+++ b/src/libs/actions/data-lake.ts
@@ -103,7 +103,7 @@ export const getDataLakeVariableInfo = (id: string): DataLakeVariable | undefine
 
 export const createDataLakeVariable = (variable: DataLakeVariable, initialValue?: string | number | boolean): void => {
   if (dataLakeVariableInfo[variable.id]) {
-    throw new Error(`Cockpit action variable with id '${variable.id}' already exists. Update it instead.`)
+    console.warn(`Cockpit action variable with id '${variable.id}' already exists. Updating it.`)
   }
   dataLakeVariableInfo[variable.id] = variable
   dataLakeVariableData[variable.id] = initialValue


### PR DESCRIPTION
Race conditions can cause this situation and break several components. Better to just issue a warn, as most of the time the variable would be created with the same info.

Fix #2095.