### PR TITLE
Add MAVLink ENUMs to the data-lake

### DIFF
--- a/src/libs/vehicle/common/data-flattener.ts
+++ b/src/libs/vehicle/common/data-flattener.ts
@@ -126,6 +126,15 @@ export function flattenData(data: Record<string, unknown>): FlattenedPair[] {
           },
         ]
       }
+      if (typeof value === 'object' && value !== null && 'type' in value && typeof (value as any).type === 'string') {
+        return [
+          {
+            path: `${messagePathWithId}/${key}`,
+            type: 'string',
+            value: (value as any).type as string,
+          },
+        ]
+      }
       if (Array.isArray(value)) {
         if (value.length === 0) return []
         if (isNumberArray(value)) {


### PR DESCRIPTION
This adds variables like `/mavlink/1/1/GPS_RAW_INT/fix_type` (with values like "GPS_FIX_TYPE_3D_FIX") to the data-lake.