### PR TITLE
Migrate several widgets to the data-lake

### DIFF
--- a/src/components/mini-widgets/BatteryIndicator.vue
+++ b/src/components/mini-widgets/BatteryIndicator.vue
@@ -215,9 +215,10 @@ import { useDebounce } from '@vueuse/core'
 import { computed, onBeforeMount, onUnmounted, ref, toRefs, watch } from 'vue'
 
 import { defaultBatteryLevelColorScheme, defaultBatteryLevelThresholds } from '@/assets/defaults'
+import { useDataLakeVariable } from '@/composables/useDataLakeVariable'
+import { useResolvedDataLakeTemplate } from '@/composables/useResolvedDataLakeTemplate'
 import { datalogger, DatalogVariable } from '@/libs/sensors-logging'
 import { useAppInterfaceStore } from '@/stores/appInterface'
-import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
 import { BatteryLevel, BatteryLevelThresholds } from '@/types/general'
 import type { MiniWidget } from '@/types/widgets'
@@ -237,9 +238,11 @@ const defaultOptions = {
   showCurrent: true,
   showPower: true,
   toggleInterval: 1000,
+  voltageVariableId: '/mavlink/{{autopilotSystemId}}/1/SYS_STATUS/voltage_battery',
+  currentVariableId: '/mavlink/{{autopilotSystemId}}/1/SYS_STATUS/current_battery',
+  remainingVariableId: '/mavlink/{{autopilotSystemId}}/1/SYS_STATUS/battery_remaining',
 }
 
-const store = useMainVehicleStore()
 const widgetStore = useWidgetManagerStore()
 const interfaceStore = useAppInterfaceStore()
 
@@ -262,11 +265,29 @@ const resetToDefaults = (): void => {
   miniWidget.value.options.batteryThresholds = Object.assign({}, defaultBatteryLevelThresholds)
 }
 
+const resolvedVoltageVariableId = useResolvedDataLakeTemplate(() => miniWidget.value.options.voltageVariableId)
+const resolvedCurrentVariableId = useResolvedDataLakeTemplate(() => miniWidget.value.options.currentVariableId)
+const resolvedRemainingVariableId = useResolvedDataLakeTemplate(() => miniWidget.value.options.remainingVariableId)
+const { value: rawVoltageFromDL } = useDataLakeVariable(resolvedVoltageVariableId)
+const { value: rawCurrentFromDL } = useDataLakeVariable(resolvedCurrentVariableId)
+const { value: rawRemainingFromDL } = useDataLakeVariable(resolvedRemainingVariableId)
+
+const rawVoltage = computed<number | null>(() => {
+  if (rawVoltageFromDL.value === undefined) return null
+  return (rawVoltageFromDL.value as number) / 1000
+})
+
 // Round voltage to 0.1V precision for values < 100V, integer precision for >= 100V
-const roundedVoltage = computed(() => {
-  const voltage = store?.powerSupply?.voltage
+const roundedVoltage = computed<number | null>(() => {
+  const voltage = rawVoltage.value
   if (voltage === undefined || voltage === null) return null
   return Math.abs(voltage) >= 100 ? Math.round(voltage) : Math.round(voltage * 10) / 10
+})
+
+const current = computed<number | undefined>(() => {
+  const raw = rawCurrentFromDL.value as number | undefined
+  if (raw === undefined || raw === -1) return undefined
+  return raw / 100
 })
 
 // Keeps a stable voltage reading for 4 seconds to avoid rapid battery level changes
@@ -298,19 +319,19 @@ const voltageDisplayValue = computed(() => {
 })
 
 const currentDisplayValue = computed(() => {
-  if (store?.powerSupply?.current === undefined) return '--'
-  return Math.abs(store.powerSupply.current) >= 100
-    ? store.powerSupply.current.toFixed(0)
-    : store.powerSupply.current.toFixed(1)
+  if (current.value === undefined) return '--'
+  return Math.abs(current.value) >= 100 ? current.value.toFixed(0) : current.value.toFixed(1)
 })
 
 const instantaneousWattsDisplayValue = computed(() => {
-  return store.instantaneousWatts !== undefined ? store.instantaneousWatts.toFixed(1) : '--'
+  if (rawVoltage.value === null || current.value === undefined) return '--'
+  return (rawVoltage.value * current.value).toFixed(1)
 })
 
 const remainingDisplayValue = computed(() => {
-  if (store?.powerSupply?.remaining === undefined) return -1
-  return Math.abs(store.powerSupply.remaining) > 100 ? 100 : store.powerSupply.remaining
+  const remaining = rawRemainingFromDL.value as number | undefined
+  if (remaining === undefined) return -1
+  return Math.abs(remaining) > 100 ? 100 : remaining
 })
 
 const setupToggleInterval = (): void => {

--- a/src/components/mini-widgets/SatelliteIndicator.vue
+++ b/src/components/mini-widgets/SatelliteIndicator.vue
@@ -2,17 +2,60 @@
   <div class="flex items-center w-fit min-w-[8rem] max-w-[9rem] h-12 p-1 text-white justify-center">
     <span class="relative w-[2.25rem] mdi mdi-satellite-variant text-4xl"></span>
     <div class="flex flex-col items-start justify-center ml-1 min-w-[4rem] max-w-[6rem] select-none">
-      <span class="font-mono font-semibold leading-4 text-end w-fit">{{ store.statusGPS.visibleSatellites }} sats</span>
-      <span class="font-mono text-sm font-semibold leading-4 text-end w-fit">{{ store.statusGPS.fixType }}</span>
+      <span class="font-mono font-semibold leading-4 text-end w-fit">{{ satellitesDisplay }} sats</span>
+      <span class="font-mono text-sm font-semibold leading-4 text-end w-fit">{{ fixTypeDisplay }}</span>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
+import { computed, onBeforeMount, toRefs } from 'vue'
+
+import { useDataLakeVariable } from '@/composables/useDataLakeVariable'
+import { useResolvedDataLakeTemplate } from '@/composables/useResolvedDataLakeTemplate'
 import { datalogger, DatalogVariable } from '@/libs/sensors-logging'
-import { useMainVehicleStore } from '@/stores/mainVehicle'
+import type { MiniWidget } from '@/types/widgets'
+
+const gpsFixTypeLabels: Record<string, string> = {
+  GPS_FIX_TYPE_NO_GPS: 'No GPS',
+  GPS_FIX_TYPE_NO_FIX: 'No fix',
+  GPS_FIX_TYPE_2D_FIX: '2D fix',
+  GPS_FIX_TYPE_3D_FIX: '3D fix',
+  GPS_FIX_TYPE_DGPS: 'DGPS fix',
+  GPS_FIX_TYPE_RTK_FLOAT: 'RTK float',
+  GPS_FIX_TYPE_RTK_FIXED: 'RTK fix',
+  GPS_FIX_TYPE_STATIC: 'Static',
+  GPS_FIX_TYPE_PPP: 'PPP fix',
+}
+
+const props = defineProps<{
+  /**
+   * Mini widget reference
+   */
+  miniWidget: MiniWidget
+}>()
+const miniWidget = toRefs(props).miniWidget
+
+const defaultOptions = {
+  satellitesVariableId: '/mavlink/{{autopilotSystemId}}/1/GPS_RAW_INT/satellites_visible',
+  fixTypeVariableId: '/mavlink/{{autopilotSystemId}}/1/GPS_RAW_INT/fix_type',
+}
+
+onBeforeMount(() => {
+  miniWidget.value.options = { ...defaultOptions, ...miniWidget.value.options }
+})
 
 datalogger.registerUsage(DatalogVariable.gpsFixType)
 datalogger.registerUsage(DatalogVariable.gpsVisibleSatellites)
-const store = useMainVehicleStore()
+
+const resolvedSatellitesVariableId = useResolvedDataLakeTemplate(() => miniWidget.value.options.satellitesVariableId)
+const resolvedFixTypeVariableId = useResolvedDataLakeTemplate(() => miniWidget.value.options.fixTypeVariableId)
+const { value: rawSatellites } = useDataLakeVariable(resolvedSatellitesVariableId)
+const { value: rawFixType } = useDataLakeVariable(resolvedFixTypeVariableId)
+
+const satellitesDisplay = computed(() => rawSatellites.value ?? '--')
+const fixTypeDisplay = computed(() => {
+  if (rawFixType.value === undefined) return '--'
+  return gpsFixTypeLabels[rawFixType.value as string] ?? rawFixType.value
+})
 </script>

--- a/src/components/widgets/Attitude.vue
+++ b/src/components/widgets/Attitude.vue
@@ -72,10 +72,11 @@ import { useElementVisibility, useWindowSize } from '@vueuse/core'
 import gsap from 'gsap'
 import { computed, nextTick, onBeforeMount, onMounted, reactive, ref, toRefs, watch } from 'vue'
 
+import { useDataLakeVariable } from '@/composables/useDataLakeVariable'
+import { useResolvedDataLakeTemplate } from '@/composables/useResolvedDataLakeTemplate'
 import { datalogger, DatalogVariable } from '@/libs/sensors-logging'
 import { constrain, degrees, radians, resetCanvas, round } from '@/libs/utils'
 import { useAppInterfaceStore } from '@/stores/appInterface'
-import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
 import type { Widget } from '@/types/widgets'
 
@@ -84,7 +85,6 @@ const interfaceStore = useAppInterfaceStore()
 
 datalogger.registerUsage(DatalogVariable.roll)
 datalogger.registerUsage(DatalogVariable.pitch)
-const store = useMainVehicleStore()
 const props = defineProps<{
   /**
    * Widget reference
@@ -146,14 +146,14 @@ const defaultOptions = {
   desiredAimRadius: 150,
   hudColor: colorSwatches.value[0][0],
   cameraFOV: 64,
+  rollVariableId: '/mavlink/{{autopilotSystemId}}/1/ATTITUDE/roll',
+  pitchVariableId: '/mavlink/{{autopilotSystemId}}/1/ATTITUDE/pitch',
+  cameraTiltVariableId: 'cameraTiltDeg',
 }
+
 onBeforeMount(() => {
   // Set initial widget options if they don't exist
-  Object.entries(defaultOptions).forEach(([key, value]) => {
-    if (widget.value.options[key] === undefined) {
-      widget.value.options[key] = value
-    }
-  })
+  widget.value.options = { ...defaultOptions, ...widget.value.options }
 })
 
 onMounted(() => {
@@ -174,27 +174,33 @@ const aimRadius = computed(() => constrain(widget.value.options.desiredAimRadius
  * Deal with high frequency update and decrease cpu usage when drawing
  * low degrees changes
  */
-let oldRoll: number | undefined = undefined
-let oldPitch: number | undefined = undefined
-watch(store.attitude, (attitude) => {
-  const rollDiff = Math.abs(degrees(attitude.roll - (oldRoll || 0)))
-  const pitchDiff = Math.abs(degrees(attitude.pitch - (oldPitch || 0)))
+const resolvedRollVariableId = useResolvedDataLakeTemplate(() => widget.value.options.rollVariableId)
+const resolvedPitchVariableId = useResolvedDataLakeTemplate(() => widget.value.options.pitchVariableId)
+const { value: rawRoll } = useDataLakeVariable(resolvedRollVariableId)
+const { value: rawPitch } = useDataLakeVariable(resolvedPitchVariableId)
+const { value: rawCameraTilt } = useDataLakeVariable(() => widget.value.options.cameraTiltVariableId)
 
-  if (rollDiff > 0.1) {
-    oldRoll = attitude.roll
-    rollAngleDeg.value = degrees(store.attitude.roll)
-  }
-
-  if (pitchDiff > 0.1) {
-    oldPitch = attitude.pitch
-    pitchAngleDeg.value = degrees(store.attitude.pitch)
+watch(rawRoll, (newRoll) => {
+  if (newRoll === undefined) return
+  const deg = degrees(newRoll as number)
+  if (Math.abs(deg - rollAngleDeg.value) > 0.1) {
+    rollAngleDeg.value = deg
   }
 })
 
-watch(store.genericVariables, (message: Record<string, unknown>) => {
-  const new_tilt = message.cameraTiltDeg as number
-  if (cameraTiltDeg.value === undefined || Math.abs(new_tilt - cameraTiltDeg.value) > 0.1) {
-    cameraTiltDeg.value = new_tilt
+watch(rawPitch, (newPitch) => {
+  if (newPitch === undefined) return
+  const deg = degrees(newPitch as number)
+  if (Math.abs(deg - pitchAngleDeg.value) > 0.1) {
+    pitchAngleDeg.value = deg
+  }
+})
+
+watch(rawCameraTilt, (newTilt) => {
+  if (newTilt === undefined) return
+  const tilt = newTilt as number
+  if (cameraTiltDeg.value === undefined || Math.abs(tilt - cameraTiltDeg.value) > 0.1) {
+    cameraTiltDeg.value = tilt
   }
 })
 
@@ -330,7 +336,7 @@ const renderCanvas = (): void => {
 // Update the height of each pitch line when the vehicle pitch is updated
 watch(pitchAngleDeg, () => {
   pitchAngles.forEach((angle: number) => {
-    const y = -round(angleY(angle + renderVars.cameraTiltDeg - degrees(store.attitude.pitch)), 2)
+    const y = -round(angleY(angle + renderVars.cameraTiltDeg - pitchAngleDeg.value), 2)
     gsap.to(renderVars.pitchLinesHeights, 0.1, { [angle]: y })
   })
   gsap.to(renderVars, 0.1, { pitchDegrees: pitchAngleDeg.value })
@@ -344,7 +350,7 @@ watch(rollAngleDeg, () => {
 watch(cameraTiltDeg, () => {
   gsap.to(renderVars, 0.1, { cameraTiltDeg: cameraTiltDeg.value })
   pitchAngles.forEach((angle: number) => {
-    const y = -round(angleY(angle + renderVars.cameraTiltDeg - degrees(store.attitude.pitch)), 2)
+    const y = -round(angleY(angle + renderVars.cameraTiltDeg - pitchAngleDeg.value), 2)
     gsap.to(renderVars.pitchLinesHeights, 0.1, { [angle]: y })
   })
 })

--- a/src/components/widgets/Compass.vue
+++ b/src/components/widgets/Compass.vue
@@ -25,16 +25,16 @@ import { computed, nextTick, onBeforeMount, onMounted, reactive, ref, toRefs, wa
 
 import Dialog from '@/components/Dialog.vue'
 import Dropdown from '@/components/Dropdown.vue'
+import { useDataLakeVariable } from '@/composables/useDataLakeVariable'
+import { useResolvedDataLakeTemplate } from '@/composables/useResolvedDataLakeTemplate'
 import { datalogger, DatalogVariable } from '@/libs/sensors-logging'
 import { degrees, radians, resetCanvas, sequentialArray } from '@/libs/utils'
-import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
 import type { Widget } from '@/types/widgets'
 
 const widgetStore = useWidgetManagerStore()
 
 datalogger.registerUsage(DatalogVariable.heading)
-const store = useMainVehicleStore()
 const compassRoot = ref()
 const canvasRef = ref<HTMLCanvasElement | undefined>()
 const canvasContext = ref()
@@ -70,13 +70,13 @@ const props = defineProps<{
 }>()
 const widget = toRefs(props).widget
 
+const defaultOptions = {
+  headingStyle: headingOptions[0],
+  yawVariableId: '/mavlink/{{autopilotSystemId}}/1/ATTITUDE/yaw',
+}
+
 onBeforeMount(() => {
-  // Set initial widget options if they don't exist
-  if (Object.keys(widget.value.options).length === 0) {
-    widget.value.options = {
-      headingStyle: headingOptions[0],
-    }
-  }
+  widget.value.options = { ...defaultOptions, ...widget.value.options }
 })
 
 onMounted(() => {
@@ -193,18 +193,15 @@ const renderCanvas = (): void => {
  * Deal with high frequency update and decrease cpu usage when drawing low degrees changes
  */
 
+const resolvedYawVariableId = useResolvedDataLakeTemplate(() => widget.value.options.yawVariableId)
+const { value: rawYaw } = useDataLakeVariable(resolvedYawVariableId)
+
 const yaw = ref(0.01)
-let oldYaw: number | undefined = undefined
-watch(store.attitude, (attitude) => {
-  if (oldYaw === undefined) {
-    yaw.value = degrees(store.attitude.yaw)
-    oldYaw = attitude.yaw
-    return
-  }
-  const yawDiff = Math.abs(degrees(attitude.yaw - oldYaw))
-  if (yawDiff > 0.1) {
-    oldYaw = attitude.yaw
-    yaw.value = degrees(store.attitude.yaw)
+watch(rawYaw, (newYaw) => {
+  if (newYaw === undefined) return
+  const deg = degrees(newYaw as number)
+  if (Math.abs(deg - yaw.value) > 0.1) {
+    yaw.value = deg
   }
 })
 

--- a/src/components/widgets/CompassHUD.vue
+++ b/src/components/widgets/CompassHUD.vue
@@ -146,7 +146,9 @@ import { colord } from 'colord'
 import gsap from 'gsap'
 import { computed, onBeforeMount, onBeforeUnmount, onMounted, reactive, ref, toRefs, watch } from 'vue'
 
+import { useDataLakeVariable } from '@/composables/useDataLakeVariable'
 import { usePointsOfInterest } from '@/composables/usePointsOfInterest'
+import { useResolvedDataLakeTemplate } from '@/composables/useResolvedDataLakeTemplate'
 import { calculateHaversineDistance } from '@/libs/mission/general-estimates'
 import { datalogger, DatalogVariable } from '@/libs/sensors-logging'
 import { degrees, radians, resetCanvas } from '@/libs/utils'
@@ -222,18 +224,21 @@ while (i < 181) {
   i += 3
 }
 
+const defaultOptions = {
+  showYawValue: true,
+  hudColor: colorSwatches.value[0][0],
+  useNegativeRange: false,
+  showHomeOnHUD: true,
+  yawVariableId: '/mavlink/{{autopilotSystemId}}/1/ATTITUDE/yaw',
+  latVariableId: '/mavlink/{{autopilotSystemId}}/1/GLOBAL_POSITION_INT/lat',
+  lonVariableId: '/mavlink/{{autopilotSystemId}}/1/GLOBAL_POSITION_INT/lon',
+  poi: {
+    showPoiOnHUD: true,
+    showDistances: 'onHudSide',
+  },
+}
+
 onBeforeMount(() => {
-  // Set initial widget options if they don't exist
-  const defaultOptions = {
-    showYawValue: true,
-    hudColor: colorSwatches.value[0][0],
-    useNegativeRange: false,
-    showHomeOnHUD: true,
-    poi: {
-      showPoiOnHUD: true,
-      showDistances: 'onHudSide',
-    },
-  }
   widget.value.options = { ...defaultOptions, ...widget.value.options }
 })
 
@@ -253,15 +258,34 @@ const canvasSize = computed(() => ({
   height: 64,
 }))
 
+const resolvedYawVariableId = useResolvedDataLakeTemplate(() => widget.value.options.yawVariableId)
+const resolvedLatVariableId = useResolvedDataLakeTemplate(() => widget.value.options.latVariableId)
+const resolvedLonVariableId = useResolvedDataLakeTemplate(() => widget.value.options.lonVariableId)
+const { value: rawYaw } = useDataLakeVariable(resolvedYawVariableId)
+const { value: rawLat } = useDataLakeVariable(resolvedLatVariableId)
+const { value: rawLon } = useDataLakeVariable(resolvedLonVariableId)
+
+const vehicleLatitude = computed<number | undefined>(() => {
+  if (rawLat.value === undefined) return undefined
+  return (rawLat.value as number) / 1e7
+})
+
+const vehicleLongitude = computed<number | undefined>(() => {
+  if (rawLon.value === undefined) return undefined
+  return (rawLon.value as number) / 1e7
+})
+
 // The implementation below makes sure we don't update the Yaw value in the widget whenever
 // the system Yaw (from vehicle) updates, preventing unnecessary performance bottlenecks.
 const yaw = ref(0)
 let oldYaw: number | undefined = undefined
-watch(store.attitude, (attitude) => {
-  const yawDiff = Math.abs(degrees(attitude.yaw - (oldYaw || 0)))
+watch(rawYaw, (newYaw) => {
+  if (newYaw === undefined) return
+  const yawRad = newYaw as number
+  const yawDiff = Math.abs(degrees(yawRad - (oldYaw || 0)))
   if (yawDiff > 0.1) {
-    oldYaw = attitude.yaw
-    yaw.value = degrees(store.attitude.yaw)
+    oldYaw = yawRad
+    yaw.value = degrees(yawRad)
   }
 })
 
@@ -293,16 +317,13 @@ const calculateBearing = (vehicleLat: number, vehicleLng: number, poiLat: number
 
 // Get POI data with bearing and distance relative to vehicle
 const poiData = computed(() => {
-  if (!store.coordinates.latitude || !store.coordinates.longitude) return []
+  if (!vehicleLatitude.value || !vehicleLongitude.value) return []
 
   return resolvedPointsOfInterest.value.map((poi) => {
-    const distance = calculateHaversineDistance(
-      [store.coordinates.latitude!, store.coordinates.longitude!],
-      poi.coordinates
-    )
+    const distance = calculateHaversineDistance([vehicleLatitude.value!, vehicleLongitude.value!], poi.coordinates)
     const bearing = calculateBearing(
-      store.coordinates.latitude!,
-      store.coordinates.longitude!,
+      vehicleLatitude.value!,
+      vehicleLongitude.value!,
       poi.coordinates[0],
       poi.coordinates[1]
     )
@@ -359,7 +380,7 @@ type HudMarkerEntry = {
 }
 
 const hudMarkerData = computed((): HudMarkerEntry[] => {
-  if (!store.coordinates.latitude || !store.coordinates.longitude) return []
+  if (!vehicleLatitude.value || !vehicleLongitude.value) return []
 
   const entries: HudMarkerEntry[] = []
 
@@ -373,8 +394,8 @@ const hudMarkerData = computed((): HudMarkerEntry[] => {
     const coords = homeCoordinates.value
     entries.push({
       poi: buildHomeHudPoi(coords),
-      distance: calculateHaversineDistance([store.coordinates.latitude!, store.coordinates.longitude!], coords),
-      bearing: calculateBearing(store.coordinates.latitude!, store.coordinates.longitude!, coords[0], coords[1]),
+      distance: calculateHaversineDistance([vehicleLatitude.value!, vehicleLongitude.value!], coords),
+      bearing: calculateBearing(vehicleLatitude.value!, vehicleLongitude.value!, coords[0], coords[1]),
       markerSize: 12,
     })
   }
@@ -530,8 +551,8 @@ const renderCanvas = (): void => {
 const updatePoiMarkers = (): void => {
   if (
     (!widget.value.options.poi?.showPoiOnHUD && !widget.value.options.showHomeOnHUD) ||
-    !store.coordinates.latitude ||
-    !store.coordinates.longitude
+    !vehicleLatitude.value ||
+    !vehicleLongitude.value
   ) {
     poiMarkers.value = []
     return
@@ -652,11 +673,8 @@ const updatePoiMarkers = (): void => {
         const fallbackName = entry?.poi.name
         const fallbackCoords = entry?.poi.coordinates
 
-        if (fallbackName && fallbackCoords && store.coordinates.latitude && store.coordinates.longitude) {
-          const distance = calculateHaversineDistance(
-            [store.coordinates.latitude, store.coordinates.longitude],
-            fallbackCoords
-          )
+        if (fallbackName && fallbackCoords && vehicleLatitude.value && vehicleLongitude.value) {
+          const distance = calculateHaversineDistance([vehicleLatitude.value, vehicleLongitude.value], fallbackCoords)
           highlightedPoiMarker.value = {
             name: fallbackName,
             distanceText:
@@ -730,7 +748,7 @@ const stopAnimationLoop = (): void => {
 }
 
 const debouncedUpdatePoiMarkers = useDebounceFn(updatePoiMarkers, 16)
-watch([hudMarkerData, store.coordinates, canvasSize, yaw], debouncedUpdatePoiMarkers)
+watch([hudMarkerData, vehicleLatitude, vehicleLongitude, canvasSize, yaw], debouncedUpdatePoiMarkers)
 
 watch(
   [() => widget.value.options.showHomeOnHUD, () => store.isVehicleOnline],

--- a/src/components/widgets/VirtualHorizon.vue
+++ b/src/components/widgets/VirtualHorizon.vue
@@ -12,11 +12,12 @@
 <script setup lang="ts">
 import { useWindowSize } from '@vueuse/core'
 import gsap from 'gsap'
-import { computed, nextTick, onMounted, reactive, ref, toRefs, watch } from 'vue'
+import { computed, nextTick, onBeforeMount, onMounted, reactive, ref, toRefs, watch } from 'vue'
 
+import { useDataLakeVariable } from '@/composables/useDataLakeVariable'
+import { useResolvedDataLakeTemplate } from '@/composables/useResolvedDataLakeTemplate'
 import { datalogger, DatalogVariable } from '@/libs/sensors-logging'
 import { degrees, radians, resetCanvas } from '@/libs/utils'
-import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
 import type { Widget } from '@/types/widgets'
 
@@ -30,9 +31,23 @@ const props = defineProps<{
 }>()
 const widget = toRefs(props).widget
 
+const defaultOptions = {
+  rollVariableId: '/mavlink/{{autopilotSystemId}}/1/ATTITUDE/roll',
+  pitchVariableId: '/mavlink/{{autopilotSystemId}}/1/ATTITUDE/pitch',
+}
+
+onBeforeMount(() => {
+  widget.value.options = { ...defaultOptions, ...widget.value.options }
+})
+
 datalogger.registerUsage(DatalogVariable.roll)
 datalogger.registerUsage(DatalogVariable.pitch)
-const store = useMainVehicleStore()
+
+const resolvedRollVariableId = useResolvedDataLakeTemplate(() => widget.value.options.rollVariableId)
+const resolvedPitchVariableId = useResolvedDataLakeTemplate(() => widget.value.options.pitchVariableId)
+const { value: rawRoll } = useDataLakeVariable(resolvedRollVariableId)
+const { value: rawPitch } = useDataLakeVariable(resolvedPitchVariableId)
+
 const virtualHorizonRoot = ref()
 const canvasRef = ref<HTMLCanvasElement | undefined>()
 const canvasContext = ref()
@@ -212,28 +227,19 @@ const renderCanvas = (): void => {
 const rollAngleDeg = ref(0.01)
 const pitchAngleDeg = ref(0.01)
 
-let oldRoll: number | undefined = undefined
-let oldPitch: number | undefined = undefined
-watch(store.attitude, (attitude) => {
-  if (oldRoll === undefined || oldPitch === undefined) {
-    rollAngleDeg.value = degrees(store.attitude.roll)
-    pitchAngleDeg.value = degrees(store.attitude.pitch)
-    oldRoll = attitude.roll
-    oldPitch = attitude.pitch
-    return
+watch(rawRoll, (newRoll) => {
+  if (newRoll === undefined) return
+  const deg = degrees(newRoll as number)
+  if (Math.abs(deg - rollAngleDeg.value) > 0.1) {
+    rollAngleDeg.value = deg
   }
+})
 
-  const rollDiff = Math.abs(degrees(attitude.roll - oldRoll))
-  const pitchDiff = Math.abs(degrees(attitude.pitch - oldPitch))
-
-  if (rollDiff > 0.1) {
-    oldRoll = attitude.roll
-    rollAngleDeg.value = degrees(store.attitude.roll)
-  }
-
-  if (pitchDiff > 0.1) {
-    oldPitch = attitude.pitch
-    pitchAngleDeg.value = degrees(store.attitude.pitch)
+watch(rawPitch, (newPitch) => {
+  if (newPitch === undefined) return
+  const deg = degrees(newPitch as number)
+  if (Math.abs(deg - pitchAngleDeg.value) > 0.1) {
+    pitchAngleDeg.value = deg
   }
 })
 

--- a/src/types/mission.ts
+++ b/src/types/mission.ts
@@ -423,7 +423,11 @@ export interface PoiMarkerStyle {
 /**
  * Extended PointOfInterest interface with UI-specific rendering properties for use on HUD components
  */
-export interface PoiMarker extends Omit<PointOfInterest, 'id' | 'description' | 'timestamp' | 'coordinates'> {
+export interface PoiMarker
+  extends Omit<
+    PointOfInterest,
+    'id' | 'description' | 'timestamp' | 'coordinates' | 'latitude' | 'longitude' | 'fallbackCoordinates'
+  > {
   /**
    * POI identifier (alias for PointOfInterest.id)
    */


### PR DESCRIPTION
Depends on #2441 and #2448.

Helps with [milestone 17](https://github.com/bluerobotics/cockpit/milestone/17) (relevant to #2153, #2154, and #2155).

I'm initially moving them to consume from the data-lake, and I will them modify them to allow for the selection of the desired source (variable).