### PR TITLE
Fix Joystick menu "bouncing" on first open

### DIFF
--- a/src/views/ConfigurationJoystickView.vue
+++ b/src/views/ConfigurationJoystickView.vue
@@ -5,6 +5,7 @@
       <div
         :class="interfaceStore.isOnSmallScreen ? 'max-w-[88vw] max-h-[95vh]' : 'max-w-[880px] max-h-[80vh]'"
         class="overflow-y-auto"
+        style="scrollbar-gutter: stable"
       >
         <div
           v-if="controllerStore.joysticks && !controllerStore.joysticks.size"


### PR DESCRIPTION
Even though I wasn’t able to reproduce the issue on my PC, the problem was fairly clear in the video attached to the issue.

Closes #2396 