### PR TITLE
workflows: ci.yml: remove Bazaar deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,15 +405,3 @@ jobs:
         run: |
           docker buildx imagetools \
             inspect ${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}
-
-  deploy-cloud:
-    needs: test
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') && success()
-    steps:
-      - name: Build and Publish Extension in BlueOS CLoud
-        uses: bluerobotics/blueos-cloud-action@0.0.3
-        with:
-          BCLOUD_PAT: ${{secrets.BCLOUD_PAT}}
-          PLATFORMS: linux/arm/v7,linux/arm64,linux/amd64
-          EXTENSION: 29fb2bc7-2bc9-4d86-a57b-4fe1ee152d1e


### PR DESCRIPTION
Bazaar development is currently halted in favour of other cloud functionalities, and will no longer be used as an alternative extensions store.