### PR TITLE
initial-screen: make spinner and logo look centered

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,8 +62,8 @@
 <body>
     <div id="non-app-main">
         <div id="loading-screen">
-            <img src="/cockpit-name-logo.png" alt="Cockpit" id="loading-logo" />
-            <div id="loading-spinner"></div>
+            <img src="/cockpit-name-logo.png" alt="Cockpit" id="loading-logo" style="margin-right: 2rem;"/>
+            <div id="loading-spinner" style="margin-left: 2rem;"></div>
         </div>
     </div>
     <div id="app"></div>


### PR DESCRIPTION
Even though the logo image and the spinner are mathematically centered (1), the combination of the logo graphic and text makes them appear slightly off-center (2).
To mitigate this optical illusion, a small right margin was added to the image and a small left margin was added to the spinner (3).

(1)
<img width="1914" height="1059" alt="2026-03-13_10-39" src="https://github.com/user-attachments/assets/5da5514a-23a4-44e2-8cd2-5536ad534393" />

(2)
<img width="1917" height="1058" alt="2026-03-13_10-39_1" src="https://github.com/user-attachments/assets/446dd34f-22f3-42d1-9a7b-d8480a4cac47" />

(3)
<img width="1914" height="1058" alt="2026-03-13_10-45" src="https://github.com/user-attachments/assets/77699b92-840b-4e89-961f-d9322bbef9c4" />