### PR TITLE
src: mini-widgets: ViewSelector: re-add visibility filtering

### DIFF
--- a/src/components/mini-widgets/ViewSelector.vue
+++ b/src/components/mini-widgets/ViewSelector.vue
@@ -3,7 +3,7 @@
     <Dropdown
       name-key="name"
       :model-value="widgetStore.currentView"
-      :options="widgetStore.currentProfile.views"
+      :options="widgetStore.currentProfile.views.filter((v) => v.visible)"
       class="min-w-[128px]"
       @update:model-value="widgetStore.selectView"
     />


### PR DESCRIPTION
Partial reversion of #965, because the previous variable [filters out hidden views](https://github.com/bluerobotics/cockpit/blob/master/src/stores/widgetManager.ts#L277), whereas the base list just includes all of them.

I have checked that it works, but I'm also unsure whether we should just go back to the old variable. It's not clear why it was changed away from.