### PR TITLE
electron: Disable `websecurity` when in dev mode

### DIFF
--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -33,6 +33,7 @@ function createWindow(): void {
       preload: join(ROOT_PATH.dist, 'electron/preload.js'),
       contextIsolation: true,
       nodeIntegration: false,
+      webSecurity: !process.env.VITE_DEV_SERVER_URL, // Disable CORS in dev mode so we don't have to deal with per-system workarounds
     },
     autoHideMenuBar: true,
     width: store.get('windowBounds')?.width ?? screen.getPrimaryDisplay().workAreaSize.width,


### PR DESCRIPTION
This way we can work our way around CORS during development without per-system implementations.