### PR TITLE
widgets: Map: Fix vehicle marker layered behind waypoint markers

### DIFF
--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -1127,7 +1127,12 @@ watch(vehicleStore.coordinates, () => {
       iconAnchor: [32, 32],
     })
 
-    vehicleMarker.value = L.marker(vehiclePosition.value, { icon: vehicleMarkerIcon })
+    if (!map.value.getPane('vehiclePane')) {
+      const vehiclePane = map.value.createPane('vehiclePane')
+      vehiclePane.style.zIndex = '650'
+    }
+
+    vehicleMarker.value = L.marker(vehiclePosition.value, { icon: vehicleMarkerIcon, pane: 'vehiclePane' })
 
     const vehicleMarkerTooltip = L.tooltip({
       content: 'No data available',


### PR DESCRIPTION
Create a dedicated Leaflet pane for the vehicle marker with a higher z-index so it always renders above waypoint markers.

<img width="510" height="561" alt="image" src="https://github.com/user-attachments/assets/0f208f27-3bb0-4ebe-b3b8-f0cf2ad046a9" />


Closes #2142