### PR TITLE
Fix initial sync for vehicles which don't have any settings

### DIFF
--- a/src/libs/settings-management.ts
+++ b/src/libs/settings-management.ts
@@ -732,7 +732,7 @@ export class SettingsManager {
     const getOldStyleVehicleSettingsFn = () => this.vehicle.getKeyData(vehicleAddress, vehicleOldStyleSettingsKey)
     const oldStyleVehicleSettings = await tryACoupleOfTimes(getOldStyleVehicleSettingsFn, 0, 300)
 
-    if (Object.keys(oldStyleVehicleSettings).length === 0) {
+    if (!oldStyleVehicleSettings || Object.keys(oldStyleVehicleSettings).length === 0) {
       console.warn('[SettingsManager] No old-style vehicle settings found. Skipping backup.')
       return
     }
@@ -768,7 +768,7 @@ export class SettingsManager {
     const getOldStyleVehicleSettingsFn = () => this.vehicle.getKeyData(vehicleAddress, vehicleOldStyleSettingsKey)
     const oldStyleVehicleSettings = await tryACoupleOfTimes(getOldStyleVehicleSettingsFn, 0, 300)
 
-    if (Object.keys(oldStyleVehicleSettings).length === 0) {
+    if (!oldStyleVehicleSettings || Object.keys(oldStyleVehicleSettings).length === 0) {
       console.warn('[SettingsManager] No old-style vehicle settings found. Skipping migration.')
       return
     }
@@ -805,7 +805,7 @@ export class SettingsManager {
     const getNewStyleVehicleSettingsFn = () => this.vehicle.getKeyData(vehicleAddress, vehicleNewStyleSettingsKey)
     const newStyleVehicleSettings = await tryACoupleOfTimes(getNewStyleVehicleSettingsFn, 0, 300)
 
-    if (Object.keys(newStyleVehicleSettings).length <= 0) {
+    if (!newStyleVehicleSettings || Object.keys(newStyleVehicleSettings).length <= 0) {
       console.info('[SettingsManager] No new-style vehicle settings found. Aborting import.')
       return
     }


### PR DESCRIPTION
When a vehicle's settings are reset/blank, `getKeyData` returns `undefined`. Calling `Object.keys(undefined)` throws a TypeError that silently kills the entire `handleVehicleGettingOnline` async flow, preventing any settings from being synced or pushed to the vehicle.