### PR TITLE
edit-menu: Fix vehicle type dropdown obscured in profile config dialog

### DIFF
--- a/src/components/EditMenu.vue
+++ b/src/components/EditMenu.vue
@@ -667,6 +667,7 @@
           <v-combobox
             v-model="vehicleTypesAssignedToCurrentProfile"
             :items="availableVehicleTypes"
+            :menu-props="{ zIndex: 10000 }"
             chips
             density="compact"
             multiple


### PR DESCRIPTION
Set a high z-index on the v-combobox menu-props so the dropdown renders above the GlassModal, which can reach z-index 2000–5000.

Fixes #2459