### PR TITLE
Allow downloading raw sensor logs

### DIFF
--- a/src/components/MainMenu.vue
+++ b/src/components/MainMenu.vue
@@ -236,6 +236,7 @@ import ConfigurationMissionView from '@/views/ConfigurationMissionView.vue'
 import ConfigurationUIView from '@/views/ConfigurationUIView.vue'
 import ConfigurationVideoView from '@/views/ConfigurationVideoView.vue'
 import ToolsDataLakeView from '@/views/ToolsDataLakeView.vue'
+import ToolsLogsView from '@/views/ToolsLogsView.vue'
 import ToolsMAVLinkView from '@/views/ToolsMAVLinkView.vue'
 
 const route = useRoute()
@@ -434,6 +435,12 @@ const toolsMenu = computed(() => {
       title: 'Data-lake',
       componentName: SubMenuComponentName.ToolsDataLake,
       component: markRaw(ToolsDataLakeView) as SubMenuComponent,
+    },
+    {
+      icon: 'mdi-file-chart-outline',
+      title: 'Data Logs',
+      componentName: SubMenuComponentName.ToolsLogs,
+      component: markRaw(ToolsLogsView) as SubMenuComponent,
     },
   ]
 

--- a/src/components/VideoLibraryModal.vue
+++ b/src/components/VideoLibraryModal.vue
@@ -834,7 +834,12 @@ import { useSnapshotStore } from '@/stores/snapshot'
 import { useVideoStore } from '@/stores/video'
 import { SnapshotLibraryFile } from '@/types/snapshot'
 import { VideoLibraryFile, VideoLibraryLogFile } from '@/types/video'
-import { videoSubtitlesFilename, videoThumbnailFilename } from '@/utils/video'
+import {
+  videoSubtitlesFilename,
+  videoTelemetryCsvFilename,
+  videoTelemetryJsonFilename,
+  videoThumbnailFilename,
+} from '@/utils/video'
 
 const videoStore = useVideoStore()
 const interfaceStore = useAppInterfaceStore()
@@ -1146,9 +1151,24 @@ const deselectAllVideos = (): void => {
 // Add the log files to the list of files to be downloaded/discarded
 const addLogDataToFileList = (fileNames: string[]): string[] => {
   const filesWithLogData = fileNames.flatMap((fileName) => {
+    const result = [fileName]
+
     const subtitleFileName = videoSubtitlesFilename(fileName)
-    const subtitleExists = availableLogFiles.value.some((video) => video.fileName === subtitleFileName)
-    return subtitleExists ? [fileName, subtitleFileName] : [fileName]
+    if (availableLogFiles.value.some((video) => video.fileName === subtitleFileName)) {
+      result.push(subtitleFileName)
+    }
+
+    const jsonFileName = videoTelemetryJsonFilename(fileName)
+    if (availableLogFiles.value.some((video) => video.fileName === jsonFileName)) {
+      result.push(jsonFileName)
+    }
+
+    const csvFileName = videoTelemetryCsvFilename(fileName)
+    if (availableLogFiles.value.some((video) => video.fileName === csvFileName)) {
+      result.push(csvFileName)
+    }
+
+    return result
   })
   return filesWithLogData
 }

--- a/src/composables/videoChunkManager.ts
+++ b/src/composables/videoChunkManager.ts
@@ -4,7 +4,12 @@ import { LiveVideoProcessor } from '@/libs/live-video-processor'
 import { formatBytes, isElectron } from '@/libs/utils'
 import { useVideoStore } from '@/stores/video'
 import { type FileDescriptor } from '@/types/video'
-import { videoFilename, videoSubtitlesFilename } from '@/utils/video'
+import {
+  videoFilename,
+  videoSubtitlesFilename,
+  videoTelemetryCsvFilename,
+  videoTelemetryJsonFilename,
+} from '@/utils/video'
 
 import { useInteractionDialog } from './interactionDialog'
 import { useSnackbar } from './snackbar'
@@ -501,15 +506,26 @@ export const useVideoChunkManager = (): {
       // Finalize the streaming process
       await window.electronAPI.finalizeVideoRecording(processId)
 
-      // Find and copy telemetry file if it exists
+      // Find and copy telemetry files if they exist (.ass, .json, .csv)
       try {
         const videoKeys = await videoStore.videoStorage.keys()
+
         const assFile = videoKeys.find((key) => key.includes(group.hash) && key.endsWith('.ass'))
         if (assFile) {
           await window.electronAPI.copyTelemetryFile(assFile, videoSubtitlesFilename(outputPath))
         }
+
+        const jsonFile = videoKeys.find((key) => key.includes(group.hash) && key.endsWith('.json'))
+        if (jsonFile) {
+          await window.electronAPI.copyTelemetryFile(jsonFile, videoTelemetryJsonFilename(outputPath))
+        }
+
+        const csvFile = videoKeys.find((key) => key.includes(group.hash) && key.endsWith('.csv'))
+        if (csvFile) {
+          await window.electronAPI.copyTelemetryFile(csvFile, videoTelemetryCsvFilename(outputPath))
+        }
       } catch (error) {
-        console.warn('Failed to copy telemetry file:', error)
+        console.warn('Failed to copy telemetry files:', error)
       }
 
       openSnackbar({

--- a/src/libs/live-video-processor.ts
+++ b/src/libs/live-video-processor.ts
@@ -1,6 +1,6 @@
 import { isElectron } from '@/libs/utils'
 import type { VideoChunkQueueItem, ZipExtractionResult } from '@/types/video'
-import { videoSubtitlesFilename } from '@/utils/video'
+import { videoSubtitlesFilename, videoTelemetryCsvFilename, videoTelemetryJsonFilename } from '@/utils/video'
 
 /**
  * Error class for LiveVideoProcessor initialization errors
@@ -237,7 +237,7 @@ export class LiveVideoProcessor {
 
       // Extract ZIP and get chunk information
       const extractionResult: ZipExtractionResult = await window.electronAPI.extractVideoChunksZip(zipFilePath)
-      const { chunkPaths, assFilePath, hash, fileName, tempDir } = extractionResult
+      const { chunkPaths, assFilePath, jsonFilePath, csvFilePath, hash, fileName, tempDir } = extractionResult
 
       console.log(`Extracted ${chunkPaths.length} chunks from ZIP file`)
       onProgress?.(30, 'Starting video processing...')
@@ -276,10 +276,18 @@ export class LiveVideoProcessor {
       // Finalize the streaming process
       await window.electronAPI.finalizeVideoRecording(processId)
 
-      // Copy telemetry file if it exists (using the full output path)
-      if (assFilePath) {
-        onProgress?.(95, 'Copying telemetry file...')
-        await window.electronAPI.copyTelemetryFile(assFilePath, videoSubtitlesFilename(outputPath))
+      // Copy telemetry files if they exist (using the full output path)
+      if (assFilePath || jsonFilePath || csvFilePath) {
+        onProgress?.(95, 'Copying telemetry files...')
+        if (assFilePath) {
+          await window.electronAPI.copyTelemetryFile(assFilePath, videoSubtitlesFilename(outputPath))
+        }
+        if (jsonFilePath) {
+          await window.electronAPI.copyTelemetryFile(jsonFilePath, videoTelemetryJsonFilename(outputPath))
+        }
+        if (csvFilePath) {
+          await window.electronAPI.copyTelemetryFile(csvFilePath, videoTelemetryCsvFilename(outputPath))
+        }
       }
 
       // Clean up temporary extraction directory

--- a/src/libs/sensors-logging.ts
+++ b/src/libs/sensors-logging.ts
@@ -129,6 +129,40 @@ export interface CockpitStandardLogPoint {
 export type CockpitStandardLog = CockpitStandardLogPoint[]
 
 /**
+ * Information about a data session (detected from raw log entries)
+ */
+export interface DataSessionInfo {
+  /**
+   * Unique identifier for the session
+   */
+  id: string
+  /**
+   * Start time of the session (epoch ms)
+   */
+  startTime: number
+  /**
+   * End time of the session (epoch ms)
+   */
+  endTime: number
+  /**
+   * Formatted date/time string
+   */
+  dateTimeFormatted: string
+  /**
+   * Number of data points in the session
+   */
+  dataPointCount: number
+  /**
+   * Duration of the session in seconds
+   */
+  durationSeconds: number
+  /**
+   * Whether this is the current active session
+   */
+  isCurrentSession: boolean
+}
+
+/**
  * Position for telemetry data on the video overlay
  */
 export interface OverlayGrid {
@@ -213,7 +247,7 @@ export class CurrentlyLoggedVariables {
 /**
  * Manager logging vehicle data and others
  */
-class DataLogger {
+export class DataLogger {
   logRequesters: string[] = []
   datetimeLastLogPoint: Date | null = null
   variablesBeingUsed: DatalogVariable[] = []
@@ -287,7 +321,7 @@ class DataLogger {
     description: 'Local backups of Cockpit sensor logs, to be retrieved in case of failure.',
   })
 
-  cockpitTemporaryLogsDB = localforage.createInstance({
+  static cockpitTemporaryLogsDB = localforage.createInstance({
     driver: localforage.INDEXEDDB,
     name: 'Cockpit - Temporary Sensor Log points',
     storeName: 'cockpit-temporary-sensor-logs-db',
@@ -351,7 +385,7 @@ class DataLogger {
         data: structuredClone(variablesData),
       }
 
-      await this.cockpitTemporaryLogsDB.setItem(`epoch=${logPoint.epoch}`, logPoint)
+      await DataLogger.cockpitTemporaryLogsDB.setItem(`epoch=${logPoint.epoch}`, logPoint)
       this.datetimeLastLogPoint = new Date()
 
       if (this.shouldBeLogging()) {
@@ -501,7 +535,7 @@ class DataLogger {
     const logDateTimeFmt = `${logDateFormat} / HH꞉mm꞉ss O`
     const fileName = `Cockpit (${format(initialTime, logDateTimeFmt)} - ${format(finalTime, logDateTimeFmt)}).clog`
 
-    const availableLogsKeys = await this.cockpitTemporaryLogsDB.keys()
+    const availableLogsKeys = await DataLogger.cockpitTemporaryLogsDB.keys()
 
     // The key is in the format epoch=<epoch>. We extract the epoch and compare it to the initial and final times
     // to see if the log point is in the range of the desired log.
@@ -536,7 +570,7 @@ class DataLogger {
 
     const logPointsInRange: CockpitStandardLogPoint[] = []
     for (const info of infoLogPointsInRange) {
-      const log = (await this.cockpitTemporaryLogsDB.getItem(info.key)) as CockpitStandardLogPoint
+      const log = (await DataLogger.cockpitTemporaryLogsDB.getItem(info.key)) as CockpitStandardLogPoint
 
       // Only consider real log points(objects with an epoch and data property, and non-empty data)
       if (log.epoch === undefined || log.data === undefined || Object.keys(log.data).length === 0) continue
@@ -559,6 +593,62 @@ class DataLogger {
     await this.cockpitLogsDB.setItem(fileName, finalLog)
 
     return finalLog
+  }
+
+  /**
+   * Convert Cockpit standard log to JSON format
+   * @param {CockpitStandardLog} log - The telemetry log data
+   * @returns {string} JSON string representation of the telemetry data
+   */
+  toJson(log: CockpitStandardLog): string {
+    return JSON.stringify(log, null, 2)
+  }
+
+  /**
+   * Convert Cockpit standard log to CSV format
+   * @param {CockpitStandardLog} log - The telemetry log data
+   * @returns {string} CSV string representation of the telemetry data
+   */
+  toCsv(log: CockpitStandardLog): string {
+    if (log.length === 0) return ''
+
+    // Helper to escape CSV values (handle quotes and special characters)
+    const escapeCSV = (value: string | undefined | null): string => {
+      if (value === undefined || value === null) return ''
+      const str = String(value).trim()
+      // Escape quotes by doubling them and wrap in quotes if contains special chars
+      if (str.includes('"') || str.includes(',') || str.includes('\n') || str.includes('\r')) {
+        return `"${str.replace(/"/g, '""')}"`
+      }
+      return str
+    }
+
+    // Get all unique variable names from all log points
+    const allVariables = new Set<string>()
+    log.forEach((logPoint) => {
+      if (logPoint.data) {
+        Object.keys(logPoint.data).forEach((key) => allVariables.add(key))
+      }
+    })
+
+    // Create header row with epoch and all variable names
+    const sortedVariables = Array.from(allVariables).sort()
+    const headers = ['epoch', 'timestamp', ...sortedVariables]
+
+    // Create CSV rows
+    const rows = log.map((logPoint) => {
+      const timestamp = new Date(logPoint.epoch).toISOString()
+      const values = sortedVariables.map((variable) => {
+        const data = logPoint.data?.[variable]
+        if (data && data.value !== undefined) {
+          return escapeCSV(data.value)
+        }
+        return ''
+      })
+      return [logPoint.epoch, timestamp, ...values].join(',')
+    })
+
+    return [headers.join(','), ...rows].join('\n')
   }
 
   /**
@@ -672,6 +762,151 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text`
     assFile = assFile.concat('\n')
 
     return assFile
+  }
+
+  // Gap threshold to consider a new session (5 minutes of no data)
+  static SESSION_GAP_THRESHOLD_MS = 5 * 60 * 1000
+
+  /**
+   * Get all data sessions detected from raw log entries
+   * Sessions are determined by gaps in the data (>5 minutes between points = new session)
+   * @returns {Promise<DataSessionInfo[]>} Array of session information
+   */
+  static async getDataSessions(): Promise<DataSessionInfo[]> {
+    const allKeys = await DataLogger.cockpitTemporaryLogsDB.keys()
+
+    if (allKeys.length === 0) return []
+
+    // Extract epochs from keys and sort them
+    const epochs = allKeys
+      .map((key) => {
+        const match = key.match(/^epoch=(\d+)$/)
+        return match ? parseInt(match[1], 10) : null
+      })
+      .filter((epoch): epoch is number => epoch !== null)
+      .sort((a, b) => a - b)
+
+    if (epochs.length === 0) return []
+
+    // Group epochs into sessions based on gaps
+    const sessions: DataSessionInfo[] = []
+    let sessionStart = epochs[0]
+    let sessionEnd = epochs[0]
+    let pointCount = 1
+
+    for (let i = 1; i < epochs.length; i++) {
+      const gap = epochs[i] - epochs[i - 1]
+
+      if (gap > DataLogger.SESSION_GAP_THRESHOLD_MS) {
+        // End current session and start a new one
+        sessions.push({
+          id: `session-${sessionStart}`,
+          startTime: sessionStart,
+          endTime: sessionEnd,
+          dateTimeFormatted: format(new Date(sessionStart), 'LLL dd, yyyy - HH:mm:ss'),
+          dataPointCount: pointCount,
+          durationSeconds: Math.round((sessionEnd - sessionStart) / 1000),
+          isCurrentSession: false,
+        })
+        sessionStart = epochs[i]
+        sessionEnd = epochs[i]
+        pointCount = 1
+      } else {
+        sessionEnd = epochs[i]
+        pointCount++
+      }
+    }
+
+    // Add the last session
+    const lastSession: DataSessionInfo = {
+      id: `session-${sessionStart}`,
+      startTime: sessionStart,
+      endTime: sessionEnd,
+      dateTimeFormatted: format(new Date(sessionStart), 'LLL dd, yyyy - HH:mm:ss'),
+      dataPointCount: pointCount,
+      durationSeconds: Math.round((sessionEnd - sessionStart) / 1000),
+      isCurrentSession: false,
+    }
+
+    // Check if this is the current session (last log point within the last minute)
+    const now = Date.now()
+    if (now - sessionEnd < 60000) {
+      lastSession.isCurrentSession = true
+    }
+
+    sessions.push(lastSession)
+
+    // Sort by date, newest first
+    return sessions.sort((a, b) => b.startTime - a.startTime)
+  }
+
+  /**
+   * Generate a data log from a session's raw data
+   * @param {DataSessionInfo} session - The session to generate log from
+   * @returns {Promise<CockpitStandardLog>} The generated log
+   */
+  static async generateLogFromSession(session: DataSessionInfo): Promise<CockpitStandardLog> {
+    const log: CockpitStandardLog = []
+
+    // Get all keys and filter by session time range
+    const allKeys = await DataLogger.cockpitTemporaryLogsDB.keys()
+
+    for (const key of allKeys) {
+      const match = key.match(/^epoch=(\d+)$/)
+      if (!match) continue
+
+      const epoch = parseInt(match[1], 10)
+      if (epoch >= session.startTime && epoch <= session.endTime) {
+        const logPoint = (await DataLogger.cockpitTemporaryLogsDB.getItem(key)) as CockpitStandardLogPoint | null
+        if (logPoint && logPoint.epoch !== undefined && logPoint.data !== undefined) {
+          log.push(logPoint)
+        }
+      }
+    }
+
+    // Sort by epoch
+    return log.sort((a, b) => a.epoch - b.epoch)
+  }
+
+  /**
+   * Delete a data session's raw data
+   * @param {DataSessionInfo} session - The session to delete
+   */
+  static async deleteDataSession(session: DataSessionInfo): Promise<void> {
+    const allKeys = await DataLogger.cockpitTemporaryLogsDB.keys()
+
+    for (const key of allKeys) {
+      const match = key.match(/^epoch=(\d+)$/)
+      if (!match) continue
+
+      const epoch = parseInt(match[1], 10)
+      if (epoch >= session.startTime && epoch <= session.endTime) {
+        await DataLogger.cockpitTemporaryLogsDB.removeItem(key)
+      }
+    }
+  }
+
+  /**
+   * Delete all data sessions older than a specified number of days
+   * @param {number} daysOld - Number of days (sessions older than this will be deleted)
+   * @returns {Promise<number>} Number of deleted sessions
+   */
+  static async deleteOldDataSessions(daysOld = 1): Promise<number> {
+    const cutoffDate = new Date()
+    cutoffDate.setDate(cutoffDate.getDate() - daysOld)
+    const cutoffMs = cutoffDate.getTime()
+
+    const sessions = await DataLogger.getDataSessions()
+    let deletedCount = 0
+
+    for (const session of sessions) {
+      if (session.endTime < cutoffMs && !session.isCurrentSession) {
+        await DataLogger.deleteDataSession(session)
+        deletedCount++
+      }
+    }
+
+    return deletedCount
   }
 }
 

--- a/src/stores/appInterface.ts
+++ b/src/stores/appInterface.ts
@@ -33,6 +33,7 @@ export enum SubMenuComponentName {
   SettingsMAVLink = 'settings-mavlink',
   ToolsMAVLink = 'tools-mavlink',
   ToolsDataLake = 'tools-datalake',
+  ToolsLogs = 'tools-logs',
 }
 
 export const useAppInterfaceStore = defineStore('responsive', {

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -37,7 +37,13 @@ import {
   VideoExtensionContainer,
   VideoStreamCorrespondency,
 } from '@/types/video'
-import { videoFilename, videoSubtitlesFilename, videoThumbnailFilename } from '@/utils/video'
+import {
+  videoFilename,
+  videoSubtitlesFilename,
+  videoTelemetryCsvFilename,
+  videoTelemetryJsonFilename,
+  videoThumbnailFilename,
+} from '@/utils/video'
 
 import { useAlertStore } from './alert'
 const { openSnackbar } = useSnackbar()
@@ -346,7 +352,7 @@ export const useVideoStore = defineStore('video', () => {
   }
 
   /**
-   * Generate .ass telemetry overlay file for a video recording
+   * Generate telemetry files (.ass, .json, .csv) for a video recording
    * @param {string} recordingHash - The hash of the recording
    */
   const generateTelemetryOverlay = async (recordingHash: string): Promise<void> => {
@@ -360,16 +366,25 @@ export const useVideoStore = defineStore('video', () => {
       const telemetryLog = await datalogger.generateLog(recordingData.dateStart!, recordingData.dateFinish!)
 
       if (telemetryLog !== undefined) {
+        // Generate and save .ass overlay file
         const assLog = datalogger.toAssOverlay(
           telemetryLog,
           recordingData.vWidth!,
           recordingData.vHeight!,
           recordingData.dateStart!.getTime()
         )
-        const logBlob = new Blob([assLog], { type: 'text/plain' })
+        const assBlob = new Blob([assLog], { type: 'text/plain' })
+        await videoStorage.setItem(videoSubtitlesFilename(recordingData.fileName), assBlob)
 
-        // Save the .ass file
-        await videoStorage.setItem(videoSubtitlesFilename(recordingData.fileName), logBlob)
+        // Generate and save .json data file
+        const jsonLog = datalogger.toJson(telemetryLog)
+        const jsonBlob = new Blob([jsonLog], { type: 'application/json' })
+        await videoStorage.setItem(videoTelemetryJsonFilename(recordingData.fileName), jsonBlob)
+
+        // Generate and save .csv data file
+        const csvLog = datalogger.toCsv(telemetryLog)
+        const csvBlob = new Blob([csvLog], { type: 'text/csv' })
+        await videoStorage.setItem(videoTelemetryCsvFilename(recordingData.fileName), csvBlob)
       }
     } catch (error) {
       throw new Error(`Failed to generate telemetry for recording '${recordingHash}': ${error}`)

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -363,6 +363,14 @@ export interface ZipExtractionResult {
    */
   assFilePath?: string
   /**
+   * Path to extracted telemetry .json file (if exists)
+   */
+  jsonFilePath?: string
+  /**
+   * Path to extracted telemetry .csv file (if exists)
+   */
+  csvFilePath?: string
+  /**
    * Recording hash extracted from chunk filenames
    */
   hash: string

--- a/src/utils/video.ts
+++ b/src/utils/video.ts
@@ -41,3 +41,23 @@ export const videoThumbnailFilename = (videoFileName: string): string => {
 export const videoSubtitlesFilename = (videoFileName: string): string => {
   return `${videoFilenameWithoutExtension(videoFileName)}.ass`
 }
+
+/**
+ * Returns the filename for the JSON telemetry data of a video.
+ * Can be used with complete paths or just the filename. It will just replace the extension with .json.
+ * @param {string} videoFileName - The filename of the video, with or without the extension.
+ * @returns {string} The filename for the JSON telemetry data of the video.
+ */
+export const videoTelemetryJsonFilename = (videoFileName: string): string => {
+  return `${videoFilenameWithoutExtension(videoFileName)}.json`
+}
+
+/**
+ * Returns the filename for the CSV telemetry data of a video.
+ * Can be used with complete paths or just the filename. It will just replace the extension with .csv.
+ * @param {string} videoFileName - The filename of the video, with or without the extension.
+ * @returns {string} The filename for the CSV telemetry data of the video.
+ */
+export const videoTelemetryCsvFilename = (videoFileName: string): string => {
+  return `${videoFilenameWithoutExtension(videoFileName)}.csv`
+}

--- a/src/views/ToolsLogsView.vue
+++ b/src/views/ToolsLogsView.vue
@@ -1,0 +1,290 @@
+<template>
+  <BaseConfigurationView>
+    <template #title>Data Logs</template>
+    <template #content>
+      <div
+        class="max-h-[85vh] overflow-y-auto -mr-4"
+        :class="interfaceStore.isOnSmallScreen ? 'max-w-[70vw]' : 'max-w-[40vw]'"
+      >
+        <ExpansiblePanel :is-expanded="true" no-top-divider>
+          <template #title>
+            <div class="flex justify-between items-center w-full">
+              <span>Data Sessions</span>
+              <div class="flex items-center gap-2">
+                <span class="text-sm text-gray-300 cursor-pointer" @click.stop="refreshSessions">
+                  <v-tooltip text="Refresh sessions">
+                    <template #activator="{ props }">
+                      <v-icon v-bind="props" :class="{ 'animate-spin': isLoading }">mdi-refresh</v-icon>
+                    </template>
+                  </v-tooltip>
+                </span>
+                <span class="text-sm text-gray-300 cursor-pointer" @click.stop="deleteOldSessions">
+                  <v-tooltip text="Delete sessions older than 24 hours">
+                    <template #activator="{ props }">
+                      <v-icon v-bind="props">mdi-delete-sweep</v-icon>
+                    </template>
+                  </v-tooltip>
+                </span>
+              </div>
+            </div>
+          </template>
+          <template #info>
+            Vehicle data is continuously logged while Cockpit is open. Download session logs in JSON or CSV format for
+            analysis. <br /><br />
+            <strong>Logged variables:</strong> Roll, Pitch, Heading, Depth, Mode, Battery voltage, Battery current, GPS
+            satellites, GPS status, Latitude, Longitude, Mission name, Time, Date, Instantaneous power, plus any values
+            displayed on Very Generic Indicators.
+          </template>
+          <template #content>
+            <div v-if="isLoading" class="flex justify-center items-center py-8">
+              <v-progress-circular indeterminate color="white" />
+            </div>
+            <div v-else-if="sessions.length === 0" class="text-center py-8 text-gray-400">
+              No data sessions found. Data is recorded automatically while Cockpit is connected to a vehicle.
+            </div>
+            <v-data-table
+              v-else
+              :items="sessions"
+              density="compact"
+              theme="dark"
+              :headers="headers"
+              class="w-full max-h-[60%] rounded-md bg-[#FFFFFF11]"
+            >
+              <template #item.dateTimeFormatted="{ item }">
+                <div class="flex items-center gap-2">
+                  <span>{{ item.dateTimeFormatted }}</span>
+                  <div v-if="item.isCurrentSession" class="current-session-indicator" />
+                </div>
+              </template>
+              <template #item.dataPointCount="{ item }"> {{ item.dataPointCount.toLocaleString() }} points </template>
+              <template #item.durationSeconds="{ item }">
+                {{ formatDuration(item.durationSeconds) }}
+              </template>
+              <template #item.actions="{ item }">
+                <div class="flex justify-center space-x-2">
+                  <v-menu>
+                    <template #activator="{ props }">
+                      <div
+                        v-bind="props"
+                        class="cursor-pointer icon-btn mdi mdi-download"
+                        :class="{ 'opacity-50': isDownloading === item.id }"
+                      />
+                    </template>
+                    <v-list density="compact" class="bg-[#333]">
+                      <v-list-item @click="downloadSession(item, 'json')">
+                        <v-list-item-title class="flex items-center gap-2">
+                          <v-icon size="small">mdi-code-json</v-icon>
+                          Download as JSON
+                        </v-list-item-title>
+                      </v-list-item>
+                      <v-list-item @click="downloadSession(item, 'csv')">
+                        <v-list-item-title class="flex items-center gap-2">
+                          <v-icon size="small">mdi-file-delimited</v-icon>
+                          Download as CSV
+                        </v-list-item-title>
+                      </v-list-item>
+                    </v-list>
+                  </v-menu>
+                  <div
+                    class="cursor-pointer icon-btn mdi mdi-delete"
+                    :class="{ 'opacity-50 pointer-events-none': item.isCurrentSession }"
+                    @click="!item.isCurrentSession && deleteSession(item)"
+                  />
+                </div>
+              </template>
+            </v-data-table>
+          </template>
+        </ExpansiblePanel>
+      </div>
+    </template>
+  </BaseConfigurationView>
+</template>
+
+<script setup lang="ts">
+// @ts-nocheck
+// TODO: As of now Vuetify does not export the necessary types for VDataTable, so we can't fix the type error.
+
+import { format } from 'date-fns'
+import { saveAs } from 'file-saver'
+import { onBeforeMount, onBeforeUnmount, ref } from 'vue'
+
+import ExpansiblePanel from '@/components/ExpansiblePanel.vue'
+import { useSnackbar } from '@/composables/snackbar'
+import { type DataSessionInfo, DataLogger, datalogger } from '@/libs/sensors-logging'
+import { useAppInterfaceStore } from '@/stores/appInterface'
+
+import BaseConfigurationView from './BaseConfigurationView.vue'
+
+const interfaceStore = useAppInterfaceStore()
+const { openSnackbar } = useSnackbar()
+
+const sessions = ref<DataSessionInfo[]>([])
+const isLoading = ref(false)
+const isDownloading = ref<string | null>(null)
+let refreshInterval: ReturnType<typeof setInterval> | null = null
+
+const headers = [
+  { title: 'Date/Time', key: 'dateTimeFormatted', sortable: true },
+  { title: 'Data Points', key: 'dataPointCount', sortable: true },
+  { title: 'Duration', key: 'durationSeconds', sortable: true },
+  { title: 'Actions', key: 'actions', sortable: false },
+]
+
+const formatDuration = (seconds: number): string => {
+  if (seconds < 60) {
+    return `${seconds}s`
+  }
+  const minutes = Math.floor(seconds / 60)
+  const remainingSeconds = seconds % 60
+  if (minutes < 60) {
+    return `${minutes}m ${remainingSeconds}s`
+  }
+  const hours = Math.floor(minutes / 60)
+  const remainingMinutes = minutes % 60
+  return `${hours}h ${remainingMinutes}m`
+}
+
+const refreshSessions = async (): Promise<void> => {
+  isLoading.value = true
+  try {
+    sessions.value = await DataLogger.getDataSessions()
+  } catch (error) {
+    console.error('Error loading data sessions:', error)
+    openSnackbar({ message: 'Failed to load data sessions', variant: 'error' })
+  } finally {
+    isLoading.value = false
+  }
+}
+
+// Light refresh that only updates the current session's data point count
+const lightRefresh = async (): Promise<void> => {
+  try {
+    const updatedSessions = await DataLogger.getDataSessions()
+    // Only update if we have sessions
+    if (updatedSessions.length > 0 && sessions.value.length > 0) {
+      // Find and update the current session
+      const currentSession = updatedSessions.find((s) => s.isCurrentSession)
+      if (currentSession) {
+        const index = sessions.value.findIndex((s) => s.isCurrentSession)
+        if (index !== -1) {
+          sessions.value[index] = currentSession
+        } else {
+          // Current session is new, do a full refresh
+          sessions.value = updatedSessions
+        }
+      }
+    } else {
+      sessions.value = updatedSessions
+    }
+  } catch (error) {
+    // Silently fail on light refresh
+  }
+}
+
+onBeforeMount(async () => {
+  await refreshSessions()
+  // Refresh current session info every 5 seconds
+  refreshInterval = setInterval(lightRefresh, 5000)
+})
+
+onBeforeUnmount(() => {
+  if (refreshInterval) {
+    clearInterval(refreshInterval)
+    refreshInterval = null
+  }
+})
+
+const downloadSession = async (session: DataSessionInfo, formatType: 'json' | 'csv'): Promise<void> => {
+  if (isDownloading.value) return
+
+  isDownloading.value = session.id
+  try {
+    openSnackbar({ message: 'Generating log file...', variant: 'info', duration: 2000 })
+
+    const log = await DataLogger.generateLogFromSession(session)
+
+    if (log.length === 0) {
+      openSnackbar({ message: 'No data points found in session', variant: 'warning' })
+      return
+    }
+
+    let content: string
+    let mimeType: string
+    let extension: string
+
+    if (formatType === 'json') {
+      content = datalogger.toJson(log)
+      mimeType = 'application/json'
+      extension = 'json'
+    } else {
+      content = datalogger.toCsv(log)
+      mimeType = 'text/csv'
+      extension = 'csv'
+    }
+
+    const blob = new Blob([content], { type: mimeType })
+    const dateStr = format(new Date(session.startTime), 'yyyy-MM-dd_HH-mm-ss')
+    const fileName = `Cockpit_Data_Log_${dateStr}.${extension}`
+    saveAs(blob, fileName)
+
+    openSnackbar({ message: `Downloaded ${fileName}`, variant: 'success' })
+  } catch (error) {
+    console.error('Error downloading session:', error)
+    openSnackbar({ message: 'Failed to download session', variant: 'error' })
+  } finally {
+    isDownloading.value = null
+  }
+}
+
+const deleteSession = async (session: DataSessionInfo): Promise<void> => {
+  if (session.isCurrentSession) {
+    openSnackbar({ message: 'Cannot delete the current active session', variant: 'warning' })
+    return
+  }
+
+  try {
+    await DataLogger.deleteDataSession(session)
+    sessions.value = sessions.value.filter((s) => s.id !== session.id)
+    openSnackbar({ message: 'Session deleted', variant: 'success' })
+  } catch (error) {
+    console.error('Error deleting session:', error)
+    openSnackbar({ message: 'Failed to delete session', variant: 'error' })
+  }
+}
+
+const deleteOldSessions = async (): Promise<void> => {
+  try {
+    const deletedCount = await DataLogger.deleteOldDataSessions(1)
+    if (deletedCount > 0) {
+      await refreshSessions()
+      openSnackbar({ message: `Deleted ${deletedCount} old session(s)`, variant: 'success' })
+    } else {
+      openSnackbar({ message: 'No old sessions to delete', variant: 'info' })
+    }
+  } catch (error) {
+    console.error('Error deleting old sessions:', error)
+    openSnackbar({ message: 'Failed to delete old sessions', variant: 'error' })
+  }
+}
+</script>
+
+<style scoped>
+.current-session-indicator {
+  width: 8px;
+  height: 8px;
+  margin-top: 2px;
+  border-radius: 50%;
+  background-color: #ef4444;
+  animation: blink 1.5s infinite;
+}
+
+@keyframes blink {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
+}
+</style>


### PR DESCRIPTION
I'm opening this so we make the binary available for users that need to try it (we had some in both the Discord and forum).

It allows users to download the sensor logs that are stored in Cockpit (the same ones that are used to generate the .ass video overlay file) in both CSV and JSON format.

We probably want to allow users to download it in ASS format as well (maybe allowing them to specify the video resolution to do that).

<img width="925" height="791" alt="image" src="https://github.com/user-attachments/assets/cb047439-c61f-491b-a8bb-ea35aa77b7b8" />


Should be used with care.

Fixes #2238