### PR TITLE
Add map rotation and heading controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "jest-diff": "^29.7.0",
     "ky": "^1.2.0",
     "leaflet": "1.9.3",
+    "leaflet-rotate": "^0.2.8",
     "leaflet.offline": "^3.1.0",
     "localforage": "^1.10.0",
     "mathjs": "^13.0.3",

--- a/src/components/mission-planning/MissionEstimates.vue
+++ b/src/components/mission-planning/MissionEstimates.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-if="modelValue"
-    class="absolute right-4 bottom-36 rounded-[10px] px-3 py-2"
+    class="absolute right-[55px] bottom-[105px] rounded-[10px] px-3 py-2 mission-estimates-container"
     :style="[interfaceStore.globalGlassMenuStyles, { width: '250px' }]"
   >
     <p class="text-sm font-semibold mb-[6px]">Mission estimates</p>
@@ -186,3 +186,12 @@ const openSettings = (): void => {
   isSettingsOpen.value = true
 }
 </script>
+
+<style scoped>
+.mission-estimates-container {
+  position: absolute !important;
+  bottom: 105px;
+  right: 55px;
+  top: auto;
+}
+</style>

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -70,7 +70,7 @@
         </template>
       </v-tooltip>
 
-      <v-tooltip location="top" :text="centerVehicleButtonTooltipText">
+      <v-tooltip location="top" :text="vehicleFollowTooltip">
         <template #activator="{ props: tooltipProps }">
           <v-btn
             v-if="showButtons"
@@ -78,14 +78,13 @@
             v-bind="tooltipProps"
             class="absolute m-3 bottom-button right-[44px] bg-slate-50 text-[14px]"
             :class="!vehiclePosition ? 'active-events-on-disabled' : ''"
-            :color="followerTarget == WhoToFollow.VEHICLE ? 'red' : ''"
+            :color="vehicleFollowColor"
             elevation="2"
             style="z-index: 1002; border-radius: 0px"
-            icon="mdi-airplane-marker"
+            :icon="vehicleFollowIcon"
             size="x-small"
             :disabled="!vehiclePosition"
-            @click.stop="targetFollower.goToTarget(WhoToFollow.VEHICLE, true)"
-            @dblclick.stop="targetFollower.follow(WhoToFollow.VEHICLE)"
+            @click.stop="cycleVehicleFollowMode"
           />
         </template>
       </v-tooltip>
@@ -179,6 +178,7 @@
       {{ tilesTotal ? Math.round((tilesSaved / tilesTotal) * 100) : 0 }}%
     </p>
   </div>
+  <div v-if="isRotatingMap" class="rotate-drag-overlay" />
 </template>
 
 <script setup lang="ts">
@@ -248,12 +248,13 @@ const zoom = ref(missionStore.userLastMapZoom ?? missionStore.defaultMapZoom)
 const mapCenter = ref<WaypointCoordinates>(missionStore.userLastMapCenter ?? missionStore.defaultMapCenter)
 const home = ref()
 const mapId = computed(() => `map-${widget.value.hash}`)
-const showButtons = computed(() => isMouseOver.value || downloadMenuOpen.value)
+const showButtons = computed(() => isMouseOver.value || downloadMenuOpen.value || isRotatingMap.value)
 const mapReady = ref(false)
 const mapWaypoints = ref<Waypoint[]>([])
 const reachedWaypoints = shallowRef<Record<number, L.Marker>>({})
 const contextMenuRef = ref()
 const isDragging = ref(false)
+const isRotatingMap = ref(false)
 const isPinching = ref(false)
 const isMissionChecklistOpen = ref(false)
 const isSavingOfflineTiles = ref(false)
@@ -497,12 +498,44 @@ const layerControl = L.control.layers(baseMaps, overlays)
 const rotateControl = shallowRef<L.Control | undefined>(undefined)
 const gridLayer = shallowRef<L.LayerGroup | undefined>(undefined)
 
+/**
+ * Attaches mousedown listener to the rotate control container to show the drag overlay,
+ * preventing overlapping elements from intercepting the drag events.
+ */
+const attachRotateControlDragOverlay = (): void => {
+  if (!rotateControl.value) return
+  // eslint-disable-next-line jsdoc/require-jsdoc
+  const container = (rotateControl.value as unknown as { _container?: HTMLElement })._container
+  if (!container) return
+  // Use capture phase because leaflet-rotate calls stopPropagation() on the inner link's mousedown.
+  container.addEventListener(
+    'mousedown',
+    () => {
+      const onMouseMove = (): void => {
+        isRotatingMap.value = true
+        document.removeEventListener('mousemove', onMouseMove)
+      }
+      const onMouseUp = (): void => {
+        isRotatingMap.value = false
+        document.removeEventListener('mouseup', onMouseUp)
+        document.removeEventListener('mousemove', onMouseMove)
+      }
+      document.addEventListener('mousemove', onMouseMove)
+      document.addEventListener('mouseup', onMouseUp)
+    },
+    true
+  )
+}
+
 watch(showButtons, () => {
   if (map.value === undefined) return
   if (showButtons.value) {
     map.value.addControl(zoomControl)
     map.value.addControl(layerControl)
-    if (rotateControl.value) map.value.addControl(rotateControl.value)
+    if (rotateControl.value) {
+      map.value.addControl(rotateControl.value)
+      attachRotateControlDragOverlay()
+    }
     createScaleControl()
   } else {
     map.value.removeControl(zoomControl)
@@ -603,20 +636,18 @@ const removeScaleControl = (): void => {
   }
 }
 
-let leafletRotateLoaded = false
-
 /**
  * Loads the leaflet-rotate plugin by injecting its source into a script tag.
  * This ensures the IIFE runs in the global scope where it can access window.L.
+ * Skips loading if the plugin is already available on L.control.
  * @returns {Promise<void>} Resolves when the plugin has been loaded and executed
  */
 const loadLeafletRotate = async (): Promise<void> => {
-  if (leafletRotateLoaded) return
+  if ((L.control as unknown as Record<string, unknown>).rotate) return
   const mod = await import('leaflet-rotate/dist/leaflet-rotate.js?raw')
   const script = document.createElement('script')
   script.textContent = (mod as unknown as Record<string, string>).default
   document.head.appendChild(script)
-  leafletRotateLoaded = true
 }
 
 onMounted(async () => {
@@ -748,6 +779,14 @@ onMounted(async () => {
   map.value.on('contextmenu', (event: LeafletMouseEvent) => {
     clickedLocation.value = [event.latlng.lat, event.latlng.lng]
   })
+
+  // Disable heading tracking when user manually rotates the map via the rotation control
+  map.value.on('rotate', () => {
+    if (!programmaticBearingChange && vehicleFollowMode.value === VehicleFollowMode.TRACK_HEADING) {
+      vehicleFollowMode.value = VehicleFollowMode.OFF
+    }
+  })
+
   // Enable auto update for target follower
   targetFollower.enableAutoUpdate()
 
@@ -773,7 +812,7 @@ onMounted(async () => {
   mapReady.value = true
 
   if (missionStore.followVehicleOnMap === true) {
-    targetFollower.follow(WhoToFollow.VEHICLE)
+    vehicleFollowMode.value = VehicleFollowMode.FOLLOW
   } else {
     targetFollower.unFollow()
   }
@@ -1108,6 +1147,96 @@ const vehiclePosition = computed(() =>
 // Calculate live vehicle heading
 const vehicleHeading = computed(() => (vehicleStore.attitude.yaw ? degrees(vehicleStore.attitude?.yaw) : 0))
 
+/** Leaflet map extended with leaflet-rotate's setBearing method */
+// eslint-disable-next-line jsdoc/require-jsdoc
+type RotatableMap = Map & { setBearing: (bearing: number) => void }
+
+/** Modes for the vehicle follow button's three-state cycle */
+enum VehicleFollowMode {
+  OFF = 'off',
+  FOLLOW = 'follow',
+  TRACK_HEADING = 'trackHeading',
+}
+
+const vehicleFollowMode = ref<VehicleFollowMode>(VehicleFollowMode.OFF)
+
+/**
+ * Cycles the vehicle follow mode through: off → follow → track heading → off
+ */
+const cycleVehicleFollowMode = (): void => {
+  switch (vehicleFollowMode.value) {
+    case VehicleFollowMode.OFF:
+      vehicleFollowMode.value = VehicleFollowMode.FOLLOW
+      break
+    case VehicleFollowMode.FOLLOW:
+      vehicleFollowMode.value = VehicleFollowMode.TRACK_HEADING
+      break
+    case VehicleFollowMode.TRACK_HEADING:
+      vehicleFollowMode.value = VehicleFollowMode.OFF
+      break
+  }
+}
+
+const vehicleFollowIcon = computed(() => {
+  switch (vehicleFollowMode.value) {
+    case VehicleFollowMode.FOLLOW:
+      return 'mdi-crosshairs-gps'
+    case VehicleFollowMode.TRACK_HEADING:
+      return 'mdi-compass-outline'
+    default:
+      return 'mdi-airplane-marker'
+  }
+})
+
+const vehicleFollowColor = computed(() => {
+  switch (vehicleFollowMode.value) {
+    case VehicleFollowMode.FOLLOW:
+      return 'red'
+    case VehicleFollowMode.TRACK_HEADING:
+      return 'blue'
+    default:
+      return ''
+  }
+})
+
+const vehicleFollowTooltip = computed(() => {
+  if (!vehicleStore.isVehicleOnline) return 'Cannot follow vehicle (vehicle offline).'
+  if (!vehiclePosition.value) return 'Cannot follow vehicle (position undefined).'
+  switch (vehicleFollowMode.value) {
+    case VehicleFollowMode.FOLLOW:
+      return 'Following vehicle. Click to track heading.'
+    case VehicleFollowMode.TRACK_HEADING:
+      return 'Tracking vehicle heading. Click to stop.'
+    default:
+      return 'Click to switch between vehicle tracking modes.'
+  }
+})
+
+// Sync map bearing with vehicle heading in track-heading mode
+let programmaticBearingChange = false
+
+// React to vehicle follow mode changes and reset bearing when leaving track-heading
+watch(vehicleFollowMode, (mode, oldMode) => {
+  if (mode === VehicleFollowMode.FOLLOW || mode === VehicleFollowMode.TRACK_HEADING) {
+    targetFollower.follow(WhoToFollow.VEHICLE)
+  } else {
+    targetFollower.unFollow()
+  }
+
+  if (map.value && oldMode === VehicleFollowMode.TRACK_HEADING && mode !== VehicleFollowMode.TRACK_HEADING) {
+    programmaticBearingChange = true
+    ;(map.value as RotatableMap).setBearing(0)
+    programmaticBearingChange = false
+  }
+})
+
+watch(vehicleHeading, (heading) => {
+  if (!map.value || vehicleFollowMode.value !== VehicleFollowMode.TRACK_HEADING) return
+  programmaticBearingChange = true
+  ;(map.value as RotatableMap).setBearing(-heading)
+  programmaticBearingChange = false
+})
+
 // Calculate time since last vehicle heartbeat
 const timeAgoSeenText = computed(() => {
   const lastBeat = vehicleStore.lastHeartbeat
@@ -1188,6 +1317,10 @@ watch(followerTarget, (newTarget) => {
     missionStore.followVehicleOnMap = true
   } else {
     missionStore.followVehicleOnMap = false
+    // Reset vehicle follow mode when the follower stops (e.g. user pans the map)
+    if (vehicleFollowMode.value !== VehicleFollowMode.OFF) {
+      vehicleFollowMode.value = VehicleFollowMode.OFF
+    }
   }
 })
 
@@ -1203,10 +1336,11 @@ watch([vehiclePosition, vehicleHeading, timeAgoSeenText, () => vehicleStore.isAr
     <p>Last seen: ${timeAgoSeenText.value}</p>
   `)
 
-  // Update the rotation
+  // When tracking heading, the map rotates so the icon should always point up (0°)
   const iconElement = vehicleMarker.value.getElement()?.querySelector('img')
   if (iconElement) {
-    iconElement.style.transform = `rotate(${vehicleHeading.value}deg)`
+    const iconAngle = vehicleFollowMode.value === VehicleFollowMode.TRACK_HEADING ? 0 : vehicleHeading.value
+    iconElement.style.transform = `rotate(${iconAngle}deg)`
   }
 })
 
@@ -1734,19 +1868,6 @@ const centerHomeButtonTooltipText = computed(() => {
   return 'Click once to center on home or twice to track it.'
 })
 
-const centerVehicleButtonTooltipText = computed(() => {
-  if (!vehicleStore.isVehicleOnline) {
-    return 'Cannot center map on vehicle (vehicle offline).'
-  }
-  if (vehiclePosition.value === undefined) {
-    return 'Cannot center map on vehicle (vehicle position undefined).'
-  }
-  if (followerTarget.value === WhoToFollow.VEHICLE) {
-    return 'Tracking vehicle position. Click to stop tracking.'
-  }
-  return 'Click once to center on vehicle or twice to track it.'
-})
-
 // POI Marker Management Functions for Map Widget
 const poiIconConfig = (poi: PointOfInterest): L.DivIconOptions => {
   const poiIconHtml = `
@@ -1887,6 +2008,13 @@ watch(
 </script>
 
 <style scoped>
+.rotate-drag-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  cursor: grabbing;
+}
+
 .page-base {
   min-height: 100vh;
   display: flex;

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -494,6 +494,7 @@ const isMouseOver = useElementHover(mapBase)
 
 const zoomControl = L.control.zoom({ position: 'bottomright' })
 const layerControl = L.control.layers(baseMaps, overlays)
+const rotateControl = shallowRef<L.Control | undefined>(undefined)
 const gridLayer = shallowRef<L.LayerGroup | undefined>(undefined)
 
 watch(showButtons, () => {
@@ -501,10 +502,12 @@ watch(showButtons, () => {
   if (showButtons.value) {
     map.value.addControl(zoomControl)
     map.value.addControl(layerControl)
+    if (rotateControl.value) map.value.addControl(rotateControl.value)
     createScaleControl()
   } else {
     map.value.removeControl(zoomControl)
     map.value.removeControl(layerControl)
+    if (rotateControl.value) map.value.removeControl(rotateControl.value)
     removeScaleControl()
   }
 })
@@ -600,11 +603,33 @@ const removeScaleControl = (): void => {
   }
 }
 
+let leafletRotateLoaded = false
+
+/**
+ * Loads the leaflet-rotate plugin by injecting its source into a script tag.
+ * This ensures the IIFE runs in the global scope where it can access window.L.
+ * @returns {Promise<void>} Resolves when the plugin has been loaded and executed
+ */
+const loadLeafletRotate = async (): Promise<void> => {
+  if (leafletRotateLoaded) return
+  const mod = await import('leaflet-rotate/dist/leaflet-rotate.js?raw')
+  const script = document.createElement('script')
+  script.textContent = (mod as unknown as Record<string, string>).default
+  document.head.appendChild(script)
+  leafletRotateLoaded = true
+}
+
 onMounted(async () => {
   reachedWaypoints.value = {}
   missionItemsInVehicle.value = []
   missionSeqToMarkerSeq.value = {}
   vehicleStore.clearReachedMissionItems()
+
+  // leaflet-rotate patches the global L object via an IIFE that references window.L.
+  // Vite's ESM bundling doesn't expose L globally, so we set it manually and load
+  // the plugin via a script tag to ensure it executes in the global scope.
+  ;(window as unknown as Record<string, unknown>).L = L
+  await loadLeafletRotate()
 
   mapBase.value?.addEventListener('touchstart', onTouchStart, { passive: true })
   mapBase.value?.addEventListener('touchend', onTouchEnd, { passive: true })
@@ -614,7 +639,10 @@ onMounted(async () => {
   map.value = L.map(mapId.value, {
     layers: [initialBaseLayer, seamarks, marineProfile],
     attributionControl: false,
-  }).setView(mapCenter.value as LatLngTuple, zoom.value) as Map
+    rotate: true,
+    touchRotate: true,
+    rotateControl: false,
+  } as L.MapOptions).setView(mapCenter.value as LatLngTuple, zoom.value) as Map
 
   // Listen for base layer changes to save user preference
   map.value.on('baselayerchange', (event: LayersControlEvent) => {
@@ -627,6 +655,12 @@ onMounted(async () => {
 
   // Remove default zoom control
   map.value.removeControl(map.value.zoomControl)
+
+  // Create rotate control (managed alongside zoom/layer controls via showButtons)
+  rotateControl.value = (L.control as unknown as Record<string, CallableFunction>).rotate({
+    closeOnZeroBearing: false,
+    position: 'bottomright',
+  }) as L.Control
 
   map.value.on('click', (event: LeafletMouseEvent) => {
     clickedLocation.value = [event.latlng.lat, event.latlng.lng]
@@ -2108,5 +2142,30 @@ watch(
 
 :deep(.leaflet-control-layers label) {
   color: var(--glass-color) !important;
+}
+
+/* Style the Leaflet rotate control — positioned bottom-right, above zoom */
+:deep(.leaflet-control-rotate.leaflet-bar) {
+  position: absolute !important;
+  right: 0;
+  bottom: calc(v-bind('bottomButtonsDisplacement') + 74px);
+  margin-right: 10px !important;
+  background: var(--glass-background);
+  backdrop-filter: var(--glass-filter);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  color: var(--glass-color);
+  border: var(--glass-border);
+  border-radius: 2px;
+  z-index: 1002;
+}
+
+:deep(.leaflet-control-rotate .leaflet-control-rotate-toggle) {
+  background: transparent !important;
+  border: none;
+  color: var(--glass-color);
+}
+
+:deep(.leaflet-control-rotate .leaflet-control-rotate-arrow) {
+  filter: invert(1);
 }
 </style>

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -6,7 +6,11 @@
     :class="widgetStore.editingMode ? 'pointer-events-none' : 'pointer-events-auto'"
     :style="glassMenuCssVars"
   >
-    <div :id="mapId" ref="map" class="map">
+    <div class="map-clip-wrapper">
+      <div :id="mapId" ref="map" class="map" />
+    </div>
+    <!-- Map UI buttons live outside the oversized map div so they stay within the visible widget bounds -->
+    <div class="map-buttons-overlay">
       <v-menu v-model="downloadMenuOpen" :close-on-content-click="false" location="top end">
         <template #activator="{ props: menuProps }">
           <v-tooltip location="top" text="Download tiles for offline use">
@@ -447,11 +451,15 @@ onBeforeMount(() => {
   targetFollower.enableAutoUpdate()
 })
 
+// Extra tile buffer to keep around the viewport so rotated views don't show white gaps
+const rotationTileBuffer = 10
+
 // Configure the available map tile providers
 const osm = tileLayerOffline('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
   maxZoom: 23,
   maxNativeZoom: 19,
   attribution: '© OpenStreetMap',
+  keepBuffer: rotationTileBuffer,
 })
 
 const esri = tileLayerOffline(
@@ -460,6 +468,7 @@ const esri = tileLayerOffline(
     maxZoom: 23,
     maxNativeZoom: 19,
     attribution: '© Esri World Imagery',
+    keepBuffer: rotationTileBuffer,
   }
 )
 
@@ -467,6 +476,7 @@ const esri = tileLayerOffline(
 const seamarks = tileLayerOffline('https://tiles.openseamap.org/seamark/{z}/{x}/{y}.png', {
   maxZoom: 18,
   attribution: '© OpenSeaMap contributors',
+  keepBuffer: rotationTileBuffer,
 })
 
 const marineProfile = L.tileLayer.wms('https://geoserver.openseamap.org/geoserver/gwc/service/wms', {
@@ -477,6 +487,7 @@ const marineProfile = L.tileLayer.wms('https://geoserver.openseamap.org/geoserve
   attribution: '© GEBCO, OpenSeaMap',
   tileSize: 256,
   maxZoom: 19,
+  keepBuffer: rotationTileBuffer,
 })
 
 const baseMaps = {
@@ -648,6 +659,38 @@ const loadLeafletRotate = async (): Promise<void> => {
   const script = document.createElement('script')
   script.textContent = (mod as unknown as Record<string, string>).default
   document.head.appendChild(script)
+
+  const ControlRotate = (
+    L.Control as unknown as Record<
+      string,
+      {
+        /**
+         * Rotate control prototype
+         */
+        prototype: Record<string, CallableFunction>
+      }
+    >
+  ).Rotate
+  if (ControlRotate) {
+    ControlRotate.prototype._handleMouseDown = function (e: MouseEvent): void {
+      L.DomEvent.stop(e)
+      this.dragging = true
+      this.dragstartX = e.pageX
+      this.dragstartY = e.pageY
+      this._startBearing = this._map.getBearing()
+      L.DomEvent.on(document as unknown as HTMLElement, 'mousemove', this._handleMouseDrag, this).on(
+        document as unknown as HTMLElement,
+        'mouseup',
+        this._handleMouseUp,
+        this
+      )
+    }
+    ControlRotate.prototype._handleMouseDrag = function (e: MouseEvent): void {
+      if (!this.dragging) return
+      const deltaX = e.clientX - this.dragstartX
+      this._map.setBearing((this._startBearing || 0) + deltaX)
+    }
+  }
 }
 
 onMounted(async () => {
@@ -2022,11 +2065,45 @@ watch(
   justify-content: center;
 }
 
+/* The clip wrapper is the visual boundary of the map widget.
+   The actual map element is made larger so Leaflet loads extra tiles
+   that fill in the corners when the map is rotated via leaflet-rotate. */
+.map-clip-wrapper {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  overflow: hidden;
+}
+
+.map-buttons-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+}
+
+.map-buttons-overlay > :deep(*) {
+  pointer-events: auto;
+}
+
 .map {
   position: absolute;
   z-index: 0;
-  height: 100%;
-  width: 100%;
+  /* ~42% larger covers the worst-case diagonal at 45° rotation (sqrt(2) ≈ 1.414) */
+  width: 150%;
+  height: 150%;
+  top: -25%;
+  left: -25%;
+}
+
+/* Reposition Leaflet's control container to match the visible (clipped) area.
+   Since the map div is 150% of the widget, the visible region starts at 1/6 ≈ 16.67% from each edge. */
+:deep(.leaflet-control-container) {
+  position: absolute !important;
+  top: 16.67%;
+  left: 16.67%;
+  right: 16.67%;
+  bottom: 16.67%;
 }
 
 .waypoint-marker-icon {

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -3108,6 +3108,22 @@ const attachOfflineProgress = (layer: any, layerName: string): void => {
   })
 }
 
+let leafletRotateLoaded = false
+
+/**
+ * Loads the leaflet-rotate plugin by injecting its source into a script tag.
+ * This ensures the IIFE runs in the global scope where it can access window.L.
+ * @returns {Promise<void>} Resolves when the plugin has been loaded and executed
+ */
+const loadLeafletRotate = async (): Promise<void> => {
+  if (leafletRotateLoaded) return
+  const mod = await import('leaflet-rotate/dist/leaflet-rotate.js?raw')
+  const script = document.createElement('script')
+  script.textContent = (mod as unknown as Record<string, string>).default
+  document.head.appendChild(script)
+  leafletRotateLoaded = true
+}
+
 onMounted(async () => {
   const osm = tileLayerOffline('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     maxZoom: 23,
@@ -3130,10 +3146,18 @@ onMounted(async () => {
 
   const initialBaseLayer = baseMaps[missionStore.userLastMapTileProvider] || esri
 
-  planningMap.value = L.map('planningMap', { layers: [initialBaseLayer] }).setView(
-    mapCenter.value as LatLngTuple,
-    zoom.value
-  )
+  // leaflet-rotate patches the global L object via an IIFE that references window.L.
+  // Vite's ESM bundling doesn't expose L globally, so we set it manually and load
+  // the plugin via a script tag to ensure it executes in the global scope.
+  ;(window as unknown as Record<string, unknown>).L = L
+  await loadLeafletRotate()
+
+  planningMap.value = L.map('planningMap', {
+    layers: [initialBaseLayer],
+    rotate: true,
+    touchRotate: true,
+    rotateControl: false,
+  } as L.MapOptions).setView(mapCenter.value as LatLngTuple, zoom.value)
   L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     maxZoom: 19,
     attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
@@ -3221,6 +3245,13 @@ onMounted(async () => {
 
   const layerControl = L.control.layers(baseMaps)
   planningMap.value.addControl(layerControl)
+
+  // Add rotate control
+  const rotateCtl = (L.control as unknown as Record<string, CallableFunction>).rotate({
+    closeOnZeroBearing: false,
+    position: 'bottomright',
+  }) as L.Control
+  planningMap.value.addControl(rotateCtl)
 
   // Initialize scale control (always show)
   createScaleControl()
@@ -4068,5 +4099,30 @@ watch(
 
 :deep(.leaflet-control-layers label) {
   color: var(--glass-color) !important;
+}
+
+/* Style the Leaflet rotate control — positioned bottom-right, above zoom */
+:deep(.leaflet-control-rotate.leaflet-bar) {
+  position: absolute !important;
+  right: 0;
+  bottom: 125px;
+  margin-right: 10px !important;
+  background: var(--glass-background);
+  backdrop-filter: var(--glass-filter);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  color: var(--glass-color);
+  border: var(--glass-border);
+  border-radius: 2px;
+  z-index: 1002;
+}
+
+:deep(.leaflet-control-rotate .leaflet-control-rotate-toggle) {
+  background: transparent !important;
+  border: none;
+  color: var(--glass-color);
+}
+
+:deep(.leaflet-control-rotate .leaflet-control-rotate-arrow) {
+  filter: invert(1);
 }
 </style>

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="mission-planning" :style="glassMenuCssVars">
-    <div id="planningMap" ref="planningMap" class="relative" />
+    <div class="map-clip-wrapper">
+      <div id="planningMap" ref="planningMap" class="planning-map" />
+    </div>
     <v-tooltip location="top" text="Generate waypoints">
       <template #activator="{ props }">
         <div
@@ -3108,27 +3110,59 @@ const attachOfflineProgress = (layer: any, layerName: string): void => {
   })
 }
 
-let leafletRotateLoaded = false
-
 /**
  * Loads the leaflet-rotate plugin by injecting its source into a script tag.
  * This ensures the IIFE runs in the global scope where it can access window.L.
+ * Skips loading if the plugin is already available on L.control.
  * @returns {Promise<void>} Resolves when the plugin has been loaded and executed
  */
 const loadLeafletRotate = async (): Promise<void> => {
-  if (leafletRotateLoaded) return
+  if ((L.control as unknown as Record<string, unknown>).rotate) return
   const mod = await import('leaflet-rotate/dist/leaflet-rotate.js?raw')
   const script = document.createElement('script')
   script.textContent = (mod as unknown as Record<string, string>).default
   document.head.appendChild(script)
-  leafletRotateLoaded = true
+
+  const ControlRotate = (
+    L.Control as unknown as Record<
+      string,
+      {
+        /**
+         * Rotate control prototype
+         */
+        prototype: Record<string, CallableFunction>
+      }
+    >
+  ).Rotate
+  if (ControlRotate) {
+    ControlRotate.prototype._handleMouseDown = function (e: MouseEvent): void {
+      L.DomEvent.stop(e)
+      this.dragging = true
+      this.dragstartX = e.pageX
+      this.dragstartY = e.pageY
+      this._startBearing = this._map.getBearing()
+      L.DomEvent.on(document as unknown as HTMLElement, 'mousemove', this._handleMouseDrag, this).on(
+        document as unknown as HTMLElement,
+        'mouseup',
+        this._handleMouseUp,
+        this
+      )
+    }
+    ControlRotate.prototype._handleMouseDrag = function (e: MouseEvent): void {
+      if (!this.dragging) return
+      const deltaX = e.clientX - this.dragstartX
+      this._map.setBearing((this._startBearing || 0) + deltaX)
+    }
+  }
 }
 
 onMounted(async () => {
+  const rotationTileBuffer = 10
   const osm = tileLayerOffline('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     maxZoom: 23,
     maxNativeZoom: 19,
     attribution: '© OpenStreetMap',
+    keepBuffer: rotationTileBuffer,
   })
   const esri = tileLayerOffline(
     'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
@@ -3136,6 +3170,7 @@ onMounted(async () => {
       maxZoom: 23,
       maxNativeZoom: 19,
       attribution: '© Esri World Imagery',
+      keepBuffer: rotationTileBuffer,
     }
   )
 
@@ -3737,8 +3772,20 @@ watch(
 #planningMap {
   position: absolute;
   z-index: 0;
-  height: 100%;
-  width: 100%;
+  width: 150%;
+  height: 150%;
+  top: -25%;
+  left: -25%;
+}
+
+/* Reposition Leaflet's control container to match the visible (clipped) area.
+   Since the map div is 150% of the widget, the visible region starts at 1/6 ≈ 16.67% from each edge. */
+#planningMap .leaflet-control-container {
+  position: absolute !important;
+  top: 16.67%;
+  left: 16.67%;
+  right: 16.67%;
+  bottom: 16.67%;
 }
 .mission-planning {
   min-height: 100vh;
@@ -3746,6 +3793,17 @@ watch(
   align-items: center;
   justify-content: center;
 }
+
+/* The clip wrapper is the visual boundary of the map.
+   The actual map element is made larger so Leaflet loads extra tiles
+   that fill in the corners when the map is rotated via leaflet-rotate. */
+.map-clip-wrapper {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  overflow: hidden;
+}
+
 .waypoint-marker-icon {
   background: none;
   border: none;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6836,6 +6836,11 @@ lazy-val@^1.0.5:
   resolved "https://registry.yarnpkg.com/lazy-val/-/lazy-val-1.0.5.tgz#6cf3b9f5bc31cee7ee3e369c0832b7583dcd923d"
   integrity sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==
 
+leaflet-rotate@^0.2.8:
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/leaflet-rotate/-/leaflet-rotate-0.2.8.tgz#41a2e6c33857af93944d1337a06c6c90cd6d9ba0"
+  integrity sha512-BHtkn35DuJ377yBNn/7XVuV0oIfwJtmqv/wFQ0Lvh7QuVCAD2wfCK0/m9oA3k/LVOnJG8VEGyf3Duf/wTVzeKQ==
+
 leaflet.offline@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/leaflet.offline/-/leaflet.offline-3.1.0.tgz#00c93dd461cee64e3f7c43113a11268dddbba809"


### PR DESCRIPTION
* Added a control for manual map rotation on mission planning and flight modes;
* Added a "track vehicle heading" feature as an extension form of the existing "track vehicle position" button functionality;
* Tap map rotation button to head map back to north;

https://github.com/user-attachments/assets/19aaf073-ef76-45fc-9ffb-5479e5159e6f

Close #2370 
Relates to #2362 
Close #312 