### PR TITLE
Edit menu: fix default widget position and size when dragging it into a view

### DIFF
--- a/src/stores/widgetManager.ts
+++ b/src/stores/widgetManager.ts
@@ -35,6 +35,7 @@ import {
   type Widget,
   CustomWidgetElement,
   CustomWidgetElementContainer,
+  DragState,
   InternalWidgetSetupInfo,
   MiniWidgetManagerVars,
   validateProfile,
@@ -70,6 +71,7 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
   const miniWidgetLastValues = useBlueOsStorage<Record<string, any>>('cockpit-mini-widget-last-values', {})
   const floatingWidgetContainers = ref<MiniWidgetContainer[]>([])
   const currentContextMenu = ref<any | null>(null)
+  const widgetDragState = ref<DragState>({ widget: null, position: null })
 
   const editWidgetByHash = (hash: string): Widget | undefined => {
     widgetToEdit.value = currentProfile.value.views
@@ -929,6 +931,7 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
     updateElementOptions,
     removeElementFromCustomWidget,
     loadWidgetFromFile,
+    widgetDragState,
     widgetToEdit,
     editWidgetByHash,
     setMiniWidgetLastValue,

--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -759,6 +759,17 @@ export type DraggableEvent = {
   item: HTMLElement
 }
 
+export type DragState = {
+  /**
+   * The widget being dragged
+   */
+  widget: InternalWidgetSetupInfo | null
+  /**
+   * The position where the widget would be dropped (normalized 0-1 coordinates)
+   */
+  position: Point2D | null
+}
+
 export type View = {
   /**
    * Unique identifier for the view

--- a/src/views/WidgetsView.vue
+++ b/src/views/WidgetsView.vue
@@ -12,6 +12,27 @@
         </div>
       </div>
       <SnappingGrid v-if="store.snapToGrid && store.editingMode" :grid-interval="store.gridInterval" />
+      <!-- Ghost preview for widget being dragged -->
+      <div
+        v-if="store.widgetDragState.widget && store.widgetDragState.position && store.editingMode"
+        class="widget-ghost-preview"
+        :style="{
+          position: 'absolute',
+          left: `${store.widgetDragState.position.x * 100}%`,
+          top: `${store.widgetDragState.position.y * 100}%`,
+          width: `${(store.widgetDragState.widget.defaultSize?.width ?? 0.2) * 100}%`,
+          height: `${(store.widgetDragState.widget.defaultSize?.height ?? 0.36) * 100}%`,
+          pointerEvents: 'none',
+          zIndex: 1000,
+        }"
+      >
+        <div
+          class="w-full h-full border-2 border-dashed border-[#ffffff21] bg-[#ffffff03] rounded-md shadow-sm"
+          style="backdrop-filter: blur(16px)"
+        >
+          <div class="w-full h-full bg-[#ffffff03] rounded-md" />
+        </div>
+      </div>
       <template v-for="widget in view.widgets.slice().reverse()" :key="widget.hash">
         <WidgetHugger
           v-if="componentExists(widget.component)"


### PR DESCRIPTION
* New widgets are now dragged into place instead of appearing at the center of the screen;
* While dragging, a transparent placeholder guides the user to place the widget in the correct position;
* Each widget now has a default size based on the default view profiles;

https://github.com/user-attachments/assets/7f1f10f3-e648-4a2f-ab1d-f41e39b326a6

Partially solves #1541 