### PR TITLE
app: main-menu: config-menus: Fix closing button not working on some situations

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -204,8 +204,6 @@ const isSlidingOut = ref(false)
 
 const { width: windowWidth } = useWindowSize()
 
-const isConfigModalVisible = computed(() => interfaceStore.isConfigModalVisible)
-
 // Check if the user data in browser storage is the same as on blueOS; if not, keep the splash screen open for a maximum of 20 seconds.
 onBeforeMount(async () => {
   if (!devStore.showSplashScreenOnStartup) {
@@ -233,11 +231,14 @@ onBeforeMount(async () => {
   interfaceStore.showSplashScreen = false
 })
 
-watch(isConfigModalVisible, (newVal) => {
-  if (newVal === false) {
-    currentSubMenuComponent.value = null
+watch(
+  () => interfaceStore.isConfigModalVisible,
+  (isVisible) => {
+    if (!isVisible) {
+      currentSubMenuComponent.value = null
+    }
   }
-})
+)
 
 const topBottomBarScale = computed(() => {
   return windowWidth.value / originalBarWidth

--- a/src/views/BaseConfigurationView.vue
+++ b/src/views/BaseConfigurationView.vue
@@ -46,6 +46,6 @@ const hasNoCloseIcon = ref(props.noCloseIcon || false)
 
 const closeModal = (): void => {
   interfaceStore.configModalVisibility = false
-  interfaceStore.configComponent = -1
+  interfaceStore.currentSubMenuComponentName = null
 }
 </script>


### PR DESCRIPTION
When called from the Tutorial component, or the Mission Planning cog icon, the close button does not work and trying to open the menu again from the outside does not work.

Fix #2172 
