### PR TITLE
electron: Re-set window title after page finishes loading

### DIFF
--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -58,6 +58,10 @@ function createWindow(): void {
     event.preventDefault()
   })
 
+  mainWindow.webContents.on('did-finish-load', () => {
+    mainWindow?.setTitle(`Cockpit (${app.getVersion()})`)
+  })
+
   if (process.env.VITE_DEV_SERVER_URL) {
     mainWindow.loadURL(process.env.VITE_DEV_SERVER_URL)
   } else {


### PR DESCRIPTION
On Windows the HTML document title could override the Electron window title. Explicitly set it again in did-finish-load to ensure consistency.

Closes #2373