### PR TITLE
Add WMS overlays support

### DIFF
--- a/src/stores/mission.ts
+++ b/src/stores/mission.ts
@@ -18,8 +18,8 @@ import {
 
 import { useMainVehicleStore } from './mainVehicle'
 
-// Default map position (centered on Florianópolis, Brazil)
-const DEFAULT_MAP_CENTER: WaypointCoordinates = [-27.5935, -48.55854]
+// Default map position (centered on Hawaii)
+const DEFAULT_MAP_CENTER: WaypointCoordinates = [19.669511014021392, -156.0242794325606]
 const DEFAULT_MAP_ZOOM = 15
 
 export const useMissionStore = defineStore('mission', () => {


### PR DESCRIPTION
This code is not intended to go to production. It was a quick test I did during a call with a sonar supplier to integrate their WMS service into ou Map widget. The result can be find below.

<img width="1902" height="965" alt="image" src="https://github.com/user-attachments/assets/654349a4-7d98-4323-9eca-4af6f04b066c" />

The following file is a dump from the `GetCapabilities` page of the WMS server, which has more information around available layers and other settings.

[wms.xml](https://github.com/user-attachments/files/23209985/wms.xml)
