### PR TITLE
ci: Pin Claude PR review model to Opus 4.6

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -49,6 +49,7 @@ jobs:
           REPO: ${{ github.repository }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          model: "claude-opus-4-6"
           max_turns: "40"
           allowed_tools: "Bash(gh:*),Bash(jq:*),Bash(wc:*),Bash(cat:*),Bash(head:*),Bash(tail:*),View,GlobTool,GrepTool,BatchTool"
           system_prompt: |


### PR DESCRIPTION
Sonnet 4 (the default model) is almost an year old, being deprecated in June, is considerably inferior and costs more than half what Opus 4.6 does.

Also, my internal tests (outside Github Actions) were already using Opus 4.6, so the cost estimates (50 USD per month) still hold.

