### PR TITLE
electron: storage: move to user's documents folder

### DIFF
--- a/src/electron/services/storage.ts
+++ b/src/electron/services/storage.ts
@@ -6,7 +6,7 @@ import { dirname, join } from 'path'
 import type { FileDialogOptions, FileStats } from '@/types/storage'
 
 // Create a new storage interface for filesystem
-export const cockpitFolderPath = join(app.getPath('home'), 'Cockpit')
+export const cockpitFolderPath = join(app.getPath('documents'), 'Cockpit')
 fs.mkdir(cockpitFolderPath, { recursive: true })
 
 export const filesystemStorage = {


### PR DESCRIPTION
[Supported by electron](https://www.electronjs.org/docs/latest/api/app#:~:text=documents%20Directory%20for%20a%20user%27s%20%22My%20Documents%22.)

Fixes #1780.