### PR TITLE
Stop emitting joystick connection events when button/axis state change

### DIFF
--- a/src/libs/joystick/manager.ts
+++ b/src/libs/joystick/manager.ts
@@ -429,13 +429,12 @@ class JoystickManager {
       if (!this.joysticks.has(data.deviceId)) {
         this.joysticks.set(data.deviceId, joystickEvent.gamepad)
         this.enabledJoysticks.push(data.deviceId)
+        // Emit joystick connection update only when a new joystick is detected
+        this.emitJoystickConnectionUpdate()
       }
 
       // Emit joystick state update
       this.emitStateEvent(joystickEvent)
-
-      // Emit joystick connection update
-      this.emitJoystickConnectionUpdate()
     })
   }
 


### PR DESCRIPTION
I noticed this bug when investigating another reported joystick issue.

I'm not sure how much it was affecting performance. Probably not that much, since only two lines of code with processing were being performed (on each call), but it was definitely not helping.