### PR TITLE
joystick: sdl: Prevent "JavaScript error" popups from appearing on joystick connection

### DIFF
--- a/src/electron/services/joystick.ts
+++ b/src/electron/services/joystick.ts
@@ -98,7 +98,11 @@ export const openController = (sdl: SDLModule, device: SDLControllerDevice): voi
         return
       }
 
-      checkControllerState(device.id)
+      try {
+        checkControllerState(device.id)
+      } catch (error) {
+        console.warn(`Could not check controller state for '${device.name}' with id '${device.id}'.`)
+      }
     }, stateCheckInterval)
   } catch (error) {
     console.error(`Error opening controller ${device.name}:`, error)
@@ -132,7 +136,11 @@ export const openJoystick = (sdl: SDLModule, device: SDLJoystickDevice): void =>
         return
       }
 
-      checkJoystickState(device.id)
+      try {
+        checkJoystickState(device.id)
+      } catch (error) {
+        console.warn(`Could not check joystick state for '${device.name}' with id '${device.id}'.`)
+      }
     }, stateCheckInterval)
   } catch (error) {
     console.error(`Error opening joystick ${device.name}:`, error)


### PR DESCRIPTION
Those were happening because the joystick can take some time to be fully opened, and we are fetching its state right away.

A try/catch block with a warning was added to make sure this popup does not appear.

Fix #2195