### PR TITLE
Fix recording of video streams with delayes SPS/PPS

### DIFF
--- a/src/electron/services/video-recording.ts
+++ b/src/electron/services/video-recording.ts
@@ -83,6 +83,10 @@ const startVideoRecording = async (
 
   // Spawn FFmpeg with stdin input and fragmented MP4 output
   const ffmpegArgs = [
+    '-probesize',
+    '100M', // 100MB to find decoding info
+    '-analyzeduration',
+    '15M', // 15 seconds to find decoding info
     '-f',
     'webm', // Input format is WebM
     '-i',


### PR DESCRIPTION
This PR effectively solves the problem of RadCam recordings made with MCM versions prior to 3.22.1 to generate completely black videos.

The solution was to increase the `--probesize` of `FFMPEG` to 100MB and the `--analyzeduration` to 15 seconds. This increases the initial buffer that `FFMPEG` uses to find the decoding information (SPS and PPS). Since the old versions of MCM send this code every 10 seconds, and the default values are 5MB and 5s, about half the recordings were failing for missing decoding info (SPS and PPS).

Did 20 records in a row with the same ROV that can rarely do two. The problem is gone.

Was also able to process the failing videos that Wilson recorded on the original issue report, with the chunk ZIPs.

Fix #2275