### PR TITLE
Fix system logs not being generated on v1.18+

### DIFF
--- a/src/libs/system-logging.ts
+++ b/src/libs/system-logging.ts
@@ -64,7 +64,7 @@ const sendLogToElectron = (level: string, message: string): void => {
 
 const enableSystemLogging = settingsManager.getKeyValue(systemLoggingEnablingKey)
 
-if (enableSystemLogging === 'true') {
+if (enableSystemLogging) {
   const isRunningInElectron = isElectron()
 
   console.log(`


### PR DESCRIPTION
Logs were not being generated on master (v1.18+) because we were checking if a boolean value had a value equals to `'true'`. This is because the legacy check over the `localStorage` API is based on strings.

No need to cherry-pick that fix to v1.17 since it was only introduced on v1.18.

Fix #2335 