### PR TITLE
Fix streams being duplicated (causing unnecessary resource usage) on reconnection

### DIFF
--- a/src/components/widgets/VideoPlayer.vue
+++ b/src/components/widgets/VideoPlayer.vue
@@ -110,7 +110,6 @@ import { storeToRefs } from 'pinia'
 import { computed, onBeforeMount, onBeforeUnmount, ref, toRefs, watch } from 'vue'
 
 import StatsForNerds from '@/components/VideoPlayerStatsForNerds.vue'
-import { isEqual } from '@/libs/utils'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useVideoStore } from '@/stores/video'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
@@ -187,7 +186,9 @@ const streamConnectionRoutine = setInterval(() => {
   if (externalStreamId.value !== undefined) {
     const updatedMediaStream = videoStore.getMediaStream(externalStreamId.value)
     // If the widget is not connected to the MediaStream, try to connect it
-    if (!isEqual(updatedMediaStream, mediaStream.value)) {
+    // Use reference comparison for MediaStream objects, not deep equality, as the media stream can be the same with one
+    // or more attributes having changed.
+    if (updatedMediaStream !== mediaStream.value) {
       mediaStream.value = updatedMediaStream
     }
 


### PR DESCRIPTION
This PR fixes the problem where an unavailability of the stream server (mavlink-camera-manager) causes the stream to be recreated, and thus duplicating the resource usage for that stream.

This unavailability can happen if MCM restarts, if BlueOS restarts, or more commonly: if the connection is intermittent. Because of this last case, this is considered to be a critical issue, as for someone with a 4K camera, or worse with more than one camera, this can quickly mean to not have enough bandwidth for controlling the vehicle, or even throttling the vehicle CPU for excessive resource usage.

Fix #1788
Fix #1760
Fix #775
Fix #812