### PR TITLE
storage: Fallback to default folder if custom user-selected one is not available

### DIFF
--- a/src/electron/services/storage.ts
+++ b/src/electron/services/storage.ts
@@ -42,6 +42,11 @@ const ensureCockpitFolder = (): void => {
 
 ensureCockpitFolder()
 
+const FOLDER_CHECK_INTERVAL_MS = 5000
+app.whenReady().then(() => {
+  setInterval(ensureCockpitFolder, FOLDER_CHECK_INTERVAL_MS)
+})
+
 export const filesystemStorage = {
   async setItem(key: string, value: ArrayBuffer, subFolders?: string[]): Promise<void> {
     ensureCockpitFolder()


### PR DESCRIPTION
I was just testing it with an external disk and realized there was no fallback for when the folder is not available, which would crash the app.