### PR TITLE
Prevent generation of binaries without joystick SDL module

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dev:electron": "cross-env ELECTRON=true vite --host",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --ignore-path .gitignore --max-warnings=0",
     "lint:fix": "eslint --fix . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --ignore-path .gitignore --max-warnings=0",
-    "postinstall": "node scripts/download-ffmpeg.js && node scripts/download-go2rtc.js",
+    "postinstall": "node scripts/download-ffmpeg.js && node scripts/download-go2rtc.js && node scripts/verify-sdl.js",
     "preview": "vite preview --port 5050",
     "serve": "vite preview",
     "test:ci": "vitest --coverage --run",

--- a/scripts/verify-sdl.js
+++ b/scripts/verify-sdl.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+/* eslint-disable no-undef */
+
+const { execSync } = require('child_process')
+const fs = require('fs')
+const path = require('path')
+
+/**
+ * Verify that the @kmamal/sdl native binary was properly installed.
+ * Yarn v1 treats dependency install script failures as warnings,
+ * so @kmamal/sdl's own install hook can fail silently, leaving no sdl.node.
+ * This script re-runs the SDL install if the binary is missing, and fails
+ * loudly if recovery also fails - preventing broken Electron builds that
+ * silently fall back to the browser Gamepad API.
+ */
+function verifySDL() {
+  const sdlDir = path.join(__dirname, '..', 'node_modules', '@kmamal', 'sdl')
+  const sdlNodePath = path.join(sdlDir, 'dist', 'sdl.node')
+
+  if (fs.existsSync(sdlNodePath)) {
+    console.log('SDL native module verified: sdl.node exists.')
+    return
+  }
+
+  console.warn('SDL native module not found. Attempting to run the SDL install script...')
+
+  try {
+    execSync('node scripts/install.mjs', { cwd: sdlDir, stdio: 'inherit' })
+  } catch (error) {
+    console.error('SDL install script failed:', error.message)
+  }
+
+  if (fs.existsSync(sdlNodePath)) {
+    console.log('SDL native module recovered successfully: sdl.node exists.')
+    return
+  }
+
+  console.error('')
+  console.error('========================================')
+  console.error('  SDL native module verification failed')
+  console.error('========================================')
+  console.error('')
+  console.error(`  Expected binary not found: ${sdlNodePath}`)
+  console.error('')
+  console.error('  The @kmamal/sdl install script failed to download the')
+  console.error('  pre-built binary. This will cause Cockpit to fall back')
+  console.error('  to the browser Gamepad API with incorrect joystick mappings.')
+  console.error('')
+  console.error('  Check your network connection and ensure you can reach')
+  console.error('  GitHub releases, then run yarn install again.')
+  console.error('')
+  process.exit(1)
+}
+
+verifySDL()


### PR DESCRIPTION
The @kmamal/sdl install script can fail silently, leaving no sdl.node binary and causing Cockpit to fall back to the browser Gamepad API with incorrect joystick mappings. This adds a postinstall check that fails loudly if the binary is missing, preventing broken builds in CI.

Fix #2520