### PR TITLE
widgets: Map: Fix vehicle tooltip missing background

### DIFF
--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -1131,7 +1131,7 @@ watch(vehicleStore.coordinates, () => {
 
     const vehicleMarkerTooltip = L.tooltip({
       content: 'No data available',
-      className: 'waypoint-tooltip',
+      className: 'vehicle-tooltip',
       offset: [40, 0],
     })
     vehicleMarker.value.bindTooltip(vehicleMarkerTooltip)
@@ -1889,10 +1889,25 @@ watch(
 .waypoint-tooltip {
   background-color: white;
   padding: 0.75rem;
-  border: 1rem;
+  border: 1px solid rgba(0, 0, 0, 0.2);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   color: black;
   z-index: 100;
+}
+
+:deep(.vehicle-tooltip) {
+  background-color: var(--glass-background) !important;
+  backdrop-filter: var(--glass-filter);
+  border: var(--glass-border) !important;
+  box-shadow: var(--glass-box-shadow);
+  color: var(--glass-color);
+  padding: 0.75rem;
+  border-radius: 8px;
+  z-index: 100;
+}
+
+:deep(.vehicle-tooltip::before) {
+  border-right-color: var(--glass-background) !important;
 }
 
 :deep(.waypoint-tooltip--current-waypoint) {


### PR DESCRIPTION
Before:
<img width="382" height="215" alt="image" src="https://github.com/user-attachments/assets/ad5198f6-c1c1-4529-bc83-125a33cb1c72" />

After:
<img width="584" height="268" alt="image" src="https://github.com/user-attachments/assets/4ce15d1c-f7f9-43f4-b5b6-8ceb82c4f767" />


Closes #2473