### PR TITLE
video: Include telemetry overlay files when downloading raw video chunks

### DIFF
--- a/src/components/VideoLibraryModal.vue
+++ b/src/components/VideoLibraryModal.vue
@@ -1147,12 +1147,16 @@ const downloadVideoAndTelemetryFiles = async (): Promise<void> => {
 
   isPreparingDownload.value = true
   if (tempProcessedVideos.length > 0) {
+    // Add log files to the list of files to be downloaded
     const dataLogFilesAdded = addLogDataToFileList(tempProcessedVideos)
 
     await videoStore.downloadFilesFromVideoDB(dataLogFilesAdded, fillProgressData)
   }
   if (tempUnprocessedVideos.length > 0) {
-    await videoStore.downloadTempVideo(tempUnprocessedVideos, fillProgressData)
+    // Generate telemetry files for unprocessed videos before download
+    await videoStore.generateTelemetryForUnprocessedVideos(tempUnprocessedVideos, fillProgressData)
+
+    await videoStore.downloadTempVideoWithTelemetry(tempUnprocessedVideos, fillProgressData)
   }
   isPreparingDownload.value = false
 }


### PR DESCRIPTION
The `.ass` telemetry overlays are only generated when a video is processed, so they were not being included when downloading chunks. The problem is that in such case there's no way to download those telemetry files afterwards.

Fix #2144.