### PR TITLE
video: Prevent camera replacement dialog from showing empty state

### DIFF
--- a/src/components/CameraReplacementDialog.vue
+++ b/src/components/CameraReplacementDialog.vue
@@ -358,8 +358,17 @@ watch(
   [stabilizationDone, orphanedWidgetStreams, unusedAvailableStreams],
   () => {
     if (!stabilizationDone.value) return
+
+    const hasOrphans = orphanedWidgetStreams.value.length > 0
+    const hasReplacements = unusedAvailableStreams.value.length > 0
+
+    if (!hasOrphans || !hasReplacements) {
+      if (showDialog.value) showDialog.value = false
+      dialogTriggered.value = false
+      return
+    }
+
     if (dialogTriggered.value) return
-    if (orphanedWidgetStreams.value.length === 0 || unusedAvailableStreams.value.length === 0) return
 
     dialogTriggered.value = true
     initReplacementMap()


### PR DESCRIPTION
Auto-close the dialog and reset the triggered latch when there are no orphaned widget streams or no available replacements, so transient reactive states can't leave the dialog open with "0 widgets will be updated".

Fix #2598 