### PR TITLE
video: Consider new "idle" stream state from MCM as "available"

### DIFF
--- a/src/libs/blueos.ts
+++ b/src/libs/blueos.ts
@@ -209,6 +209,7 @@ type VideoSource = {
 type StreamInfo = {
   id: string
   running: boolean
+  state?: string
   error: string | null
   video_and_stream: {
     name: string
@@ -491,7 +492,7 @@ export const getStreamInformationFromVehicle = async (vehicleAddress: string): P
         width: config.width,
         height: config.height,
         fps,
-        running: stream.running,
+        running: stream.running || stream.state === 'idle' || stream.state === 'running',
         rtspSourceUrl,
       }
     })


### PR DESCRIPTION
New MCM versions introduce a `state` property on streams. When state is "idle" (no one currently connected), `running` is false, but the stream is still available. Treat `state === "idle"` as running so these streams show as available rather than offline.

Backward-compatible: when `state` is absent (old MCM), the logic falls back to `running` alone.

Fix #2534