### PR TITLE
joysticks: Add the `Thrustmaster SimTask FarmStick` flight joystick

### DIFF
--- a/src/assets/joystick-profiles.ts
+++ b/src/assets/joystick-profiles.ts
@@ -276,6 +276,11 @@ export const availableGamepadToCockpitMaps: { [key in JoystickModel]: GamepadToC
     axes: [0, 1, 2, 3, 4, 5],
     buttons: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
   },
+  [JoystickModel.ThrustmasterSimTaskFarmStick]: {
+    name: 'Thrustmaster SimTask FarmStick',
+    axes: [0, 1, 2, 3, 4, 5, 6, 7],
+    buttons: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25],
+  },
   [JoystickModel.Unknown]: {
     name: 'Standard gamepad',
     axes: [0, 1, 2, 3, 4, 5, 6, 7],

--- a/src/libs/joystick/manager.ts
+++ b/src/libs/joystick/manager.ts
@@ -42,6 +42,7 @@ export enum JoystickModel {
   SteamDeckLCD = 'Steam Deck LCD',
   SteamDeckOLED = 'Steam Deck OLED',
   EightBitDoUltimate2C = '8BitDo Ultimate 2C',
+  ThrustmasterSimTaskFarmStick = 'Thrustmaster SimTask FarmStick',
   Unknown = 'Unknown',
 }
 
@@ -60,6 +61,7 @@ const JoystickMapVidPid: Map<string, JoystickModel> = new Map([
   ['28de:11ff', JoystickModel.SteamDeckLCD],
   ['28de:1205', JoystickModel.SteamDeckOLED],
   ['2dc8:301b', JoystickModel.EightBitDoUltimate2C],
+  ['044f:0416', JoystickModel.ThrustmasterSimTaskFarmStick],
 ])
 
 // Necessary to add functions


### PR DESCRIPTION
Based on some information provided by a user (Geoffrey) in our forums and by email exchanges.

<img width="800" alt="image" src="https://github.com/user-attachments/assets/187872c0-5a9d-4f7b-8482-d59357258f33" />

```
productName: SimTask FarmStick Right
vendorId:    0x044F (1103) ThrustMaster, Inc.
productId:   0x0416 (1046)
opened:      true
collections[0]
  Usage: 0001:0004 (Generic Desktop > Joystick)
  Input reports: 0x01
  Feature reports: 0xF3, 0xF1, 0xF2
Input report 0x01
  33 values * 1 bit (bits 0 to 32)
    Data,Var,Abs
    Usages: 0009:0001 (Button Button 1) to 0009:0021 (Button Button 33)
    Logical bounds: 0 to 1
  7 values * 1 bit (bits 33 to 39)
    Cnst,Var,Abs
    Logical bounds: 0 to 1
  3 values * 16 bits (bits 40 to 87)
    Data,Var,Abs
    Usages:
      0001:0030 (Generic Desktop > X)
      0001:0031 (Generic Desktop > Y)
      0001:0032 (Generic Desktop > Z)
    Logical bounds: 0 to 65535
  5 values * 8 bits (bits 88 to 127)
    Data,Var,Abs
    Usages:
      0001:0033 (Generic Desktop > Rx)
      0001:0034 (Generic Desktop > Ry)
      0001:0035 (Generic Desktop > Rz)
      0001:0036 (Generic Desktop > Slider)
      0001:0037 (Generic Desktop > Dial)
    Logical bounds: 0 to 255
  47 values * 8 bits (bits 128 to 503)
    Cnst,Var,Abs
    Usage: 0001:0050 (Generic Desktop usage 0x0050)
    Logical bounds: 0 to 255
Feature report 0xF3
  63 values * 8 bits (bits 0 to 503)
    Data,Var,Abs
    Usage: 0001:0048 (Generic Desktop > Resolution Multiplier)
    Logical bounds: 0 to 255
Feature report 0xF1
  63 values * 8 bits (bits 0 to 503)
    Data,Var,Abs
    Usage: 0001:0047 (Generic Desktop > Feature Notification)
    Logical bounds: 0 to 255
Feature report 0xF2
  63 values * 8 bits (bits 0 to 503)
    Data,Var,Abs
    Usage: 0001:0047 (Generic Desktop > Feature Notification)
    Logical bounds: 0 to 255
```
Relevant to #2128