### PR TITLE
Fix logs list not loading when heavy logs are present

### DIFF
--- a/src/electron/services/electron-log.ts
+++ b/src/electron/services/electron-log.ts
@@ -92,9 +92,10 @@ export const setupElectronLogService = (): void => {
 
       return await Promise.all(
         syslogFiles.map(async (logFile) => {
-          const logContent = await readFile(join(getElectronLogsPath(), logFile), 'utf-8')
+          const filePath = join(getElectronLogsPath(), logFile)
 
-          // Extract date and time from filename
+          // Extract date, time and size from file
+          const stats = await stat(filePath)
           const match = logFile.match(/Cockpit \((.+?)\)\.syslog/)
           let initialDate = format(new Date(), systemLogDateFormat)
           let initialTime = format(new Date(), systemLogTimeFormat)
@@ -108,7 +109,7 @@ export const setupElectronLogService = (): void => {
           }
 
           return {
-            content: logContent,
+            size: stats.size,
             path: logFile,
             initialTime,
             initialDate,

--- a/src/types/electron-general.ts
+++ b/src/types/electron-general.ts
@@ -3,9 +3,9 @@
  */
 export interface ElectronLog {
   /**
-   * The log file content
+   * The size of the log file in bytes
    */
-  content: string
+  size: number
   /**
    * The path to the log file
    */


### PR DESCRIPTION
Replace showing number of log lines with showing file size.

<img width="1279" height="1058" alt="image" src="https://github.com/user-attachments/assets/7a8d38e5-9893-471f-93ea-ee3b15b69a82" />

Fix #2264
Fix #2329
