### PR TITLE
settings-manager-ui: Adapt it to the new settings-management backend format

### DIFF
--- a/src/components/configuration/CockpitSettingsManager.vue
+++ b/src/components/configuration/CockpitSettingsManager.vue
@@ -11,6 +11,48 @@
 
       <v-container>
         <div class="flex flex-col h-[70vh] border border-[rgba(255,255,255,0.3)] rounded elevation-3">
+          <div class="p-2 border-b border-b-[rgba(255,255,255,0.3)] bg-[rgba(0,0,0,0.15)]">
+            <div class="flex flex-col gap-y-2">
+              <div class="flex gap-x-2">
+                <v-select
+                  v-model="selectedUserId"
+                  :items="availableUsers"
+                  label="User"
+                  density="compact"
+                  variant="outlined"
+                  hide-details
+                  theme="dark"
+                  class="w-full"
+                />
+                <v-select
+                  v-model="selectedVehicleId"
+                  :items="availableVehicles"
+                  label="Vehicle"
+                  density="compact"
+                  variant="outlined"
+                  hide-details
+                  theme="dark"
+                  class="w-full"
+                  :disabled="availableVehicles.length === 0"
+                />
+              </div>
+              <div v-if="interfaceStore.pirateMode" class="flex flex-wrap gap-x-4">
+                <v-checkbox
+                  v-model="showLegacyInternalKeys"
+                  label="Show legacy/internal keys"
+                  density="compact"
+                  hide-details
+                />
+                <v-checkbox
+                  v-model="showAllKeyPairs"
+                  label="Show all localStorage key-pairs"
+                  density="compact"
+                  hide-details
+                />
+              </div>
+            </div>
+          </div>
+
           <div class="flex-none sticky top-0 bg-inherit z-[2]">
             <table class="w-full border-collapse">
               <thead>
@@ -23,10 +65,15 @@
           </div>
 
           <div class="flex-auto overflow-y-auto">
-            <template v-if="settingsArray.length === 0">
+            <template v-if="!isLoaded">
               <div class="flex flex-row w-full h-full justify-center items-center text-center py-4">
                 <v-circular-progress size="40" color="white" />
                 <p>Loading settings...</p>
+              </div>
+            </template>
+            <template v-else-if="settingsArray.length === 0">
+              <div class="flex flex-row w-full h-full justify-center items-center text-center py-4">
+                <p>No settings available for current selection.</p>
               </div>
             </template>
             <template v-else>
@@ -34,11 +81,21 @@
                 <tbody>
                   <tr v-for="item in filteredSettings" :key="item.originalKey">
                     <td class="text-start align-top p-2 pl-4 w-[300px] border-b border-b-[rgba(255,255,255,0.3)]">
-                      {{ item.setting }}
+                      {{ displaySettingName(item) }}
                     </td>
                     <td class="text-center border-b border-b-[rgba(255,255,255,0.3)] pr-4">
-                      <template v-if="isPrimitive(editedValues[item.originalKey])">
-                        <div class="text-center py-0 cursor-pointer" @dblclick="startEditing(item)">
+                      <template v-if="saving[item.originalKey]">
+                        <div class="flex w-full justify-center items-center gap-x-2 py-2">
+                          <v-progress-circular size="16" width="2" indeterminate />
+                          <span class="text-xs opacity-80">Updating...</span>
+                        </div>
+                      </template>
+                      <template v-else-if="isPrimitive(editedValues[item.originalKey])">
+                        <div
+                          class="text-center py-0 cursor-pointer"
+                          :class="{ 'pointer-events-none opacity-70': saving[item.originalKey] }"
+                          @dblclick="startEditing(item)"
+                        >
                           <template v-if="editing[item.originalKey]">
                             <div class="flex w-full justify-between items-center">
                               <div />
@@ -70,7 +127,6 @@
                                 />
                               </template>
                               <div>
-                                <!-- Save/Cancel buttons -->
                                 <v-tooltip location="top" text="Cancel">
                                   <template #activator="{ props: tooltipProps }">
                                     <v-btn
@@ -78,6 +134,7 @@
                                       icon="mdi-close"
                                       variant="text"
                                       class="self-end text-red-300 mb-[3px]"
+                                      :disabled="saving[item.originalKey]"
                                       v-bind="tooltipProps"
                                       @click="cancelEditingItem(item)"
                                     />
@@ -90,6 +147,8 @@
                                       icon="mdi-content-save"
                                       variant="text"
                                       class="self-end text-green-300 mb-[3px]"
+                                      :loading="saving[item.originalKey]"
+                                      :disabled="saving[item.originalKey]"
                                       v-bind="tooltipProps"
                                       @click="commitChanges(item)"
                                     />
@@ -110,6 +169,7 @@
                                     icon="mdi-pencil"
                                     variant="text"
                                     class="self-end"
+                                    :disabled="saving[item.originalKey]"
                                     @click="startEditing(item)"
                                   />
                                 </template>
@@ -127,13 +187,21 @@
                             :class="{ 'border-2 border-[#FF000055]': JsonEditError }"
                           />
                           <div class="flex justify-end gap-x-6 pt-[2px]">
-                            <v-btn size="x-small" variant="text" class="bgb-transparent" @click="cancelJsonEditing()">
+                            <v-btn
+                              size="x-small"
+                              variant="text"
+                              class="bgb-transparent"
+                              :disabled="saving[item.originalKey]"
+                              @click="cancelJsonEditing()"
+                            >
                               close
                             </v-btn>
                             <v-btn
                               size="x-small"
                               variant="text"
                               class="bg-[#FFFFFF22]"
+                              :loading="saving[item.originalKey]"
+                              :disabled="saving[item.originalKey]"
                               @click="finishInlineJsonEditing(item.originalKey)"
                             >
                               Save
@@ -154,6 +222,7 @@
                                   icon="mdi-pencil"
                                   variant="text"
                                   class="self-end"
+                                  :disabled="saving[item.originalKey]"
                                   @click="startInlineJsonEditing(item.originalKey)"
                                 />
                               </template>
@@ -221,14 +290,48 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, reactive, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, reactive, ref, watch } from 'vue'
 
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { useSnackbar } from '@/composables/snackbar'
+import {
+  cockpitLastConnectedUserKey,
+  cockpitLastConnectedVehicleKey,
+  localOldStyleSettingsKey,
+  localSyncedSettingsKey,
+  settingsManager,
+  vehicleIdKey,
+} from '@/libs/settings-management'
+import { isEqual } from '@/libs/utils'
 import { reloadCockpitAndWarnUser } from '@/libs/utils-vue'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMissionStore } from '@/stores/mission'
-import { SettingItem, Settings } from '@/types/general'
+import { Settings } from '@/types/general'
+import { LocalSyncedSettings, SettingsPackage } from '@/types/settings-management'
+
+type SettingsRowSource = 'v2' | 'legacy' | 'all-local-storage'
+type SettingsRow = {
+  /**
+   * The name of the setting
+   */
+  setting: string
+  /**
+   * The original key of the setting
+   */
+  originalKey: string
+  /**
+   * The storage key of the setting
+   */
+  storageKey: string
+  /**
+   * The source of the setting
+   */
+  source: SettingsRowSource
+  /**
+   * The v2 setting key of the setting
+   */
+  v2SettingKey?: string
+}
 
 const props = defineProps<{
   /**
@@ -250,62 +353,199 @@ const searchTerm = ref('')
 const editing = reactive<Record<string, boolean>>({})
 const inlineJsonEditing = reactive<Record<string, boolean>>({})
 const inlineJsonText = reactive<Record<string, string>>({})
+const saving = reactive<Record<string, boolean>>({})
 const JsonEditError = ref(false)
+const isLoaded = ref(false)
+const selectedUserId = ref('')
+const selectedVehicleId = ref('')
+const showLegacyInternalKeys = ref(false)
+const showAllKeyPairs = ref(false)
+const legacyInternalKeys = [
+  localOldStyleSettingsKey,
+  vehicleIdKey,
+  cockpitLastConnectedVehicleKey,
+  cockpitLastConnectedUserKey,
+]
+const v2WriteWaitTimeoutMs = 5000
+const v2WriteWaitIntervalMs = 100
 
-const settingsArray = computed<SettingItem[]>(() =>
-  Object.keys(editedValues).map((key) => ({
-    setting: key.replace(/^cockpit-/, ''),
-    originalKey: key,
-  }))
+const localSyncedSettings = ref<LocalSyncedSettings>({})
+const localStorageSnapshot = ref<Settings>({})
+
+const availableUsers = computed<string[]>(() => Object.keys(localSyncedSettings.value).sort())
+const availableVehicles = computed<string[]>(() =>
+  Object.keys(localSyncedSettings.value[selectedUserId.value] ?? {}).sort()
+)
+const selectedV2Package = computed<SettingsPackage>(
+  () => localSyncedSettings.value[selectedUserId.value]?.[selectedVehicleId.value] ?? {}
 )
 
-const filteredSettings = computed<SettingItem[]>(() => {
+const makeRowOriginalKey = (source: SettingsRowSource, storageKey: string, v2SettingKey?: string): string => {
+  if (source === 'v2') return `v2:${selectedUserId.value}:${selectedVehicleId.value}:${v2SettingKey ?? ''}`
+  return `local:${storageKey}`
+}
+
+const allRows = computed<SettingsRow[]>(() => {
+  const rows: SettingsRow[] = Object.keys(selectedV2Package.value)
+    .sort()
+    .map((settingKey) => ({
+      setting: settingKey,
+      originalKey: makeRowOriginalKey('v2', localSyncedSettingsKey, settingKey),
+      storageKey: localSyncedSettingsKey,
+      source: 'v2',
+      v2SettingKey: settingKey,
+    }))
+
+  if (interfaceStore.pirateMode && showAllKeyPairs.value) {
+    Object.keys(localStorageSnapshot.value)
+      .sort()
+      .forEach((key) =>
+        rows.push({
+          setting: key,
+          originalKey: makeRowOriginalKey('all-local-storage', key),
+          storageKey: key,
+          source: 'all-local-storage',
+        })
+      )
+    return rows
+  }
+
+  if (interfaceStore.pirateMode && showLegacyInternalKeys.value) {
+    legacyInternalKeys.forEach((key) => {
+      if (!(key in localStorageSnapshot.value)) return
+      rows.push({
+        setting: key,
+        originalKey: makeRowOriginalKey('legacy', key),
+        storageKey: key,
+        source: 'legacy',
+      })
+    })
+  }
+
+  return rows
+})
+
+const settingsArray = computed<SettingsRow[]>(() => allRows.value)
+
+const displaySettingName = (item: SettingsRow): string => {
+  if (item.source === 'v2') {
+    return item.setting.replace(/^cockpit-/, '')
+  }
+  return item.setting
+}
+
+const filteredSettings = computed<SettingsRow[]>(() => {
   const lowerSearch = searchTerm.value.toLowerCase()
   return settingsArray.value
     .filter((item) => {
-      const nameMatch = item.setting.toLowerCase().includes(lowerSearch)
+      const nameMatch = displaySettingName(item).toLowerCase().includes(lowerSearch)
       const value = editedValues[item.originalKey]
-      const valueString = value ? JSON.stringify(value).toLowerCase() : ''
+      const valueString = value === undefined ? '' : JSON.stringify(value).toLowerCase()
       const valueMatch = valueString.includes(lowerSearch)
       return nameMatch || valueMatch
     })
-    .sort((a, b) => a.setting.localeCompare(b.setting))
+    .sort((a, b) => displaySettingName(a).localeCompare(displaySettingName(b)))
 })
-
-// Makes userSettings persistent saving to localStorage, thus calling the settingSyncer
-watch(
-  () => userSettings.value,
-  (value) => {
-    Object.keys(value).forEach((key) => {
-      localStorage.setItem(key, isPrimitive(value[key]) ? value[key] : JSON.stringify(value[key]))
-    })
-  },
-  { deep: true }
-)
 
 watch(
   () => props.openConfigDialog,
   (value) => {
     openConfigDialog.value = value
+    if (value) {
+      loadUserSettings()
+    }
   }
+)
+
+watch(availableUsers, (users) => {
+  if (users.length === 0) {
+    selectedUserId.value = ''
+    selectedVehicleId.value = ''
+    return
+  }
+  if (!selectedUserId.value || !users.includes(selectedUserId.value)) {
+    selectedUserId.value = users[0]
+  }
+})
+
+watch(availableVehicles, (vehicles) => {
+  if (vehicles.length === 0) {
+    selectedVehicleId.value = ''
+    return
+  }
+  if (!selectedVehicleId.value || !vehicles.includes(selectedVehicleId.value)) {
+    selectedVehicleId.value = vehicles[0]
+  }
+})
+
+watch(
+  [settingsArray, selectedUserId, selectedVehicleId, showLegacyInternalKeys, showAllKeyPairs],
+  () => {
+    const nextValues: Settings = {}
+    settingsArray.value.forEach((row) => {
+      if (row.source === 'v2') {
+        nextValues[row.originalKey] = selectedV2Package.value[row.v2SettingKey ?? '']?.value
+      } else {
+        nextValues[row.originalKey] = localStorageSnapshot.value[row.storageKey]
+      }
+    })
+    Object.keys(editedValues).forEach((key) => delete editedValues[key])
+    Object.assign(editedValues, nextValues)
+    userSettings.value = { ...nextValues }
+  },
+  { immediate: true }
 )
 
 const isPrimitive = (val: any): boolean => val !== Object(val)
 
-const loadUserSettings = async (): Promise<void> => {
-  const storedSettings: Record<string, any> = Object.keys(localStorage)
-    .filter((key) => key.startsWith('cockpit-'))
-    .reduce((acc: Record<string, any>, key: string) => {
-      const value = localStorage.getItem(key)
-      try {
-        acc[key] = value ? JSON.parse(value) : null
-      } catch {
-        acc[key] = value
-      }
-      return acc
-    }, {} as Record<string, any>)
-  Object.assign(editedValues, storedSettings)
-  userSettings.value = storedSettings
+const parseStoredItem = (value: string | null): any => {
+  try {
+    return value ? JSON.parse(value) : null
+  } catch {
+    return value
+  }
+}
+
+const readLocalStorageSnapshot = (): Settings =>
+  Object.keys(localStorage).reduce((acc: Settings, key: string) => {
+    acc[key] = parseStoredItem(localStorage.getItem(key))
+    return acc
+  }, {} as Settings)
+
+const readSyncedSettings = (): LocalSyncedSettings => {
+  const raw = localStorage.getItem(localSyncedSettingsKey)
+  if (!raw) return {}
+  try {
+    const parsed = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object') return {}
+    return parsed as LocalSyncedSettings
+  } catch {
+    return {}
+  }
+}
+
+const waitForV2ValueToPersist = async (
+  key: string,
+  expectedValue: any,
+  userId: string,
+  vehicleId: string
+): Promise<void> => {
+  const start = Date.now()
+  while (Date.now() - start < v2WriteWaitTimeoutMs) {
+    const latestSettings = readSyncedSettings()
+    const latestValue = latestSettings[userId]?.[vehicleId]?.[key]?.value
+    if (isEqual(latestValue, expectedValue)) {
+      return
+    }
+    await new Promise((resolve) => setTimeout(resolve, v2WriteWaitIntervalMs))
+  }
+  throw new Error('Timed out while waiting for settings update to be persisted.')
+}
+
+const loadUserSettings = (): void => {
+  localStorageSnapshot.value = readLocalStorageSnapshot()
+  localSyncedSettings.value = readSyncedSettings()
+  isLoaded.value = true
 }
 
 const closeConfigDialog = (): void => {
@@ -313,32 +553,71 @@ const closeConfigDialog = (): void => {
   emits('update:openConfigDialog', false)
 }
 
-const startEditing = (item: SettingItem): void => {
+const startEditing = (item: SettingsRow): void => {
+  if (saving[item.originalKey]) return
   editing[item.originalKey] = true
 }
 
-const cancelEditingItem = (item: SettingItem): void => {
+const cancelEditingItem = (item: SettingsRow): void => {
+  if (saving[item.originalKey]) return
   editing[item.originalKey] = false
   editedValues[item.originalKey] = userSettings.value[item.originalKey]
 }
 
-const commitChanges = (item: SettingItem): void => {
-  editing[item.originalKey] = false
-  userSettings.value = { ...editedValues }
+const localStorageValueToString = (value: any): string => {
+  if (typeof value === 'string') return value
+  return JSON.stringify(value)
+}
+
+const commitChanges = async (item: SettingsRow): Promise<void> => {
+  if (saving[item.originalKey]) return
+  const editedValue = editedValues[item.originalKey]
+  const previousValue = userSettings.value[item.originalKey]
+  saving[item.originalKey] = true
+  try {
+    if (item.source === 'v2' && item.v2SettingKey) {
+      if (!selectedUserId.value || !selectedVehicleId.value) return
+      await settingsManager.setKeyValue(
+        item.v2SettingKey,
+        editedValue,
+        Date.now(),
+        selectedUserId.value,
+        selectedVehicleId.value
+      )
+      await waitForV2ValueToPersist(item.v2SettingKey, editedValue, selectedUserId.value, selectedVehicleId.value)
+      loadUserSettings()
+    } else {
+      localStorage.setItem(item.storageKey, localStorageValueToString(editedValue))
+      localStorageSnapshot.value[item.storageKey] = editedValue
+    }
+    editing[item.originalKey] = false
+    userSettings.value[item.originalKey] = editedValue
+  } catch (error: any) {
+    editedValues[item.originalKey] = previousValue
+    openSnackbar({
+      message: `Failed to update setting: ${error?.message ?? 'Unknown error'}`,
+      variant: 'error',
+      duration: 5000,
+    })
+  } finally {
+    saving[item.originalKey] = false
+  }
 }
 
 const startInlineJsonEditing = (key: string): void => {
+  if (saving[key]) return
   inlineJsonEditing[key] = true
   inlineJsonText[key] = JSON.stringify(editedValues[key], null, 2)
 }
 
-const finishInlineJsonEditing = (key: string): void => {
+const finishInlineJsonEditing = async (key: string): Promise<void> => {
   try {
     const parsed = JSON.parse(inlineJsonText[key])
     editedValues[key] = parsed
     inlineJsonEditing[key] = false
     JsonEditError.value = false
-    userSettings.value[key] = parsed
+    const row = settingsArray.value.find((item) => item.originalKey === key)
+    if (row) await commitChanges(row)
   } catch (error: any) {
     JsonEditError.value = true
     openSnackbar({ message: 'Invalid JSON: ' + error.message, variant: 'error', duration: 5000 })
@@ -353,7 +632,11 @@ const cancelJsonEditing = (): void => {
 }
 
 const downloadConfigFile = (): void => {
-  const dataStr = JSON.stringify(userSettings.value, null, 2)
+  const exportedData: Settings = {}
+  settingsArray.value.forEach((row) => {
+    exportedData[row.setting] = editedValues[row.originalKey]
+  })
+  const dataStr = JSON.stringify(exportedData, null, 2)
   const blob = new Blob([dataStr], { type: 'application/json' })
   const url = URL.createObjectURL(blob)
   const a = document.createElement('a')
@@ -375,7 +658,7 @@ const uploadConfigFile = (): void => {
     const file = (event.target as HTMLInputElement).files?.[0]
     if (!file) return
     const reader = new FileReader()
-    reader.onload = (e: ProgressEvent<FileReader>) => {
+    reader.onload = async (e: ProgressEvent<FileReader>) => {
       try {
         const text = e.target?.result as string
         const json = JSON.parse(text)
@@ -387,8 +670,11 @@ const uploadConfigFile = (): void => {
           })
           return
         }
-        Object.assign(editedValues, json)
-        userSettings.value = json
+        for (const row of settingsArray.value) {
+          if (!(row.setting in json)) continue
+          editedValues[row.originalKey] = json[row.setting]
+          await commitChanges(row)
+        }
         openSnackbar({ message: 'Configuration file applied successfully.', variant: 'success', duration: 5000 })
       } catch (error: any) {
         console.error('Error parsing configuration file: ' + error.message)
@@ -431,15 +717,16 @@ const resetAllCockpitSettings = (): void => {
 }
 
 const handleStorageChange = (event: StorageEvent): void => {
-  if (event.key && event.key.startsWith('cockpit-')) {
-    console.log('Storage change detected for:', event.key)
-    loadUserSettings()
-  }
+  console.log('Storage change detected for:', event.key)
+  loadUserSettings()
 }
 
 onMounted(() => {
   loadUserSettings()
-  // This will keep checking for changes in localStorage and updates the settings manager if any
   window.addEventListener('storage', handleStorageChange)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('storage', handleStorageChange)
 })
 </script>


### PR DESCRIPTION
Users can now edit the settings for all user + vehicle combinations.

<img width="828" height="910" alt="image" src="https://github.com/user-attachments/assets/6bc5c0d7-f3c9-42c2-b8de-47c244bd1f66" />

We probably want to include that on 1.18 so we don't brake/degrade the current functionality of this tool. 

Fix #2409