### PR TITLE
widgets: map: use a copter icon for copters

### DIFF
--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -192,6 +192,7 @@ import {
   watch,
 } from 'vue'
 
+import copterMarkerImage from '@/assets/arducopter-top-view.png'
 import blueboatMarkerImage from '@/assets/blueboat-marker.png'
 import brov2MarkerImage from '@/assets/brov2-marker.png'
 import genericVehicleMarkerImage from '@/assets/generic-vehicle-marker.png'
@@ -789,6 +790,16 @@ watch(vehicleStore.coordinates, () => {
       vehicleIconUrl = blueboatMarkerImage
     } else if (vehicleStore.vehicleType === MavType.MAV_TYPE_SUBMARINE) {
       vehicleIconUrl = brov2MarkerImage
+    } else if (
+      [
+        MavType.MAV_TYPE_QUADROTOR,
+        MavType.MAV_TYPE_HEXAROTOR,
+        MavType.MAV_TYPE_OCTOROTOR,
+        MavType.MAV_TYPE_TRICOPTER,
+        MavType.MAV_TYPE_DODECAROTOR,
+      ].includes(vehicleStore.vehicleType)
+    ) {
+      vehicleIconUrl = copterMarkerImage
     }
 
     const vehicleMarkerIcon = L.divIcon({


### PR DESCRIPTION
We already had the image in the repo, for the README, so we may as well use it for known copter vehicles 🤷‍♂️ 

<img width="564" height="332" alt="Screenshot 2025-11-14 at 7 24 13 am" src="https://github.com/user-attachments/assets/a723cfec-a64f-468a-941a-f0c9dd7ce515" />

Could be good if we had a direction arrow on the image, since the black markings are quite hard to see, but I don't have time right now - we can leave it to the future (perhaps when we implement some other common vehicle type images, like planes and rovers) 😅 