### PR TITLE
src: components: DataLakeVariableDialog: fix custom variable IDs

### DIFF
--- a/src/components/DataLakeVariableDialog.vue
+++ b/src/components/DataLakeVariableDialog.vue
@@ -183,7 +183,7 @@ watch(
   () => variable.name,
   (newName) => {
     if (!isManualIdEnabled.value && !editMode.value) {
-      variable.id = machinizeString(newName)
+      variable.id = 'user/custom/' + machinizeString(newName)
     }
   }
 )
@@ -196,19 +196,6 @@ watch(
   (isPersistent) => {
     if (!isPersistent) {
       variable.persistValue = false
-    }
-  }
-)
-
-/**
- * Watch for changes to variable.id
- * If manual ID editing is not enabled, update variable.name to match the new ID
- */
-watch(
-  () => variable.id,
-  (newId) => {
-    if (!isManualIdEnabled.value && !editMode.value) {
-      variable.id = 'user/custom/' + machinizeString(newId)
     }
   }
 )


### PR DESCRIPTION
Fixes #2415:

- Moves the ID prefix prepending to when the ID is determined based on a name change
- Removes a seemingly unneeded self-referential loop
    - @rafaellehmkuhl do you remember what that was originally intended for? If the ID is not being edited by the user then as far as I can tell it should only ever change because of an automated update from the name, which should already be machinized