### PR TITLE
Add a limit to the number of points in the vehicle history path

### DIFF
--- a/src/stores/mission.ts
+++ b/src/stores/mission.ts
@@ -24,6 +24,10 @@ import { useMainVehicleStore } from './mainVehicle'
 const DEFAULT_MAP_CENTER: WaypointCoordinates = [-27.5935, -48.55854]
 const DEFAULT_MAP_ZOOM = 15
 
+// Default cap on the vehicle position history. At 5Hz (default sampling rate), 50k samples is about 3 hours.
+export const DEFAULT_MAX_POSITION_HISTORY_SIZE = 50000
+export const MIN_MAX_POSITION_HISTORY_SIZE = 100
+
 export const useMissionStore = defineStore('mission', () => {
   const username = useStorage<string>('cockpit-username', fallbackUsername)
   const lastConnectedUser = localStorage.getItem(cockpitLastConnectedUserKey) || undefined
@@ -156,9 +160,12 @@ export const useMissionStore = defineStore('mission', () => {
   const isVehiclePositionHistoryPersistent = useBlueOsStorage('cockpit-vehicle-position-history-persistent', true)
   const vehiclePositionHistory = ref<WaypointCoordinates[]>([...persistedPositionHistory.value])
 
+  let positionHistoryDirty = false
+
   const flushPositionHistory = (): void => {
     if (!isVehiclePositionHistoryPersistent.value) return
-    if (vehiclePositionHistory.value.length === persistedPositionHistory.value.length) return
+    if (!positionHistoryDirty) return
+    positionHistoryDirty = false
     persistedPositionHistory.value = [...vehiclePositionHistory.value]
   }
 
@@ -168,6 +175,7 @@ export const useMissionStore = defineStore('mission', () => {
 
   const clearVehicleHistory = (): void => {
     vehiclePositionHistory.value = []
+    positionHistoryDirty = false
     if (isVehiclePositionHistoryPersistent.value) {
       persistedPositionHistory.value = []
     }
@@ -495,11 +503,21 @@ export const useMissionStore = defineStore('mission', () => {
     { deep: true }
   )
 
+  // Maximum number of positions to store in the vehicle position history
+  const maxPositionHistorySize = useBlueOsStorage(
+    'cockpit-vehicle-position-history-max-size',
+    DEFAULT_MAX_POSITION_HISTORY_SIZE
+  )
+
   watch(
     () => [mainVehicleStore.coordinates?.latitude, mainVehicleStore.coordinates?.longitude] as const,
     ([lat, lng]) => {
       if (!lat || !lng) return
-      vehiclePositionHistory.value = [...vehiclePositionHistory.value, [lat, lng] as WaypointCoordinates]
+      vehiclePositionHistory.value.push([lat, lng] as WaypointCoordinates)
+      if (vehiclePositionHistory.value.length > maxPositionHistorySize.value) {
+        vehiclePositionHistory.value.shift()
+      }
+      positionHistoryDirty = true
     }
   )
 
@@ -561,6 +579,7 @@ export const useMissionStore = defineStore('mission', () => {
     callMapClearMapDrawing,
     vehiclePositionHistory,
     isVehiclePositionHistoryPersistent,
+    maxPositionHistorySize,
     clearVehicleHistory,
     pushUndoSnapshot,
     popUndoSnapshot,

--- a/src/stores/mission.ts
+++ b/src/stores/mission.ts
@@ -1,3 +1,4 @@
+import * as turf from '@turf/turf'
 import { useStorage } from '@vueuse/core'
 import { defineStore } from 'pinia'
 import { computed, reactive, ref, watch } from 'vue'
@@ -24,8 +25,8 @@ import { useMainVehicleStore } from './mainVehicle'
 const DEFAULT_MAP_CENTER: WaypointCoordinates = [-27.5935, -48.55854]
 const DEFAULT_MAP_ZOOM = 15
 
-// Default cap on the vehicle position history. At 5Hz (default sampling rate), 50k samples is about 3 hours.
-export const DEFAULT_MAX_POSITION_HISTORY_SIZE = 50000
+// Default cap on the vehicle position history. At 5Hz (default sampling rate), 500k samples is about 30 hours.
+export const DEFAULT_MAX_POSITION_HISTORY_SIZE = 500000
 export const MIN_MAX_POSITION_HISTORY_SIZE = 100
 
 export const useMissionStore = defineStore('mission', () => {
@@ -161,6 +162,7 @@ export const useMissionStore = defineStore('mission', () => {
   const vehiclePositionHistory = ref<WaypointCoordinates[]>([...persistedPositionHistory.value])
 
   let positionHistoryDirty = false
+  let simplifiedBoundary = 0
 
   const flushPositionHistory = (): void => {
     if (!isVehiclePositionHistoryPersistent.value) return
@@ -176,6 +178,7 @@ export const useMissionStore = defineStore('mission', () => {
   const clearVehicleHistory = (): void => {
     vehiclePositionHistory.value = []
     positionHistoryDirty = false
+    simplifiedBoundary = 0
     if (isVehiclePositionHistoryPersistent.value) {
       persistedPositionHistory.value = []
     }
@@ -503,11 +506,40 @@ export const useMissionStore = defineStore('mission', () => {
     { deep: true }
   )
 
-  // Maximum number of positions to store in the vehicle position history
+  // Maximum number of positions to store in the vehicle position history before simplifying
   const maxPositionHistorySize = useBlueOsStorage(
     'cockpit-vehicle-position-history-max-size',
     DEFAULT_MAX_POSITION_HISTORY_SIZE
   )
+
+  /**
+   * Simplifies the next unsimplified chunk of the vehicle position history using the
+   * Ramer-Douglas-Peucker algorithm. The chunk starts at `simplifiedBoundary` and spans
+   * one third of `maxPositionHistorySize`, ensuring each portion of the history is only
+   * ever simplified once.
+   * @returns {boolean} True if a chunk was simplified, false if no unsimplified data is available.
+   */
+  const simplifyNextChunk = (): boolean => {
+    const history = vehiclePositionHistory.value
+    const chunkSize = Math.floor(maxPositionHistorySize.value / 3)
+    const chunkEnd = simplifiedBoundary + chunkSize
+
+    if (simplifiedBoundary >= history.length - chunkSize || chunkEnd > history.length) return false
+
+    const alreadySimplified = history.slice(0, simplifiedBoundary)
+    const chunkSegment = history.slice(simplifiedBoundary, chunkEnd)
+    const recentSegment = history.slice(chunkEnd)
+
+    if (chunkSegment.length < 2) return false
+
+    const line = turf.lineString(chunkSegment.map(([lat, lng]) => [lng, lat]))
+    const simplified = turf.simplify(line, { tolerance: 0.000001, highQuality: true })
+    const simplifiedPoints = simplified.geometry.coordinates.map(([lng, lat]) => [lat, lng] as WaypointCoordinates)
+
+    vehiclePositionHistory.value = [...alreadySimplified, ...simplifiedPoints, ...recentSegment]
+    simplifiedBoundary += simplifiedPoints.length
+    return true
+  }
 
   watch(
     () => [mainVehicleStore.coordinates?.latitude, mainVehicleStore.coordinates?.longitude] as const,
@@ -515,7 +547,12 @@ export const useMissionStore = defineStore('mission', () => {
       if (!lat || !lng) return
       vehiclePositionHistory.value.push([lat, lng] as WaypointCoordinates)
       if (vehiclePositionHistory.value.length > maxPositionHistorySize.value) {
-        vehiclePositionHistory.value.shift()
+        const didSimplify = simplifyNextChunk()
+        // Fallback: if no unsimplified chunk was available or RDP freed nothing, drop oldest point
+        if (!didSimplify || vehiclePositionHistory.value.length > maxPositionHistorySize.value) {
+          vehiclePositionHistory.value.shift()
+          if (simplifiedBoundary > 0) simplifiedBoundary -= 1
+        }
       }
       positionHistoryDirty = true
     }

--- a/src/views/ConfigurationMissionView.vue
+++ b/src/views/ConfigurationMissionView.vue
@@ -55,14 +55,6 @@
             base-color="#FFFFFF33"
             class="mt-2 -mb-2 ml-3"
           />
-          <v-switch
-            v-model="vehicleStore.isVehiclePositionHistoryPersistent"
-            label="Make vehicle history line persistent"
-            color="white"
-            hide-details
-            base-color="#FFFFFF33"
-            class="mt-2 -mb-2 ml-3"
-          />
         </div>
         <ExpansiblePanel no-bottom-divider :is-expanded="!interfaceStore.isOnPhoneScreen">
           <template #title>Enable confirmation on specific categories:</template>
@@ -145,6 +137,48 @@
             </div>
           </template>
         </ExpansiblePanel>
+
+        <ExpansiblePanel no-bottom-divider :is-expanded="!interfaceStore.isOnPhoneScreen">
+          <template #title>Vehicle options</template>
+          <template #info>
+            <strong>Max. displayed path points:</strong> Once the limit is reached, the last third of the mission trail
+            will be simplified. Keep this value reasonable — larger histories use more memory and may affect performance
+            over long missions, especially when using high frequency positioning data (e.g. from a DVL or RTK setup).
+          </template>
+          <template #content>
+            <div class="flex flex-col gap-y-3 px-4 pb-4 pt-2">
+              <div class="flex items-center gap-x-16">
+                <v-switch
+                  v-model="missionStore.isVehiclePositionHistoryPersistent"
+                  label="Make vehicle history line persistent"
+                  color="white"
+                  hide-details
+                  base-color="#FFFFFF33"
+                  class="-my-1"
+                />
+                <div class="flex items-center gap-x-2 ml-4">
+                  <span class="text-white text-sm whitespace-nowrap">Max. path points</span>
+                  <input
+                    v-model.number="missionStore.maxPositionHistorySize"
+                    type="number"
+                    :min="MIN_MAX_POSITION_HISTORY_SIZE"
+                    step="100"
+                    class="px-2 py-1 w-24 rounded-sm bg-[#FFFFFF22] text-white text-sm"
+                    @change="clampMaxPositionHistorySize"
+                  />
+                  <v-icon
+                    v-tooltip.bottom="'Reset to default'"
+                    icon="mdi-restore"
+                    size="14"
+                    color="white"
+                    class="cursor-pointer opacity-70 hover:opacity-100"
+                    @click="resetMaxPositionHistorySize"
+                  />
+                </div>
+              </div>
+            </div>
+          </template>
+        </ExpansiblePanel>
       </div>
     </template>
   </BaseConfigurationView>
@@ -157,7 +191,7 @@ import ExpansiblePanel from '@/components/ExpansiblePanel.vue'
 import { EventCategory } from '@/libs/slide-to-confirm'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
-import { useMissionStore } from '@/stores/mission'
+import { DEFAULT_MAX_POSITION_HISTORY_SIZE, MIN_MAX_POSITION_HISTORY_SIZE, useMissionStore } from '@/stores/mission'
 import type { WaypointCoordinates } from '@/types/mission'
 
 import BaseConfigurationView from './BaseConfigurationView.vue'
@@ -187,5 +221,16 @@ watch(
 
 const saveMapPosition = (): void => {
   missionStore.setDefaultMapPosition(defaultMapCenter.value, defaultMapZoom.value)
+}
+
+const clampMaxPositionHistorySize = (): void => {
+  const value = missionStore.maxPositionHistorySize
+  if (!Number.isFinite(value) || value < MIN_MAX_POSITION_HISTORY_SIZE) {
+    missionStore.maxPositionHistorySize = MIN_MAX_POSITION_HISTORY_SIZE
+  }
+}
+
+const resetMaxPositionHistorySize = (): void => {
+  missionStore.maxPositionHistorySize = DEFAULT_MAX_POSITION_HISTORY_SIZE
 }
 </script>


### PR DESCRIPTION
* Added a default limit of 50.000 what stores 3 hours of vehicle history at 5 Hz (default max. vehicle position update rate).
* After the limit is reached, the last third of the history path will be simplified using the Ramer-Douglas-Peuker algorithm, which reduces samples to 1/10th of its original value..
* Added an input into settings->mission to let the user set this storage limit before RDP simplification.

Before RDP simplification:
<img width="478" height="425" alt="image" src="https://github.com/user-attachments/assets/0478436e-9d9e-439e-bf62-9f88fc54d02e" />

After:
<img width="345" height="374" alt="image" src="https://github.com/user-attachments/assets/13a4dd85-0391-4ec9-aa33-6cf0554665a3" />


Fix #2569 (to be confirmed)