### PR TITLE
snapshot: Create dedicated action to allow taking snapshots with a button click

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -182,11 +182,15 @@ import { useMainVehicleStore } from './stores/mainVehicle'
 import { useWidgetManagerStore } from './stores/widgetManager'
 import { SubMenuComponent } from './types/general'
 const { openSnackbar } = useSnackbar()
+import { useSnapshotStore } from './stores/snapshot'
 
 const widgetStore = useWidgetManagerStore()
 const vehicleStore = useMainVehicleStore()
 const interfaceStore = useAppInterfaceStore()
 const devStore = useDevelopmentStore()
+
+// Initialize the snapshot store to register action callbacks
+useSnapshotStore()
 
 const showAboutDialog = ref(false)
 const currentSubMenuComponent = ref<SubMenuComponent>(null)

--- a/src/libs/joystick/protocols/cockpit-actions.ts
+++ b/src/libs/joystick/protocols/cockpit-actions.ts
@@ -17,6 +17,7 @@ export enum CockpitActionsFunction {
   start_recording_all_streams = 'start_recording_all_streams',
   stop_recording_all_streams = 'stop_recording_all_streams',
   toggle_recording_all_streams = 'toggle_recording_all_streams',
+  take_snapshot = 'take_snapshot',
   hold_to_confirm = 'hold_to_confirm',
 }
 
@@ -47,6 +48,7 @@ export const predefinedCockpitActions: { [key in CockpitActionsFunction]: Cockpi
   [CockpitActionsFunction.start_recording_all_streams]: new CockpitAction(CockpitActionsFunction.start_recording_all_streams, 'Start recording all streams'),
   [CockpitActionsFunction.stop_recording_all_streams]: new CockpitAction(CockpitActionsFunction.stop_recording_all_streams, 'Stop recording all streams'),
   [CockpitActionsFunction.toggle_recording_all_streams]: new CockpitAction(CockpitActionsFunction.toggle_recording_all_streams, 'Toggle recording all streams'),
+  [CockpitActionsFunction.take_snapshot]: new CockpitAction(CockpitActionsFunction.take_snapshot, 'Take snapshot'),
   [CockpitActionsFunction.hold_to_confirm]: new CockpitAction(CockpitActionsFunction.hold_to_confirm, 'Hold to confirm'),
 }
 


### PR DESCRIPTION
This action takes a snapshot of all available streams, including the workspace (if running the standalone/electron version).

Fix #2007.