### PR TITLE
Fix map tiles turning white during panning

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "jest-diff": "^29.7.0",
     "ky": "^1.2.0",
     "leaflet": "1.9.3",
+    "leaflet-edgebuffer": "^1.0.7",
     "leaflet.offline": "^3.1.0",
     "localforage": "^1.10.0",
     "mathjs": "^13.0.3",

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -225,6 +225,8 @@
 </template>
 
 <script setup lang="ts">
+import 'leaflet-edgebuffer'
+
 import { useDebounceFn, useElementHover } from '@vueuse/core'
 import { formatDistanceToNow } from 'date-fns'
 import L, { type LatLngTuple, LayersControlEvent, LeafletMouseEvent, Map } from 'leaflet'
@@ -501,11 +503,14 @@ onBeforeMount(() => {
   targetFollower.enableAutoUpdate()
 })
 
+const tileBufferOptions = { edgeBufferTiles: 2, keepBuffer: 8, updateWhenIdle: false } as const
+
 // Configure the available map tile providers
 const osm = tileLayerOffline('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
   maxZoom: 23,
   maxNativeZoom: 19,
   attribution: '© OpenStreetMap',
+  ...tileBufferOptions,
 })
 
 const esri = tileLayerOffline(
@@ -514,6 +519,7 @@ const esri = tileLayerOffline(
     maxZoom: 23,
     maxNativeZoom: 19,
     attribution: '© Esri World Imagery',
+    ...tileBufferOptions,
   }
 )
 
@@ -521,6 +527,7 @@ const esri = tileLayerOffline(
 const seamarks = tileLayerOffline('https://tiles.openseamap.org/seamark/{z}/{x}/{y}.png', {
   maxZoom: 18,
   attribution: '© OpenSeaMap contributors',
+  ...tileBufferOptions,
 })
 
 const marineProfile = L.tileLayer.wms('https://geoserver.openseamap.org/geoserver/gwc/service/wms', {
@@ -531,6 +538,7 @@ const marineProfile = L.tileLayer.wms('https://geoserver.openseamap.org/geoserve
   attribution: '© GEBCO, OpenSeaMap',
   tileSize: 256,
   maxZoom: 19,
+  ...tileBufferOptions,
 })
 
 const baseMaps = {

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -588,6 +588,7 @@
 </template>
 <script setup lang="ts">
 import 'leaflet/dist/leaflet.css'
+import 'leaflet-edgebuffer'
 
 import { useDebounceFn, useWindowSize } from '@vueuse/core'
 import { formatDistanceToNow } from 'date-fns'
@@ -3642,10 +3643,13 @@ const attachOfflineProgress = (layer: any, layerName: string): void => {
 }
 
 onMounted(async () => {
+  const tileBufferOptions = { edgeBufferTiles: 2, keepBuffer: 8, updateWhenIdle: false } as const
+
   const osm = tileLayerOffline('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     maxZoom: 23,
     maxNativeZoom: 19,
     attribution: '© OpenStreetMap',
+    ...tileBufferOptions,
   })
   const esri = tileLayerOffline(
     'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
@@ -3653,6 +3657,7 @@ onMounted(async () => {
       maxZoom: 23,
       maxNativeZoom: 19,
       attribution: '© Esri World Imagery',
+      ...tileBufferOptions,
     }
   )
 
@@ -3670,6 +3675,7 @@ onMounted(async () => {
   L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     maxZoom: 19,
     attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+    ...tileBufferOptions,
   }).addTo(planningMap.value)
   planningMap.value.zoomControl.setPosition('bottomright')
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6851,6 +6851,11 @@ lazy-val@^1.0.5:
   resolved "https://registry.yarnpkg.com/lazy-val/-/lazy-val-1.0.5.tgz#6cf3b9f5bc31cee7ee3e369c0832b7583dcd923d"
   integrity sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==
 
+leaflet-edgebuffer@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/leaflet-edgebuffer/-/leaflet-edgebuffer-1.0.7.tgz#74008c8d3ff434255c1ae22b33d26ccb78ce1d92"
+  integrity sha512-ayapUPbKJPTCNr50xYtYGJRfXTLIqs60goyHxCV3XREMqV4Ima8R3GUCKU/UIxzLPc+Be8U6yuxKqkBFoHE0Rw==
+
 leaflet.offline@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/leaflet.offline/-/leaflet.offline-3.1.0.tgz#00c93dd461cee64e3f7c43113a11268dddbba809"


### PR DESCRIPTION
* Added an external lib `leaflet-edgebuffer` that prevents map tiles from being reloaded when they go offscreen;

The first time the map is dragged, the tiles are loaded (that first time inevitably causes white tiles) and kept in a buffer to prevent white tiles during future panning.

https://github.com/user-attachments/assets/4f841fff-6e0a-4547-92cb-26a1a3ae738e


Closes #2544 
Closes #312 