### PR TITLE
map: mavlink: Consider commands with coordinates 0/0 to be non-nav

### DIFF
--- a/src/libs/vehicle/mavlink/types.ts
+++ b/src/libs/vehicle/mavlink/types.ts
@@ -80,7 +80,7 @@ export const convertCockpitWaypointsToMavlink = (
 export const convertMavlinkWaypointsToCockpit = (mavlinkWaypoints: Message.MissionItemInt[]): Waypoint[] => {
   const cockpitWaypoints: Waypoint[] = []
   mavlinkWaypoints.forEach((mavlinkWaypoint) => {
-    if (mavlinkWaypoint.command.type.includes('MAV_CMD_NAV')) {
+    if (mavlinkWaypoint.command.type.includes('MAV_CMD_NAV') && mavlinkWaypoint.x !== 0 && mavlinkWaypoint.y !== 0) {
       const altitudeReferenceType =
         cockpitAltRefFromMavlinkFrame(mavlinkWaypoint.frame.type) || AltitudeReferenceType.RELATIVE_TO_HOME
       cockpitWaypoints.push({


### PR DESCRIPTION
Before:
<img width="600"  alt="image" src="https://github.com/user-attachments/assets/4637799d-ef93-4a5c-9b84-f0e8284b1583" />


After:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/72039fc1-8c41-47b1-bddf-1a13fbf56a01" />
