### PR TITLE
map: mavlink: fix overly broad command condition

### DIFF
--- a/src/libs/vehicle/mavlink/types.ts
+++ b/src/libs/vehicle/mavlink/types.ts
@@ -80,7 +80,8 @@ export const convertCockpitWaypointsToMavlink = (
 export const convertMavlinkWaypointsToCockpit = (mavlinkWaypoints: Message.MissionItemInt[]): Waypoint[] => {
   const cockpitWaypoints: Waypoint[] = []
   mavlinkWaypoints.forEach((mavlinkWaypoint) => {
-    if (mavlinkWaypoint.command.type.includes('MAV_CMD_NAV') && mavlinkWaypoint.x !== 0 && mavlinkWaypoint.y !== 0) {
+    // Split into navigation waypoints (not at the global origin), and commands triggered at them
+    if (mavlinkWaypoint.command.type.includes('MAV_CMD_NAV') && !(mavlinkWaypoint.x == 0 && mavlinkWaypoint.y == 0)) {
       const altitudeReferenceType =
         cockpitAltRefFromMavlinkFrame(mavlinkWaypoint.frame.type) || AltitudeReferenceType.RELATIVE_TO_HOME
       cockpitWaypoints.push({


### PR DESCRIPTION
Building on #2205:
- Fixes a non-nav waypoint filtering edge-case, by treating only the global origin as non-nav waypoints (not every location with a zero component)
- Adds a human-readable description of that condition