### PR TITLE
ci: Bump Node heap limit to avoid OOM during vite build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,12 @@ on:
   # Run every 6 days to help us stay on our toes
   - cron: '0 0 */6 * *'
 
+env:
+  # Raise Node's V8 old-space limit so `vite build` doesn't OOM.
+  # The bundle sits near the default ~2 GB cap on every platform and
+  # intermittently crashes (seen most often on macos-15 arm64).
+  NODE_OPTIONS: --max-old-space-size=6144
+
 jobs:
   test:
     name: Test


### PR DESCRIPTION
The Vite build step has been intermittently crashing with "Ineffective mark-compacts near heap limit" right around the default ~2 GB V8 old-space cap. It shows up most often on the macos-15 arm64 runner but the bundle size is close to the limit on every platform, so any runner can flake. Raising NODE_OPTIONS to --max-old-space-size=6144 on both "Install and build" steps gives the bundler enough headroom to finish reliably across all runners.