### PR TITLE
DIY widget: autocomplete provide data-lake variables

### DIFF
--- a/src/components/widgets/DoItYourself.vue
+++ b/src/components/widgets/DoItYourself.vue
@@ -231,6 +231,39 @@ const addChangeListener = (editor: monaco.editor.IStandaloneCodeEditor): void =>
   })
 }
 
+// Autocomplete provider for cockpit data lake variables
+monaco.languages.registerCompletionItemProvider('javascript', {
+  triggerCharacters: ['('],
+
+  provideCompletionItems: (model, position) => {
+    // Get current word and define replacement range
+    const word = model.getWordUntilPosition(position)
+    const range: monaco.IRange = {
+      startLineNumber: position.lineNumber,
+      startColumn: word.startColumn,
+      endLineNumber: position.lineNumber,
+      endColumn: word.endColumn,
+    }
+
+    // Create suggestions from cockpit data variables
+    const suggestions: monaco.languages.CompletionItem[] = Object.entries(window.cockpit.dataLakeVariableData).map(
+      ([key, value]) => {
+        return {
+          label: key,
+          kind: monaco.languages.CompletionItemKind.Variable,
+          documentation: `${key}: ${value} (${typeof value})`,
+          insertText: `window.cockpit.dataLakeVariableData['${key}']`,
+          range: range,
+        }
+      }
+    )
+
+    return {
+      suggestions,
+    }
+  },
+})
+
 const initEditor = async (): Promise<void> => {
   if (htmlEditor || !htmlEditorContainer.value) return
   if (jsEditor || !jsEditorContainer.value) return


### PR DESCRIPTION
# DIY widget autocomplete Provide Data-Lake Variables

## Summary
Added intelligent autocomplete support for JavaScript in Monaco Editor that suggests variables from `window.cockpit.dataLakeVariableData` with proper documentation and insertion templates.

## Changes
- Registered a completion item provider for JavaScript language
- Configured trigger character '(' to activate autocomplete
- Implemented dynamic suggestion generation from data-lake variables

## Technical Details
- **Range Detection**: Uses `getWordUntilPosition()` to identify the current word boundary for precise text replacement
- **Dynamic Suggestions**: Maps object entries to completion items with proper formatting
- **Documentation**: Displays variable name, current value, and type in tooltips
- **Insertion Template**: Generates proper JavaScript access syntax (`window.cockpit.dataLakeVariableData['variableName']`)

## Benefits
- Improves developer productivity with context-aware suggestions
- Reduces errors by providing correct access syntax
- Enhances code discovery with real-time value documentation
- Maintains consistency in variable access patterns

## Usage
Developers can now autocomplete cockpit variables by typing any character and selecting from the suggested list, which includes current values and types for better context.