### PR TITLE
ui: joystick: Fix vertical spacing in the input mapping dialog

### DIFF
--- a/src/views/ConfigurationJoystickView.vue
+++ b/src/views/ConfigurationJoystickView.vue
@@ -512,7 +512,7 @@
                   Unmap Input
                 </v-btn>
               </div>
-              <div class="flex-1"></div>
+              <div class="flex-1 my-4"></div>
               <div class="flex flex-col items-start text-sm font-semibold gap-y-1">
                 <div class="flex items-center">
                   <img src="@/assets/cockpit-logo.avif" class="w-4 h-4 mr-2" alt="Cockpit" />


### PR DESCRIPTION
Before:

<img width="672" height="614" alt="image" src="https://github.com/user-attachments/assets/b1e79124-79b3-4ec5-a2ca-cdf57465b8c7" />

After:

<img width="638" height="578" alt="image" src="https://github.com/user-attachments/assets/831268ab-8e38-4e40-8d74-fcced765987a" />
