### PR TITLE
feat: Add debounce to the notification on data-lake list update

### DIFF
--- a/src/libs/actions/data-lake.ts
+++ b/src/libs/actions/data-lake.ts
@@ -280,9 +280,22 @@ export const unlistenToDataLakeVariablesInfoChanges = (listenerId: string): void
   delete dataLakeVariableInfoListeners[listenerId]
 }
 
+// Debounce timer for variable info change notifications
+let notifyInfoListenersTimeout: ReturnType<typeof setTimeout> | null = null
+const notifyInfoDebounceMs = 1000
+
 const notifyDataLakeVariableInfoListeners = (): void => {
-  const updatedVariables = getAllDataLakeVariablesInfo()
-  Object.values(dataLakeVariableInfoListeners).forEach((listener) => listener(updatedVariables))
+  // Clear any pending notification
+  if (notifyInfoListenersTimeout) {
+    clearTimeout(notifyInfoListenersTimeout)
+  }
+
+  // Schedule a new notification after the debounce period
+  notifyInfoListenersTimeout = setTimeout(() => {
+    const updatedVariables = getAllDataLakeVariablesInfo()
+    Object.values(dataLakeVariableInfoListeners).forEach((listener) => listener(updatedVariables))
+    notifyInfoListenersTimeout = null
+  }, notifyInfoDebounceMs)
 }
 
 // Initialize by loading persistent variables


### PR DESCRIPTION
Those listening to updates in the data-lake variables list need to know it updated, and which are the new values, but when hundreds of values are being added at once (which happens during startup and vehicle connection) they don't need to be updated hundreds of times.

This update makes it so the listeners are notified only if no updates are made to the list for at least 1 second.

Reduces from 40 to 2 notifications per Plotter, and from 40 to 2 notifications per VeryGenericIndicator.

In my default profile/view (5 Plotters and 2 VGIs) it reduced the number of updates from 280 to 14.