### PR TITLE
Add download size to tile downloading

### DIFF
--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -258,8 +258,7 @@
   >
     <p>
       Saving offline map content
-      <span v-if="savingLayerName">({{ savingLayerName }})</span>:&nbsp;
-      {{ tilesTotal ? Math.round((tilesSaved / tilesTotal) * 100) : 0 }}%
+      <span v-if="savingLayerName">({{ savingLayerName }})</span>:&nbsp; {{ savePercentage }}%
     </p>
   </div>
 </template>
@@ -270,7 +269,7 @@ import 'leaflet-edgebuffer'
 import { useDebounceFn, useElementHover } from '@vueuse/core'
 import { formatDistanceToNow } from 'date-fns'
 import L, { type LatLngTuple, LayersControlEvent, LeafletMouseEvent, Map } from 'leaflet'
-import { SaveStatus, savetiles, tileLayerOffline } from 'leaflet.offline'
+import { tileLayerOffline } from 'leaflet.offline'
 import {
   computed,
   nextTick,
@@ -296,6 +295,7 @@ import PoiMapArrows from '@/components/poi/PoiMapArrows.vue'
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { provideMapContext } from '@/composables/map/useMapContext'
 import { openSnackbar } from '@/composables/snackbar'
+import { useOfflineTiles } from '@/composables/useOfflineTiles'
 import { MavCmd, MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import type { NoiseTileOptions } from '@/libs/map/map-tile-fallback'
 import { attachTileNoiseFallback, refreshNoiseFallbackTiles } from '@/libs/map/map-tile-fallback'
@@ -307,7 +307,6 @@ import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useMissionStore } from '@/stores/mission'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
-import { DialogActions } from '@/types/general'
 import type {
   IconDimensions,
   MapTileProvider,
@@ -326,6 +325,8 @@ const props = defineProps<{ widget: Widget }>()
 const widget = toRefs(props).widget
 const interfaceStore = useAppInterfaceStore()
 const { showDialog, closeDialog } = useInteractionDialog()
+const { isSavingOfflineTiles, savingLayerName, savePercentage, downloadOfflineMapTiles, attachOfflineProgress } =
+  useOfflineTiles({ showDialog, closeDialog, openSnackbar })
 // Instantiate the necessary stores
 const vehicleStore = useMainVehicleStore()
 const missionStore = useMissionStore()
@@ -351,10 +352,6 @@ const contextMenuRef = ref()
 const isDragging = ref(false)
 const isPinching = ref(false)
 const isMissionChecklistOpen = ref(false)
-const isSavingOfflineTiles = ref(false)
-const tilesSaved = ref(0)
-const tilesTotal = ref(0)
-const savingLayerName = ref<string>('')
 let esriSaveBtn: HTMLAnchorElement | undefined
 let osmSaveBtn: HTMLAnchorElement | undefined
 let seamarksSaveBtn: HTMLAnchorElement | undefined
@@ -940,86 +937,6 @@ watch(
     downloadMissionFromVehicle()
   }
 )
-
-const confirmDownloadDialog =
-  (layerLabel: string) =>
-  (status: SaveStatus, ok: () => void): void => {
-    showDialog({
-      variant: 'info',
-      message: `Save ${status._tilesforSave.length} ${layerLabel} tiles for offline use?`,
-      persistent: false,
-      maxWidth: '450px',
-      actions: [
-        { text: 'Cancel', color: 'white', action: closeDialog },
-        {
-          text: 'Save tiles',
-          color: 'white',
-          action: () => {
-            ok()
-            closeDialog()
-          },
-        },
-      ] as DialogActions[],
-    })
-  }
-
-const deleteDownloadedTilesDialog =
-  (layerLabel: string) =>
-  (_status: SaveStatus, ok: () => void): void => {
-    showDialog({
-      variant: 'warning',
-      message: `Remove all saved ${layerLabel} tiles for this layer?`,
-      persistent: false,
-      maxWidth: '450px',
-      actions: [
-        { text: 'Cancel', color: 'white', action: closeDialog },
-        {
-          text: 'Remove tiles',
-          color: 'white',
-          action: () => {
-            ok()
-            closeDialog()
-            openSnackbar({ message: `${layerLabel} offline tiles removed`, variant: 'info', duration: 3000 })
-          },
-        },
-      ] as DialogActions[],
-    })
-  }
-
-const downloadOfflineMapTiles = (layer: any, layerLabel: string, maxZoom: number): L.Control => {
-  return savetiles(layer, {
-    saveWhatYouSee: true,
-    maxZoom,
-    alwaysDownload: false,
-    position: 'topright',
-    parallel: 20,
-    confirm: confirmDownloadDialog(layerLabel),
-    confirmRemoval: deleteDownloadedTilesDialog(layerLabel),
-    saveText: `<i class="mdi mdi-download" title="Save ${layerLabel} tiles"></i>`,
-    rmText: `<i class="mdi mdi-trash-can" title="Remove ${layerLabel} tiles"></i>`,
-  })
-}
-
-const attachOfflineProgress = (layer: any, layerName: string): void => {
-  layer.on('savestart', (e: any) => {
-    tilesSaved.value = 0
-    tilesTotal.value = e?._tilesforSave?.length ?? 0
-    savingLayerName.value = layerName
-    isSavingOfflineTiles.value = true
-    openSnackbar({ message: `Saving ${tilesTotal.value} ${layerName} tiles...`, variant: 'info', duration: 2000 })
-  })
-
-  layer.on('loadtileend', () => {
-    tilesSaved.value += 1
-    if (tilesTotal.value > 0 && tilesSaved.value >= tilesTotal.value) {
-      openSnackbar({ message: `${layerName} offline tiles saved!`, variant: 'success', duration: 3000 })
-      isSavingOfflineTiles.value = false
-      savingLayerName.value = ''
-      tilesSaved.value = 0
-      tilesTotal.value = 0
-    }
-  })
-}
 
 const handleContextMenu = {
   open: async (event: MouseEvent): Promise<void> => {

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -259,6 +259,9 @@
     <p>
       Saving offline map content
       <span v-if="savingLayerName">({{ savingLayerName }})</span>:&nbsp; {{ savePercentage }}%
+      <span v-if="estimatedDownloadedMB && estimatedTotalMB">
+        (~{{ estimatedDownloadedMB }} / {{ estimatedTotalMB }} MB)
+      </span>
     </p>
   </div>
 </template>
@@ -325,8 +328,15 @@ const props = defineProps<{ widget: Widget }>()
 const widget = toRefs(props).widget
 const interfaceStore = useAppInterfaceStore()
 const { showDialog, closeDialog } = useInteractionDialog()
-const { isSavingOfflineTiles, savingLayerName, savePercentage, downloadOfflineMapTiles, attachOfflineProgress } =
-  useOfflineTiles({ showDialog, closeDialog, openSnackbar })
+const {
+  isSavingOfflineTiles,
+  savingLayerName,
+  estimatedTotalMB,
+  estimatedDownloadedMB,
+  savePercentage,
+  downloadOfflineMapTiles,
+  attachOfflineProgress,
+} = useOfflineTiles({ showDialog, closeDialog, openSnackbar })
 // Instantiate the necessary stores
 const vehicleStore = useMainVehicleStore()
 const missionStore = useMissionStore()

--- a/src/composables/interactionDialog.ts
+++ b/src/composables/interactionDialog.ts
@@ -9,7 +9,7 @@ import { DialogActions } from '@/types/general'
 /**
  * Options to configure the interaction dialog.
  */
-interface DialogOptions {
+export interface DialogOptions {
   /**
    * Message to display in the dialog. If an array, elements will be displayed as an item list.
    * @type {string}
@@ -51,11 +51,11 @@ interface DialogOptions {
 }
 
 /**
- *
+ * Result returned when the interaction dialog is resolved or dismissed.
  */
-interface DialogResult {
+export interface DialogResult {
   /**
-   *
+   * Whether the user confirmed the dialog (`true`) or dismissed it (`false`).
    */
   isConfirmed: boolean
 }

--- a/src/composables/snackbar.ts
+++ b/src/composables/snackbar.ts
@@ -3,7 +3,7 @@ import { reactive } from 'vue'
 /**
  * Options to configure the snackbar.
  */
-interface SnackbarOptions {
+export interface SnackbarOptions {
   /**
    * The message to display in the snackbar
    */

--- a/src/composables/useOfflineTiles.ts
+++ b/src/composables/useOfflineTiles.ts
@@ -1,5 +1,5 @@
 import L from 'leaflet'
-import { type SaveStatus, savetiles } from 'leaflet.offline'
+import { type SaveStatus, type TileInfo, downloadTile, savetiles } from 'leaflet.offline'
 import { computed, ref } from 'vue'
 
 import { type DialogOptions, type DialogResult } from '@/composables/interactionDialog'
@@ -24,9 +24,37 @@ interface OfflineTilesDeps {
   openSnackbar: (options: SnackbarOptions) => void
 }
 
+const SAMPLE_COUNT = 3
+
+/**
+ * Estimates the average byte size of tiles by downloading a small sample.
+ * @param {TileInfo[]} tiles - The array of tile info objects to sample from
+ * @param {number} count - How many tiles to sample
+ * @returns {Promise<number>} Average tile size in bytes, or 0 on failure
+ */
+async function estimateAvgTileSize(tiles: TileInfo[], count: number = SAMPLE_COUNT): Promise<number> {
+  const samples = tiles.slice(0, Math.min(count, tiles.length))
+  if (samples.length === 0) return 0
+  try {
+    const blobs = await Promise.all(samples.map((t) => downloadTile(t.url)))
+    return blobs.reduce((sum, b) => sum + b.size, 0) / blobs.length
+  } catch {
+    return 0
+  }
+}
+
+/**
+ * Formats a byte value into a human-readable MB string.
+ * @param {number} bytes - Size in bytes
+ * @returns {string} Formatted size string (e.g. "12.3 MB")
+ */
+function formatMB(bytes: number): string {
+  return (bytes / (1024 * 1024)).toFixed(1)
+}
+
 /**
  * Composable that encapsulates offline tile download logic including
- * confirmation dialogs and download progress tracking.
+ * size estimation, confirmation dialogs, and download progress tracking.
  * @param {OfflineTilesDeps} deps - Dialog and snackbar functions from the consuming component
  * @returns {object} Reactive state and helper functions for offline tile management
  */
@@ -38,6 +66,17 @@ export function useOfflineTiles(deps: OfflineTilesDeps) {
   const tilesSaved = ref(0)
   const tilesTotal = ref(0)
   const savingLayerName = ref('')
+  const avgTileSize = ref(0)
+
+  const estimatedTotalMB = computed(() => {
+    if (avgTileSize.value <= 0 || tilesTotal.value <= 0) return ''
+    return formatMB(avgTileSize.value * tilesTotal.value)
+  })
+
+  const estimatedDownloadedMB = computed(() => {
+    if (avgTileSize.value <= 0) return ''
+    return formatMB(avgTileSize.value * tilesSaved.value)
+  })
 
   const savePercentage = computed(() => {
     if (tilesTotal.value <= 0) return 0
@@ -46,10 +85,22 @@ export function useOfflineTiles(deps: OfflineTilesDeps) {
 
   const confirmDownloadDialog =
     (layerLabel: string) =>
-    (status: SaveStatus, ok: () => void): void => {
+    async (status: SaveStatus, ok: () => void): Promise<void> => {
+      const tileCount = status._tilesforSave.length
+      let sizeInfo = ''
+      try {
+        const avg = await estimateAvgTileSize(status._tilesforSave)
+        if (avg > 0) {
+          avgTileSize.value = avg
+          sizeInfo = ` (~${formatMB(avg * tileCount)} MB)`
+        }
+      } catch {
+        // Fall back to count-only display
+      }
+
       showDialog({
         variant: 'info',
-        message: `Save ${status._tilesforSave.length} ${layerLabel} tiles for offline use?`,
+        message: `Save ${tileCount} ${layerLabel} tiles${sizeInfo} for offline use?`,
         persistent: false,
         maxWidth: '450px',
         actions: [
@@ -90,7 +141,7 @@ export function useOfflineTiles(deps: OfflineTilesDeps) {
     }
 
   /**
-   * Creates a savetiles control for the given layer.
+   * Creates a savetiles control for the given layer with download size estimation.
    * @param {any} layer - The TileLayerOffline instance
    * @param {string} layerLabel - Human-readable label for the layer (e.g. "Esri")
    * @param {number} maxZoom - Maximum zoom level to save
@@ -132,6 +183,7 @@ export function useOfflineTiles(deps: OfflineTilesDeps) {
         savingLayerName.value = ''
         tilesSaved.value = 0
         tilesTotal.value = 0
+        avgTileSize.value = 0
       }
     })
   }
@@ -141,6 +193,9 @@ export function useOfflineTiles(deps: OfflineTilesDeps) {
     tilesSaved,
     tilesTotal,
     savingLayerName,
+    avgTileSize,
+    estimatedTotalMB,
+    estimatedDownloadedMB,
     savePercentage,
     downloadOfflineMapTiles,
     attachOfflineProgress,

--- a/src/composables/useOfflineTiles.ts
+++ b/src/composables/useOfflineTiles.ts
@@ -1,0 +1,148 @@
+import L from 'leaflet'
+import { type SaveStatus, savetiles } from 'leaflet.offline'
+import { computed, ref } from 'vue'
+
+import { type DialogOptions, type DialogResult } from '@/composables/interactionDialog'
+import { type SnackbarOptions } from '@/composables/snackbar'
+import { type DialogActions } from '@/types/general'
+
+/**
+ * Dialog and snackbar functions the composable needs from the consuming component.
+ */
+interface OfflineTilesDeps {
+  /**
+   * Shows an interaction dialog and resolves once the user confirms or dismisses it.
+   */
+  showDialog: (options: DialogOptions) => Promise<DialogResult>
+  /**
+   * Closes the currently open interaction dialog.
+   */
+  closeDialog: () => void
+  /**
+   * Opens a snackbar with the given options.
+   */
+  openSnackbar: (options: SnackbarOptions) => void
+}
+
+/**
+ * Composable that encapsulates offline tile download logic including
+ * confirmation dialogs and download progress tracking.
+ * @param {OfflineTilesDeps} deps - Dialog and snackbar functions from the consuming component
+ * @returns {object} Reactive state and helper functions for offline tile management
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export function useOfflineTiles(deps: OfflineTilesDeps) {
+  const { showDialog, closeDialog, openSnackbar } = deps
+
+  const isSavingOfflineTiles = ref(false)
+  const tilesSaved = ref(0)
+  const tilesTotal = ref(0)
+  const savingLayerName = ref('')
+
+  const savePercentage = computed(() => {
+    if (tilesTotal.value <= 0) return 0
+    return Math.round((tilesSaved.value / tilesTotal.value) * 100)
+  })
+
+  const confirmDownloadDialog =
+    (layerLabel: string) =>
+    (status: SaveStatus, ok: () => void): void => {
+      showDialog({
+        variant: 'info',
+        message: `Save ${status._tilesforSave.length} ${layerLabel} tiles for offline use?`,
+        persistent: false,
+        maxWidth: '450px',
+        actions: [
+          { text: 'Cancel', color: 'white', action: closeDialog },
+          {
+            text: 'Save tiles',
+            color: 'white',
+            action: () => {
+              ok()
+              closeDialog()
+            },
+          },
+        ] as DialogActions[],
+      })
+    }
+
+  const deleteDownloadedTilesDialog =
+    (layerLabel: string) =>
+    (_status: SaveStatus, ok: () => void): void => {
+      showDialog({
+        variant: 'warning',
+        message: `Remove all saved ${layerLabel} tiles for this layer?`,
+        persistent: false,
+        maxWidth: '450px',
+        actions: [
+          { text: 'Cancel', color: 'white', action: closeDialog },
+          {
+            text: 'Remove tiles',
+            color: 'white',
+            action: () => {
+              ok()
+              closeDialog()
+              openSnackbar({ message: `${layerLabel} offline tiles removed`, variant: 'info', duration: 3000 })
+            },
+          },
+        ] as DialogActions[],
+      })
+    }
+
+  /**
+   * Creates a savetiles control for the given layer.
+   * @param {any} layer - The TileLayerOffline instance
+   * @param {string} layerLabel - Human-readable label for the layer (e.g. "Esri")
+   * @param {number} maxZoom - Maximum zoom level to save
+   * @returns {L.Control} The savetiles control instance
+   */
+  const downloadOfflineMapTiles = (layer: any, layerLabel: string, maxZoom: number): L.Control => {
+    return savetiles(layer, {
+      saveWhatYouSee: true,
+      maxZoom,
+      alwaysDownload: false,
+      position: 'topright',
+      parallel: 20,
+      confirm: confirmDownloadDialog(layerLabel),
+      confirmRemoval: deleteDownloadedTilesDialog(layerLabel),
+      saveText: `<i class="mdi mdi-download" title="Save ${layerLabel} tiles"></i>`,
+      rmText: `<i class="mdi mdi-trash-can" title="Remove ${layerLabel} tiles"></i>`,
+    })
+  }
+
+  /**
+   * Attaches progress event listeners to a tile layer for tracking download state.
+   * @param {any} layer - The TileLayerOffline instance
+   * @param {string} layerName - Human-readable name for snackbar messages
+   */
+  const attachOfflineProgress = (layer: any, layerName: string): void => {
+    layer.on('savestart', (e: any) => {
+      tilesSaved.value = 0
+      tilesTotal.value = e?._tilesforSave?.length ?? 0
+      savingLayerName.value = layerName
+      isSavingOfflineTiles.value = true
+      openSnackbar({ message: `Saving ${tilesTotal.value} ${layerName} tiles...`, variant: 'info', duration: 2000 })
+    })
+
+    layer.on('loadtileend', () => {
+      tilesSaved.value += 1
+      if (tilesTotal.value > 0 && tilesSaved.value >= tilesTotal.value) {
+        openSnackbar({ message: `${layerName} offline tiles saved!`, variant: 'success', duration: 3000 })
+        isSavingOfflineTiles.value = false
+        savingLayerName.value = ''
+        tilesSaved.value = 0
+        tilesTotal.value = 0
+      }
+    })
+  }
+
+  return {
+    isSavingOfflineTiles,
+    tilesSaved,
+    tilesTotal,
+    savingLayerName,
+    savePercentage,
+    downloadOfflineMapTiles,
+    attachOfflineProgress,
+  }
+}

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -652,6 +652,9 @@
     <p>
       Saving offline map content
       <span v-if="savingLayerName">({{ savingLayerName }})</span>:&nbsp; {{ savePercentage }}%
+      <span v-if="estimatedDownloadedMB && estimatedTotalMB">
+        (~{{ estimatedDownloadedMB }} / {{ estimatedTotalMB }} MB)
+      </span>
     </p>
   </div>
   <MissionEstimatesPanel v-if="!speedDialOpen" v-model="missionStore.showMissionEstimates" />
@@ -734,8 +737,15 @@ const { height: windowHeight } = useWindowSize()
 
 const { showDialog, closeDialog } = useInteractionDialog()
 const { openSnackbar } = useSnackbar()
-const { isSavingOfflineTiles, savingLayerName, savePercentage, downloadOfflineMapTiles, attachOfflineProgress } =
-  useOfflineTiles({ showDialog, closeDialog, openSnackbar })
+const {
+  isSavingOfflineTiles,
+  savingLayerName,
+  estimatedTotalMB,
+  estimatedDownloadedMB,
+  savePercentage,
+  downloadOfflineMapTiles,
+  attachOfflineProgress,
+} = useOfflineTiles({ showDialog, closeDialog, openSnackbar })
 
 const clearMissionOnVehicle = (): void => {
   vehicleStore.clearMissions()

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -649,7 +649,10 @@
     class="absolute top-14 left-2 flex justify-start items-center text-white text-md py-2 px-4 rounded-lg"
     :style="interfaceStore.globalGlassMenuStyles"
   >
-    <p>Saving offline map content:&nbsp;{{ tilesTotal ? Math.round((tilesSaved / tilesTotal) * 100) : 0 }}%</p>
+    <p>
+      Saving offline map content
+      <span v-if="savingLayerName">({{ savingLayerName }})</span>:&nbsp; {{ savePercentage }}%
+    </p>
   </div>
   <MissionEstimatesPanel v-if="!speedDialOpen" v-model="missionStore.showMissionEstimates" />
 </template>
@@ -662,7 +665,7 @@ import { formatDistanceToNow } from 'date-fns'
 import { format } from 'date-fns'
 import { saveAs } from 'file-saver'
 import L, { type LatLngTuple, LayersControlEvent, LeafletMouseEvent, Map, Marker, Polygon } from 'leaflet'
-import { SaveStatus, savetiles, tileLayerOffline } from 'leaflet.offline'
+import { tileLayerOffline } from 'leaflet.offline'
 import { v4 as uuid } from 'uuid'
 import { type InstanceType, computed, nextTick, onMounted, onUnmounted, ref, shallowRef, toRaw, watch } from 'vue'
 
@@ -688,6 +691,7 @@ import {
   setSurveyAreaSquareMeters,
   useMissionEstimates,
 } from '@/composables/useMissionEstimates'
+import { useOfflineTiles } from '@/composables/useOfflineTiles'
 import { MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import { MavCmd } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import type { NoiseTileOptions } from '@/libs/map/map-tile-fallback'
@@ -701,7 +705,7 @@ import { SubMenuComponentName, SubMenuName, useAppInterfaceStore } from '@/store
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useMissionStore } from '@/stores/mission'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
-import { DialogActions, Point2D } from '@/types/general'
+import { Point2D } from '@/types/general'
 import {
   type CockpitMission,
   type Waypoint,
@@ -730,6 +734,8 @@ const { height: windowHeight } = useWindowSize()
 
 const { showDialog, closeDialog } = useInteractionDialog()
 const { openSnackbar } = useSnackbar()
+const { isSavingOfflineTiles, savingLayerName, savePercentage, downloadOfflineMapTiles, attachOfflineProgress } =
+  useOfflineTiles({ showDialog, closeDialog, openSnackbar })
 
 const clearMissionOnVehicle = (): void => {
   vehicleStore.clearMissions()
@@ -980,10 +986,6 @@ const cruiseSpeedStatus = computed<'invalid' | 'unchanged' | 'valid'>(() => {
   return 'valid'
 })
 const isSettingHomeWaypoint = ref(false)
-const isSavingOfflineTiles = ref(false)
-const tilesSaved = ref(0)
-const tilesTotal = ref(0)
-const savingLayerName = ref<string>('')
 const downloadMenuOpen = ref(false)
 const speedDialOpen = ref(false)
 const gridLayer = shallowRef<L.LayerGroup | undefined>(undefined)
@@ -3680,86 +3682,6 @@ const onMapClick = (e: L.LeafletMouseEvent): void => {
     }
     clearLiveMeasure()
   }
-}
-
-const confirmDownloadDialog =
-  (layerLabel: string) =>
-  (status: SaveStatus, ok: () => void): void => {
-    showDialog({
-      variant: 'info',
-      message: `Save ${status._tilesforSave.length} ${layerLabel} tiles for offline use?`,
-      persistent: false,
-      maxWidth: '450px',
-      actions: [
-        { text: 'Cancel', color: 'white', action: closeDialog },
-        {
-          text: 'Save tiles',
-          color: 'white',
-          action: () => {
-            ok()
-            closeDialog()
-          },
-        },
-      ] as DialogActions[],
-    })
-  }
-
-const deleteDownloadedTilesDialog =
-  (layerLabel: string) =>
-  (_status: SaveStatus, ok: () => void): void => {
-    showDialog({
-      variant: 'warning',
-      message: `Remove all saved ${layerLabel} tiles for this layer?`,
-      persistent: false,
-      maxWidth: '450px',
-      actions: [
-        { text: 'Cancel', color: 'white', action: closeDialog },
-        {
-          text: 'Remove tiles',
-          color: 'white',
-          action: () => {
-            ok()
-            closeDialog()
-            openSnackbar({ message: `${layerLabel} offline tiles removed`, variant: 'info', duration: 3000 })
-          },
-        },
-      ] as DialogActions[],
-    })
-  }
-
-const downloadOfflineMapTiles = (layer: any, layerLabel: string, maxZoom: number): L.Control => {
-  return savetiles(layer, {
-    saveWhatYouSee: true,
-    maxZoom,
-    alwaysDownload: false,
-    position: 'topright',
-    parallel: 20,
-    confirm: confirmDownloadDialog(layerLabel),
-    confirmRemoval: deleteDownloadedTilesDialog(layerLabel),
-    saveText: `<i class="mdi mdi-download" title="Save ${layerLabel} tiles"></i>`,
-    rmText: `<i class="mdi mdi-trash-can" title="Remove ${layerLabel} tiles"></i>`,
-  })
-}
-
-const attachOfflineProgress = (layer: any, layerName: string): void => {
-  layer.on('savestart', (e: any) => {
-    tilesSaved.value = 0
-    tilesTotal.value = e?._tilesforSave?.length ?? 0
-    savingLayerName.value = layerName
-    isSavingOfflineTiles.value = true
-    openSnackbar({ message: `Saving ${tilesTotal.value} ${layerName} tiles...`, variant: 'info', duration: 2000 })
-  })
-
-  layer.on('loadtileend', () => {
-    tilesSaved.value += 1
-    if (tilesTotal.value > 0 && tilesSaved.value >= tilesTotal.value) {
-      openSnackbar({ message: `${layerName} offline tiles saved!`, variant: 'success', duration: 3000 })
-      isSavingOfflineTiles.value = false
-      savingLayerName.value = ''
-      tilesSaved.value = 0
-      tilesTotal.value = 0
-    }
-  })
 }
 
 let detachTileFallbacks: (() => void)[] = []


### PR DESCRIPTION
Also refactor the functionality to a composable shared between the Map widget and Mission Planning view.

<img width="535" height="259" alt="SCR-20260609-oltb" src="https://github.com/user-attachments/assets/f54e41ed-8e42-4f13-8cb0-4bfba2017e9d" />

<img width="469" height="71" alt="SCR-20260609-oluv" src="https://github.com/user-attachments/assets/2f405e66-f331-4738-9760-467890bb0174" />

Fix #2686