### PR TITLE
joystick: migrate MANUAL_CONTROL axes to data lake

### DIFF
--- a/src/assets/joystick-profiles.ts
+++ b/src/assets/joystick-profiles.ts
@@ -1,10 +1,8 @@
 import { MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import { availableCockpitActions } from '@/libs/joystick/protocols/cockpit-actions'
-import {
-  availableMavlinkManualControlButtonFunctions,
-  mavlinkManualControlAxes,
-} from '@/libs/joystick/protocols/mavlink-manual-control'
+import { availableMavlinkManualControlButtonFunctions } from '@/libs/joystick/protocols/mavlink-manual-control'
 import { modifierKeyActions, otherAvailableActions } from '@/libs/joystick/protocols/other'
+import { joystickInputAxes } from '@/libs/joystick/protocols/predefined-resources'
 import { getVehicleModeAction } from '@/libs/vehicle/ardupilot/common'
 import { RoverMode } from '@/libs/vehicle/ardupilot/types/modes'
 import { Type as VehicleType } from '@/libs/vehicle/vehicle'
@@ -50,10 +48,10 @@ export const cockpitStandardToProtocols: JoystickProtocolActionsMapping[] = [
     name: 'ROV functions mapping',
     hash: defaultRovMappingHash,
     axesCorrespondencies: {
-      [JoystickAxis.A0]: { action: mavlinkManualControlAxes.axis_y, min: -1000, max: +1000 },
-      [JoystickAxis.A1]: { action: mavlinkManualControlAxes.axis_x, min: +1000, max: -1000 },
-      [JoystickAxis.A2]: { action: mavlinkManualControlAxes.axis_r, min: -1000, max: +1000 },
-      [JoystickAxis.A3]: { action: mavlinkManualControlAxes.axis_z, min: +1000, max: 0 },
+      [JoystickAxis.A0]: { action: joystickInputAxes.axis_y, min: -1000, max: +1000 },
+      [JoystickAxis.A1]: { action: joystickInputAxes.axis_x, min: +1000, max: -1000 },
+      [JoystickAxis.A2]: { action: joystickInputAxes.axis_r, min: -1000, max: +1000 },
+      [JoystickAxis.A3]: { action: joystickInputAxes.axis_z, min: +1000, max: 0 },
     },
     buttonsCorrespondencies: {
       [CockpitModifierKeyOption.regular]: {
@@ -102,10 +100,10 @@ export const cockpitStandardToProtocols: JoystickProtocolActionsMapping[] = [
     name: 'Boat functions mapping',
     hash: defaultBoatMappingHash,
     axesCorrespondencies: {
-      [JoystickAxis.A0]: { action: mavlinkManualControlAxes.axis_y, min: -1000, max: +1000 },
-      [JoystickAxis.A1]: { action: mavlinkManualControlAxes.axis_x, min: +1000, max: -1000 },
-      [JoystickAxis.A2]: { action: mavlinkManualControlAxes.axis_r, min: -1000, max: +1000 },
-      [JoystickAxis.A3]: { action: mavlinkManualControlAxes.axis_z, min: +1000, max: -1000 },
+      [JoystickAxis.A0]: { action: joystickInputAxes.axis_y, min: -1000, max: +1000 },
+      [JoystickAxis.A1]: { action: joystickInputAxes.axis_x, min: +1000, max: -1000 },
+      [JoystickAxis.A2]: { action: joystickInputAxes.axis_r, min: -1000, max: +1000 },
+      [JoystickAxis.A3]: { action: joystickInputAxes.axis_z, min: +1000, max: -1000 },
     },
     buttonsCorrespondencies: {
       [CockpitModifierKeyOption.regular]: {
@@ -154,10 +152,10 @@ export const cockpitStandardToProtocols: JoystickProtocolActionsMapping[] = [
     name: 'MAV functions mapping',
     hash: defaultMavMappingHash,
     axesCorrespondencies: {
-      [JoystickAxis.A0]: { action: mavlinkManualControlAxes.axis_r, min: -1000, max: +1000 },
-      [JoystickAxis.A1]: { action: mavlinkManualControlAxes.axis_z, min: +1000, max: 0 },
-      [JoystickAxis.A2]: { action: mavlinkManualControlAxes.axis_y, min: -1000, max: +1000 },
-      [JoystickAxis.A3]: { action: mavlinkManualControlAxes.axis_x, min: +1000, max: -1000 },
+      [JoystickAxis.A0]: { action: joystickInputAxes.axis_r, min: -1000, max: +1000 },
+      [JoystickAxis.A1]: { action: joystickInputAxes.axis_z, min: +1000, max: 0 },
+      [JoystickAxis.A2]: { action: joystickInputAxes.axis_y, min: -1000, max: +1000 },
+      [JoystickAxis.A3]: { action: joystickInputAxes.axis_x, min: +1000, max: -1000 },
     },
     buttonsCorrespondencies: {
       [CockpitModifierKeyOption.regular]: {

--- a/src/libs/joystick/protocols.ts
+++ b/src/libs/joystick/protocols.ts
@@ -4,17 +4,13 @@ import { availableCockpitActions } from './protocols/cockpit-actions'
 import { availableDataLakeActions } from './protocols/data-lake'
 import {
   availableMavlinkManualControlButtonFunctions,
-  mavlinkManualControlAxes,
+  migrateMavlinkManualControlAxes,
   migrateMavlinkManualControlButtons,
 } from './protocols/mavlink-manual-control'
 import { modifierKeyActions, otherAvailableActions } from './protocols/other'
 
 export const allAvailableAxes = (): ProtocolAction[] => {
-  return [
-    ...Object.values(mavlinkManualControlAxes),
-    ...Object.values(availableDataLakeActions()),
-    otherAvailableActions.no_function,
-  ]
+  return [...Object.values(availableDataLakeActions()), otherAvailableActions.no_function]
 }
 
 export const allAvailableButtons = (): ProtocolAction[] => {
@@ -30,5 +26,5 @@ export const allAvailableButtons = (): ProtocolAction[] => {
 export const performJoystickMappingMigrations = (
   mappings: JoystickProtocolActionsMapping[]
 ): JoystickProtocolActionsMapping[] => {
-  return migrateMavlinkManualControlButtons(mappings)
+  return migrateMavlinkManualControlAxes(migrateMavlinkManualControlButtons(mappings))
 }

--- a/src/libs/joystick/protocols/mavlink-manual-control.ts
+++ b/src/libs/joystick/protocols/mavlink-manual-control.ts
@@ -5,11 +5,12 @@
 import { capitalize } from 'vue'
 
 import { useInteractionDialog } from '@/composables/interactionDialog'
+import { getDataLakeVariableData } from '@/libs/actions/data-lake'
 import { sendManualControl } from '@/libs/communication/mavlink'
 import { modifierKeyActions, otherAvailableActions } from '@/libs/joystick/protocols/other'
-import { round, scale } from '@/libs/utils'
+import { round } from '@/libs/utils'
 import type { ArduPilot } from '@/libs/vehicle/ardupilot/ardupilot'
-import { type JoystickProtocolActionsMapping, type JoystickState, type ProtocolAction, CockpitModifierKeyOption, JoystickAxis, JoystickButton, JoystickProtocol } from '@/types/joystick'
+import { type JoystickProtocolActionsMapping, type JoystickState, type ProtocolAction, CockpitModifierKeyOption, JoystickButton, JoystickProtocol } from '@/types/joystick'
 
 /**
  * Possible axes in the MAVLink `MANUAL_CONTROL` message protocol
@@ -220,19 +221,6 @@ const manualControlButtonFromParameterName = (name: string): MAVLinkManualContro
 }
 
 /**
- * An axis action meant to be used with MAVLink's `MANUAL_CONTROL` message
- */
-export class MAVLinkManualControlAxisAction implements ProtocolAction {
-  readonly protocol = JoystickProtocol.MAVLinkManualControl
-  /**
-   * Create an axis input
-   * @param {MAVLinkAxisFunction} id Axis identification
-   * @param {string} name Axis human-readable name
-   */
-  constructor(public id: MAVLinkAxisFunction, public name: string) { }
-}
-
-/**
  * A button action meant to be used with MAVLink's `MANUAL_CONTROL` message
  */
 export class MAVLinkManualControlButtonAction implements ProtocolAction {
@@ -243,16 +231,6 @@ export class MAVLinkManualControlButtonAction implements ProtocolAction {
    * @param {string} name Button human-readable name
    */
   constructor(public id: MAVLinkButtonFunction, public name: string) { }
-}
-
-// Available axis actions
-export const mavlinkManualControlAxes: { [key in MAVLinkAxisFunction]: MAVLinkManualControlAxisAction } = {
-  [MAVLinkAxisFunction.X]: new MAVLinkManualControlAxisAction(MAVLinkAxisFunction.X, 'Axis X'),
-  [MAVLinkAxisFunction.Y]: new MAVLinkManualControlAxisAction(MAVLinkAxisFunction.Y, 'Axis Y'),
-  [MAVLinkAxisFunction.Z]: new MAVLinkManualControlAxisAction(MAVLinkAxisFunction.Z, 'Axis Z'),
-  [MAVLinkAxisFunction.R]: new MAVLinkManualControlAxisAction(MAVLinkAxisFunction.R, 'Axis R'),
-  [MAVLinkAxisFunction.S]: new MAVLinkManualControlAxisAction(MAVLinkAxisFunction.S, 'Axis S'),
-  [MAVLinkAxisFunction.T]: new MAVLinkManualControlAxisAction(MAVLinkAxisFunction.T, 'Axis T'),
 }
 
 // Available button actions
@@ -500,21 +478,21 @@ export class MavlinkManualControlManager {
       }
     }
 
-    // Calculate axes values
-    const xCorrespondency = Object.entries(this.currentActionsMapping.axesCorrespondencies).find((entry) => entry[1].action.protocol === JoystickProtocol.MAVLinkManualControl && entry[1].action.id === mavlinkManualControlAxes.axis_x.id)
-    const yCorrespondency = Object.entries(this.currentActionsMapping.axesCorrespondencies).find((entry) => entry[1].action.protocol === JoystickProtocol.MAVLinkManualControl && entry[1].action.id === mavlinkManualControlAxes.axis_y.id)
-    const zCorrespondency = Object.entries(this.currentActionsMapping.axesCorrespondencies).find((entry) => entry[1].action.protocol === JoystickProtocol.MAVLinkManualControl && entry[1].action.id === mavlinkManualControlAxes.axis_z.id)
-    const rCorrespondency = Object.entries(this.currentActionsMapping.axesCorrespondencies).find((entry) => entry[1].action.protocol === JoystickProtocol.MAVLinkManualControl && entry[1].action.id === mavlinkManualControlAxes.axis_r.id)
-    const sCorrespondency = Object.entries(this.currentActionsMapping.axesCorrespondencies).find((entry) => entry[1].action.protocol === JoystickProtocol.MAVLinkManualControl && entry[1].action.id === mavlinkManualControlAxes.axis_s.id)
-    const tCorrespondency = Object.entries(this.currentActionsMapping.axesCorrespondencies).find((entry) => entry[1].action.protocol === JoystickProtocol.MAVLinkManualControl && entry[1].action.id === mavlinkManualControlAxes.axis_t.id)
-
-    // Populate MAVLink Manual Control state of axes and buttons
-    this.manualControlState.x = xCorrespondency === undefined ? 0 : round(scale(this.joystickState.axes[xCorrespondency[0] as unknown as JoystickAxis] ?? 0, -1, 1, xCorrespondency[1].min, xCorrespondency[1].max), 0)
-    this.manualControlState.y = yCorrespondency === undefined ? 0 : round(scale(this.joystickState.axes[yCorrespondency[0] as unknown as JoystickAxis] ?? 0, -1, 1, yCorrespondency[1].min, yCorrespondency[1].max), 0)
-    this.manualControlState.z = zCorrespondency === undefined ? 0 : round(scale(this.joystickState.axes[zCorrespondency[0] as unknown as JoystickAxis] ?? 0, -1, 1, zCorrespondency[1].min, zCorrespondency[1].max), 0)
-    this.manualControlState.r = rCorrespondency === undefined ? 0 : round(scale(this.joystickState.axes[rCorrespondency[0] as unknown as JoystickAxis] ?? 0, -1, 1, rCorrespondency[1].min, rCorrespondency[1].max), 0)
-    this.manualControlState.s = sCorrespondency === undefined ? 0 : round(scale(this.joystickState.axes[sCorrespondency[0] as unknown as JoystickAxis] ?? 0, -1, 1, sCorrespondency[1].min, sCorrespondency[1].max), 0)
-    this.manualControlState.t = tCorrespondency === undefined ? 0 : round(scale(this.joystickState.axes[tCorrespondency[0] as unknown as JoystickAxis] ?? 0, -1, 1, tCorrespondency[1].min, tCorrespondency[1].max), 0)
+    // Read axis values from data lake output variables (scaling is handled by the data-lake protocol handler)
+    const xVal = Number(getDataLakeVariableData('outputs/mavlink/axis-x') ?? 0)
+    const yVal = Number(getDataLakeVariableData('outputs/mavlink/axis-y') ?? 0)
+    const zVal = Number(getDataLakeVariableData('outputs/mavlink/axis-z') ?? 0)
+    const rVal = Number(getDataLakeVariableData('outputs/mavlink/axis-r') ?? 0)
+    const sVal = Number(getDataLakeVariableData('outputs/mavlink/axis-s') ?? 0)
+    const tVal = Number(getDataLakeVariableData('outputs/mavlink/axis-t') ?? 0)
+    // Users can modify the inputs arbitrarily, so handle NaN values gracefully.
+    // TODO: replace fallback value (0) with INT16_MAX (ignored) when ArduSub supports it (ArduPilot/ardupilot#32639)
+    this.manualControlState.x = round(Number.isNaN(xVal) ? 0 : xVal, 0)
+    this.manualControlState.y = round(Number.isNaN(yVal) ? 0 : yVal, 0)
+    this.manualControlState.z = round(Number.isNaN(zVal) ? 0 : zVal, 0)
+    this.manualControlState.r = round(Number.isNaN(rVal) ? 0 : rVal, 0)
+    this.manualControlState.s = round(Number.isNaN(sVal) ? 0 : sVal, 0)
+    this.manualControlState.t = round(Number.isNaN(tVal) ? 0 : tVal, 0)
     this.manualControlState.buttons = buttons_int
     this.manualControlState.buttons2 = buttons2_int
   }
@@ -702,4 +680,34 @@ const migrateServoSubButtonsToActuators = (mappings: JoystickProtocolActionsMapp
 
 export const migrateMavlinkManualControlButtons = (mappings: JoystickProtocolActionsMapping[]): JoystickProtocolActionsMapping[] => {
   return migrateServoSubButtonsToActuators(mappings)
+}
+
+const mavlinkAxisToDataLakeMap: Record<string, { id: string; name: string }> = {
+  [MAVLinkAxisFunction.X]: { id: 'inputs/mavlink/axis-x', name: 'Axis X' },
+  [MAVLinkAxisFunction.Y]: { id: 'inputs/mavlink/axis-y', name: 'Axis Y' },
+  [MAVLinkAxisFunction.Z]: { id: 'inputs/mavlink/axis-z', name: 'Axis Z' },
+  [MAVLinkAxisFunction.R]: { id: 'inputs/mavlink/axis-r', name: 'Axis R' },
+  [MAVLinkAxisFunction.S]: { id: 'inputs/mavlink/axis-s', name: 'Axis S' },
+  [MAVLinkAxisFunction.T]: { id: 'inputs/mavlink/axis-t', name: 'Axis T' },
+}
+
+// Migrate any joystick axes configured for (deprecated) direct MAVLink Manual Control to use the Data Lake pipeline instead.
+// Added in v1.19.0 - remove once usage proportion is negligible.
+export const migrateMavlinkManualControlAxes = (mappings: JoystickProtocolActionsMapping[]): JoystickProtocolActionsMapping[] => {
+  const migratedMappings: JoystickProtocolActionsMapping[] = JSON.parse(JSON.stringify(mappings))
+  mappings.forEach((mapping, mappingIndex) => {
+    Object.entries(mapping.axesCorrespondencies).forEach(([axisIndex, axisConfig]) => {
+      if (axisConfig.action.protocol === JoystickProtocol.MAVLinkManualControl) {
+        const replacement = mavlinkAxisToDataLakeMap[axisConfig.action.id]
+        if (replacement) {
+          migratedMappings[mappingIndex].axesCorrespondencies[axisIndex as unknown as number].action = {
+            protocol: JoystickProtocol.DataLakeVariable,
+            id: replacement.id,
+            name: replacement.name,
+          }
+        }
+      }
+    })
+  })
+  return migratedMappings
 }

--- a/src/libs/joystick/protocols/predefined-resources.ts
+++ b/src/libs/joystick/protocols/predefined-resources.ts
@@ -10,8 +10,35 @@ import { getUnindentedString } from '@/libs/utils'
 import { MessageFieldType } from '@/types/cockpit-actions'
 import { customActionTypes } from '@/types/cockpit-actions'
 
+import { DataLakeVariableAction } from './data-lake'
+
 export let mavlinkCameraZoomActionId: string | undefined = undefined
 export let mavlinkCameraFocusActionId: string | undefined = undefined
+
+// Info required to map joystick axis inputs to MAVLink MANUAL_CONTROL outputs, via the data lake
+const joystickAxisConfig = [
+  { key: 'axis_x', name: 'Axis X', inputId: 'inputs/mavlink/axis-x', outputId: 'outputs/mavlink/axis-x' },
+  { key: 'axis_y', name: 'Axis Y', inputId: 'inputs/mavlink/axis-y', outputId: 'outputs/mavlink/axis-y' },
+  { key: 'axis_z', name: 'Axis Z', inputId: 'inputs/mavlink/axis-z', outputId: 'outputs/mavlink/axis-z' },
+  { key: 'axis_r', name: 'Axis R', inputId: 'inputs/mavlink/axis-r', outputId: 'outputs/mavlink/axis-r' },
+  { key: 'axis_s', name: 'Axis S', inputId: 'inputs/mavlink/axis-s', outputId: 'outputs/mavlink/axis-s' },
+  { key: 'axis_t', name: 'Axis T', inputId: 'inputs/mavlink/axis-t', outputId: 'outputs/mavlink/axis-t' },
+] as const
+
+/**
+ * Pre-built data lake variable actions for joystick axis inputs, used in joystick profile mappings
+ */
+export const joystickInputAxes: Record<(typeof joystickAxisConfig)[number]['key'], DataLakeVariableAction> =
+  Object.fromEntries(
+    joystickAxisConfig.map((axis) => [
+      axis.key,
+      new DataLakeVariableAction({
+        id: axis.inputId,
+        name: axis.name,
+        type: 'number' as DataLakeVariableType,
+      }),
+    ])
+  ) as Record<(typeof joystickAxisConfig)[number]['key'], DataLakeVariableAction>
 
 export const setupMavlinkCameraResources = (): void => {
   const commonVariableConfig = { type: 'number' as DataLakeVariableType, allowUserToChangeValue: true }
@@ -128,6 +155,30 @@ export const setupMavlinkCameraResources = (): void => {
   }
 }
 
+const setupJoystickAxesResources = (): void => {
+  const commonVariableConfig = { type: 'number' as DataLakeVariableType, allowUserToChangeValue: true }
+
+  for (const axis of joystickAxisConfig) {
+    createDataLakeVariable({ id: axis.inputId, name: axis.name, ...commonVariableConfig }, 0)
+
+    try {
+      const existing = getAllTransformingFunctions().find((f) => f.id === axis.outputId)
+      if (!existing) {
+        createTransformingFunction(
+          axis.outputId,
+          `${axis.name} Output`,
+          'number',
+          `{{${axis.inputId}}}`,
+          `Output value for MANUAL_CONTROL ${axis.name}.`
+        )
+      }
+    } catch (error) {
+      console.error(`Error creating transforming function for ${axis.name}:`, error)
+    }
+  }
+}
+
 export const setupPredefinedLakeAndActionResources = (): void => {
   setupMavlinkCameraResources()
+  setupJoystickAxesResources()
 }

--- a/src/libs/joystick/protocols/predefined-resources.ts
+++ b/src/libs/joystick/protocols/predefined-resources.ts
@@ -40,7 +40,7 @@ export const joystickInputAxes: Record<(typeof joystickAxisConfig)[number]['key'
     ])
   ) as Record<(typeof joystickAxisConfig)[number]['key'], DataLakeVariableAction>
 
-export const setupMavlinkCameraResources = (): void => {
+const setupMavlinkCameraResources = (): void => {
   const commonVariableConfig = { type: 'number' as DataLakeVariableType, allowUserToChangeValue: true }
   // Initialize camera zoom variables
   createDataLakeVariable({ id: 'camera-zoom-decrease', name: 'Camera Zoom Decrease', ...commonVariableConfig }, 0)


### PR DESCRIPTION
Relevant to #1759, per [this suggestion](https://github.com/bluerobotics/cockpit/issues/1759#issuecomment-4007515775) about only needing to expose the axes.

Fixes #714:
- It doesn't provide an intuitive UI, and there are challenges around scaling, but it makes it possible
- As an example, it's possible to define numerical data-lake variables for Axis Z+ (`inputs/mavlink/axis-z-plus`) and Axis Z-,  (`inputs/mavlink/axis-z-minus`) that then get assigned to the joystick shoulder triggers, with the values scaled and summed in the `Axis Z Output` compound variable (`500 * ({{ inputs/mavlink/axis-z-plus }} - {{ inputs/mavlink/axis-z-minus }} + 1)`) to provide up/down control for an ArduSub vehicle
    - I considered implementing limit and split control variables for each axis, but the scaling (and offset) functionality is vehicle-type-specific (mostly because Sub uses the wrong Z range), and I'm unsure how to implement that without causing conflicts with the values users currently control from the joystick config interface (so leaving it up to users to implement the axes they want, for now)

Enables #2221 (option 2):
- Relevant joystick axis output compound variables could be modified to have something like `({{ inputs/mavlink/reverse }} ? -1 : 1) * {{ inputs/mavlink/axis-x }}`, which can then be controlled by the joystick and/or on-screen buttons/toggles, via the data lake and/or custom Actions
    - Implemented in #2477 - I thought it would be nicer to not review everything at once, but we can also just directly merge that instead if desired 🤷‍♂️ 