### PR TITLE
mavlink: Allows disabling the generation of legacy data-lake variables

### DIFF
--- a/src/libs/vehicle/mavlink/vehicle.ts
+++ b/src/libs/vehicle/mavlink/vehicle.ts
@@ -93,6 +93,7 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
   _flying = false
 
   shouldCreateDatalakeVariablesFromOtherSystems = false
+  shouldCreateLegacyDataLakeVariables = true
 
   protected currentSystemId = 1
 
@@ -1475,7 +1476,11 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
       }
       setDataLakeVariableData(path, mavlinkPackage.message.value)
 
-      if (messageSystemId === this.currentSystemId && messageComponentId === 1) {
+      if (
+        this.shouldCreateLegacyDataLakeVariables &&
+        messageSystemId === this.currentSystemId &&
+        messageComponentId === 1
+      ) {
         // Create duplicated variables for legacy purposes (that was how they were stored in the old generic-variables system)
         const oldVariablePath = mavlinkPackage.message.name.join('').replaceAll('\x00', '')
         if (getDataLakeVariableInfo(oldVariablePath) === undefined) {
@@ -1490,7 +1495,11 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
         if (value === null) return
         if (typeof value !== 'string' && typeof value !== 'number') return
 
-        if (messageSystemId === this.currentSystemId && messageComponentId === 1) {
+        if (
+          this.shouldCreateLegacyDataLakeVariables &&
+          messageSystemId === this.currentSystemId &&
+          messageComponentId === 1
+        ) {
           // Create the variable in the old style path for legacy purposes (that was how they were stored in the old generic-variables system)
           const oldStylePath = `${path}`
           if (getDataLakeVariableInfo(oldStylePath) === undefined) {

--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -175,6 +175,10 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     false
   )
 
+  // Store setting to enable/disable legacy data lake variable names (e.g., 'ATTITUDE/roll' in addition to '/mavlink/1/1/ATTITUDE/roll')
+  // Enabled by default for backward compatibility reasons - users with old devices may want to disable this to improve performance
+  const enableLegacyDataLakeVariableNames = useBlueOsStorage('cockpit-enable-legacy-datalake-variable-names', true)
+
   const MAVLink2RestWebsocketURI = computed(() => {
     const queryURI = new URLSearchParams(window.location.search).get('MAVLink2RestWebsocketURI')
     const customURI = customMAVLink2RestWebsocketURI.value.enabled
@@ -215,6 +219,11 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
   watch(enableDatalakeVariablesFromOtherSystems, (newValue) => {
     if (!mainVehicle.value) return
     mainVehicle.value.shouldCreateDatalakeVariablesFromOtherSystems = newValue
+  })
+
+  watch(enableLegacyDataLakeVariableNames, (newValue) => {
+    if (!mainVehicle.value) return
+    mainVehicle.value.shouldCreateLegacyDataLakeVariables = newValue
   })
 
   watch(
@@ -543,6 +552,8 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
 
     // Set callback to check if datalake variables from other systems should be created
     mainVehicle.value.shouldCreateDatalakeVariablesFromOtherSystems = enableDatalakeVariablesFromOtherSystems.value
+    // Set whether to create legacy data lake variable names
+    mainVehicle.value.shouldCreateLegacyDataLakeVariables = enableLegacyDataLakeVariableNames.value
 
     mainVehicle.value.onAltitude.add((newAltitude: Altitude) => {
       Object.assign(altitude, newAltitude)
@@ -985,6 +996,7 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     vehiclePayloadParameters,
     vehiclePositionMaxSampleRate,
     enableDatalakeVariablesFromOtherSystems,
+    enableLegacyDataLakeVariableNames,
     getVehicleAddress,
   }
 })

--- a/src/views/ConfigurationMAVLinkView.vue
+++ b/src/views/ConfigurationMAVLinkView.vue
@@ -6,19 +6,33 @@
         <ExpansiblePanel no-top-divider :is-expanded="!interfaceStore.isOnPhoneScreen">
           <template #title>DataLake variables creation</template>
           <template #info>
-            <p class="max-w-[500px]">
-              Enable the creation of DataLake variables from MAVLink messages originating from systems/components other
-              than the main vehicle (System ID {{ mainVehicleStore.mainVehicle?.systemId }}, Component ID 1). When
-              enabled, variables from all MAVLink systems on the network will be available in the DataLake. When
-              disabled, only variables from the main vehicle will be created.
-            </p>
+            <ul class="max-w-[700px] list-disc pl-4 space-y-2">
+              <li>
+                <strong>Variables from other systems:</strong> Enable creation of DataLake variables from MAVLink
+                messages originating from systems/components other than the main vehicle (System ID
+                {{ mainVehicleStore.mainVehicle?.systemId }}, Component ID 1). When enabled, variables from all MAVLink
+                systems on the network will be available in the DataLake.
+              </li>
+              <li>
+                <strong>Legacy variable names:</strong> Creates duplicate variables with the old naming format for
+                backward compatibility. Enabled by default - users with old devices may want to disable this to improve
+                performance. If disabled, you will need to manually replace the usage of legacy variables with the new
+                ones in your widgets (e.g.: VGI, Plotter) and scripts (e.g.: DataLake Transforming functions).
+              </li>
+            </ul>
           </template>
           <template #content>
-            <div class="flex w-full px-2 mb-3">
+            <div class="flex flex-col w-full px-2 mb-3 gap-1">
               <v-switch
                 v-model="mainVehicleStore.enableDatalakeVariablesFromOtherSystems"
                 color="white"
                 label="Enable DataLake variables from other systems"
+                hide-details
+              />
+              <v-switch
+                v-model="mainVehicleStore.enableLegacyDataLakeVariableNames"
+                color="white"
+                label="Enable legacy variable names (e.g., 'ATTITUDE/roll')"
                 hide-details
               />
             </div>


### PR DESCRIPTION
Those are variables in the legacy ID pattern. For compatibility purposes, we generate them by default.

The generation of those legacy variables can cause a performance overhead in the application, as it basically doubles the amount of data-lake variables in the system.

This patch allows users to disable them if necessary (e.g.: when running on low-end machines).