### PR TITLE
Fix survey path with acute angles

### DIFF
--- a/src/libs/utils-map.ts
+++ b/src/libs/utils-map.ts
@@ -220,14 +220,22 @@ export const generateSurveyPath = (
       const clipped = turf.lineIntersect(poly, line)
 
       if (clipped.features.length >= 2) {
-        const coords = clipped.features.map((f) => f.geometry.coordinates)
+        const sortedFeatures = clipped.features.sort((a, b) => {
+          const coordsA = a.geometry.coordinates
+          const coordsB = b.geometry.coordinates
+          const distA = Math.pow(coordsA[0] - lineStart[0], 2) + Math.pow(coordsA[1] - lineStart[1], 2)
+          const distB = Math.pow(coordsB[0] - lineStart[0], 2) + Math.pow(coordsB[1] - lineStart[1], 2)
+          return distA - distB
+        })
+
+        const coords = sortedFeatures.map((f) => f.geometry.coordinates)
         if (isReverse) coords.reverse()
 
         const linePoints = coords.map((c) => L.latLng(c[1], c[0]))
 
         if (continuousPath.length > 0) {
           const lastPoint = continuousPath[continuousPath.length - 1]
-          const edgePath = moveAlongEdge(poly, lastPoint, linePoints[0], distanceBetweenLines / 111000)
+          const edgePath = moveAlongEdge(poly, lastPoint, linePoints[0], diagonal)
           continuousPath.push(...edgePath)
         }
 


### PR DESCRIPTION
Prevent path lines with acute angles to be created (red arrows in 1)
(1)
<img width="698" height="785" alt="acute_angle" src="https://github.com/user-attachments/assets/ca6a7ec2-327b-41fa-8124-a12ead0e498a" />

Fixed path generation:

https://github.com/user-attachments/assets/e5e534f9-fb95-4d35-8518-7c2076de9bb6

Closes #1421