### PR TITLE
index: change browser app title to use Lite branding

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,10 +9,10 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
     <link rel="manifest" href="/site.webmanifest">
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
-    <meta name="apple-mobile-web-app-title" content="Cockpit">
-    <meta name="application-name" content="Cockpit">
+    <meta name="apple-mobile-web-app-title" content="Cockpit Lite">
+    <meta name="application-name" content="Cockpit Lite">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <title>Cockpit</title>
+    <title>Cockpit Lite</title>
     <meta name="description" content="An intuitive and customizable cross-platform ground control station for remote vehicles of all types.">
 </head>
 

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -39,6 +39,7 @@ function createWindow(): void {
     height: store.get('windowBounds')?.height ?? screen.getPrimaryDisplay().workAreaSize.height,
     x: store.get('windowBounds')?.x ?? screen.getPrimaryDisplay().bounds.x,
     y: store.get('windowBounds')?.y ?? screen.getPrimaryDisplay().bounds.y,
+    title: `Cockpit (${app.getVersion()})`,
   })
 
   linkService.setMainWindow(mainWindow)
@@ -47,6 +48,11 @@ function createWindow(): void {
     const windowBounds = mainWindow!.getBounds()
     const { x, y, width, height } = windowBounds
     store.set('windowBounds', { x, y, width, height })
+  })
+
+  // Don't use the browser page title
+  mainWindow.on('page-title-updated', (event) => {
+    event.preventDefault()
   })
 
   if (process.env.VITE_DEV_SERVER_URL) {


### PR DESCRIPTION
Continuing [ongoing efforts](https://github.com/bluerobotics/cockpit/issues/2166#issuecomment-3566779269) to rebrand the browser version as "Cockpit Lite" - this corrects the page title, which shows up as the name on tabs.

Also added the version to the name for the Electron application, after some discussion with @rafaellehmkuhl in a support call.