### PR TITLE
Fix and extend support for external widgets from BlueOS extensions

### DIFF
--- a/src/components/EditMenu.vue
+++ b/src/components/EditMenu.vue
@@ -716,8 +716,9 @@ const allAvailableWidgets = computed(() => {
       isExternal: true,
       options: {
         source: widget.iframeUrl,
+        isCollapsible: widget.collapsibleContainerName !== undefined,
         containerName: widget.collapsibleContainerName,
-        startCollapsed: widget.startCollapsed,
+        startCollapsed: widget.startCollapsed ?? false,
         useVehicleAddressAsBase: widget.useExtensionPathAsBaseUrl ?? false,
       },
       defaultSize: widgetDefaultSizes[WidgetType.IFrame],

--- a/src/components/EditMenu.vue
+++ b/src/components/EditMenu.vue
@@ -718,7 +718,7 @@ const allAvailableWidgets = computed(() => {
         source: widget.iframeUrl,
         containerName: widget.collapsibleContainerName,
         startCollapsed: widget.startCollapsed,
-        useVehicleAddressAsBase: widget.useVehicleAddressAsBaseUrl,
+        useVehicleAddressAsBase: widget.useExtensionPathAsBaseUrl ?? false,
       },
       defaultSize: widgetDefaultSizes[WidgetType.IFrame],
     })),

--- a/src/libs/blueos.ts
+++ b/src/libs/blueos.ts
@@ -87,12 +87,15 @@ export const getWidgetsFromBlueOS = async (vehicleAddress: string): Promise<Exte
         const extraJson = await getExtrasJsonFromBlueOsService(vehicleAddress, service)
         const baseUrl = blueOsServiceUrl(vehicleAddress, service)
         if (extraJson !== null) {
+          const extensionPath = new URL(baseUrl).pathname
           widgets.push(
             ...extraJson.widgets.map((widget) => {
+              const useExtPath = widget.useExtensionPathAsBaseUrl ?? false
+
               return {
                 ...widget,
-                iframeUrl: baseUrl + widget.iframeUrl,
-                iframeIcon: baseUrl + widget.iframeIcon,
+                iframeUrl: useExtPath ? extensionPath + widget.iframeUrl : widget.iframeUrl,
+                iframeIcon: useExtPath ? baseUrl + widget.iframeIcon : widget.iframeIcon,
               }
             })
           )

--- a/src/libs/blueos.ts
+++ b/src/libs/blueos.ts
@@ -91,11 +91,12 @@ export const getWidgetsFromBlueOS = async (vehicleAddress: string): Promise<Exte
           widgets.push(
             ...extraJson.widgets.map((widget) => {
               const useExtPath = widget.useExtensionPathAsBaseUrl ?? false
+              const iconUrl = widget.iconUrl ?? widget.iframeIcon ?? ''
 
               return {
                 ...widget,
                 iframeUrl: useExtPath ? extensionPath + widget.iframeUrl : widget.iframeUrl,
-                iframeIcon: useExtPath ? baseUrl + widget.iframeIcon : widget.iframeIcon,
+                iframeIcon: useExtPath ? baseUrl + iconUrl : iconUrl,
               }
             })
           )

--- a/src/libs/blueos/schemas.ts
+++ b/src/libs/blueos/schemas.ts
@@ -50,7 +50,7 @@ const ExternalWidgetSetupInfoSchema = z.object({
   collapsibleContainerName: z.string().optional(),
   version: z.string().optional(),
   startCollapsed: z.boolean().optional(),
-  useVehicleAddressAsBaseUrl: z.boolean().optional(),
+  useExtensionPathAsBaseUrl: z.boolean().optional(),
 })
 
 const HttpRequestActionConfigSchema = z.object({

--- a/src/libs/blueos/schemas.ts
+++ b/src/libs/blueos/schemas.ts
@@ -43,15 +43,20 @@ export const ServiceSchema = preprocessCamelCase(
   })
 )
 
-const ExternalWidgetSetupInfoSchema = z.object({
-  name: z.string(),
-  iframeUrl: z.string(),
-  iframeIcon: z.string(),
-  collapsibleContainerName: z.string().optional(),
-  version: z.string().optional(),
-  startCollapsed: z.boolean().optional(),
-  useExtensionPathAsBaseUrl: z.boolean().optional(),
-})
+const ExternalWidgetSetupInfoSchema = z
+  .object({
+    name: z.string(),
+    iframeUrl: z.string(),
+    iconUrl: z.string().optional(),
+    iframeIcon: z.string().optional(),
+    collapsibleContainerName: z.string().optional(),
+    version: z.string().optional(),
+    startCollapsed: z.boolean().optional(),
+    useExtensionPathAsBaseUrl: z.boolean().optional(),
+  })
+  .refine((data) => data.iconUrl !== undefined || data.iframeIcon !== undefined, {
+    message: 'Either iconUrl or iframeIcon must be provided',
+  })
 
 const HttpRequestActionConfigSchema = z.object({
   name: z.string(),

--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -18,9 +18,14 @@ export interface ExternalWidgetSetupInfo {
   iframeUrl: string
 
   /**
-   * The icon of the widget, this is displayed on the widget browser
+   * The icon URL of the widget, displayed on the widget browser
    */
-  iframeIcon: string
+  iconUrl?: string
+
+  /**
+   * @deprecated Use iconUrl instead
+   */
+  iframeIcon?: string
 
   /**
    * The name of the collapsed container, this is displayed on the widget browser

--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -38,9 +38,11 @@ export interface ExternalWidgetSetupInfo {
   startCollapsed?: boolean
 
   /**
-   * Whether to use vehicle address as base URL for the widget (optional)
+   * Whether to prepend the extension's service path to the widget URLs (optional).
+   * When true, the extension path (e.g. /extensionv2/servicename) is prepended to iframeUrl and the icon URL,
+   * and the IFrame widget's useVehicleAddressAsBase option is set to true.
    */
-  useVehicleAddressAsBaseUrl?: boolean
+  useExtensionPathAsBaseUrl?: boolean
 }
 
 /**


### PR DESCRIPTION
Does not work with the current RadCam Manager version. To be tested with an upcoming extension release.

Fix #2528