### PR TITLE
widgets: collapsible-container: avoid shallow construction

### DIFF
--- a/src/stores/widgetManager.ts
+++ b/src/stores/widgetManager.ts
@@ -581,7 +581,7 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
 
     if (widget.component === WidgetType.CollapsibleContainer) {
       newWidget.options = {
-        elementContainers: defaultCustomWidgetContainers,
+        elementContainers: structuredClone(defaultCustomWidgetContainers),
         columns: 1,
         leftColumnWidth: 50,
         backgroundOpacity: 0.2,


### PR DESCRIPTION
Fixes #1527. This is just intended to fix the problem of unintentionally linked container widgets - it unfortunately doesn't follow the suggested solution of allowing for intentionally linked ones (covered by #1690).

By deeply copying the default container elements, there is no longer cross-pollution of references to them between newly created widget containers. Ideally the defaults shouldn't be set in a special case in the widget manager, but I decided to keep this PR simple and make the smallest fixing change I could, especially given implementing #2114 will likely rework a bunch of the relevant code anyway.

Before:

https://github.com/user-attachments/assets/7b653f02-1056-4a95-94ec-e133b3dd2798

After:

https://github.com/user-attachments/assets/1e65db0e-853f-4b2a-a101-eeebaba5b8d7
