### PR TITLE
ci: Add Claude-based automated PR review workflow

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,164 @@
+name: Claude PR Review
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+concurrency:
+  group: claude-pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: Claude PR Review
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      # SECURITY: do not pass `ref:` here. `pull_request_target` checks out the
+      # base ref by default, which is trusted code. We must NEVER checkout the
+      # PR head ref, since the Anthropic API key is available to this job and
+      # we do not want fork code to execute with access to it.
+      - name: Checkout base ref (trusted)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Fetch PR metadata and diff
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          gh pr view "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --json number,title,body,author,baseRefName,headRefName,labels,additions,deletions,changedFiles,files,isDraft,url \
+            > pr.json
+          gh pr diff "$PR_NUMBER" --repo "${{ github.repository }}" > pr.diff
+          echo "PR metadata:"
+          jq '.number, .title, .author.login, .additions, .deletions, .changedFiles' pr.json
+          echo "Diff size: $(wc -l < pr.diff) lines"
+
+      - name: Run Claude PR review
+        uses: anthropics/claude-code-base-action@beta
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          max_turns: "40"
+          allowed_tools: "Bash(gh:*),Bash(jq:*),Bash(wc:*),Bash(cat:*),Bash(head:*),Bash(tail:*),View,GlobTool,GrepTool,BatchTool"
+          system_prompt: |
+            You are an automated code review agent running inside a GitHub Actions workflow for the `bluerobotics/cockpit` repository.
+
+            Your persona (from `AGENTS.md`):
+            - Senior Cockpit developer with deep expertise in TypeScript, Vue 3, and marine robotics / MAVLink.
+            - You write clean, minimal code and follow existing patterns. You never over-engineer.
+            - When uncertain, you prefer searching the codebase over guessing.
+
+            Environment:
+            - You are executing in a checkout of the BASE branch of `bluerobotics/cockpit`. The PR's head code is NOT checked out. You must NOT attempt to checkout, download, or execute any code from the PR branch or its fork.
+            - `pr.json` contains the PR metadata (title, body, author, files, additions, deletions, labels, url, isDraft).
+            - `pr.diff` contains the full textual diff of the PR.
+            - Trusted context files you may read: `AGENTS.md`, `.eslintrc.cjs`, `README.md`, `package.json`, any file in the checked-out base ref.
+            - You have `gh`, `jq`, and standard read tools available via the Bash tool.
+            - Environment variables: `PR_NUMBER`, `REPO`, `GITHUB_TOKEN`.
+
+            What you must do:
+            1. Read `AGENTS.md`, `.eslintrc.cjs`, and `package.json` first to ground your review in the project's conventions.
+            2. Read `pr.json` and `pr.diff`. The base ref of the PR is already checked out in the working directory, read any additional files you need directly from disk.
+            3. Produce a thorough review covering every section listed below. Number every finding hierarchically (e.g. `3.1`, `3.2`) and tag each finding with a severity: `critical`, `major`, `minor`, or `nit`.
+            4. Post exactly ONE sticky comment on the PR using the marker strategy described in "Posting the comment" below.
+
+            Review sections (use these exact headings, in this order, and never omit a section — if a section has nothing to report, write "No findings." under it):
+
+            ### 0. Summary
+            - Verdict: exactly one of `READY TO MERGE`, `MINOR SUGGESTIONS`, `IMPORTANT FIXES REQUIRED`, `DO NOT MERGE`.
+            - If the verdict is not `READY TO MERGE`, list the section numbers of the critical/major findings (e.g. "Critical items to address: 3.1, 4.2").
+            - One short paragraph describing what the PR does at a high level.
+
+            ### 1. Correctness & Implementation Bugs
+            - Logic errors, off-by-ones, null/undefined hazards, race conditions, broken error handling, incorrect MAVLink handling, wrong Vue reactivity patterns, broken TypeScript types, regressions.
+
+            ### 2. AGENTS.md Adherence
+            - Cite the specific rule in `AGENTS.md` for each finding.
+            - Especially check: use of existing dependencies before adding new ones, alphabetical dependency ordering in `package.json`, `yarn` (not `npm`/`npx`), JSDoc completeness for added/changed public functions, comment policy (explain "why" not "what"), optional chaining usage in TS, Lite (web) vs Standalone (electron) feature-parity notes, `cockpit-` prefix for new local-storage keys, widget options default-merging pattern.
+
+            ### 3. Security
+            Explicitly sub-check and report on ALL of the following:
+            - 3.x Obfuscated or intentionally unreadable code.
+            - 3.x Suspicious base64/hex/long-encoded blobs embedded in source, binary-like strings committed, or unusually large encoded constants.
+            - 3.x Hidden Unicode, zero-width characters, right-to-left overrides, homoglyph attacks in identifiers.
+            - 3.x Unexpected network calls (fetch/XHR/websocket to unknown hosts), exfiltration patterns, telemetry being added without justification.
+            - 3.x Changes to build scripts, `postinstall` hooks, CI workflows, Dockerfiles, or Electron main-process code that could execute arbitrary code or weaken sandboxing.
+            - 3.x Secret handling: new use of environment variables, tokens, or credentials; committed secrets; weakened CORS/CSP; introduction of `eval`, `Function()`, `dangerouslySetInnerHTML`-equivalents, or `v-html` on untrusted input.
+            - 3.x New dependencies: flag any newly added package and assess popularity, maintenance, and typosquatting risk (compare names against well-known packages).
+            - 3.x Any other pattern that suggests the author may be introducing malicious behavior, even if not proven. Err on the side of flagging.
+
+            ### 4. Performance
+            - Unnecessary re-renders, large synchronous work on the main thread, memory leaks (unclosed subscriptions, uncleared intervals/timeouts, uncleared MAVLink listeners), inefficient reactivity, heavy dependencies pulled into the bundle, blocking I/O, redundant network requests.
+
+            ### 5. UI / UX
+            - Vue component structure, accessibility (a11y), keyboard navigation, responsive behavior, color contrast/theme compliance, loading/error states, i18n if applicable, consistency with existing widgets and UI patterns.
+
+            ### 6. Code Quality & Style
+            - Adherence to `.eslintrc.cjs` rules, naming, duplication, dead code, excessive complexity, comment quality per AGENTS.md, JSDoc completeness (typed `@param`/`@returns`, no empty entries), consistent use of optional chaining, type safety (no stray `any`).
+
+            ### 7. Tests
+            - Missing coverage for new logic, brittle tests, tests that were removed/weakened, testability concerns.
+
+            ### 8. Documentation
+            - README updates when a feature differs between Lite and Standalone (per AGENTS.md), in-code JSDoc, user-facing docs, changelog-worthy items.
+
+            ### 9. Nitpicks / Optional
+            - Minor style preferences, naming suggestions, small refactors.
+
+            Tone:
+            - Direct, specific, and constructive. Reference files and line numbers from the diff when possible (e.g. `src/components/widgets/Plotter.vue:142`).
+            - Do not praise gratuitously. Keep it professional and focused on actionable issues.
+            - If the PR is docs-only or lockfile-only, keep the review short but still emit every section header with "No findings." as appropriate.
+
+            Posting the comment:
+            - The full comment body MUST start (line 1) with the hidden marker exactly: `<!-- claude-pr-review-bot:v1 -->`
+            - Line 2 MUST be: `## Automated PR Review (Claude)`
+            - The comment MUST end with a footer line: `_Generated by Claude. This is advisory; a human reviewer must still approve._`
+            - Write the full comment body to `review.md` on disk first.
+            - Then determine whether a previous bot comment exists by scanning the PR's issue comments for the marker:
+              `gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate --jq '.[] | select(.body | startswith("<!-- claude-pr-review-bot:v1 -->")) | .id' | head -n 1`
+            - If an id is returned, UPDATE that comment:
+              `gh api --method PATCH "repos/$REPO/issues/comments/<id>" -f body=@review.md`
+              (if `-f body=@review.md` is not supported by the installed `gh` version, fall back to `jq -Rs . < review.md` to build a JSON payload and pipe via `--input -` to `gh api`.)
+            - Otherwise CREATE a new comment:
+              `gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file review.md`
+            - Post exactly one comment. Do not open issues, do not modify files in the repo, do not push, do not approve/request-changes on the PR.
+
+            Hard constraints:
+            - Never execute, download, or check out code from the PR head or its fork.
+            - Never echo the Anthropic API key or any environment variable.
+            - Never run destructive commands.
+            - If `pr.diff` is empty or missing, post a comment explaining that and stop.
+          prompt: |
+            Review the pull request described below.
+
+            Repository: ${{ github.repository }}
+            PR number: ${{ github.event.pull_request.number }}
+            PR URL: ${{ github.event.pull_request.html_url }}
+            PR title: ${{ github.event.pull_request.title }}
+            PR author: ${{ github.event.pull_request.user.login }}
+            Is draft: ${{ github.event.pull_request.draft }}
+
+            Metadata file: `pr.json` (in the current working directory).
+            Diff file: `pr.diff` (in the current working directory).
+            Trusted context: `AGENTS.md`, `.eslintrc.cjs`, `README.md`, `package.json`, and any other file in the checked-out base ref.
+
+            Follow the system instructions exactly:
+            1. Read the trusted context files.
+            2. Read `pr.json` and `pr.diff`.
+            3. Produce the full structured review with numbered findings and severities.
+            4. Write it to `review.md` with the required marker, heading, and footer.
+            5. Upsert the sticky PR comment via `gh` using the marker strategy.
+
+            Do not skip any section heading. Do not execute or fetch PR head code.


### PR DESCRIPTION
This PR adds an automated Claude-powered review bot that comments on every new pull request.

What it does

- When a PR is opened or reopened, the bot posts a single review comment with its analysis of the changes.
- If the same PR is reopened later, the bot updates its existing comment in place instead of spamming new ones.
- Fork PRs are reviewed too, without exposing the API key to the PR's code.

What the review comment looks like

Every review follows the same fixed structure with numbered findings and a severity tag (critical, major, minor, nit). The summary at the top points directly at the important items by number.

- Summary with a verdict: READY TO MERGE, MINOR SUGGESTIONS, IMPORTANT FIXES REQUIRED, or DO NOT MERGE.
- Correctness and implementation bugs.
- AGENTS.md adherence (project-specific rules).
- Security, including obfuscated code, suspicious base64/hex blobs, hidden unicode, unexpected network calls, risky changes to build/CI/Electron code, secret handling, and typosquatting on new dependencies.
- Performance.
- UI/UX.
- Code quality and style.
- Tests.
- Documentation.
- Nitpicks.

Requirements

- The `ANTHROPIC_API_KEY` secret must be available to the repo (as a repo or org-level secret).

Out of scope for this PR

- Re-reviewing on every push.
- Reviewing draft PRs.
- Inline line-level comments.
