### PR TITLE
Do not disable joystick forwarding automatically when multiple joysticks connect at the same time

### DIFF
--- a/src/stores/controller.ts
+++ b/src/stores/controller.ts
@@ -171,10 +171,11 @@ export const useControllerStore = defineStore('controller', () => {
   const processJoystickConnectionEvent = async (event: JoysticksMap): Promise<void> => {
     const newMap = new Map(Array.from(event).map(([index, gamepad]) => [index, new Joystick(gamepad)]))
 
-    const thereWereJoysticksBefore = joysticks.value.size > 0
-
     // Add new joysticks
     for (const [index, joystick] of newMap) {
+      // Check if there were joysticks connected before this one
+      const thereWereJoysticksBefore = joysticks.value.size > 0
+
       if (joysticks.value.has(index)) continue
       joystick.model = joystickManager.getModel(joystick.gamepad.id)
       const { product_id, vendor_id } = joystickManager.getVidPid(joystick.gamepad.id)


### PR DESCRIPTION
If multiple joysticks connect together, the first one enables message forwarding (if no other GCS is detected) but the second joystick will always disable the forwarding, as it will detect the messages from the first one and the `thereWereJoysticksBefore` variable was already computed as false. Now it does account for that case correctly.

The artifacts for this fix cherry-picked to 1.17.0 can be found [here](https://github.com/rafaellehmkuhl/cockpit-public/actions/runs/21173025872).

Fix #2346 
