### PR TITLE
Limit vehicle position max sampling rate on Vehicle-Store

### DIFF
--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -1,4 +1,5 @@
 import { useStorage, useTimestamp } from '@vueuse/core'
+import { useThrottleFn } from '@vueuse/core'
 import { differenceInSeconds } from 'date-fns'
 import { defineStore } from 'pinia'
 import { v4 as uuid } from 'uuid'
@@ -136,6 +137,7 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
   const statusGPS: StatusGPS = reactive({} as StatusGPS)
   const vehicleArmingTime = ref<Date | undefined>(undefined)
   const currentVehicleName = ref<string | undefined>(undefined)
+  const vehiclePositionMaxSampleRate = useStorage('cockpit-vehicle-position-max-sampling-ms', 200) // Limits the frequency of vehicle position updates
 
   const defaultVehiclePayload: VehiclePayloadParameters = {
     extraPayloadKg: 0,
@@ -477,6 +479,13 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
 
   ConnectionManager.addConnection(MAVLink2RestWebsocketURI.value, Protocol.Type.MAVLink)
 
+  let applyThrottledCoordinates = useThrottleFn(
+    (nc: Coordinates) => Object.assign(coordinates, nc),
+    vehiclePositionMaxSampleRate.value,
+    true,
+    true
+  )
+
   const getAutoPilot = (vehicles: WeakRef<Vehicle.Abstract>[]): ArduPilot => {
     const vehicle = vehicles?.last()?.deref()
     return (vehicle as ArduPilot) || undefined
@@ -516,7 +525,7 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
       cpuLoad.value = newCpuLoad
     })
     mainVehicle.value.onPosition.add((newCoordinates: Coordinates) => {
-      Object.assign(coordinates, newCoordinates)
+      applyThrottledCoordinates(newCoordinates)
     })
     mainVehicle.value.onVelocity.add((newVelocity: Velocity) => {
       Object.assign(velocity, newVelocity)
@@ -804,6 +813,11 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     registerActionCallback(availableCockpitActions.mavlink_disarm, disarm)
   })
 
+  // Updates throttling function when the vehicle's position max sample rate changes
+  watch(vehiclePositionMaxSampleRate, (ms) => {
+    applyThrottledCoordinates = useThrottleFn((nc: Coordinates) => Object.assign(coordinates, nc), ms, true, true)
+  })
+
   const mavlinkManualControlManager = new MavlinkManualControlManager()
   controllerStore.registerControllerUpdateCallback(mavlinkManualControlManager.updateControllerData)
 
@@ -917,5 +931,6 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     fetchHomeWaypoint,
     setHomeWaypoint,
     vehiclePayloadParameters,
+    vehiclePositionMaxSampleRate,
   }
 })

--- a/src/views/ConfigurationMissionView.vue
+++ b/src/views/ConfigurationMissionView.vue
@@ -73,40 +73,59 @@
         </ExpansiblePanel>
 
         <ExpansiblePanel no-bottom-divider :is-expanded="!interfaceStore.isOnPhoneScreen">
-          <template #title>Default Map Position</template>
-          <template #info> Set the default position and zoom level for maps. </template>
+          <template #title>Map options</template>
+          <template #info>
+            <strong>Default map position:</strong> Defines the initial center and zoom level for the map. <br />
+            <strong>Max. vehicle position update rate:</strong> Limits how often the vehicle's position is updated on
+            the map to reduce CPU usage.
+          </template>
           <template #content>
             <div class="flex flex-wrap gap-4 px-4 pb-4">
-              <div class="flex flex-col max-w-[9rem]">
-                <p class="text-sm text-slate-200 mb-2">Latitude</p>
-                <input
-                  v-model.number="defaultMapCenter[0]"
-                  type="number"
-                  step="0.000001"
-                  class="px-2 py-1 rounded-sm bg-[#FFFFFF22]"
-                />
+              <p class="w-full text-md">Default map position</p>
+              <div class="flex w-[70%] justify-around items-center">
+                <div class="flex flex-col max-w-[9rem]">
+                  <p class="text-sm text-slate-200 mb-2">Latitude</p>
+                  <input
+                    v-model.number="defaultMapCenter[0]"
+                    type="number"
+                    step="0.000001"
+                    class="px-2 py-1 rounded-sm bg-[#FFFFFF22]"
+                  />
+                </div>
+                <div class="flex flex-col max-w-[9rem]">
+                  <p class="text-sm text-slate-200 mb-2 ml-4">Longitude</p>
+                  <input
+                    v-model.number="defaultMapCenter[1]"
+                    type="number"
+                    step="0.000001"
+                    class="px-2 py-1 rounded-sm bg-[#FFFFFF22] ml-4"
+                  />
+                </div>
+                <div class="flex flex-col max-w-[9rem]">
+                  <p class="text-sm text-slate-200 mb-2 ml-4">Zoom Level (1-19)</p>
+                  <input
+                    v-model.number="defaultMapZoom"
+                    type="number"
+                    min="1"
+                    max="19"
+                    class="px-2 py-1 rounded-sm bg-[#FFFFFF22] ml-4"
+                  />
+                </div>
+                <div class="flex-grow-1" />
+                <v-btn class="mt-7 bg-[#FFFFFF22]" variant="plain" size="small" @click="saveMapPosition">Save</v-btn>
               </div>
-              <div class="flex flex-col max-w-[9rem]">
-                <p class="text-sm text-slate-200 mb-2">Longitude</p>
-                <input
-                  v-model.number="defaultMapCenter[1]"
-                  type="number"
-                  step="0.000001"
-                  class="px-2 py-1 rounded-sm bg-[#FFFFFF22]"
-                />
+              <div class="flex w-[63%] justify-between items-center mt-4">
+                <p class="w-full text-md">Max. vehicle position update rate</p>
+                <div class="flex flex-col max-w-[118px]">
+                  <input
+                    v-model.number="vehicleStore.vehiclePositionMaxSampleRate"
+                    type="number"
+                    min="0"
+                    class="px-2 py-1 rounded-sm bg-[#FFFFFF22]"
+                  />
+                </div>
+                <p class="ml-2">ms</p>
               </div>
-              <div class="flex flex-col max-w-[8rem]">
-                <p class="text-sm text-slate-200 mb-2">Zoom Level (1-19)</p>
-                <input
-                  v-model.number="defaultMapZoom"
-                  type="number"
-                  min="1"
-                  max="19"
-                  class="px-2 py-1 rounded-sm bg-[#FFFFFF22]"
-                />
-              </div>
-              <div class="flex-grow-1" />
-              <v-btn class="mt-5" variant="plain" @click="saveMapPosition">Save</v-btn>
             </div>
           </template>
         </ExpansiblePanel>
@@ -121,6 +140,7 @@ import { ref, watch } from 'vue'
 import ExpansiblePanel from '@/components/ExpansiblePanel.vue'
 import { EventCategory } from '@/libs/slide-to-confirm'
 import { useAppInterfaceStore } from '@/stores/appInterface'
+import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useMissionStore } from '@/stores/mission'
 import type { WaypointCoordinates } from '@/types/mission'
 
@@ -128,6 +148,7 @@ import BaseConfigurationView from './BaseConfigurationView.vue'
 
 const missionStore = useMissionStore()
 const interfaceStore = useAppInterfaceStore()
+const vehicleStore = useMainVehicleStore()
 
 // Create local reactive copies of the map settings
 const defaultMapCenter = ref<WaypointCoordinates>([...missionStore.defaultMapCenter])


### PR DESCRIPTION
Users reported that when using DVL as a positioning system, the map widget consumed excessive resources, causing Cockpit to run at very low frame rates.
@joaomariolago  pointed out that DVLs provide position updates at a very high refresh rate (about 20 Hz), which led to oversampling of vehicle positioning data and consequently triggered unnecessary redraws of the map widget and its related components.

* To prevent vehicle position oversampling, the max rate now can be set on `Settings -> Mission` (1) 
* Defaults to 200 ms

<img width="1914" height="1036" alt="oversampling" src="https://github.com/user-attachments/assets/b53a719d-b2ff-4ea0-9d06-df000e87110c" />
