### PR TITLE
Add turnaround distance for surveys

### DIFF
--- a/src/libs/utils-map.ts
+++ b/src/libs/utils-map.ts
@@ -2,7 +2,7 @@ import * as turf from '@turf/turf'
 import type { Feature, Polygon } from 'geojson'
 import * as L from 'leaflet'
 
-import type { WaypointCoordinates } from '@/types/mission'
+import type { SurveyPath, WaypointCoordinates } from '@/types/mission'
 
 /**
  * Default target follower update interval in milliseconds.
@@ -176,14 +176,17 @@ export class TargetFollower {
  * @param {L.LatLng[]} polygonPoints - The points of the polygon.
  * @param {number} distanceBetweenLines - The distance between survey lines in meters.
  * @param {number} linesAngle - The angle of the survey lines in degrees.
- * @returns {L.LatLng[]} The generated survey path.
+ * @param {number} turnaroundDistance - Distance in meters to extend (positive) or inset (negative) from the polygon
+ *   boundary before turning. Positive values make the vehicle fly past the edges; negative values keep it away.
+ * @returns {SurveyPath} The generated survey path and turnaround segments.
  */
 export const generateSurveyPath = (
   polygonPoints: L.LatLng[],
   distanceBetweenLines: number,
-  linesAngle: number
-): L.LatLng[] => {
-  if (polygonPoints.length < 4) return []
+  linesAngle: number,
+  turnaroundDistance = 0
+): SurveyPath => {
+  if (polygonPoints.length < 4) return { path: [], turnaroundSegments: [] }
 
   const polygonCoords = polygonPoints.map((p) => [p.lng, p.lat])
   if (
@@ -203,8 +206,17 @@ export const generateSurveyPath = (
     const angleRad = (adjustedAngle * Math.PI) / 180
 
     const continuousPath: L.LatLng[] = []
+    const turnaroundSegments: L.LatLng[][] = []
     let d = -diagonal
     let isReverse = false
+
+    let prevExitBoundary: L.LatLng | null = null
+    let prevExitTurnaround: L.LatLng | null = null
+
+    const lineBearing = turf.bearing(
+      turf.point([minX - diagonal * Math.sin(angleRad), minY + diagonal * Math.cos(angleRad)]),
+      turf.point([minX + diagonal * Math.sin(angleRad), minY - diagonal * Math.cos(angleRad)])
+    )
 
     while (d <= diagonal * 2) {
       const lineStart = [
@@ -229,11 +241,51 @@ export const generateSurveyPath = (
         })
 
         const coords = sortedFeatures.map((f) => f.geometry.coordinates)
-        if (isReverse) coords.reverse()
+
+        if (turnaroundDistance !== 0 && coords.length >= 2) {
+          const origFirst = L.latLng(coords[0][1], coords[0][0])
+          const origLast = L.latLng(coords[coords.length - 1][1], coords[coords.length - 1][0])
+
+          if (turnaroundDistance < 0 && Math.abs(turnaroundDistance) * 2 >= origFirst.distanceTo(origLast)) {
+            d += distanceBetweenLines / 111000
+            continue
+          }
+
+          const turnaroundKm = turnaroundDistance / 1000
+          const extFirst = turf.destination(turf.point(coords[0]), turnaroundKm, lineBearing + 180, {
+            units: 'kilometers',
+          })
+          coords[0] = extFirst.geometry.coordinates
+
+          const lastIdx = coords.length - 1
+          const extLast = turf.destination(turf.point(coords[lastIdx]), turnaroundKm, lineBearing, {
+            units: 'kilometers',
+          })
+          coords[lastIdx] = extLast.geometry.coordinates
+
+          const entryBoundary = isReverse ? origLast : origFirst
+          const exitBoundary = isReverse ? origFirst : origLast
+
+          if (isReverse) coords.reverse()
+
+          const entryTurnaround = L.latLng(coords[0][1], coords[0][0])
+          const exitTurnaround = L.latLng(coords[coords.length - 1][1], coords[coords.length - 1][0])
+
+          if (prevExitBoundary && prevExitTurnaround) {
+            turnaroundSegments.push([prevExitBoundary, prevExitTurnaround, entryTurnaround, entryBoundary])
+          } else {
+            turnaroundSegments.push([entryTurnaround, entryBoundary])
+          }
+
+          prevExitBoundary = exitBoundary
+          prevExitTurnaround = exitTurnaround
+        } else {
+          if (isReverse) coords.reverse()
+        }
 
         const linePoints = coords.map((c) => L.latLng(c[1], c[0]))
 
-        if (continuousPath.length > 0) {
+        if (continuousPath.length > 0 && turnaroundDistance === 0) {
           const lastPoint = continuousPath[continuousPath.length - 1]
           const edgePath = moveAlongEdge(poly, lastPoint, linePoints[0], diagonal)
           continuousPath.push(...edgePath)
@@ -246,10 +298,14 @@ export const generateSurveyPath = (
       d += distanceBetweenLines / 111000
     }
 
-    return continuousPath
+    if (turnaroundDistance !== 0 && prevExitBoundary && prevExitTurnaround) {
+      turnaroundSegments.push([prevExitBoundary, prevExitTurnaround])
+    }
+
+    return { path: continuousPath, turnaroundSegments }
   } catch (error) {
     console.error('Error in generateSurveyPath:', error)
-    return []
+    return { path: [], turnaroundSegments: [] }
   }
 }
 

--- a/src/types/mission.ts
+++ b/src/types/mission.ts
@@ -170,9 +170,30 @@ export interface Survey {
    */
   surveyLinesAngle: number
   /**
+   * Distance in meters to extend (positive) or inset (negative) from the polygon boundary before
+   * the vehicle turns. Positive values fly past the edges; negative values keep the vehicle away.
+   */
+  turnaroundDistance: number
+  /**
    * Executable mission waypoints.
    */
   waypoints: Waypoint[]
+}
+
+/**
+ * Result of survey path generation, containing the full flight path
+ * and optional turnaround segments at the polygon boundary.
+ */
+export interface SurveyPath {
+  /**
+   * The full continuous flight path including turnaround extensions or insets.
+   */
+  path: L.LatLng[]
+  /**
+   * Polyline segments representing the turnaround portions at the polygon boundary.
+   * Each entry is a polyline connecting boundary ↔ turnaround points.
+   */
+  turnaroundSegments: L.LatLng[][]
 }
 
 // TODO - Replace leaflet types with agnostic types

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -21,7 +21,7 @@
           v-if="isCreatingSurvey && surveyPolygonVertexesPositions.length >= 3"
           v-bind="props"
           :style="confirmButtonStyle"
-          class="absolute mt-[73px] ml-[10px] rounded-lg elevation-4"
+          class="absolute mt-[46px] ml-[10px] rounded-lg elevation-4"
           variant="text"
         >
           <input
@@ -33,13 +33,49 @@
         </div>
       </template>
     </v-tooltip>
+    <v-tooltip location="top" text="Turnaround distance">
+      <template #activator="{ props }">
+        <div
+          v-if="isCreatingSurvey && surveyPolygonVertexesPositions.length >= 3"
+          v-bind="props"
+          :style="confirmButtonStyle"
+          class="absolute mt-[76px] ml-[10px] rounded-lg elevation-4"
+          variant="text"
+        >
+          <input
+            v-model.number="turnaroundDistance"
+            class="rounded-lg bg-[#333333EE] text-white w-12 pl-2 pa-0"
+            type="number"
+          />
+        </div>
+      </template>
+    </v-tooltip>
+    <v-tooltip location="top" text="Cruise speed">
+      <template #activator="{ props }">
+        <div
+          v-if="isCreatingSurvey && surveyPolygonVertexesPositions.length >= 3"
+          v-bind="props"
+          :style="confirmButtonStyle"
+          class="absolute mt-[106px] ml-[10px] rounded-lg elevation-4"
+          variant="text"
+        >
+          <input
+            v-model.number="missionStore.defaultCruiseSpeed"
+            class="rounded-lg bg-[#333333EE] text-white w-12 pl-2 pa-0"
+            type="number"
+            min="1"
+            step="0.5"
+          />
+        </div>
+      </template>
+    </v-tooltip>
     <v-tooltip location="top" text="Clear survey">
       <template #activator="{ props }">
         <div
           v-if="isCreatingSurvey && surveyPolygonVertexesPositions.length >= 3"
           v-bind="props"
           :style="confirmButtonStyle"
-          class="absolute text-[14px] mt-[130px] ml-[3px] bg-transparent rounded-full cursor-pointer elevation-4"
+          class="absolute text-[14px] mt-[140px] ml-[3px] bg-transparent rounded-full cursor-pointer elevation-4"
           variant="text"
           @click="clearSurveyCreation"
         >
@@ -181,6 +217,12 @@
             type="number"
             min="0"
             max="359"
+          />
+          <p class="m-1 overflow-visible text-sm text-slate-200">Turnaround distance (m)</p>
+          <input
+            v-model.number="turnaroundDistance"
+            class="px-2 py-1 mt-1 mb-2 mx-5 rounded-sm bg-[#FFFFFF22]"
+            type="number"
           />
           <button
             :class="{
@@ -557,6 +599,7 @@ import {
   MissionCommandType,
   PointOfInterest,
   Survey,
+  SurveyPath,
   SurveyPolygon,
 } from '@/types/mission'
 
@@ -2082,6 +2125,7 @@ const loadMissionFromFile = async (e: Event): Promise<void> => {
 const surveyPolygonVertexesMarkers = shallowRef<L.Marker[]>([])
 const rawDistanceBetweenSurveyLines = ref(10)
 const rawSurveyLinesAngle = ref(0)
+const rawTurnaroundDistance = ref(0)
 const existingWaypoints = ref<Waypoint[]>([])
 const surveyWaypoints = ref<Waypoint[]>([])
 
@@ -2089,6 +2133,11 @@ const surveyWaypoints = ref<Waypoint[]>([])
 const distanceBetweenSurveyLines = computed({
   get: () => Math.max(1, rawDistanceBetweenSurveyLines.value),
   set: (value) => (rawDistanceBetweenSurveyLines.value = Math.max(1, value)), // Ensure the distance is at least 1
+})
+
+const turnaroundDistance = computed({
+  get: () => rawTurnaroundDistance.value,
+  set: (value) => (rawTurnaroundDistance.value = value),
 })
 
 // Angle of the survey path lines
@@ -2111,6 +2160,7 @@ const onSurveyLinesAngleChange = (angle: number): void => {
 }
 
 const surveyPathLayer = shallowRef<L.Polyline | null>(null)
+const surveyTurnaroundLayers = shallowRef<L.Polyline[]>([])
 const surveyPolygonLayer = shallowRef<L.Polygon | null>(null)
 
 const clearSurveyPath = (): void => {
@@ -2118,6 +2168,8 @@ const clearSurveyPath = (): void => {
     planningMap.value?.removeLayer(surveyPathLayer.value as unknown as L.Layer)
     surveyPathLayer.value = null
   }
+  surveyTurnaroundLayers.value.forEach((layer) => planningMap.value?.removeLayer(layer as unknown as L.Layer))
+  surveyTurnaroundLayers.value = []
   if (surveyPolygonLayer.value) {
     disablePolygonDragging()
     planningMap.value?.removeLayer(surveyPolygonLayer.value as unknown as L.Layer)
@@ -2211,6 +2263,8 @@ const checkAndRemoveSurveyPath = (): void => {
   if (surveyPolygonVertexesPositions.value.length >= 4 || !surveyPathLayer.value) return
   planningMap.value?.removeLayer(surveyPathLayer.value as unknown as L.Layer)
   surveyPathLayer.value = null
+  surveyTurnaroundLayers.value.forEach((layer) => planningMap.value?.removeLayer(layer as unknown as L.Layer))
+  surveyTurnaroundLayers.value = []
 }
 
 const createSurveyPath = (): void => {
@@ -2221,13 +2275,14 @@ const createSurveyPath = (): void => {
 
   try {
     const adjustedAngle = 90 - surveyLinesAngle.value
-    const continuousPath = generateSurveyPath(
+    const result: SurveyPath = generateSurveyPath(
       surveyPolygonVertexesPositions.value,
       distanceBetweenSurveyLines.value,
-      adjustedAngle
+      adjustedAngle,
+      turnaroundDistance.value
     )
 
-    if (continuousPath.length === 0) {
+    if (result.path.length === 0) {
       showDialog({
         variant: 'error',
         message: 'No valid path could be generated. Try adjusting the angle or distance between lines.',
@@ -2240,12 +2295,26 @@ const createSurveyPath = (): void => {
       planningMap.value?.removeLayer(surveyPathLayer.value as unknown as L.Layer)
     }
 
-    surveyPathLayer.value = L.polyline(continuousPath, {
+    surveyTurnaroundLayers.value.forEach((layer) => planningMap.value?.removeLayer(layer as unknown as L.Layer))
+    surveyTurnaroundLayers.value = []
+
+    surveyPathLayer.value = L.polyline(result.path, {
       color: '#2563EB',
       weight: 3,
       opacity: 0.8,
       className: 'survey-path',
     }).addTo(toRaw(planningMap.value)!)
+
+    if (result.turnaroundSegments.length > 0) {
+      surveyTurnaroundLayers.value = result.turnaroundSegments.map((segment) =>
+        L.polyline(segment, {
+          color: '#F97316',
+          weight: 5,
+          opacity: 0.6,
+          className: 'survey-turnaround-path',
+        }).addTo(toRaw(planningMap.value)!)
+      )
+    }
   } catch (error) {
     showDialog({
       variant: 'error',
@@ -2267,8 +2336,8 @@ watch(
   }
 )
 
-// Watch for changes in distanceBetweenSurveyLines and surveyLinesAngle
-watch([distanceBetweenSurveyLines, surveyLinesAngle], () => createSurveyPath())
+// Watch for changes in distanceBetweenSurveyLines, surveyLinesAngle, and turnaroundDistance
+watch([distanceBetweenSurveyLines, surveyLinesAngle, turnaroundDistance], () => createSurveyPath())
 
 const surveyEdgeAddMarkers: L.Marker[] = []
 
@@ -2416,10 +2485,11 @@ const generateWaypointsFromSurvey = (): void => {
   }
 
   const adjustedAngle = 90 - surveyLinesAngle.value
-  const continuousPath = generateSurveyPath(
+  const { path: continuousPath } = generateSurveyPath(
     surveyPolygonVertexesPositions.value,
     distanceBetweenSurveyLines.value,
-    adjustedAngle
+    adjustedAngle,
+    turnaroundDistance.value
   )
 
   if (!continuousPath.length) {
@@ -2446,6 +2516,7 @@ const generateWaypointsFromSurvey = (): void => {
     polygonCoordinates: polygonCoordinates,
     distanceBetweenLines: distanceBetweenSurveyLines.value,
     surveyLinesAngle: surveyLinesAngle.value,
+    turnaroundDistance: turnaroundDistance.value,
     waypoints: newSurveyWaypoints,
   }
 
@@ -2548,10 +2619,11 @@ const regenerateSurveyWaypoints = (angle?: number): void => {
     })
 
     const adjustedAngle = 90 - (angle || selectedSurvey.value.surveyLinesAngle)
-    const continuousPath = generateSurveyPath(
+    const { path: continuousPath } = generateSurveyPath(
       selectedSurvey.value.polygonCoordinates.map((coord) => L.latLng(coord[0], coord[1])),
       selectedSurvey.value.distanceBetweenLines,
-      adjustedAngle
+      adjustedAngle,
+      selectedSurvey.value.turnaroundDistance
     )
 
     if (!continuousPath.length) {


### PR DESCRIPTION
Feature requested by Tony

* Add a turnaround distance on surveys so vehicles can stabilize before entering back on the survey area;

<img width="1913" height="1056" alt="2026-03-12_11-48" src="https://github.com/user-attachments/assets/899e7208-9a1d-4a3e-81ba-ba565d587e30" />

https://github.com/user-attachments/assets/8524be5f-c023-4f4a-a2e5-6cdda195cd61

Close #1351 