### PR TITLE
joystick: sdl: Fix initial trigger values being incorrectly mapped

### DIFF
--- a/src/electron/services/joystick.ts
+++ b/src/electron/services/joystick.ts
@@ -195,8 +195,8 @@ export const checkControllerState = (deviceId: number): void => {
   }
 
   const state = { buttons: structuredClone(instance.buttons), axes: structuredClone(instance.axes) }
-  state.axes.leftTrigger = scale(state.axes.leftTrigger, 0.5, 1, 0, 1)
-  state.axes.rightTrigger = scale(state.axes.rightTrigger, 0.5, 1, 0, 1)
+  state.axes.leftTrigger = state.axes.leftTrigger > 0 ? scale(state.axes.leftTrigger, 0.5, 1, 0, 1) : 0
+  state.axes.rightTrigger = state.axes.rightTrigger > 0 ? scale(state.axes.rightTrigger, 0.5, 1, 0, 1) : 0
   state.buttons.extra = state.buttons[''] ?? false
   delete state.buttons['']
 


### PR DESCRIPTION
For some reason the triggers have a value that ranges from 0.5 to 1.0, but they start with a 0 value in the rest position that goes to 0.5 (for the same rest position) after the first interaction.

This change makes sure the initial "undefined" 0 value is always mapped to 0, and not to -1, as it was previously.

I didn't find any issue open for that, but I remember this being mentioned in the forums at some point, and Wilson also mentioned that to me last week.

This would not affect users that were using those triggers as buttons (almost all users), as both -1 and 0 are mapped to `false`, but would affect users trying to use the triggers as floating values.