### PR TITLE
Include snapshot widget in the camera replacement assistant

### DIFF
--- a/src/components/CameraReplacementDialog.vue
+++ b/src/components/CameraReplacementDialog.vue
@@ -325,6 +325,8 @@ const replaceStreams = (): void => {
         streams[idx] = newInternalName
       }
     }
+
+    videoStore.deleteStreamCorrespondency(orphan.externalId)
   }
 
   markDismissed()

--- a/src/components/CameraReplacementDialog.vue
+++ b/src/components/CameraReplacementDialog.vue
@@ -191,10 +191,19 @@ const allMiniVideoRecorders = computed((): MiniWidget[] => {
     .filter((w) => w.component === MiniWidgetType.MiniVideoRecorder)
 })
 
+const allSnapshotTools = computed((): MiniWidget[] => {
+  const fixedContainers = widgetStore.currentMiniWidgetsProfile.containers
+  const viewContainers = widgetStore.currentProfile.views.flatMap((v) => v.miniWidgetContainers)
+  return [...fixedContainers, ...viewContainers]
+    .flatMap((c) => c.widgets)
+    .filter((w) => w.component === MiniWidgetType.SnapshotTool)
+})
+
 const allWidgetStreamNames = computed((): string[] => {
   return [
     ...allVideoPlayerWidgets.value.map((w) => w.options.internalStreamName as string | undefined),
     ...allMiniVideoRecorders.value.map((w) => w.options.internalStreamName as string | undefined),
+    ...allSnapshotTools.value.flatMap((w) => (w.options.selectedStreams as string[] | undefined) ?? []),
   ].filter((name): name is string => name !== undefined && name !== null)
 })
 
@@ -306,6 +315,14 @@ const replaceStreams = (): void => {
     for (const miniWidget of allMiniVideoRecorders.value) {
       if (miniWidget.options.internalStreamName === orphan.internalName) {
         miniWidget.options.internalStreamName = newInternalName
+      }
+    }
+    for (const snapshotWidget of allSnapshotTools.value) {
+      const streams = snapshotWidget.options.selectedStreams as string[] | undefined
+      if (!streams) continue
+      const idx = streams.indexOf(orphan.internalName)
+      if (idx !== -1) {
+        streams[idx] = newInternalName
       }
     }
   }

--- a/src/components/mini-widgets/SnapshotTool.vue
+++ b/src/components/mini-widgets/SnapshotTool.vue
@@ -267,9 +267,10 @@ const flashEffect = async (): Promise<void> => {
 }
 
 const captureSnapshot = async (): Promise<SnapshotResult> => {
-  const streamNames = miniWidget.value.options.snapshotAllAvailableSources
+  const allStreamNames = miniWidget.value.options.snapshotAllAvailableSources
     ? videoStore.namesAvailableStreams
     : miniWidget.value.options.selectedStreams ?? []
+  const streamNames = allStreamNames.filter((name) => !videoStore.ignoredStreamExternalIds.includes(name))
   return snapshotStore.takeSnapshot(streamNames, miniWidget.value.options.captureWorkspace)
 }
 

--- a/src/components/mini-widgets/SnapshotTool.vue
+++ b/src/components/mini-widgets/SnapshotTool.vue
@@ -92,7 +92,7 @@
       <v-select
         v-model="miniWidget.options.selectedStreams"
         :items="enrichedStreamItems"
-        item-value="externalName"
+        item-value="internalName"
         :disabled="miniWidget.options.snapshotAllAvailableSources"
         density="compact"
         multiple
@@ -267,11 +267,17 @@ const flashEffect = async (): Promise<void> => {
 }
 
 const captureSnapshot = async (): Promise<SnapshotResult> => {
-  const allStreamNames = miniWidget.value.options.snapshotAllAvailableSources
+  const allExternalIds = miniWidget.value.options.snapshotAllAvailableSources
     ? videoStore.namesAvailableStreams
-    : miniWidget.value.options.selectedStreams ?? []
-  const streamNames = allStreamNames.filter((name) => !videoStore.ignoredStreamExternalIds.includes(name))
+    : ((miniWidget.value.options.selectedStreams as string[]) ?? [])
+        .map((name: string) => videoStore.externalStreamId(name))
+        .filter((id): id is string => !!id)
+  const streamNames = allExternalIds.filter((id) => !videoStore.ignoredStreamExternalIds.includes(id))
   return snapshotStore.takeSnapshot(streamNames, miniWidget.value.options.captureWorkspace)
+}
+
+const toInternalName = (externalId: string): string => {
+  return videoStore.streamsCorrespondency.find((c) => c.externalId === externalId)?.name ?? externalId
 }
 
 const handleSnapshotResult = (result: SnapshotResult): void => {
@@ -283,10 +289,12 @@ const handleSnapshotResult = (result: SnapshotResult): void => {
     return
   }
 
+  const failedNames = failed.map(toInternalName).join(', ')
+
   if (succeeded.length > 0 && failed.length > 0) {
     flashEffect()
     openSnackbar({
-      message: `Snapshot captured, but failed for: ${failed.join(', ')}.`,
+      message: `Snapshot captured, but failed for: ${failedNames}.`,
       variant: 'warning',
       duration: 4000,
     })
@@ -300,7 +308,7 @@ const handleSnapshotResult = (result: SnapshotResult): void => {
     title: 'Error taking snapshot',
     message:
       failed.length > 0
-        ? `Failed to capture: ${failed.join(', ')}. Make sure the streams have finished loading.`
+        ? `Failed to capture: ${failedNames}. Make sure the streams have finished loading.`
         : 'No sources available for capture. Make sure streams are connected or select specific ones in the widget settings.',
     variant: 'error',
     persistent: false,
@@ -374,6 +382,15 @@ watch(isTakingTimedSnapshot, (newValue) => {
   timerProgress.value = 0
 })
 
+const migrateSelectedStreamsToInternalNames = (): void => {
+  const streams = miniWidget.value.options.selectedStreams as string[] | undefined
+  if (!streams || streams.length === 0) return
+  miniWidget.value.options.selectedStreams = streams.map((name: string) => {
+    const corr = videoStore.streamsCorrespondency.find((c) => c.externalId === name)
+    return corr ? corr.name : name
+  })
+}
+
 onBeforeMount(() => {
   const defaultOptions = {
     snapshotAllAvailableSources: true,
@@ -383,6 +400,7 @@ onBeforeMount(() => {
     timedSnapshotInterval: 5,
   }
   miniWidget.value.options = { ...defaultOptions, ...miniWidget.value.options }
+  migrateSelectedStreamsToInternalNames()
 })
 
 onMounted(() => {

--- a/src/stores/snapshot.ts
+++ b/src/stores/snapshot.ts
@@ -318,7 +318,10 @@ export const useSnapshotStore = defineStore('snapshot', () => {
   }
 
   const takeSnapshotAction = async (): Promise<void> => {
-    const { succeeded, failed } = await takeSnapshot(videoStore.namesAvailableStreams, isElectron())
+    const activeStreams = videoStore.namesAvailableStreams.filter(
+      (name: string) => !videoStore.ignoredStreamExternalIds.includes(name)
+    )
+    const { succeeded, failed } = await takeSnapshot(activeStreams, isElectron())
     if (failed.length > 0) {
       console.error(`Snapshot action failed for: ${failed.join(', ')}`)
     }


### PR DESCRIPTION
With those changes the Snapshot widget is finally ready for the RadCam release.

Fix #2585 
Fix #2587