### PR TITLE
register_service: update Extension name to Cockpit Lite

### DIFF
--- a/public/register_service
+++ b/public/register_service
@@ -1,6 +1,6 @@
 {
-    "name": "Cockpit",
-    "description": "An intuitive and customizable cross-platform ground control station for remote vehicles of all types.",
+    "name": "Cockpit Lite",
+    "description": "A browser-based version of the Cockpit application - an intuitive and customizable ground control station for remote vehicles of all types.",
     "icon": "mdi-gamepad-square",
     "company": "Blue Robotics",
     "version": "0.0.0",


### PR DESCRIPTION
Building on #2148, this renames the Extension in the BlueOS sidebar, to better reflects its reduced functionality compared to the freestanding application, and help communicate to Extension users that there's a more complete experience available.

Suggested by @rjehangir.