### PR TITLE
Prevent measuring tag to be displayed over the last waypointp marker

### DIFF
--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -848,11 +848,15 @@ const handleMapMouseMove = (e: L.LeafletMouseEvent): void => {
   const midX = (a.x + b.x) / 2
   const midY = (a.y + b.y) / 2
   const dist = anchor!.distanceTo(e.latlng)
+
+  const hidePill = isOverSurveyHandle(e) || isOverLastWaypointMarker(e) || dist < 1 // hide if closer than 1 meter to last wp on the array
+
   const text = missionEstimates.formatMetersShort(dist)
   if (measureTextEl) {
     measureTextEl.textContent = text
     measureTextEl.style.left = `${midX}px`
     measureTextEl.style.top = `${midY}px`
+    measureTextEl.style.display = hidePill ? 'none' : 'block'
   }
 }
 
@@ -1422,6 +1426,17 @@ const createSurveyAreaLabel = (surveyId: string, coords: [number, number][]): vo
   addAreaToMeasureLayer(marker)
   surveyAreaMarkers.value[surveyId] = marker
   setSurveyAreaSquareMeters(surveyId, m2)
+}
+
+const isOverLastWaypointMarker = (event: L.LeafletMouseEvent): boolean => {
+  const el = event.originalEvent?.target as HTMLElement | null
+  if (!el) return false
+  const waypoints = missionStore.currentPlanningWaypoints
+  if (!Array.isArray(waypoints) || waypoints.length === 0) return false
+  const lastWp = waypoints[waypoints.length - 1]
+  const lastMarker = waypointMarkers.value[lastWp.id]
+  const lastElement = lastMarker?.getElement?.()
+  return !!lastElement && (lastElement === el || lastElement.contains(el))
 }
 
 const onPolygonMouseDown = (event: L.LeafletMouseEvent): void => {


### PR DESCRIPTION
Prevent the measurement tag from being displyed over the waypoint marker, what could make the selection confusing for the user;


https://github.com/user-attachments/assets/05ecd3dc-8c0e-4ae6-a310-788128dc7274

