### PR TITLE
Update Electron to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "c8": "^7.11.3",
     "cross-env": "^10.1.0",
     "dotenv": "^16.5.0",
-    "electron": "^29.2.0",
+    "electron": "37.9.0",
     "electron-builder": "^25.1.8",
     "eslint": "^8.5.0",
     "eslint-plugin-jsdoc": "^43.1.1",

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -6,8 +6,8 @@ import WidgetsView from '../views/WidgetsView.vue'
 
 const router = createRouter({
   history: process.env.IS_ELECTRON
-    ? createWebHistory(import.meta.env.BASE_URL)
-    : createWebHashHistory(import.meta.env.BASE_URL),
+    ? createWebHashHistory(import.meta.env.BASE_URL)
+    : createWebHistory(import.meta.env.BASE_URL),
   routes: [
     {
       path: '/',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3340,10 +3340,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.45.tgz#2c0fafd78705e7a18b7906b5201a522719dc5190"
   integrity sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==
 
-"@types/node@^20.9.0":
-  version "20.19.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.19.4.tgz#c4b8ce51a0f675a354225c58980ccacfe0af5d74"
-  integrity sha512-OP+We5WV8Xnbuvw0zC2m4qfB/BJvjyCwtNjhHdJxV1639SGSKrLmJkc3fMnp2Qy8nJyHp8RO6umxELN/dS1/EA==
+"@types/node@^22.7.7":
+  version "22.19.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.19.0.tgz#849606ef3920850583a4e7ee0930987c35ad80be"
+  integrity sha512-xpr/lmLPQEj+TUnHmR+Ab91/glhJvsqcjB+yY0Ix9GO70H6Lb4FHH5GeqdOE5btAx7eIMwuHkp4H2MSkLcqWbA==
   dependencies:
     undici-types "~6.21.0"
 
@@ -5035,13 +5035,13 @@ electron-updater@^6.6.2:
     semver "^7.6.3"
     tiny-typed-emitter "^2.1.0"
 
-electron@^29.2.0:
-  version "29.4.6"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-29.4.6.tgz#10826aaebea13c1de781399c3bbbebde6343d70d"
-  integrity sha512-fz8ndj8cmmf441t4Yh2FDP3Rn0JhLkVGvtUf2YVMbJ5SdJPlc0JWll9jYkhh60jDKVVCr/tBAmfxqRnXMWJpzg==
+electron@37.9.0:
+  version "37.9.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-37.9.0.tgz#7f30519f5f1e8e19a1aee1035b2334ced2143db4"
+  integrity sha512-4NJK/TeS2MbIjq45UmuEqsue3ziHueu45k1HlPLRQ/OPQWt2ArAU3rtyG0NJxSVzX5mSaLHOH20rKLWZD3+tBw==
   dependencies:
     "@electron/get" "^2.0.0"
-    "@types/node" "^20.9.0"
+    "@types/node" "^22.7.7"
     extract-zip "^2.0.1"
 
 emoji-regex@^8.0.0:


### PR DESCRIPTION
An update released during October [is believed to](https://github.com/electron/electron/pull/48376) increase the performance on macOS significantly (with a strong support other devs, based on the reactions to the mentioned PR).

I also investigated the bug we had last time around blank screens on Windows, and I believe to have fixed it in the 3rd commit ([router: Fix reversed history mode](https://github.com/bluerobotics/cockpit/commit/d1d553406ebd93ab539f28e3146cb5f5b7ddc19b)).

Needs some extra testing on Windows to make sure there are indeed no new bugs.

Maybe to be merged only after the 1.17.0 stable release.