### PR TITLE
Map: Show waypoint numbers on low zoom levels

### DIFF
--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -253,6 +253,11 @@ import {
   TargetFollower,
   WhoToFollow,
 } from '@/libs/map/utils-map'
+import {
+  bindWaypointNumberTooltip,
+  getIconDimensionsFromMarkerSize,
+  getMarkerSizeFromZoom,
+} from '@/libs/map/waypoint-markers'
 import { datalogger, DatalogVariable } from '@/libs/sensors-logging'
 import { copyToClipboard, degrees } from '@/libs/utils'
 import type { MAVLinkVehicle } from '@/libs/vehicle/mavlink/vehicle'
@@ -260,13 +265,7 @@ import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useMissionStore } from '@/stores/mission'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
-import type {
-  IconDimensions,
-  MarkerSizes,
-  ResolvedPointOfInterest,
-  Waypoint,
-  WaypointCoordinates,
-} from '@/types/mission'
+import type { ResolvedPointOfInterest, Waypoint, WaypointCoordinates } from '@/types/mission'
 import type { Widget } from '@/types/widgets'
 
 import ContextMenu from '../ContextMenu.vue'
@@ -309,6 +308,7 @@ const showButtons = computed(
 const mapReady = ref(false)
 const mapWaypoints = ref<Waypoint[]>([])
 const reachedWaypoints = shallowRef<Record<number, L.Marker>>({})
+const persistentTooltipSeq = ref<number | undefined>(undefined)
 const contextMenuRef = ref()
 const isDragging = ref(false)
 const isPinching = ref(false)
@@ -392,22 +392,6 @@ const getReachedWaypointIndices = computed(() => {
   return waypointIndices
 })
 
-const getMarkerSizeFromZoom = (zoomLevel: number): MarkerSizes => {
-  if (zoomLevel <= 17) return 'xs'
-  if (zoomLevel > 17 && zoomLevel <= 19) return 'sm'
-  return 'md'
-}
-
-const getIconDimensionsFromMarkerSize = (size: MarkerSizes): IconDimensions => {
-  if (size === 'xs') {
-    return { iconSize: [6, 6], iconAnchor: [3, 3] }
-  }
-  if (size === 'sm') {
-    return { iconSize: [12, 12], iconAnchor: [6, 6] }
-  }
-  return { iconSize: [26, 26], iconAnchor: [13, 13] } // md size
-}
-
 const createWaypointMarkerHtml = (isReached: boolean, isCurrent = false): string => {
   let baseClass = 'marker-icon'
   if (isReached) {
@@ -437,47 +421,50 @@ const createWaypointMarkerIcon = (isReached: boolean, isCurrent = false): L.DivI
   })
 }
 
+const waypointTooltipClass = (isReached: boolean, isCurrent: boolean): string => {
+  if (isReached) return 'waypoint-tooltip waypoint-tooltip--reached'
+  if (isCurrent) return 'waypoint-tooltip waypoint-tooltip--current-waypoint'
+  return 'waypoint-tooltip'
+}
+
 const applyWaypointMarkerStyle = (seq: number): void => {
   const marker = reachedWaypoints.value[seq]
   if (!marker) return
   const isReached = getReachedWaypointIndices.value.has(seq)
   const idx = seq - 1
   const isCurrent = currentMapWpIndex.value >= 0 && idx === currentMapWpIndex.value
-  const markerSize = getMarkerSizeFromZoom(zoom.value)
-  const dimensions = getIconDimensionsFromMarkerSize(markerSize)
 
-  marker.setIcon(
-    L.divIcon({
-      html: createWaypointMarkerHtml(isReached, isCurrent),
-      className: 'waypoint-marker-icon',
-      iconSize: dimensions.iconSize,
-      iconAnchor: dimensions.iconAnchor,
-    })
-  )
+  marker.setIcon(createWaypointMarkerIcon(isReached, isCurrent))
 
-  // Updates the tooltip class for reached/current waypoints and visibility based on size
-  const tooltip = marker.getTooltip()
-  if (tooltip) {
-    if (markerSize === 'xs' || markerSize === 'sm') {
-      tooltip.setOpacity(0)
-    } else {
-      tooltip.setOpacity(1)
-    }
-
-    const tooltipElement = tooltip.getElement()
-    if (tooltipElement) {
-      tooltipElement.classList.remove('waypoint-tooltip--reached', 'waypoint-tooltip--current-waypoint')
-      if (isReached) {
-        tooltipElement.classList.add('waypoint-tooltip--reached')
-      } else if (isCurrent) {
-        tooltipElement.classList.add('waypoint-tooltip--current-waypoint')
-      }
-    }
-  }
+  bindWaypointNumberTooltip(marker, {
+    label: seq.toString(),
+    size: getMarkerSizeFromZoom(zoom.value),
+    permanentClassName: waypointTooltipClass(isReached, isCurrent),
+    compactClassName: 'waypoint-hover-tooltip',
+    pinned: persistentTooltipSeq.value === seq,
+  })
 }
 
 const refreshReachedWaypointMarkerStyles = (): void => {
   Object.keys(reachedWaypoints.value).forEach((k) => applyWaypointMarkerStyle(Number(k)))
+}
+
+// Pins the number tooltip of a waypoint too small to show it inline, restyling only the two markers
+// whose pinned state actually changed.
+const togglePersistentTooltip = (seq: number): void => {
+  if (getMarkerSizeFromZoom(zoom.value) === 'md') return
+  const previousSeq = persistentTooltipSeq.value
+  persistentTooltipSeq.value = previousSeq === seq ? undefined : seq
+  logUserAction(`${persistentTooltipSeq.value === seq ? 'Pinned' : 'Unpinned'} the tooltip of waypoint ${seq}`)
+  if (previousSeq !== undefined) applyWaypointMarkerStyle(previousSeq)
+  if (persistentTooltipSeq.value !== undefined) applyWaypointMarkerStyle(persistentTooltipSeq.value)
+}
+
+const clearPersistentTooltip = (): void => {
+  const pinnedSeq = persistentTooltipSeq.value
+  if (pinnedSeq === undefined) return
+  persistentTooltipSeq.value = undefined
+  applyWaypointMarkerStyle(pinnedSeq)
 }
 
 const poiManagerMapWidgetRef = ref<typeof PoiManager | null>(null)
@@ -744,6 +731,7 @@ onMounted(async () => {
   map.value.on('click', (event: LeafletMouseEvent) => {
     clickedLocation.value = [event.latlng.lat, event.latlng.lng]
     poiPopupRef.value?.close()
+    clearPersistentTooltip()
   })
 
   // Update center value after panning
@@ -1313,6 +1301,9 @@ watch(mapWaypoints, (newWaypoints) => {
   mapWaypointMarkers.value.forEach((m) => m.remove())
   mapWaypointMarkers.value = []
 
+  // Waypoint numbers are positional, so a surviving pin would migrate to whichever waypoint now holds its seq
+  persistentTooltipSeq.value = undefined
+
   // Add a marker for each point
   newWaypoints.forEach((waypoint, idx) => {
     const seq = idx + 1
@@ -1324,68 +1315,30 @@ watch(mapWaypoints, (newWaypoints) => {
       marker = L.marker(waypoint.coordinates, { icon: markerIcon })
       reachedWaypoints.value[seq] = marker
 
-      const markerSizeForTooltip = getMarkerSizeFromZoom(zoom.value)
-      const markerTooltip = L.tooltip({
-        content: seq.toString(),
-        permanent: true,
-        direction: 'center',
-        className: isReached
-          ? 'waypoint-tooltip waypoint-tooltip--reached'
-          : isCurrent
-          ? 'waypoint-tooltip waypoint-tooltip--current-waypoint'
-          : 'waypoint-tooltip',
-        opacity: markerSizeForTooltip === 'md' ? 1 : 0,
+      marker.on('click', (event: L.LeafletMouseEvent) => {
+        L.DomEvent.stopPropagation(event)
+        poiPopupRef.value?.close()
+        togglePersistentTooltip(seq)
       })
 
-      marker.bindTooltip(markerTooltip)
       marker.on('contextmenu', (e: L.LeafletMouseEvent) => {
         L.DomEvent.stopPropagation(e)
         e.originalEvent.stopPropagation()
         e.originalEvent.preventDefault()
         openContextMenuAt(e.originalEvent, seq)
       })
+
       map.value?.addLayer(marker)
     } else {
       marker.setLatLng(waypoint.coordinates as LatLngTuple)
-      const markerSizeForUpdate = getMarkerSizeFromZoom(zoom.value)
-      const tooltip = marker.getTooltip()
-      if (tooltip) {
-        if (markerSizeForUpdate === 'xs' || markerSizeForUpdate === 'sm') {
-          tooltip.setOpacity(0)
-        } else {
-          tooltip.setContent(seq.toString())
-          tooltip.setOpacity(1)
-        }
-      }
-      applyWaypointMarkerStyle(seq)
     }
+    applyWaypointMarkerStyle(seq)
   })
 })
 
 // Keep an eye on the current mission status and update the waypoint markers accordingly
 watch([getReachedWaypointIndices, currentMapWpIndex], () => {
-  Object.entries(reachedWaypoints.value).forEach(([seqStr, marker]) => {
-    const seq = Number(seqStr)
-    const idx = seq - 1
-    const isCurrent = currentMapWpIndex.value >= 0 && idx === currentMapWpIndex.value
-    const isReached = getReachedWaypointIndices.value.has(seq)
-
-    applyWaypointMarkerStyle(seq)
-
-    const tooltip = marker.getTooltip()
-    if (tooltip) {
-      const tooltipElement = tooltip.getElement()
-      if (tooltipElement) {
-        tooltipElement.classList.remove('waypoint-tooltip--reached', 'waypoint-tooltip--current-waypoint')
-        if (isReached) {
-          tooltipElement.classList.add('waypoint-tooltip--reached')
-        } else if (isCurrent) {
-          tooltipElement.classList.add('waypoint-tooltip--current-waypoint')
-        }
-      }
-      tooltip.update()
-    }
-  })
+  refreshReachedWaypointMarkerStyles()
 })
 
 // Create polyline for the vehicle path using a dedicated Canvas renderer to prevent performance issues
@@ -1889,6 +1842,18 @@ const centerOnMission = (): void => {
   box-shadow: 0 0 6px rgba(255, 255, 255, 0.2);
 }
 
+:deep(.waypoint-hover-tooltip) {
+  background-color: #1e498f;
+  color: white;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 8px;
+  padding: 4px 8px;
+  font-size: 12px;
+  font-weight: bold;
+  margin-top: -12px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
 :global(.marker-icon) {
   background-color: #1e498f;
   border: 1px solid #ffffff55;
@@ -1920,6 +1885,7 @@ const centerOnMission = (): void => {
  * the waypoint marker DOM elements. Singular icon tooltips (home, goto, global origin,
  * default-position) are kept visible. */
 :global(.leaflet-container.cockpit-drag-active .waypoint-tooltip:not(.waypoint-tooltip--icon)),
+:global(.leaflet-container.cockpit-drag-active .waypoint-hover-tooltip),
 :global(.leaflet-container.cockpit-drag-active .waypoint-marker-icon) {
   display: none !important;
 }

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -303,6 +303,7 @@ import {
   TargetFollower,
   WhoToFollow,
 } from '@/libs/map/utils-map'
+import { bindWaypointNumberTooltip, getIconDimensionsFromMarkerSize } from '@/libs/map/waypoint-markers'
 import { missionControlPanelSetupInfo } from '@/libs/mission-control-panel'
 import { datalogger, DatalogVariable } from '@/libs/sensors-logging'
 import { copyToClipboard, degrees, messageFromError } from '@/libs/utils'
@@ -311,13 +312,7 @@ import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useMissionStore } from '@/stores/mission'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
-import type {
-  IconDimensions,
-  MarkerSizes,
-  ResolvedPointOfInterest,
-  Waypoint,
-  WaypointCoordinates,
-} from '@/types/mission'
+import type { ResolvedPointOfInterest, Waypoint, WaypointCoordinates } from '@/types/mission'
 import { type Widget, WidgetType } from '@/types/widgets'
 
 import ContextMenu from '../ContextMenu.vue'
@@ -361,6 +356,7 @@ const showButtons = computed(
 const mapReady = ref(false)
 const mapWaypoints = ref<Waypoint[]>([])
 const reachedWaypoints = shallowRef<Record<number, L.Marker>>({})
+const persistentTooltipSeq = ref<number | undefined>(undefined)
 const contextMenuRef = ref()
 const isDragging = ref(false)
 const isPinching = ref(false)
@@ -448,16 +444,6 @@ const { getEffectiveMarkerSize } = useWaypointMarkerSize(() => {
   if (map.value) refreshReachedWaypointMarkerStyles()
 })
 
-const getIconDimensionsFromMarkerSize = (size: MarkerSizes): IconDimensions => {
-  if (size === 'xs') {
-    return { iconSize: [6, 6], iconAnchor: [3, 3] }
-  }
-  if (size === 'sm') {
-    return { iconSize: [12, 12], iconAnchor: [6, 6] }
-  }
-  return { iconSize: [26, 26], iconAnchor: [13, 13] } // md size
-}
-
 const createWaypointMarkerHtml = (isReached: boolean, isCurrent = false): string => {
   let baseClass = 'marker-icon'
   if (isReached) {
@@ -487,43 +473,50 @@ const createWaypointMarkerIcon = (isReached: boolean, isCurrent = false): L.DivI
   })
 }
 
+const waypointTooltipClass = (isReached: boolean, isCurrent: boolean): string => {
+  if (isReached) return 'waypoint-tooltip waypoint-tooltip--reached'
+  if (isCurrent) return 'waypoint-tooltip waypoint-tooltip--current-waypoint'
+  return 'waypoint-tooltip'
+}
+
 const applyWaypointMarkerStyle = (seq: number): void => {
   const marker = reachedWaypoints.value[seq]
   if (!marker) return
   const isReached = getReachedWaypointIndices.value.has(seq)
   const idx = seq - 1
   const isCurrent = currentMapWpIndex.value >= 0 && idx === currentMapWpIndex.value
-  const markerSize = getEffectiveMarkerSize(zoom.value)
-  const dimensions = getIconDimensionsFromMarkerSize(markerSize)
 
-  marker.setIcon(
-    L.divIcon({
-      html: createWaypointMarkerHtml(isReached, isCurrent),
-      className: 'waypoint-marker-icon',
-      iconSize: dimensions.iconSize,
-      iconAnchor: dimensions.iconAnchor,
-    })
-  )
+  marker.setIcon(createWaypointMarkerIcon(isReached, isCurrent))
 
-  // Updates the tooltip class for reached/current waypoints and visibility based on size
-  const tooltip = marker.getTooltip()
-  if (tooltip) {
-    tooltip.setOpacity(markerSize === 'md' ? 1 : 0)
-
-    const tooltipElement = tooltip.getElement()
-    if (tooltipElement) {
-      tooltipElement.classList.remove('waypoint-tooltip--reached', 'waypoint-tooltip--current-waypoint')
-      if (isReached) {
-        tooltipElement.classList.add('waypoint-tooltip--reached')
-      } else if (isCurrent) {
-        tooltipElement.classList.add('waypoint-tooltip--current-waypoint')
-      }
-    }
-  }
+  bindWaypointNumberTooltip(marker, {
+    label: seq.toString(),
+    size: getEffectiveMarkerSize(zoom.value),
+    permanentClassName: waypointTooltipClass(isReached, isCurrent),
+    compactClassName: 'waypoint-hover-tooltip',
+    pinned: persistentTooltipSeq.value === seq,
+  })
 }
 
 const refreshReachedWaypointMarkerStyles = (): void => {
   Object.keys(reachedWaypoints.value).forEach((k) => applyWaypointMarkerStyle(Number(k)))
+}
+
+// Pins the number tooltip of a waypoint too small to show it inline, restyling only the two markers
+// whose pinned state actually changed.
+const togglePersistentTooltip = (seq: number): void => {
+  if (getEffectiveMarkerSize(zoom.value) === 'md') return
+  const previousSeq = persistentTooltipSeq.value
+  persistentTooltipSeq.value = previousSeq === seq ? undefined : seq
+  logUserAction(`${persistentTooltipSeq.value === seq ? 'Pinned' : 'Unpinned'} the tooltip of waypoint ${seq}`)
+  if (previousSeq !== undefined) applyWaypointMarkerStyle(previousSeq)
+  if (persistentTooltipSeq.value !== undefined) applyWaypointMarkerStyle(persistentTooltipSeq.value)
+}
+
+const clearPersistentTooltip = (): void => {
+  const pinnedSeq = persistentTooltipSeq.value
+  if (pinnedSeq === undefined) return
+  persistentTooltipSeq.value = undefined
+  applyWaypointMarkerStyle(pinnedSeq)
 }
 
 const poiManagerMapWidgetRef = ref<typeof PoiManager | null>(null)
@@ -784,6 +777,7 @@ onMounted(async () => {
   map.value.on('click', (event: LeafletMouseEvent) => {
     clickedLocation.value = [event.latlng.lat, event.latlng.lng]
     poiPopupRef.value?.close()
+    clearPersistentTooltip()
   })
 
   // Update center value after panning
@@ -1364,6 +1358,9 @@ watch(mapWaypoints, (newWaypoints) => {
   mapWaypointMarkers.value.forEach((m) => m.remove())
   mapWaypointMarkers.value = []
 
+  // Waypoint numbers are positional, so a surviving pin would migrate to whichever waypoint now holds its seq
+  persistentTooltipSeq.value = undefined
+
   // Add a marker for each point
   newWaypoints.forEach((waypoint, idx) => {
     const seq = idx + 1
@@ -1375,65 +1372,30 @@ watch(mapWaypoints, (newWaypoints) => {
       marker = L.marker(waypoint.coordinates, { icon: markerIcon })
       reachedWaypoints.value[seq] = marker
 
-      const markerSizeForTooltip = getEffectiveMarkerSize(zoom.value)
-      const markerTooltip = L.tooltip({
-        content: seq.toString(),
-        permanent: true,
-        direction: 'center',
-        className: isReached
-          ? 'waypoint-tooltip waypoint-tooltip--reached'
-          : isCurrent
-          ? 'waypoint-tooltip waypoint-tooltip--current-waypoint'
-          : 'waypoint-tooltip',
-        opacity: markerSizeForTooltip === 'md' ? 1 : 0,
+      marker.on('click', (event: L.LeafletMouseEvent) => {
+        L.DomEvent.stopPropagation(event)
+        poiPopupRef.value?.close()
+        togglePersistentTooltip(seq)
       })
 
-      marker.bindTooltip(markerTooltip)
       marker.on('contextmenu', (e: L.LeafletMouseEvent) => {
         L.DomEvent.stopPropagation(e)
         e.originalEvent.stopPropagation()
         e.originalEvent.preventDefault()
         openContextMenuAt(e.originalEvent, seq)
       })
+
       map.value?.addLayer(marker)
     } else {
       marker.setLatLng(waypoint.coordinates as LatLngTuple)
-      const markerSizeForUpdate = getEffectiveMarkerSize(zoom.value)
-      const tooltip = marker.getTooltip()
-      if (tooltip) {
-        const showNumber = markerSizeForUpdate === 'md'
-        if (showNumber) tooltip.setContent(seq.toString())
-        tooltip.setOpacity(showNumber ? 1 : 0)
-      }
-      applyWaypointMarkerStyle(seq)
     }
+    applyWaypointMarkerStyle(seq)
   })
 })
 
 // Keep an eye on the current mission status and update the waypoint markers accordingly
 watch([getReachedWaypointIndices, currentMapWpIndex], () => {
-  Object.entries(reachedWaypoints.value).forEach(([seqStr, marker]) => {
-    const seq = Number(seqStr)
-    const idx = seq - 1
-    const isCurrent = currentMapWpIndex.value >= 0 && idx === currentMapWpIndex.value
-    const isReached = getReachedWaypointIndices.value.has(seq)
-
-    applyWaypointMarkerStyle(seq)
-
-    const tooltip = marker.getTooltip()
-    if (tooltip) {
-      const tooltipElement = tooltip.getElement()
-      if (tooltipElement) {
-        tooltipElement.classList.remove('waypoint-tooltip--reached', 'waypoint-tooltip--current-waypoint')
-        if (isReached) {
-          tooltipElement.classList.add('waypoint-tooltip--reached')
-        } else if (isCurrent) {
-          tooltipElement.classList.add('waypoint-tooltip--current-waypoint')
-        }
-      }
-      tooltip.update()
-    }
-  })
+  refreshReachedWaypointMarkerStyles()
 })
 
 // Create polyline for the vehicle path using a dedicated Canvas renderer to prevent performance issues
@@ -2057,6 +2019,7 @@ const centerOnMission = (): void => {
  * the waypoint marker DOM elements. Singular icon tooltips (home, goto, global origin,
  * default-position) are kept visible. */
 :global(.leaflet-container.cockpit-drag-active .waypoint-tooltip:not(.waypoint-tooltip--icon)),
+:global(.leaflet-container.cockpit-drag-active .waypoint-hover-tooltip),
 :global(.leaflet-container.cockpit-drag-active .waypoint-marker-icon) {
   display: none !important;
 }

--- a/src/composables/map/useWaypointMarkerSize.ts
+++ b/src/composables/map/useWaypointMarkerSize.ts
@@ -1,13 +1,8 @@
 import { watch } from 'vue'
 
+import { getMarkerSizeFromZoom } from '@/libs/map/waypoint-markers'
 import { useMissionStore } from '@/stores/mission'
 import type { MarkerSizes } from '@/types/mission'
-
-const getMarkerSizeFromZoom = (zoomLevel: number): MarkerSizes => {
-  if (zoomLevel <= 17) return 'xs'
-  if (zoomLevel > 17 && zoomLevel <= 19) return 'sm'
-  return 'md'
-}
 
 /**
  * Return type of {@link useWaypointMarkerSize}.

--- a/src/libs/map/waypoint-markers.ts
+++ b/src/libs/map/waypoint-markers.ts
@@ -1,0 +1,120 @@
+import * as L from 'leaflet'
+
+import type { IconDimensions, MarkerSizes } from '@/types/mission'
+
+/**
+ * Size bucket to render waypoint markers at for a given zoom level.
+ * @param {number} zoomLevel - The current map zoom level.
+ * @returns {MarkerSizes} The bucket the markers should be drawn with.
+ */
+export const getMarkerSizeFromZoom = (zoomLevel: number): MarkerSizes => {
+  if (zoomLevel <= 17) return 'xs'
+  if (zoomLevel <= 19) return 'sm'
+  return 'md'
+}
+
+/**
+ * Leaflet icon dimensions matching a marker size bucket.
+ * @param {MarkerSizes} size - The marker size bucket.
+ * @returns {IconDimensions} The icon size and anchor, in pixels.
+ */
+export const getIconDimensionsFromMarkerSize = (size: MarkerSizes): IconDimensions => {
+  if (size === 'xs') {
+    return { iconSize: [6, 6], iconAnchor: [3, 3] }
+  }
+  if (size === 'sm') {
+    return { iconSize: [12, 12], iconAnchor: [6, 6] }
+  }
+  return { iconSize: [26, 26], iconAnchor: [13, 13] } // md size
+}
+
+/**
+ * How a waypoint's number tooltip should be rendered.
+ */
+export interface WaypointNumberTooltipOptions {
+  /**
+   * The already-formatted number to display.
+   */
+  label: string
+  /**
+   * Marker size bucket the tooltip has to match.
+   */
+  size: MarkerSizes
+  /**
+   * Class for the centered tooltip used when the number fits inside the marker.
+   */
+  permanentClassName: string
+  /**
+   * Class for the compact tooltip shown above markers too small to hold the number.
+   */
+  compactClassName: string
+  /**
+   * Keeps the compact tooltip open without hovering.
+   */
+  pinned?: boolean
+  /**
+   * Binds no tooltip, for markers that already render their number inside the icon.
+   */
+  suppressed?: boolean
+}
+
+const openTooltipOnHover = (event: L.LeafletEvent): void => {
+  const marker = event.target as L.Marker
+  marker.openTooltip()
+}
+
+const closeTooltipOnHover = (event: L.LeafletEvent): void => {
+  const marker = event.target as L.Marker
+  marker.closeTooltip()
+}
+
+const unbindWaypointTooltip = (marker: L.Marker): void => {
+  marker.off('mouseover', openTooltipOnHover)
+  marker.off('mouseout', closeTooltipOnHover)
+  marker.unbindTooltip()
+}
+
+/**
+ * Binds the tooltip carrying a waypoint's number, picking the centered always-open form when the
+ * number fits inside the marker and the compact hover form when it does not. Reuses the tooltip
+ * already bound whenever only its text changed, since rebinding replaces the tooltip DOM element.
+ * @param {L.Marker} marker - The waypoint marker to bind onto.
+ * @param {WaypointNumberTooltipOptions} options - How the tooltip should be rendered.
+ * @returns {void}
+ */
+export const bindWaypointNumberTooltip = (marker: L.Marker, options: WaypointNumberTooltipOptions): void => {
+  if (options.suppressed) {
+    unbindWaypointTooltip(marker)
+    return
+  }
+
+  const isCompact = options.size !== 'md'
+  const permanent = !isCompact || Boolean(options.pinned)
+  const className = isCompact ? options.compactClassName : options.permanentClassName
+
+  const bound = marker.getTooltip()
+  if (bound?.options.className === className && bound.options.permanent === permanent) {
+    if (bound.getContent() !== options.label) bound.setContent(options.label)
+    return
+  }
+
+  unbindWaypointTooltip(marker)
+  marker.bindTooltip(
+    L.tooltip({
+      content: options.label,
+      permanent,
+      direction: isCompact ? 'top' : 'center',
+      className,
+      opacity: 1,
+      interactive: false,
+    })
+  )
+
+  if (permanent) {
+    marker.openTooltip()
+    return
+  }
+
+  marker.on('mouseover', openTooltipOnHover)
+  marker.on('mouseout', closeTooltipOnHover)
+}

--- a/src/libs/map/waypoint-markers.ts
+++ b/src/libs/map/waypoint-markers.ts
@@ -1,6 +1,6 @@
 import * as L from 'leaflet'
 
-import type { IconDimensions, MarkerSizes } from '@/types/mission'
+import type { IconDimensions, MarkerSizes, Waypoint } from '@/types/mission'
 
 /**
  * Size bucket to render waypoint markers at for a given zoom level.
@@ -26,6 +26,23 @@ export const getIconDimensionsFromMarkerSize = (size: MarkerSizes): IconDimensio
     return { iconSize: [12, 12], iconAnchor: [6, 6] }
   }
   return { iconSize: [26, 26], iconAnchor: [13, 13] } // md size
+}
+
+/**
+ * Display number of each waypoint, keyed by waypoint id. The count advances by the number of
+ * commands a waypoint carries, so it matches the mission-item sequence rather than the waypoint
+ * index.
+ * @param {Waypoint[]} waypoints - The ordered mission waypoints.
+ * @returns {Record<string, number>} The display number for every waypoint id.
+ */
+export const waypointNumbersById = (waypoints: Waypoint[]): Record<string, number> => {
+  const numbers: Record<string, number> = {}
+  let nextNumber = 1
+  waypoints.forEach((waypoint) => {
+    numbers[waypoint.id] = nextNumber
+    nextNumber += waypoint.commands.length
+  })
+  return numbers
 }
 
 /**

--- a/src/libs/map/waypoint-markers.ts
+++ b/src/libs/map/waypoint-markers.ts
@@ -1,0 +1,99 @@
+import * as L from 'leaflet'
+
+import type { IconDimensions, MarkerSizes } from '@/types/mission'
+
+/**
+ * Size bucket to render waypoint markers at for a given zoom level.
+ * @param {number} zoomLevel - The current map zoom level.
+ * @returns {MarkerSizes} The bucket the markers should be drawn with.
+ */
+export const getMarkerSizeFromZoom = (zoomLevel: number): MarkerSizes => {
+  if (zoomLevel <= 17) return 'xs'
+  if (zoomLevel <= 19) return 'sm'
+  return 'md'
+}
+
+/**
+ * Leaflet icon dimensions matching a marker size bucket.
+ * @param {MarkerSizes} size - The marker size bucket.
+ * @returns {IconDimensions} The icon size and anchor, in pixels.
+ */
+export const getIconDimensionsFromMarkerSize = (size: MarkerSizes): IconDimensions => {
+  if (size === 'xs') {
+    return { iconSize: [6, 6], iconAnchor: [3, 3] }
+  }
+  if (size === 'sm') {
+    return { iconSize: [12, 12], iconAnchor: [6, 6] }
+  }
+  return { iconSize: [26, 26], iconAnchor: [13, 13] } // md size
+}
+
+/**
+ * How a waypoint's number tooltip should be rendered.
+ */
+export interface WaypointNumberTooltipOptions {
+  /**
+   * The already-formatted number to display.
+   */
+  label: string
+  /**
+   * Marker size bucket the tooltip has to match.
+   */
+  size: MarkerSizes
+  /**
+   * Class for the centered tooltip used when the number fits inside the marker.
+   */
+  permanentClassName: string
+  /**
+   * Class for the compact tooltip shown above markers too small to hold the number.
+   */
+  compactClassName: string
+  /**
+   * Keeps the compact tooltip open without hovering.
+   */
+  pinned?: boolean
+  /**
+   * Binds no tooltip, for markers that already render their number inside the icon.
+   */
+  suppressed?: boolean
+}
+
+/**
+ * Binds the tooltip carrying a waypoint's number, picking the centered always-open form when the
+ * number fits inside the marker and the compact hover form when it does not. Reuses the tooltip
+ * already bound whenever only its text changed, since rebinding replaces the tooltip DOM element.
+ * @param {L.Marker} marker - The waypoint marker to bind onto.
+ * @param {WaypointNumberTooltipOptions} options - How the tooltip should be rendered.
+ * @returns {void}
+ */
+export const bindWaypointNumberTooltip = (marker: L.Marker, options: WaypointNumberTooltipOptions): void => {
+  if (options.suppressed) {
+    marker.unbindTooltip()
+    return
+  }
+
+  const isCompact = options.size !== 'md'
+  const permanent = !isCompact || Boolean(options.pinned)
+  const className = isCompact ? options.compactClassName : options.permanentClassName
+
+  const bound = marker.getTooltip()
+  if (bound?.options.className === className && bound.options.permanent === permanent) {
+    if (bound.getContent() !== options.label) bound.setContent(options.label)
+    return
+  }
+
+  marker.unbindTooltip()
+  marker.bindTooltip(
+    L.tooltip({
+      content: options.label,
+      permanent,
+      direction: isCompact ? 'top' : 'center',
+      className,
+      opacity: 1,
+      interactive: false,
+    })
+  )
+
+  // A non-permanent tooltip is opened by leaflet's own hover and focus handlers.
+  if (permanent) marker.openTooltip()
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -79,3 +79,20 @@ select:focus {
     0% { background-color: rgba(255, 234, 43, 0.438); }
     100% { background-color: transparent; }
 }
+
+/* Container-qualified so it outranks leaflet's .leaflet-tooltip regardless of stylesheet order. */
+.leaflet-container .waypoint-hover-tooltip {
+    background-color: #1e498f;
+    color: white;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    border-radius: 8px;
+    padding: 4px 8px;
+    font-size: 12px;
+    font-weight: bold;
+    margin-top: -12px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+.leaflet-container .waypoint-hover-tooltip.leaflet-tooltip-top::before {
+    border-top-color: #1e498f;
+}

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -943,6 +943,11 @@ import {
 } from '@/libs/map/utils-map'
 import { orderedSurveyPath, surveyEndpointEdgeBearing, surveyEntryCornerCount } from '@/libs/map/utils-map'
 import {
+  bindWaypointNumberTooltip,
+  getIconDimensionsFromMarkerSize,
+  waypointNumbersById,
+} from '@/libs/map/waypoint-markers'
+import {
   bearingBetween,
   calculateHaversineDistance,
   centroidLatLng,
@@ -966,9 +971,7 @@ import {
   AltitudeReferenceType,
   ClosestSegmentInfo,
   ContextMenuTypes,
-  IconDimensions,
   instanceOfCockpitMission,
-  MarkerSizes,
   MissionCommand,
   MissionCommandType,
   Survey,
@@ -1210,6 +1213,7 @@ const onPlannedVehicleTypeChange = (value?: MavType): void => {
   logUserAction(`Selected "${vehicleTypeLabel(value)}" as the planning vehicle type`)
 }
 const waypointMarkers = shallowRef<{ [id: string]: Marker }>({})
+const waypointNumbers = computed(() => waypointNumbersById(missionStore.currentPlanningWaypoints))
 const isCreatingSimplePath = ref(false)
 const contextMenuVisible = ref(false)
 const contextMenuPosition = ref({ x: 0, y: 0 })
@@ -3104,28 +3108,16 @@ const addWaypoint = (
     showContextMenu(e)
   })
 
-  const currentMarkerSize = getEffectiveMarkerSize(zoom.value)
-  const iconDimensions = getIconDimensionsFromMarkerSize(currentMarkerSize)
-  const markerIcon = L.divIcon({
-    html: createWaypointMarkerHtml(
+  newMarker.setIcon(
+    createWaypointMarkerIcon(
       waypoint.commands.length,
       false,
       surveyEntryExitWaypointIds.value.has(waypoint.id),
-      isEndpointWaypoint(waypointId)
-    ),
-    className: 'waypoint-marker-icon',
-    iconSize: iconDimensions.iconSize,
-    iconAnchor: iconDimensions.iconAnchor,
-  })
-  newMarker.setIcon(markerIcon)
-  const markerTooltip = L.tooltip({
-    content: '',
-    permanent: true,
-    direction: 'center',
-    className: 'waypoint-tooltip',
-    opacity: currentMarkerSize === 'md' ? 1 : 0,
-  })
-  newMarker.bindTooltip(markerTooltip)
+      isEndpointWaypoint(waypointId),
+      waypointNumbers.value[waypointId]
+    )
+  )
+  applyWaypointNumberTooltip(newMarker, waypointId, false)
   planningMap.value.addLayer(newMarker)
   waypointMarkers.value[waypointId] = newMarker
 
@@ -3797,7 +3789,8 @@ const createWaypointMarkerHtml = (
   commandCount: number,
   isSelected = false,
   isEntryExit = false,
-  isEndpoint = false
+  isEndpoint = false,
+  waypointNumber?: number
 ): string => {
   const baseClass = isSelected ? 'selected-marker' : 'marker-icon'
   const size = getEffectiveMarkerSize(zoom.value)
@@ -3806,12 +3799,14 @@ const createWaypointMarkerHtml = (
   const showCommandCount = size === 'md' && commandCount > 1
   const entryExitClass = isEntryExit ? ' green-marker' : ''
   const endpointClass = isEndpoint ? ' endpoint-marker' : ''
+  const showWaypointNumber = isSelected && waypointNumber !== undefined && (size === 'xs' || size === 'sm')
 
   return `
     <div class="${markerSizeClass}">
       <div class="${baseClass} waypoint-main-marker${entryExitClass}${endpointClass}"></div>
       ${showCommandCount ? `<div class="command-count-indicator">${commandCount}</div>` : ''}
       ${showSmallCommandCount ? `<div class="command-count-indicator small">${commandCount}</div>` : ''}
+      ${showWaypointNumber ? `<div class="waypoint-number-indicator">${waypointNumber}</div>` : ''}
     </div>
   `
 }
@@ -3822,46 +3817,57 @@ const isEndpointWaypoint = (waypointId: string): boolean => {
   return waypointId === wps[0].id || waypointId === wps[wps.length - 1].id
 }
 
-const updateWaypointMarkers = (): void => {
-  let cumulativeCommandCount = 1 // Start numbering from 1
-  if (!planningMap.value) return
+const createWaypointMarkerIcon = (
+  commandCount: number,
+  isSelected: boolean,
+  isEntryExit: boolean,
+  isEndpoint: boolean,
+  waypointNumber?: number
+): L.DivIcon => {
+  const dimensions = getIconDimensionsFromMarkerSize(getEffectiveMarkerSize(zoom.value))
 
-  const currentZoom = zoom.value
-  const markerSize = getEffectiveMarkerSize(currentZoom)
+  return L.divIcon({
+    html: createWaypointMarkerHtml(commandCount, isSelected, isEntryExit, isEndpoint, waypointNumber),
+    className: 'waypoint-marker-icon',
+    iconSize: dimensions.iconSize,
+    iconAnchor: dimensions.iconAnchor,
+  })
+}
+
+// Binds the number tooltip of a waypoint marker. Small selected markers render their number inside
+// the icon instead, so they get no tooltip.
+const applyWaypointNumberTooltip = (marker: Marker, waypointId: string, isSelected: boolean): void => {
+  const markerSize = getEffectiveMarkerSize(zoom.value)
+
+  bindWaypointNumberTooltip(marker, {
+    label: `${waypointNumbers.value[waypointId] ?? ''}`,
+    size: markerSize,
+    permanentClassName: 'waypoint-tooltip',
+    compactClassName: 'waypoint-hover-tooltip',
+    suppressed: isSelected && markerSize !== 'md',
+  })
+}
+
+const updateWaypointMarkers = (): void => {
+  if (!planningMap.value) return
 
   const wps = missionStore.currentPlanningWaypoints
   wps.forEach((wp, idx) => {
     const marker = waypointMarkers.value[wp.id]
-    if (marker) {
-      // Update marker icon to show command count
-      const isSelected = selectedWaypoint.value?.id === wp.id
-      const isEndpoint = idx === 0 || idx === wps.length - 1
-      const dimensions = getIconDimensionsFromMarkerSize(markerSize)
+    if (!marker) return
 
-      marker.setIcon(
-        L.divIcon({
-          html: createWaypointMarkerHtml(
-            wp.commands.length,
-            isSelected,
-            surveyEntryExitWaypointIds.value.has(wp.id),
-            isEndpoint
-          ),
-          className: 'waypoint-marker-icon',
-          iconSize: dimensions.iconSize,
-          iconAnchor: dimensions.iconAnchor,
-        })
+    const isSelected = selectedWaypoint.value?.id === wp.id
+    const isEndpoint = idx === 0 || idx === wps.length - 1
+    marker.setIcon(
+      createWaypointMarkerIcon(
+        wp.commands.length,
+        isSelected,
+        surveyEntryExitWaypointIds.value.has(wp.id),
+        isEndpoint,
+        waypointNumbers.value[wp.id]
       )
-
-      // Update tooltip visibility and content based on size
-      const tooltip = marker.getTooltip()
-      if (tooltip) {
-        const showNumber = markerSize === 'md'
-        tooltip.setContent(showNumber ? `${cumulativeCommandCount}` : '')
-        tooltip.setOpacity(showNumber ? 1 : 0)
-      }
-
-      cumulativeCommandCount += wp.commands.length
-    }
+    )
+    applyWaypointNumberTooltip(marker, wp.id, isSelected)
   })
 }
 
@@ -4158,30 +4164,16 @@ const addWaypointMarker = (waypoint: Waypoint): void => {
     interfaceStore.configPanelVisible = true
   })
 
-  const currentMarkerSize = getEffectiveMarkerSize(zoom.value)
-  const dimensions = getIconDimensionsFromMarkerSize(currentMarkerSize)
-  const markerIcon = L.divIcon({
-    html: createWaypointMarkerHtml(
+  newMarker.setIcon(
+    createWaypointMarkerIcon(
       waypoint.commands.length,
       false,
       surveyEntryExitWaypointIds.value.has(waypoint.id),
-      isEndpointWaypoint(waypoint.id)
-    ),
-    className: 'waypoint-marker-icon',
-    iconSize: dimensions.iconSize,
-    iconAnchor: dimensions.iconAnchor,
-  })
-  newMarker.setIcon(markerIcon)
-
-  const currentMarkerSizeForTooltip = getEffectiveMarkerSize(zoom.value)
-  const markerTooltip = L.tooltip({
-    content: '',
-    permanent: true,
-    direction: 'center',
-    className: 'waypoint-tooltip',
-    opacity: currentMarkerSizeForTooltip === 'md' ? 1 : 0,
-  })
-  newMarker.bindTooltip(markerTooltip)
+      isEndpointWaypoint(waypoint.id),
+      waypointNumbers.value[waypoint.id]
+    )
+  )
+  applyWaypointNumberTooltip(newMarker, waypoint.id, false)
 
   newMarker.addTo(planningMap.value)
   waypointMarkers.value[waypoint.id] = newMarker
@@ -4191,61 +4183,27 @@ const { getEffectiveMarkerSize } = useWaypointMarkerSize(() => {
   if (planningMap.value) updateWaypointMarkers()
 })
 
-const getIconDimensionsFromMarkerSize = (size: MarkerSizes): IconDimensions => {
-  if (size === 'xs') {
-    return { iconSize: [6, 6], iconAnchor: [3, 3] }
-  }
-  if (size === 'sm') {
-    return { iconSize: [12, 12], iconAnchor: [6, 6] }
-  }
-  return { iconSize: [26, 26], iconAnchor: [13, 13] } // md size
+const applyWaypointMarkerSelection = (waypointId: string, isSelected: boolean): void => {
+  const marker = waypointMarkers.value[waypointId]
+  if (!marker) return
+
+  const waypoint = missionStore.currentPlanningWaypoints.find((wp) => wp.id === waypointId)
+  marker.setIcon(
+    createWaypointMarkerIcon(
+      waypoint?.commands.length ?? 0,
+      isSelected,
+      surveyEntryExitWaypointIds.value.has(waypointId),
+      isEndpointWaypoint(waypointId),
+      waypointNumbers.value[waypointId]
+    )
+  )
+  applyWaypointNumberTooltip(marker, waypointId, isSelected)
 }
 
 // single source of truth for selected-marker visuals
 const applySelectedWaypointMarkerVisual = (newWaypointId?: string, oldWaypointId?: string): void => {
-  const markerSize = getEffectiveMarkerSize(zoom.value)
-
-  if (oldWaypointId) {
-    const oldMarker = waypointMarkers.value[oldWaypointId]
-    if (oldMarker) {
-      const oldWp = missionStore.currentPlanningWaypoints.find((w) => w.id === oldWaypointId)
-      const dimensions = getIconDimensionsFromMarkerSize(markerSize)
-      oldMarker.setIcon(
-        L.divIcon({
-          html: createWaypointMarkerHtml(
-            oldWp?.commands.length ?? 0,
-            false,
-            surveyEntryExitWaypointIds.value.has(oldWaypointId),
-            isEndpointWaypoint(oldWaypointId)
-          ),
-          className: 'waypoint-marker-icon',
-          iconSize: dimensions.iconSize,
-          iconAnchor: dimensions.iconAnchor,
-        })
-      )
-    }
-  }
-
-  if (newWaypointId) {
-    const newMarker = waypointMarkers.value[newWaypointId]
-    if (newMarker) {
-      const newWp = missionStore.currentPlanningWaypoints.find((w) => w.id === newWaypointId)
-      const dimensions = getIconDimensionsFromMarkerSize(markerSize)
-      newMarker.setIcon(
-        L.divIcon({
-          html: createWaypointMarkerHtml(
-            newWp?.commands.length ?? 0,
-            true,
-            surveyEntryExitWaypointIds.value.has(newWaypointId),
-            isEndpointWaypoint(newWaypointId)
-          ),
-          className: 'waypoint-marker-icon',
-          iconSize: dimensions.iconSize,
-          iconAnchor: dimensions.iconAnchor,
-        })
-      )
-    }
-  }
+  if (oldWaypointId) applyWaypointMarkerSelection(oldWaypointId, false)
+  if (newWaypointId) applyWaypointMarkerSelection(newWaypointId, true)
 }
 
 let homeRetryTimer: ReturnType<typeof setInterval> | null = null
@@ -4481,26 +4439,7 @@ const onMapClick = (e: L.LeafletMouseEvent): void => {
   if (touchDrawingSwallowsClick()) return
 
   const oldWaypoint = selectedWaypoint.value
-  if (oldWaypoint) {
-    const oldMarker = waypointMarkers.value[oldWaypoint.id]
-    if (oldMarker) {
-      const markerSize = getEffectiveMarkerSize(zoom.value)
-      const dimensions = getIconDimensionsFromMarkerSize(markerSize)
-      oldMarker.setIcon(
-        L.divIcon({
-          html: createWaypointMarkerHtml(
-            oldWaypoint.commands.length,
-            false,
-            surveyEntryExitWaypointIds.value.has(oldWaypoint.id),
-            isEndpointWaypoint(oldWaypoint.id)
-          ),
-          className: 'waypoint-marker-icon',
-          iconSize: dimensions.iconSize,
-          iconAnchor: dimensions.iconAnchor,
-        })
-      )
-    }
-  }
+  if (oldWaypoint) applyWaypointMarkerSelection(oldWaypoint.id, false)
 
   if (interfaceStore.configPanelVisible && !isCreatingSurvey.value) {
     selectedWaypoint.value = undefined
@@ -5125,6 +5064,10 @@ watch(
 }
 
 .wp-marker-xs .selected-marker {
+  width: 14px;
+  height: 14px;
+  top: -4px;
+  left: -4px;
   border: 1px solid #ffff0099;
   box-shadow: 0 0 2px 1px rgba(255, 235, 59, 0.2);
   filter: drop-shadow(0 0 2px rgba(255, 235, 59, 0.1));
@@ -5139,6 +5082,10 @@ watch(
 }
 
 .wp-marker-sm .selected-marker {
+  width: 20px;
+  height: 20px;
+  top: -4px;
+  left: -4px;
   border: 1.5px solid #ffff0099;
   box-shadow: 0 0 3px 1.5px rgba(255, 235, 59, 0.2), 0 0 9px 4px rgba(255, 193, 7, 0.12);
   filter: drop-shadow(0 0 3px rgba(255, 235, 59, 0.1));
@@ -5209,6 +5156,24 @@ watch(
   border: 1px solid white;
   top: -2px;
   right: -2px;
+}
+.waypoint-number-indicator {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: white;
+  font-size: 8px;
+  font-weight: bold;
+  text-shadow: 0 0 2px rgba(0, 0, 0, 0.8), 0 0 4px rgba(0, 0, 0, 0.6);
+  pointer-events: none;
+  z-index: 300;
+}
+.wp-marker-xs .waypoint-number-indicator {
+  font-size: 8px;
+}
+.wp-marker-sm .waypoint-number-indicator {
+  font-size: 10px;
 }
 .waypoint-tooltip {
   background-color: transparent;

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -723,6 +723,12 @@ import {
 } from '@/libs/map/utils-map'
 import { generateSurveyPath } from '@/libs/map/utils-map'
 import {
+  bindWaypointNumberTooltip,
+  getIconDimensionsFromMarkerSize,
+  getMarkerSizeFromZoom,
+  waypointNumbersById,
+} from '@/libs/map/waypoint-markers'
+import {
   bearingBetween,
   centroidLatLng,
   formatBearing,
@@ -746,9 +752,7 @@ import {
   AltitudeReferenceType,
   ClosestSegmentInfo,
   ContextMenuTypes,
-  IconDimensions,
   instanceOfCockpitMission,
-  MarkerSizes,
   MissionCommand,
   MissionCommandType,
   Survey,
@@ -979,6 +983,7 @@ const onPlannedVehicleTypeChange = (value?: MavType): void => {
   logUserAction(`Selected "${vehicleTypeLabel(value)}" as the planning vehicle type`)
 }
 const waypointMarkers = shallowRef<{ [id: string]: Marker }>({})
+const waypointNumbers = computed(() => waypointNumbersById(missionStore.currentPlanningWaypoints))
 const isCreatingSimplePath = ref(false)
 const contextMenuVisible = ref(false)
 const contextMenuPosition = ref({ x: 0, y: 0 })
@@ -2736,23 +2741,8 @@ const addWaypoint = (
     showContextMenu(e)
   })
 
-  const currentMarkerSize = getMarkerSizeFromZoom(zoom.value)
-  const iconDimensions = getIconDimensionsFromMarkerSize(currentMarkerSize)
-  const markerIcon = L.divIcon({
-    html: createWaypointMarkerHtml(waypoint.commands.length, false),
-    className: 'waypoint-marker-icon',
-    iconSize: iconDimensions.iconSize,
-    iconAnchor: iconDimensions.iconAnchor,
-  })
-  newMarker.setIcon(markerIcon)
-  const markerTooltip = L.tooltip({
-    content: '',
-    permanent: true,
-    direction: 'center',
-    className: 'waypoint-tooltip',
-    opacity: currentMarkerSize === 'md' ? 1 : 0,
-  })
-  newMarker.bindTooltip(markerTooltip)
+  newMarker.setIcon(createWaypointMarkerIcon(waypoint.commands.length, false, waypointNumbers.value[waypointId]))
+  applyWaypointNumberTooltip(newMarker, waypointId, false)
   planningMap.value.addLayer(newMarker)
   waypointMarkers.value[waypointId] = newMarker
 
@@ -3299,59 +3289,59 @@ const generateWaypointsFromSurvey = (): void => {
 }
 
 // Helper function to create waypoint marker HTML with command count indicator
-const createWaypointMarkerHtml = (commandCount: number, isSelected = false): string => {
+const createWaypointMarkerHtml = (commandCount: number, isSelected = false, waypointNumber?: number): string => {
   const baseClass = isSelected ? 'selected-marker' : 'marker-icon'
   const size = getMarkerSizeFromZoom(zoom.value)
   const markerSizeClass = `wp-marker-${size}`
   const showSmallCommandCount = size !== 'md' && commandCount > 1
   const showCommandCount = size === 'md' && commandCount > 1
+  const showWaypointNumber = isSelected && waypointNumber !== undefined && (size === 'xs' || size === 'sm')
 
   return `
     <div class="${markerSizeClass}">
       <div class="${baseClass} waypoint-main-marker"></div>
       ${showCommandCount ? `<div class="command-count-indicator">${commandCount}</div>` : ''}
       ${showSmallCommandCount ? `<div class="command-count-indicator small">${commandCount}</div>` : ''}
+      ${showWaypointNumber ? `<div class="waypoint-number-indicator">${waypointNumber}</div>` : ''}
     </div>
   `
 }
 
-const updateWaypointMarkers = (): void => {
-  let cumulativeCommandCount = 1 // Start numbering from 1
-  if (!planningMap.value) return
+const createWaypointMarkerIcon = (commandCount: number, isSelected: boolean, waypointNumber?: number): L.DivIcon => {
+  const dimensions = getIconDimensionsFromMarkerSize(getMarkerSizeFromZoom(zoom.value))
 
-  const currentZoom = zoom.value
-  const markerSize = getMarkerSizeFromZoom(currentZoom)
+  return L.divIcon({
+    html: createWaypointMarkerHtml(commandCount, isSelected, waypointNumber),
+    className: 'waypoint-marker-icon',
+    iconSize: dimensions.iconSize,
+    iconAnchor: dimensions.iconAnchor,
+  })
+}
+
+// Binds the number tooltip of a waypoint marker. Small selected markers render their number inside
+// the icon instead, so they get no tooltip.
+const applyWaypointNumberTooltip = (marker: Marker, waypointId: string, isSelected: boolean): void => {
+  const markerSize = getMarkerSizeFromZoom(zoom.value)
+
+  bindWaypointNumberTooltip(marker, {
+    label: `${waypointNumbers.value[waypointId] ?? ''}`,
+    size: markerSize,
+    permanentClassName: 'waypoint-tooltip',
+    compactClassName: 'waypoint-hover-tooltip',
+    suppressed: isSelected && markerSize !== 'md',
+  })
+}
+
+const updateWaypointMarkers = (): void => {
+  if (!planningMap.value) return
 
   missionStore.currentPlanningWaypoints.forEach((wp) => {
     const marker = waypointMarkers.value[wp.id]
-    if (marker) {
-      // Update marker icon to show command count
-      const isSelected = selectedWaypoint.value?.id === wp.id
-      const dimensions = getIconDimensionsFromMarkerSize(markerSize)
+    if (!marker) return
 
-      marker.setIcon(
-        L.divIcon({
-          html: createWaypointMarkerHtml(wp.commands.length, isSelected),
-          className: 'waypoint-marker-icon',
-          iconSize: dimensions.iconSize,
-          iconAnchor: dimensions.iconAnchor,
-        })
-      )
-
-      // Update tooltip visibility and content based on size
-      const tooltip = marker.getTooltip()
-      if (tooltip) {
-        if (markerSize === 'xs' || markerSize === 'sm') {
-          tooltip.setContent('')
-          tooltip.setOpacity(0)
-        } else {
-          tooltip.setContent(`${cumulativeCommandCount}`)
-          tooltip.setOpacity(1)
-        }
-      }
-
-      cumulativeCommandCount += wp.commands.length
-    }
+    const isSelected = selectedWaypoint.value?.id === wp.id
+    marker.setIcon(createWaypointMarkerIcon(wp.commands.length, isSelected, waypointNumbers.value[wp.id]))
+    applyWaypointNumberTooltip(marker, wp.id, isSelected)
   })
 
   refreshSurveyEntryExitMarkers()
@@ -3654,81 +3644,28 @@ const addWaypointMarker = (waypoint: Waypoint): void => {
     interfaceStore.configPanelVisible = true
   })
 
-  const currentMarkerSize = getMarkerSizeFromZoom(zoom.value)
-  const dimensions = getIconDimensionsFromMarkerSize(currentMarkerSize)
-  const markerIcon = L.divIcon({
-    html: createWaypointMarkerHtml(waypoint.commands.length, false),
-    className: 'waypoint-marker-icon',
-    iconSize: dimensions.iconSize,
-    iconAnchor: dimensions.iconAnchor,
-  })
-  newMarker.setIcon(markerIcon)
-
-  const currentMarkerSizeForTooltip = getMarkerSizeFromZoom(zoom.value)
-  const markerTooltip = L.tooltip({
-    content: '',
-    permanent: true,
-    direction: 'center',
-    className: 'waypoint-tooltip',
-    opacity: currentMarkerSizeForTooltip === 'md' ? 1 : 0,
-  })
-  newMarker.bindTooltip(markerTooltip)
+  newMarker.setIcon(createWaypointMarkerIcon(waypoint.commands.length, false, waypointNumbers.value[waypoint.id]))
+  applyWaypointNumberTooltip(newMarker, waypoint.id, false)
 
   newMarker.addTo(planningMap.value)
   waypointMarkers.value[waypoint.id] = newMarker
 }
 
-const getMarkerSizeFromZoom = (zoomLevel: number): MarkerSizes => {
-  if (zoomLevel <= 17) return 'xs'
-  if (zoomLevel > 17 && zoomLevel <= 19) return 'sm'
-  return 'md'
-}
+const applyWaypointMarkerSelection = (waypointId: string, isSelected: boolean): void => {
+  const marker = waypointMarkers.value[waypointId]
+  if (!marker) return
 
-const getIconDimensionsFromMarkerSize = (size: MarkerSizes): IconDimensions => {
-  if (size === 'xs') {
-    return { iconSize: [6, 6], iconAnchor: [3, 3] }
-  }
-  if (size === 'sm') {
-    return { iconSize: [12, 12], iconAnchor: [6, 6] }
-  }
-  return { iconSize: [26, 26], iconAnchor: [13, 13] } // md size
+  const waypoint = missionStore.currentPlanningWaypoints.find((wp) => wp.id === waypointId)
+  marker.setIcon(
+    createWaypointMarkerIcon(waypoint?.commands.length ?? 0, isSelected, waypointNumbers.value[waypointId])
+  )
+  applyWaypointNumberTooltip(marker, waypointId, isSelected)
 }
 
 // single source of truth for selected-marker visuals
 const applySelectedWaypointMarkerVisual = (newWaypointId?: string, oldWaypointId?: string): void => {
-  const markerSize = getMarkerSizeFromZoom(zoom.value)
-
-  if (oldWaypointId) {
-    const oldMarker = waypointMarkers.value[oldWaypointId]
-    if (oldMarker) {
-      const oldWp = missionStore.currentPlanningWaypoints.find((w) => w.id === oldWaypointId)
-      const dimensions = getIconDimensionsFromMarkerSize(markerSize)
-      oldMarker.setIcon(
-        L.divIcon({
-          html: createWaypointMarkerHtml(oldWp?.commands.length ?? 0, false),
-          className: 'waypoint-marker-icon',
-          iconSize: dimensions.iconSize,
-          iconAnchor: dimensions.iconAnchor,
-        })
-      )
-    }
-  }
-
-  if (newWaypointId) {
-    const newMarker = waypointMarkers.value[newWaypointId]
-    if (newMarker) {
-      const newWp = missionStore.currentPlanningWaypoints.find((w) => w.id === newWaypointId)
-      const dimensions = getIconDimensionsFromMarkerSize(markerSize)
-      newMarker.setIcon(
-        L.divIcon({
-          html: createWaypointMarkerHtml(newWp?.commands.length ?? 0, true),
-          className: 'waypoint-marker-icon',
-          iconSize: dimensions.iconSize,
-          iconAnchor: dimensions.iconAnchor,
-        })
-      )
-    }
-  }
+  if (oldWaypointId) applyWaypointMarkerSelection(oldWaypointId, false)
+  if (newWaypointId) applyWaypointMarkerSelection(newWaypointId, true)
 
   refreshSurveyEntryExitMarkers() // keep entry/exit green after selection updates
 }
@@ -3864,21 +3801,7 @@ const onMapClick = (e: L.LeafletMouseEvent): void => {
   if (isSettingHomeWaypoint.value) return
 
   const oldWaypoint = selectedWaypoint.value
-  if (oldWaypoint) {
-    const oldMarker = waypointMarkers.value[oldWaypoint.id]
-    if (oldMarker) {
-      const markerSize = getMarkerSizeFromZoom(zoom.value)
-      const dimensions = getIconDimensionsFromMarkerSize(markerSize)
-      oldMarker.setIcon(
-        L.divIcon({
-          html: createWaypointMarkerHtml(oldWaypoint.commands.length, false),
-          className: 'waypoint-marker-icon',
-          iconSize: dimensions.iconSize,
-          iconAnchor: dimensions.iconAnchor,
-        })
-      )
-    }
-  }
+  if (oldWaypoint) applyWaypointMarkerSelection(oldWaypoint.id, false)
 
   if (interfaceStore.configPanelVisible && !isCreatingSurvey.value) {
     selectedWaypoint.value = undefined
@@ -4487,6 +4410,10 @@ watch(
 }
 
 .wp-marker-xs .selected-marker {
+  width: 14px;
+  height: 14px;
+  top: -4px;
+  left: -4px;
   border: 1px solid #ffff0099;
   box-shadow: 0 0 2px 1px rgba(255, 235, 59, 0.2);
   filter: drop-shadow(0 0 2px rgba(255, 235, 59, 0.1));
@@ -4501,6 +4428,10 @@ watch(
 }
 
 .wp-marker-sm .selected-marker {
+  width: 20px;
+  height: 20px;
+  top: -4px;
+  left: -4px;
   border: 1.5px solid #ffff0099;
   box-shadow: 0 0 3px 1.5px rgba(255, 235, 59, 0.2), 0 0 9px 4px rgba(255, 193, 7, 0.12);
   filter: drop-shadow(0 0 3px rgba(255, 235, 59, 0.1));
@@ -4563,6 +4494,35 @@ watch(
   border: 1px solid white;
   top: -2px;
   right: -2px;
+}
+.waypoint-number-indicator {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: white;
+  font-size: 8px;
+  font-weight: bold;
+  text-shadow: 0 0 2px rgba(0, 0, 0, 0.8), 0 0 4px rgba(0, 0, 0, 0.6);
+  pointer-events: none;
+  z-index: 300;
+}
+.wp-marker-xs .waypoint-number-indicator {
+  font-size: 8px;
+}
+.wp-marker-sm .waypoint-number-indicator {
+  font-size: 10px;
+}
+.waypoint-hover-tooltip {
+  background-color: #1e498f;
+  color: white;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 8px;
+  padding: 4px 8px;
+  font-size: 12px;
+  font-weight: bold;
+  margin-top: -12px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
 }
 .waypoint-tooltip {
   background-color: transparent;


### PR DESCRIPTION
* Waypoint numbers show in a hover tooltip above markers too small to render them inline, in both the map widget and the mission-planning view;
* Clicking a small marker in the map widget pins its number open; clicking the map clears the pin;
* In the planning view the selected small marker draws its number inside the icon instead of in a bubble;
* Marker sizing and number-tooltip binding move into a shared `src/libs/map/waypoint-markers.ts`, consumed by both surfaces and by `useWaypointMarkerSize`, so the always-show-waypoint-numbers toggle still decides the effective size.

https://github.com/user-attachments/assets/253aafb6-4b00-40c6-9197-2a0f59091a12