### PR TITLE
Allow setting bounds of the Y axis in the plotter widget

### DIFF
--- a/src/components/widgets/Plotter.vue
+++ b/src/components/widgets/Plotter.vue
@@ -381,6 +381,21 @@ const renderCanvas = (): void => {
 
     const currentValue = valuesHistory[valuesHistory.length - 1]
 
+    // Draw zero reference line if zero is within the visible range
+    if (minY <= 0 && maxY >= 0) {
+      const zeroY = canvasHeight - ((0 - minY) / (maxY - minY)) * canvasHeight
+      ctx.beginPath()
+      ctx.setLineDash([5, 5])
+      ctx.strokeStyle = 'rgba(255, 255, 255, 0.3)'
+      ctx.lineWidth = 1
+      ctx.moveTo(0, zeroY)
+      ctx.lineTo(canvasWidth, zeroY)
+      ctx.stroke()
+      // Restore line settings for the main graph
+      ctx.strokeStyle = widget.value.options.lineColor
+      ctx.lineWidth = Math.max(widget.value.options.lineThickness, 1)
+    }
+
     // Draw the graph
     ctx.beginPath()
     ctx.moveTo(0, canvasHeight / 2)


### PR DESCRIPTION
In a lot of cases, automatically-set bounds do not reflect the reality of what's happening. 

When one is trying to measure noise, for example, if the noise is low (like when one is measuring the app frame-rate and it oscillates less than 10% around the average) for an auto-bounded graph it looks like the value is oscillating a lot, but if the user sets proper bounds (to 0-120 for a 60 average, in this case) it becomes clear that the value is very stable.

<img width="752" height="737" alt="image" src="https://github.com/user-attachments/assets/4a0063ec-be77-4a7d-9561-ed21b0dfbc71" />