### PR TITLE
Fix PR Review Assistant not being able to push the review comment

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -51,7 +51,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           model: "claude-opus-4-6"
           max_turns: "40"
-          allowed_tools: "Bash(gh:*),Bash(jq:*),Bash(wc:*),Bash(cat:*),Bash(head:*),Bash(tail:*),View,GlobTool,GrepTool,BatchTool"
+          allowed_tools: "Bash(gh:*),Bash(jq:*),Bash(wc:*),Bash(cat:*),Bash(head:*),Bash(tail:*),View,GlobTool,GrepTool,BatchTool,Write"
           system_prompt: |
             You are an automated code review agent running inside a GitHub Actions workflow for the `bluerobotics/cockpit` repository.
 


### PR DESCRIPTION
As can be seen on #2603, the PR Review Assistant action is running correctly, but is failing to push the comment to Github. This PR fixes that.

The system prompt instructs the model to write the review to `review.md` before posting it via `gh pr comment --body-file`, but `Write` was not in `allowed_tools`, so every file-creation attempt was denied. Sonnet 4 coincidentally pivoted to an inline `--body` fallback; Opus 4.6 kept retrying file-write variants and exhausted `max_turns` before falling back, so no review was posted.

This is safe: the job runs on the trusted base ref (never the PR head), `permissions: contents: read` prevents any repo/push writes, and the runner filesystem is ephemeral — `Write` only lets the model create scratch files like `review.md` inside the throwaway runner.