### PR TITLE
sensor-logging: Record for the entire run of the application

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ import { app_version } from '@/libs/cosmos'
 import eventTracker from '@/libs/external-telemetry/event-tracking'
 import { setupPredefinedLakeAndActionResources } from '@/libs/joystick/protocols/predefined-resources'
 import { setupPostPiniaConnections } from '@/libs/post-pinia-connections'
+import { datalogger } from '@/libs/sensors-logging'
 import { runMigrations } from '@/utils/migrations'
 
 import App from './App.vue'
@@ -72,6 +73,9 @@ setupPredefinedLakeAndActionResources()
 
 // Initialize auto-run for actions
 initializeActionAutoRun()
+
+// Start logging as soon as the app is loaded to always have telemetry for videos
+datalogger.startLogging('cockpit-telemetry-logging')
 
 // If the app has successfully loaded, announce that so the console capture can be stopped
 window.dispatchEvent(new CustomEvent('cockpit-app-loaded'))

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -265,7 +265,6 @@ export const useVideoStore = defineStore('video', () => {
 
     activeStreams.value[streamName]!.mediaRecorder!.stop()
 
-    datalogger.stopLogging(streamName)
     alertStore.pushAlert(new Alert(AlertLevel.Success, `Stopped recording stream ${streamName}.`))
   }
 
@@ -425,7 +424,6 @@ export const useVideoStore = defineStore('video', () => {
       return
     }
 
-    datalogger.startLogging(streamName)
     await sleep(100)
 
     activeStreams.value[streamName]!.timeRecordingStart = new Date()


### PR DESCRIPTION
We were previously recording only when a video recording started or stopped, but this opens space for problems. If for some reason an exception raises there, the user could have a video but no telemetry. Not only that, but it closed the space for downloading sensor logs if one is not recording videos (and many vehicles don't).

With this change we start the logging as soon as the application starts and never stop.

I've measured the size of the packages and consider it to be negligible. It takes about 5MB per hour (which is about the same as 3 seconds of video recording).

This PR does not fix #2186 but goes in this direction.