### PR TITLE
Fix importing of HTTP Actions from External Features (BlueOS extensions)

### DIFF
--- a/src/libs/blueos/schemas.ts
+++ b/src/libs/blueos/schemas.ts
@@ -111,12 +111,10 @@ const JoystickMapSuggestionGroupSchema = z.object({
   version: z.string().optional(),
 })
 
-export const ExtrasJsonSchema = preprocessCamelCase(
-  z.object({
-    targetCockpitApiVersion: z.string(),
-    targetSystem: z.string(),
-    widgets: z.array(ExternalWidgetSetupInfoSchema).default([]),
-    actions: z.array(ActionConfigSchema).default([]),
-    joystickSuggestions: z.array(JoystickMapSuggestionGroupSchema).optional(),
-  })
-)
+export const ExtrasJsonSchema = z.object({
+  targetCockpitApiVersion: z.string(),
+  targetSystem: z.string(),
+  widgets: z.array(ExternalWidgetSetupInfoSchema).default([]),
+  actions: z.array(ActionConfigSchema).default([]),
+  joystickSuggestions: z.array(JoystickMapSuggestionGroupSchema).optional(),
+})


### PR DESCRIPTION
The deep camelcaseKeys preprocessing was converting HTTP header keys like Content-Type to contentType in extension manifest action configs, causing fetch to default to text/plain and triggering 415 errors. Extensions already provide camelCase keys, so the conversion is unnecessary and harmful for freeform dictionaries like headers.

Fix #2586