### PR TITLE
Allow reseting Actions and Button Mapping Suggestion from the External Features dialog

### DIFF
--- a/src/components/ExternalFeaturesDiscoveryModal.vue
+++ b/src/components/ExternalFeaturesDiscoveryModal.vue
@@ -393,7 +393,12 @@
                           <div
                             v-for="suggestion in group.buttonMappingSuggestions"
                             :key="suggestion.id"
-                            class="suggestion-item-compact p-3 border border-green-500/30 rounded-lg bg-green-900/10"
+                            class="suggestion-item-compact p-3 rounded-lg"
+                            :class="
+                              suggestionDiffersFromCurrentMapping(suggestion)
+                                ? 'border border-orange-500/30 bg-orange-900/10'
+                                : 'border border-green-500/30 bg-green-900/10'
+                            "
                           >
                             <div class="text-center mb-3">
                               <h4 class="font-medium text-white mb-1">{{ suggestion.actionName }}</h4>
@@ -410,9 +415,45 @@
                               </div>
                             </div>
                             <div class="flex justify-center">
-                              <v-chip color="green" variant="tonal" prepend-icon="mdi-check" size="small">
+                              <v-chip
+                                v-if="!suggestionDiffersFromCurrentMapping(suggestion)"
+                                color="green"
+                                variant="tonal"
+                                prepend-icon="mdi-check"
+                                size="small"
+                              >
                                 Applied
                               </v-chip>
+                              <v-chip
+                                v-else
+                                color="orange"
+                                variant="tonal"
+                                prepend-icon="mdi-alert-outline"
+                                size="small"
+                              >
+                                Applied but changed
+                              </v-chip>
+                            </div>
+                            <div
+                              v-if="suggestionDiffersFromCurrentMapping(suggestion)"
+                              class="flex justify-center gap-4 mt-3"
+                            >
+                              <v-btn
+                                variant="text"
+                                prepend-icon="mdi-close"
+                                size="small"
+                                @click="moveAppliedSuggestionToIgnored(suggestion)"
+                              >
+                                Ignore
+                              </v-btn>
+                              <v-btn
+                                variant="tonal"
+                                prepend-icon="mdi-plus-circle-outline"
+                                size="small"
+                                @click="openJoystickSuggestionDialog(suggestion, extensionGroup.extensionName)"
+                              >
+                                Re-apply
+                              </v-btn>
                             </div>
                           </div>
                         </div>
@@ -1095,6 +1136,19 @@ const ignoreSuggestion = (suggestion: JoystickMapSuggestion): void => {
 }
 
 /**
+ * Move an applied suggestion to the ignored list
+ * @param {JoystickMapSuggestion} suggestion - The suggestion to move
+ */
+const moveAppliedSuggestionToIgnored = (suggestion: JoystickMapSuggestion): void => {
+  handledSuggestions.value.applied = handledSuggestions.value.applied.filter((id) => id !== suggestion.id)
+  addIgnoredSuggestionIds([suggestion.id])
+  openSnackbar({
+    message: `Mapping "${suggestion.actionName}" moved to ignored.`,
+    variant: 'info',
+  })
+}
+
+/**
  * Ignore all currently visible suggestions from an extension
  * @param {FilteredExtensionGroups} extensionGroup - Extension with filtered remaining suggestions
  */
@@ -1356,25 +1410,13 @@ const restoreAllIgnoredSuggestions = (extensionName: string): void => {
 
   const suggestionsToRestore = getAllSuggestionsFromExtension(extensionGroup)
 
-  if (suggestionsToRestore.length === 0) {
-    openSnackbar({
-      message: `No ignored suggestions found for ${extensionName}.`,
-      variant: 'info',
-    })
-    return
-  }
+  if (suggestionsToRestore.length === 0) return
 
-  const confirmed = confirm(
-    `Are you sure you want to restore all ${suggestionsToRestore.length} ignored joystick mappings from ${extensionName}? They will appear in the New Suggestions section.`
-  )
-
-  if (confirmed) {
-    removeIgnoredSuggestionIds(suggestionsToRestore.map((suggestion) => suggestion.id))
-    openSnackbar({
-      message: `Restored ${suggestionsToRestore.length} ignored joystick mappings from ${extensionName}.`,
-      variant: 'success',
-    })
-  }
+  removeIgnoredSuggestionIds(suggestionsToRestore.map((suggestion) => suggestion.id))
+  openSnackbar({
+    message: `Restored ${suggestionsToRestore.length} ignored joystick mappings from ${extensionName}.`,
+    variant: 'success',
+  })
 }
 
 /**
@@ -1382,22 +1424,11 @@ const restoreAllIgnoredSuggestions = (extensionName: string): void => {
  * @param {JoystickMapSuggestion} suggestion - The suggestion to restore
  */
 const restoreIgnoredSuggestion = (suggestion: JoystickMapSuggestion): void => {
-  const extensionGroup = ignoredJoystickSuggestionsByExtension.value.find((ext) =>
-    getAllSuggestionsFromExtension(ext).some((s) => s.id === suggestion.id)
-  )
-  const extensionName = extensionGroup?.extensionName || 'Unknown Extension'
-
-  const confirmed = confirm(
-    `Are you sure you want to restore the ignored joystick mapping "${suggestion.actionName}" from ${extensionName}? It will appear in the New Suggestions section.`
-  )
-
-  if (confirmed) {
-    removeIgnoredSuggestionIds([suggestion.id])
-    openSnackbar({
-      message: `Restored ignored joystick mapping "${suggestion.actionName}" from ${extensionName}.`,
-      variant: 'success',
-    })
-  }
+  removeIgnoredSuggestionIds([suggestion.id])
+  openSnackbar({
+    message: `Mapping "${suggestion.actionName}" restored.`,
+    variant: 'success',
+  })
 }
 
 /**

--- a/src/components/ExternalFeaturesDiscoveryModal.vue
+++ b/src/components/ExternalFeaturesDiscoveryModal.vue
@@ -16,43 +16,171 @@
       <v-tabs-window v-model="activeTab">
         <!-- Actions Tab -->
         <v-tabs-window-item value="actions">
-          <div v-if="filteredActions.length === 0" class="text-center py-8">
-            <v-icon size="50" color="grey" class="mb-3">mdi-lightning-bolt-outline</v-icon>
-            <p class="text-grey-lighten-1">No new actions available.</p>
-          </div>
+          <div class="actions-container">
+            <div
+              v-if="filteredActions.length === 0 && appliedActions.length === 0 && ignoredActions.length === 0"
+              class="text-center py-8"
+            >
+              <v-icon size="50" color="grey" class="mb-3">mdi-lightning-bolt-outline</v-icon>
+              <p class="text-grey-lighten-1">No actions available from extensions.</p>
+            </div>
 
-          <div v-else class="actions-container">
-            <p class="mb-2">The following actions are offered to be added by BlueOS extensions:</p>
+            <!-- New Actions -->
+            <div v-if="filteredActions.length > 0" class="mb-4">
+              <div class="flex items-center gap-2 mb-2">
+                <v-icon size="24" color="blue">mdi-lightning-bolt-outline</v-icon>
+                <h2 class="text-xl font-semibold">New Actions</h2>
+              </div>
+              <p class="mb-2 text-grey-lighten-1">
+                The following actions are offered to be added by BlueOS extensions:
+              </p>
+              <v-list class="bg-transparent">
+                <v-list-item v-for="action in filteredActions" :key="action.id" class="mb-3 p-0">
+                  <v-card variant="outlined" class="w-full action-card">
+                    <v-card-item>
+                      <v-card-title class="font-medium pb-0">{{ action.name }}</v-card-title>
+                      <v-card-subtitle class="text-grey-lighten-1">
+                        {{ getActionTypeName(action.type) }}
+                      </v-card-subtitle>
+                      <v-card-text v-if="getActionDescription(action)" class="pt-1 text-sm">
+                        {{ getActionDescription(action) }}
+                      </v-card-text>
+                      <div class="flex justify-between items-center mt-2">
+                        <v-btn variant="text" prepend-icon="mdi-close" size="small" @click="ignoreAction(action)">
+                          Ignore
+                        </v-btn>
+                        <span class="text-xs text-grey-lighten-1">from {{ action.extensionName }}</span>
+                        <v-btn
+                          variant="tonal"
+                          prepend-icon="mdi-plus-circle-outline"
+                          size="small"
+                          @click="addAction(action)"
+                        >
+                          Add Action
+                        </v-btn>
+                      </div>
+                    </v-card-item>
+                  </v-card>
+                </v-list-item>
+              </v-list>
+            </div>
 
-            <v-list class="bg-transparent">
-              <v-list-item v-for="action in filteredActions" :key="action.id" class="mb-3 p-0">
-                <v-card variant="outlined" class="w-full action-card">
-                  <v-card-item>
-                    <v-card-title class="font-medium pb-0">{{ action.name }}</v-card-title>
-                    <v-card-subtitle class="text-grey-lighten-1">
-                      {{ getActionTypeName(action.type) }}
-                    </v-card-subtitle>
-                    <v-card-text v-if="getActionDescription(action)" class="pt-1 text-sm">
-                      {{ getActionDescription(action) }}
-                    </v-card-text>
-                    <div class="flex justify-between items-center mt-2">
-                      <v-btn variant="text" prepend-icon="mdi-close" size="small" @click="ignoreAction(action)">
-                        Ignore
-                      </v-btn>
-                      <span class="text-xs text-grey-lighten-1">from {{ action.extensionName }}</span>
-                      <v-btn
-                        variant="tonal"
-                        prepend-icon="mdi-plus-circle-outline"
-                        size="small"
-                        @click="addAction(action)"
-                      >
-                        Add Action
-                      </v-btn>
-                    </div>
-                  </v-card-item>
-                </v-card>
-              </v-list-item>
-            </v-list>
+            <!-- Applied Actions -->
+            <div v-if="appliedActions.length > 0" class="mb-4">
+              <v-btn
+                variant="text"
+                color="grey-lighten-1"
+                class="opacity-70 hover:opacity-100"
+                :prepend-icon="showAppliedActions ? 'mdi-chevron-up' : 'mdi-chevron-down'"
+                @click="showAppliedActions = !showAppliedActions"
+              >
+                {{ showAppliedActions ? 'Hide applied actions' : 'Show applied actions' }}
+              </v-btn>
+              <div v-if="showAppliedActions" class="mt-2">
+                <v-list class="bg-transparent">
+                  <v-list-item v-for="action in appliedActions" :key="action.id" class="mb-3 p-0">
+                    <v-card
+                      variant="outlined"
+                      class="w-full"
+                      :class="existingActionNames.has(action.name) ? 'border-green-500/30' : 'border-orange-500/30'"
+                    >
+                      <v-card-item>
+                        <v-card-title class="font-medium pb-0">{{ action.name }}</v-card-title>
+                        <v-card-subtitle class="text-grey-lighten-1">
+                          {{ getActionTypeName(action.type) }}
+                        </v-card-subtitle>
+                        <div class="flex justify-between items-center mt-2">
+                          <v-chip
+                            v-if="existingActionNames.has(action.name)"
+                            color="green"
+                            variant="tonal"
+                            prepend-icon="mdi-check"
+                            size="small"
+                          >
+                            Applied
+                          </v-chip>
+                          <v-chip v-else color="orange" variant="tonal" prepend-icon="mdi-alert-outline" size="small">
+                            Applied but removed
+                          </v-chip>
+                          <span class="text-xs text-grey-lighten-1">from {{ action.extensionName }}</span>
+                        </div>
+                        <div v-if="!existingActionNames.has(action.name)" class="flex justify-center gap-4 mt-3">
+                          <v-btn
+                            variant="text"
+                            prepend-icon="mdi-close"
+                            size="small"
+                            @click="moveAppliedToIgnored(action)"
+                          >
+                            Ignore
+                          </v-btn>
+                          <v-btn
+                            variant="tonal"
+                            prepend-icon="mdi-plus-circle-outline"
+                            size="small"
+                            @click="reAddAction(action)"
+                          >
+                            Re-add
+                          </v-btn>
+                        </div>
+                      </v-card-item>
+                    </v-card>
+                  </v-list-item>
+                </v-list>
+              </div>
+            </div>
+
+            <!-- Ignored Actions -->
+            <div v-if="ignoredActions.length > 0" class="mb-4">
+              <v-btn
+                variant="text"
+                color="grey-lighten-1"
+                class="opacity-70 hover:opacity-100"
+                :prepend-icon="showIgnoredActions ? 'mdi-chevron-up' : 'mdi-chevron-down'"
+                @click="showIgnoredActions = !showIgnoredActions"
+              >
+                {{ showIgnoredActions ? 'Hide ignored actions' : 'Show ignored actions' }}
+              </v-btn>
+              <div v-if="showIgnoredActions" class="mt-2">
+                <div class="flex justify-end mb-2">
+                  <v-btn
+                    variant="tonal"
+                    color="blue"
+                    prepend-icon="mdi-restore"
+                    size="small"
+                    @click="restoreAllIgnoredActions"
+                  >
+                    Restore All
+                  </v-btn>
+                </div>
+                <v-list class="bg-transparent">
+                  <v-list-item v-for="action in ignoredActions" :key="action.id" class="mb-3 p-0">
+                    <v-card variant="outlined" class="w-full border-orange-500/30">
+                      <v-card-item>
+                        <v-card-title class="font-medium pb-0">{{ action.name }}</v-card-title>
+                        <v-card-subtitle class="text-grey-lighten-1">
+                          {{ getActionTypeName(action.type) }}
+                        </v-card-subtitle>
+                        <div class="flex justify-between items-center mt-2">
+                          <v-chip color="orange" variant="tonal" prepend-icon="mdi-close-circle" size="small">
+                            Ignored
+                          </v-chip>
+                          <span class="text-xs text-grey-lighten-1">from {{ action.extensionName }}</span>
+                          <v-btn
+                            variant="tonal"
+                            color="blue"
+                            prepend-icon="mdi-restore"
+                            size="small"
+                            @click="restoreIgnoredAction(action)"
+                          >
+                            Restore
+                          </v-btn>
+                        </div>
+                      </v-card-item>
+                    </v-card>
+                  </v-list-item>
+                </v-list>
+              </div>
+            </div>
           </div>
         </v-tabs-window-item>
 
@@ -625,6 +753,16 @@ const showAppliedMappings = ref(false)
 const showIgnoredMappings = ref(false)
 
 /**
+ * Controls visibility of applied actions section
+ */
+const showAppliedActions = ref(false)
+
+/**
+ * Controls visibility of ignored actions section
+ */
+const showIgnoredActions = ref(false)
+
+/**
  * Action with extension name
  */
 type ActionWithExtensionName = ActionConfig & {
@@ -762,12 +900,46 @@ const acceptAllGroupSuggestionDiffRows = computed(() => {
 })
 
 /**
- * Filter out actions that have already been applied or ignored
+ * Reactive trigger to force re-evaluation of existingActionNames after registration changes
+ */
+const actionRegistryVersion = ref(0)
+
+/**
+ * Names of actions already registered in the app
+ */
+const existingActionNames = computed(() => {
+  void actionRegistryVersion.value
+  return new Set([
+    ...Object.values(getAllHttpRequestActionConfigs()).map((a) => a.name),
+    ...Object.values(getAllMavlinkMessageActionConfigs()).map((a) => a.name),
+    ...Object.values(getAllJavascriptActionConfigs()).map((a) => a.name),
+  ])
+})
+
+/**
+ * New actions not yet applied, ignored, or already registered in the app
  */
 const filteredActions = computed(() => {
   return discoveredActions.value.filter(
-    (action) => !appliedActionIds.value.includes(action.id) && !ignoredActionIds.value.includes(action.id)
+    (action) =>
+      !appliedActionIds.value.includes(action.id) &&
+      !ignoredActionIds.value.includes(action.id) &&
+      !existingActionNames.value.has(action.name)
   )
+})
+
+/**
+ * Actions that have been applied
+ */
+const appliedActions = computed(() => {
+  return discoveredActions.value.filter((action) => appliedActionIds.value.includes(action.id))
+})
+
+/**
+ * Actions that have been ignored
+ */
+const ignoredActions = computed(() => {
+  return discoveredActions.value.filter((action) => ignoredActionIds.value.includes(action.id))
 })
 
 /**
@@ -1112,6 +1284,28 @@ const addAction = (action: ActionConfig): void => {
 }
 
 /**
+ * Re-add a previously applied action that was removed from the app
+ * @param {ActionConfig} action - The action to re-add
+ */
+const reAddAction = (action: ActionConfig): void => {
+  addAction(action)
+  actionRegistryVersion.value++
+}
+
+/**
+ * Move an action from the applied list to the ignored list
+ * @param {ActionWithExtensionName} action - The action to move
+ */
+const moveAppliedToIgnored = (action: ActionWithExtensionName): void => {
+  handledActions.value.applied = handledActions.value.applied.filter((id) => id !== action.id)
+  handledActions.value.ignored.push(action.id)
+  openSnackbar({
+    message: `Action "${action.name}" moved to ignored.`,
+    variant: 'info',
+  })
+}
+
+/**
  * Ignore an action
  * @param {ActionConfig} action - The action to ignore
  */
@@ -1120,6 +1314,33 @@ const ignoreAction = (action: ActionConfig): void => {
   openSnackbar({
     message: `Action "${action.name}" has been ignored.`,
     variant: 'info',
+  })
+}
+
+/**
+ * Restore a single ignored action back to the new actions list
+ * @param {ActionWithExtensionName} action - The action to restore
+ */
+const restoreIgnoredAction = (action: ActionWithExtensionName): void => {
+  handledActions.value.ignored = handledActions.value.ignored.filter((id) => id !== action.id)
+  openSnackbar({
+    message: `Action "${action.name}" restored.`,
+    variant: 'success',
+  })
+}
+
+/**
+ * Restore all ignored actions back to the new actions list
+ */
+const restoreAllIgnoredActions = (): void => {
+  const count = ignoredActions.value.length
+  if (count === 0) return
+
+  const idsToRestore = ignoredActions.value.map((a) => a.id)
+  handledActions.value.ignored = handledActions.value.ignored.filter((id) => !idsToRestore.includes(id))
+  openSnackbar({
+    message: `Restored ${count} ignored action(s).`,
+    variant: 'success',
   })
 }
 
@@ -1202,27 +1423,7 @@ const checkForBlueOSActions = async (): Promise<void> => {
       }))
     )
 
-    if (actions.length > 0) {
-      // Get all existing actions from the app
-      const existingHttpActions = getAllHttpRequestActionConfigs()
-      const existingMavlinkActions = getAllMavlinkMessageActionConfigs()
-      const existingJavascriptActions = getAllJavascriptActionConfigs()
-
-      // Extract names of existing actions
-      const existingActionNames = new Set([
-        ...Object.values(existingHttpActions).map((action) => action.name),
-        ...Object.values(existingMavlinkActions).map((action) => action.name),
-        ...Object.values(existingJavascriptActions).map((action) => action.name),
-      ])
-
-      // Filter out actions that have the same name as existing ones
-      const actionsToDisplay = actions.filter((action) => !existingActionNames.has(action.name))
-
-      if (actionsToDisplay.length > 0) {
-        // Actions now include extension names from the getActionsFromBlueOS function
-        discoveredActions.value = actionsToDisplay
-      }
-    }
+    discoveredActions.value = actions
   } catch (error) {
     console.error('Failed to fetch actions from BlueOS:', error)
   }
@@ -1242,30 +1443,53 @@ const checkForBlueOSJoystickSuggestions = async (): Promise<void> => {
 }
 
 /**
- * Check for both actions and joystick suggestions
+ * Whether the modal was opened manually by the user (vs auto-opened on mount)
  */
-const checkForBlueOSFeatures = async (): Promise<void> => {
-  await Promise.all([checkForBlueOSActions(), checkForBlueOSJoystickSuggestions()])
+const openedManually = ref(false)
 
-  // Show modal if there are any features available
+/**
+ * Guard to prevent the isVisible watcher from treating an auto-open as manual
+ */
+let isAutoOpening = false
+
+/**
+ * Fetch features from BlueOS without changing modal visibility
+ */
+const fetchBlueOSFeatures = async (): Promise<void> => {
+  await Promise.all([checkForBlueOSActions(), checkForBlueOSJoystickSuggestions()])
+}
+
+onMounted(async () => {
+  if (!props.autoCheckOnMount) return
+  await fetchBlueOSFeatures()
   if (hasPendingBlueOSFeatures.value) {
+    isAutoOpening = true
     isVisible.value = true
-    // Set active tab based on what's available
     if (filteredJoystickSuggestionsByExtension.value.length > 0 && filteredActions.value.length === 0) {
       activeTab.value = 'joystick-suggestions'
     }
   }
-}
+})
 
-// Check for features on mount if autoCheckOnMount is true
-onMounted(() => {
-  if (props.autoCheckOnMount) {
-    checkForBlueOSFeatures()
+watch(isVisible, (visible, oldVisible) => {
+  if (!visible) {
+    openedManually.value = false
+    return
   }
+  actionRegistryVersion.value++
+  if (!oldVisible && !isAutoOpening) {
+    openedManually.value = true
+    fetchBlueOSFeatures()
+  }
+  isAutoOpening = false
+})
+
+watch(activeTab, () => {
+  actionRegistryVersion.value++
 })
 
 watch(hasPendingBlueOSFeatures, (hasPending) => {
-  if (!hasPending) {
+  if (!hasPending && !openedManually.value) {
     isVisible.value = false
   }
 })

--- a/src/components/ExternalFeaturesDiscoveryModal.vue
+++ b/src/components/ExternalFeaturesDiscoveryModal.vue
@@ -602,10 +602,12 @@ const ignoredActionIds = computed(() => handledActions.value.ignored)
 const appliedSuggestionIds = computed(() => handledSuggestions.value.applied ?? [])
 const ignoredSuggestionIds = computed(() => handledSuggestions.value.ignored ?? [])
 
-/**
- * Track the visibility of the modal
- */
-const isVisible = ref(false)
+const isVisible = computed({
+  get: () => interfaceStore.isExternalFeaturesModalVisible,
+  set: (v: boolean) => {
+    interfaceStore.isExternalFeaturesModalVisible = v
+  },
+})
 
 /**
  * Active tab for the tabs component

--- a/src/components/ExternalFeaturesDiscoveryModal.vue
+++ b/src/components/ExternalFeaturesDiscoveryModal.vue
@@ -1474,12 +1474,7 @@ const checkForBlueOSJoystickSuggestions = async (): Promise<void> => {
 }
 
 /**
- * Whether the modal was opened manually by the user (vs auto-opened on mount)
- */
-const openedManually = ref(false)
-
-/**
- * Guard to prevent the isVisible watcher from treating an auto-open as manual
+ * Guard to prevent the isVisible watcher from re-fetching when auto-opened on mount
  */
 let isAutoOpening = false
 
@@ -1503,13 +1498,9 @@ onMounted(async () => {
 })
 
 watch(isVisible, (visible, oldVisible) => {
-  if (!visible) {
-    openedManually.value = false
-    return
-  }
+  if (!visible) return
   actionRegistryVersion.value++
   if (!oldVisible && !isAutoOpening) {
-    openedManually.value = true
     fetchBlueOSFeatures()
   }
   isAutoOpening = false
@@ -1517,12 +1508,6 @@ watch(isVisible, (visible, oldVisible) => {
 
 watch(activeTab, () => {
   actionRegistryVersion.value++
-})
-
-watch(hasPendingBlueOSFeatures, (hasPending) => {
-  if (!hasPending && !openedManually.value) {
-    isVisible.value = false
-  }
 })
 </script>
 

--- a/src/stores/appInterface.ts
+++ b/src/stores/appInterface.ts
@@ -59,6 +59,7 @@ export const useAppInterfaceStore = defineStore('responsive', {
     currentSubMenuComponentName: ref<SubMenuComponentName | null>(null),
     isGlassModalAlwaysOnTop: false,
     isTutorialVisible: false,
+    isExternalFeaturesModalVisible: false,
     userHasSeenTutorial: useBlueOsStorage('cockpit-has-seen-tutorial', false),
     configPanelVisible: false,
     showSplashScreen: true,

--- a/src/views/ConfigurationGeneralView.vue
+++ b/src/views/ConfigurationGeneralView.vue
@@ -60,6 +60,9 @@
                 >
                   {{ interfaceStore.pirateMode ? 'Disable pirate mode' : 'Enable pirate mode' }}
                 </v-btn>
+                <v-btn size="x-small" class="bg-[#FFFFFF22] shadow-1" variant="flat" @click="openExternalFeaturesModal">
+                  Extension features
+                </v-btn>
               </div>
               <v-divider v-if="isElectron()" class="w-full opacity-[0.08]" />
               <div v-if="isElectron()" class="flex flex-col w-full py-4 gap-1">
@@ -731,6 +734,14 @@ const tryToPrettifyRtcConfig = (): void => {
 const openTutorial = (): void => {
   interfaceStore.isMainMenuVisible = false
   interfaceStore.isTutorialVisible = true
+}
+
+const openExternalFeaturesModal = (): void => {
+  interfaceStore.isMainMenuVisible = false
+  interfaceStore.mainMenuCurrentStep = 1
+  interfaceStore.currentSubMenuName = null
+  interfaceStore.currentSubMenuComponentName = null
+  interfaceStore.isExternalFeaturesModalVisible = true
 }
 
 watch(customRtcConfiguration, () => tryToPrettifyRtcConfig())


### PR DESCRIPTION
- Allows opening the dialog explicitly from the general menu
<img width="709" height="286" alt="image" src="https://github.com/user-attachments/assets/d0d5b583-0b3c-479a-a395-b0d648386dbd" />

- Allow reseting applied and ignored features if they were removed from the user settings (both actions and button mappings)

<img width="539" height="189" alt="image" src="https://github.com/user-attachments/assets/e50fb5e7-642d-417a-b574-61a27e0dc766" />

<img width="783" height="432" alt="image" src="https://github.com/user-attachments/assets/f5308f8f-bed2-4ab0-b02f-1bbef7991d85" />

- Stop auto-closing when something is applied

Fix #1865
Fix #2545
