### PR TITLE
Allow manually resizing full-screen widgets

### DIFF
--- a/src/components/WidgetHugger.vue
+++ b/src/components/WidgetHugger.vue
@@ -338,25 +338,7 @@ watch(allowMoving, (isAllowing, wasAllowing) => {
 const widgetStore = useWidgetManagerStore()
 const temporaryPosition = computed(() => {
   let tempPos = { x: position.value.x, y: position.value.y }
-  const clearanceOffset = widgetStore.visibleAreaMinClearancePixels
 
-  const barClearances = widgetStore.widgetClearanceForVisibleArea(widget.value)
-
-  // If the widget is under both bars, dont touch it, as it could be full screened by purpose, and if we apply the rules below, it will keep jumping
-  if (barClearances.top < clearanceOffset && barClearances.bottom < clearanceOffset) return tempPos
-
-  // If the widget is partially under the top or bottom bar, move it so that it gets fully visible
-  // Skip these adjustments during active resize to prevent position jumps when resizing from full-screen
-  if (!isResizing.value) {
-    if (barClearances.top < clearanceOffset) {
-      tempPos.y = (widgetStore.currentTopBarHeightPixels + clearanceOffset) / windowHeight.value
-    } else if (barClearances.bottom < clearanceOffset) {
-      const maxBottomEdgePosition = (widgetStore.currentBottomBarHeightPixels + clearanceOffset) / windowHeight.value
-      tempPos.y = 1 - maxBottomEdgePosition - size.value.height
-    }
-  }
-
-  // Use grid to snap to grid
   if (widgetStore.snapToGrid) {
     tempPos.x = Math.round(tempPos.x / widgetStore.gridInterval) * widgetStore.gridInterval
     tempPos.y = Math.round(tempPos.y / widgetStore.gridInterval) * widgetStore.gridInterval


### PR DESCRIPTION
This PR makes it so when a widget has its resizing handles underneath the top or bottom bar, those handles are moved to an inside position, where they can be dragged from.

<img width="932" height="575" alt="image" src="https://github.com/user-attachments/assets/7e3a27d4-4267-49a0-a4e7-936ad5f76797" />


With this change I also eliminated the auto-reposition mechanism that was there to prevent a widget from going underneath the top/bottom bar and becoming unresizable.

Fix #2497
Fix #2458