### PR TITLE
Keep vehicle path history persistent on the maps

### DIFF
--- a/src/components/mission-planning/ContextMenu.vue
+++ b/src/components/mission-planning/ContextMenu.vue
@@ -156,6 +156,18 @@
           ></v-icon>
           <span class="text-white text-sm ml-4">Set home waypoint</span>
         </v-list-item>
+        <v-divider />
+        <v-list-item class="flex items-center gap-x-2 pb-2" @click="handleClearVehiclePathHistory">
+          <v-icon
+            variant="text"
+            icon="mdi-map-marker-path"
+            rounded="full"
+            size="x-small"
+            color="white"
+            class="text-[16px]"
+          ></v-icon>
+          <span class="text-white text-sm ml-4">Clear vehicle path history</span>
+        </v-list-item>
       </div>
     </div>
 
@@ -267,6 +279,7 @@ const emit = defineEmits<{
   (event: 'removeWaypoint'): void
   (event: 'placePointOfInterest'): void
   (event: 'setHomePosition'): void
+  (event: 'clearVehiclePathHistory'): void
 }>()
 
 const menuType = computed(() => props.menuType)
@@ -336,6 +349,11 @@ const handleRemoveWaypoint = (): void => {
 
 const handleSetHomePosition = (): void => {
   emit('setHomePosition')
+  emit('close')
+}
+
+const handleClearVehiclePathHistory = (): void => {
+  emit('clearVehiclePathHistory')
   emit('close')
 }
 

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -741,12 +741,12 @@ onMounted(async () => {
   }
   await refreshMission()
 
-  // Initialize vehicle history polyline if exists
-  if (map.value && vehicleStore.vehiclePositionHistory.length > 0) {
+  // Initialize vehicle history polyline if vehicle marker is on screen
+  if (map.value && vehicleMarker.value && missionStore.vehiclePositionHistory.length > 0) {
     if (vehicleHistoryPolyline.value === undefined) {
       vehicleHistoryPolyline.value = L.polyline([], { color: '#ffff00' }).addTo(map.value)
     }
-    vehicleHistoryPolyline.value.setLatLngs(vehicleStore.vehiclePositionHistory as L.LatLngExpression[])
+    vehicleHistoryPolyline.value.setLatLngs(missionStore.vehiclePositionHistory as L.LatLngExpression[])
   }
   // Register mission actions for map widget
   missionStore.registerMapMissionActions({
@@ -1288,9 +1288,15 @@ watch([vehicleStore.currentMissionSeq, currentVehicleWpIndex, getReachedWaypoint
 // Create polyline for the vehicle path
 const vehicleHistoryPolyline = shallowRef<L.Polyline>()
 watch(
-  () => vehicleStore.vehiclePositionHistory,
+  () => missionStore.vehiclePositionHistory,
   (newPoints) => {
-    if (map.value === undefined || newPoints === undefined || newPoints.length === 0) return
+    if (map.value === undefined || !vehicleMarker.value || !newPoints || newPoints.length === 0) {
+      if (vehicleHistoryPolyline.value && map.value) {
+        map.value.removeLayer(vehicleHistoryPolyline.value)
+        vehicleHistoryPolyline.value = undefined
+      }
+      return
+    }
 
     if (vehicleHistoryPolyline.value === undefined) {
       vehicleHistoryPolyline.value = L.polyline([], { color: '#ffff00' }).addTo(map.value)
@@ -1333,6 +1339,11 @@ const menuItems = reactive([
     item: 'Set default map position',
     action: () => onMenuOptionSelect('set-default-map-position'),
     icon: 'mdi-map-check',
+  },
+  {
+    item: 'Clear vehicle path history',
+    action: () => onMenuOptionSelect('clear-vehicle-path-history'),
+    icon: 'mdi-gesture',
   },
 ])
 
@@ -1519,6 +1530,11 @@ const onMenuOptionSelect = async (option: string): Promise<void> => {
       }
       break
     }
+    case 'clear-vehicle-path-history':
+      missionStore.clearVehicleHistory()
+      openSnackbar({ message: 'Vehicle path history cleared', variant: 'success' })
+      break
+
     default:
       console.warn('Unknown menu option selected:', option)
   }

--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -49,9 +49,10 @@ import type {
 import { Coordinates } from '@/libs/vehicle/types'
 import * as Vehicle from '@/libs/vehicle/vehicle'
 import { VehicleFactory } from '@/libs/vehicle/vehicle-factory'
-import type { MissionLoadingCallback, Waypoint, WaypointCoordinates } from '@/types/mission'
+import type { MissionLoadingCallback, Waypoint } from '@/types/mission'
 
 import { useControllerStore } from './controller'
+import { useMissionStore } from './mission'
 import { useWidgetManagerStore } from './widgetManager'
 
 /**
@@ -79,6 +80,7 @@ const { openSnackbar } = useSnackbar()
 export const useMainVehicleStore = defineStore('main-vehicle', () => {
   const controllerStore = useControllerStore()
   const widgetStore = useWidgetManagerStore()
+  const missionStore = useMissionStore()
   const ws_protocol = location?.protocol === 'https:' ? 'wss' : 'ws'
   const http_protocol = location?.protocol === 'https:' ? 'https' : 'http'
 
@@ -127,12 +129,6 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
   const velocity: Velocity = reactive({} as Velocity)
   const mainVehicle = ref<ArduPilot | undefined>(undefined)
   const isArmed = ref<boolean | undefined>(undefined)
-
-  const vehiclePositionHistory = reactive<WaypointCoordinates[]>([])
-
-  const clearVehicleHistory = (): void => {
-    vehiclePositionHistory.splice(0)
-  }
   const flying = ref<boolean | undefined>(undefined)
   const icon = ref<string | undefined>(undefined)
   const configurationPages = ref<PageDescription[]>([])
@@ -592,9 +588,9 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
       const wasArmed = isArmed.value
       isArmed.value = armed
 
-      // Clear vehicle history on disarm/arm transition
-      if (wasArmed !== undefined && wasArmed !== armed) {
-        clearVehicleHistory()
+      // Clear vehicle history on disarm/arm transition only when not persistent (persistent history is cleared only via map context menu)
+      if (wasArmed !== undefined && wasArmed !== armed && !isVehiclePositionHistoryPersistent.value) {
+        missionStore.clearVehicleHistory()
       }
 
       // If the vehicle was already in the desired state or it's the first time we are checking, do not capture an event
@@ -911,16 +907,6 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     applyThrottledCoordinates = useThrottleFn((nc: Coordinates) => Object.assign(coordinates, nc), ms, true, true)
   })
 
-  // Track vehicle position history
-  watch(
-    () => [coordinates.latitude, coordinates.longitude] as const,
-    ([lat, lng]) => {
-      if (lat && lng) {
-        vehiclePositionHistory.push([lat, lng] as WaypointCoordinates)
-      }
-    }
-  )
-
   const mavlinkManualControlManager = new MavlinkManualControlManager()
   controllerStore.registerControllerUpdateCallback(mavlinkManualControlManager.updateControllerData)
 
@@ -1033,8 +1019,6 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     isArmed,
     flying,
     isVehicleOnline,
-    vehiclePositionHistory,
-    clearVehicleHistory,
     icon,
     configurationPages,
     rtcConfiguration,

--- a/src/stores/mission.ts
+++ b/src/stores/mission.ts
@@ -63,6 +63,26 @@ export const useMissionStore = defineStore('mission', () => {
   watch(missionName, () => (lastMissionName.value = missionName.value))
 
   const currentPlanningWaypoints = reactive<Waypoint[]>([])
+  const persistedPositionHistory = useBlueOsStorage<WaypointCoordinates[]>('cockpit-vehicle-position-history', [])
+  const isVehiclePositionHistoryPersistent = useBlueOsStorage('cockpit-vehicle-position-history-persistent', true)
+  const vehiclePositionHistory = ref<WaypointCoordinates[]>([...persistedPositionHistory.value])
+
+  const flushPositionHistory = (): void => {
+    if (!isVehiclePositionHistoryPersistent.value) return
+    if (vehiclePositionHistory.value.length === persistedPositionHistory.value.length) return
+    persistedPositionHistory.value = [...vehiclePositionHistory.value]
+  }
+
+  const positionHistoryFlushInterval = 10000
+  setInterval(flushPositionHistory, positionHistoryFlushInterval)
+  window.addEventListener('beforeunload', flushPositionHistory)
+
+  const clearVehicleHistory = (): void => {
+    vehiclePositionHistory.value = []
+    if (isVehiclePositionHistoryPersistent.value) {
+      persistedPositionHistory.value = []
+    }
+  }
 
   const moveWaypoint = (id: string, newCoordinates: WaypointCoordinates): void => {
     const waypoint = currentPlanningWaypoints.find((w) => w.id === id)
@@ -384,6 +404,14 @@ export const useMissionStore = defineStore('mission', () => {
     { deep: true }
   )
 
+  watch(
+    () => [mainVehicleStore.coordinates?.latitude, mainVehicleStore.coordinates?.longitude] as const,
+    ([lat, lng]) => {
+      if (!lat || !lng) return
+      vehiclePositionHistory.value = [...vehiclePositionHistory.value, [lat, lng] as WaypointCoordinates]
+    }
+  )
+
   watch(username, () => window.dispatchEvent(new CustomEvent('user-changed', { detail: { username: username.value } })))
 
   return {
@@ -438,5 +466,8 @@ export const useMissionStore = defineStore('mission', () => {
     registerMapMissionActions,
     callMapDownloadMissionFromVehicle,
     callMapClearMapDrawing,
+    vehiclePositionHistory,
+    isVehiclePositionHistoryPersistent,
+    clearVehicleHistory,
   }
 })

--- a/src/views/ConfigurationMissionView.vue
+++ b/src/views/ConfigurationMissionView.vue
@@ -4,7 +4,7 @@
     <template #content>
       <div
         class="flex flex-col justify-between items-start ml-[1vw] max-h-[85vh] overflow-y-auto"
-        :class="interfaceStore.isOnSmallScreen ? 'max-w-[70vw]' : 'max-w-[40vw]'"
+        :class="interfaceStore.isOnSmallScreen ? 'max-w-[75vw]' : 'max-w-[50vw]'"
       >
         <div class="grid grid-cols-3 gap-x-4 mb-4">
           <v-switch
@@ -42,6 +42,14 @@
           <v-switch
             v-model="missionStore.showGridOnMissionPlanning"
             label="Show coordinate grid on maps"
+            color="white"
+            hide-details
+            base-color="#FFFFFF33"
+            class="mt-2 -mb-2 ml-3"
+          />
+          <v-switch
+            v-model="vehicleStore.isVehiclePositionHistoryPersistent"
+            label="Make vehicle history line persistent"
             color="white"
             hide-details
             base-color="#FFFFFF33"

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -450,6 +450,7 @@
     @remove-waypoint="removeSelectedWaypoint"
     @place-point-of-interest="openPoiDialog"
     @add-waypoint-at-cursor="addWaypointFromContextMenu"
+    @clear-vehicle-path-history="clearVehiclePathHistory"
   />
   <SideConfigPanel
     v-if="isCreatingSurvey || selectedWaypoint"
@@ -1574,6 +1575,11 @@ const showContextMenu = (event: L.LeafletMouseEvent): void => {
 const hideContextMenu = (): void => {
   contextMenuVisible.value = false
   selectedSurveyId.value = ''
+}
+
+const clearVehiclePathHistory = (): void => {
+  missionStore.clearVehicleHistory()
+  openSnackbar({ message: 'Vehicle path history cleared', variant: 'success' })
 }
 
 const setHomePosition = async (): Promise<void> => {
@@ -3443,6 +3449,30 @@ watch(
     }
   },
   { immediate: true, deep: true }
+)
+
+// Create polyline for the vehicle history path (only shown when vehicle marker is on screen)
+const vehicleHistoryPolyline = shallowRef<L.Polyline>()
+watch(
+  () => missionStore.vehiclePositionHistory,
+  () => {
+    const newPoints = missionStore.vehiclePositionHistory
+
+    if (!planningMap.value || !vehicleMarker.value || !newPoints || newPoints.length === 0) {
+      if (vehicleHistoryPolyline.value) {
+        planningMap.value?.removeLayer(vehicleHistoryPolyline.value)
+        vehicleHistoryPolyline.value = undefined
+      }
+      return
+    }
+
+    if (vehicleHistoryPolyline.value === undefined) {
+      vehicleHistoryPolyline.value = L.polyline([], { color: '#ffff00' }).addTo(planningMap.value)
+    }
+
+    vehicleHistoryPolyline.value.setLatLngs(newPoints as L.LatLngExpression[])
+  },
+  { deep: true }
 )
 
 watch([isCtrlDown, isShiftDown, isCreatingSurvey, isCreatingSimplePath, isSettingHomeWaypoint], () => setMapCursor())


### PR DESCRIPTION
* Add persistence to the vehicle's path history;
* Vehicle history can be erased by a context menu command on map;
* User can choose to keep the old behavior, on which the history was erased after an arm-disam cycle 