### PR TITLE
Pulse and persist vehicle disconnection indicators (border and widget)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -44,11 +44,7 @@
       </teleport>
 
       <div ref="routerSection" class="router-view">
-        <div
-          class="main-view"
-          :class="{ 'edit-mode': widgetStore.editingMode, 'vehicle-disconnected': !vehicleStore.isVehicleOnline }"
-          :style="connectionStatusFeedback"
-        >
+        <div class="main-view" :class="{ 'edit-mode': widgetStore.editingMode }">
           <WidgetBar
             v-show="showTopBarNow"
             id="mainTopBar"
@@ -84,6 +80,11 @@
       </div>
     </v-main>
   </v-app>
+  <div
+    class="vehicle-connection-overlay"
+    :class="{ 'is-disconnected': !vehicleStore.isVehicleOnline, 'is-reconnected': showReconnectedFeedback }"
+    aria-hidden="true"
+  />
   <About v-if="showAboutDialog" @update:show-about-dialog="showAboutDialog = $event" />
   <Tutorial v-if="interfaceStore.isTutorialVisible" />
   <VideoLibraryModal v-if="interfaceStore.isVideoLibraryVisible" />
@@ -235,22 +236,17 @@ onBeforeUnmount(() => {
 })
 
 /* eslint-disable jsdoc/require-jsdoc  */
-const connectionStatusFeedback = ref<{ border: string; transition?: string }>({ border: '0px' })
-
-// Fades the border out a few seconds after the vehicle reconnects, so the success feedback is not permanent.
-const fadeOutConnectionStatusFeedback = (): void => {
-  setTimeout(() => {
-    connectionStatusFeedback.value = {
-      border: '0px solid transparent',
-      transition: 'border 4s ease-out',
-    }
-  }, 4000)
-}
+// Drives the brief green flash shown right after the vehicle reconnects; the persistent red pulse
+// while disconnected is handled purely via CSS on the overlay element.
+const showReconnectedFeedback = ref(false)
+let reconnectedFeedbackTimeout: ReturnType<typeof setTimeout> | undefined
 
 // Connection monitoring and visual feedback
 watch(
   () => vehicleStore.isVehicleOnline,
   (isOnline) => {
+    if (reconnectedFeedbackTimeout) clearTimeout(reconnectedFeedbackTimeout)
+
     if (!isOnline) {
       openSnackbar({
         message: 'Vehicle connection lost: reestablishing',
@@ -258,15 +254,13 @@ watch(
         duration: 3000,
         closeButton: false,
       })
-      connectionStatusFeedback.value = { border: '3px solid red' }
-
+      showReconnectedFeedback.value = false
       return
     }
 
     openSnackbar({ message: 'Vehicle connected', variant: 'success', duration: 3000, closeButton: false })
-    connectionStatusFeedback.value = { border: '3px solid green' }
-
-    fadeOutConnectionStatusFeedback()
+    showReconnectedFeedback.value = true
+    reconnectedFeedbackTimeout = setTimeout(() => (showReconnectedFeedback.value = false), 4000)
   }
 )
 
@@ -362,17 +356,32 @@ body.hide-cursor {
   top: -11%;
 }
 
-.main-view.vehicle-disconnected {
+.vehicle-connection-overlay {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9999;
+  /* Matches the rounded corners of the OS window so the border is not clipped at the vertices. */
+  border-radius: 0 0 12px 12px;
+  box-shadow: inset 0 0 0 0 transparent;
+  transition: box-shadow 1s ease-out;
+}
+
+.vehicle-connection-overlay.is-disconnected {
   animation: vehicle-disconnected-pulse 1.6s ease-in-out infinite;
+}
+
+.vehicle-connection-overlay.is-reconnected {
+  box-shadow: inset 0 0 0 3px rgb(34, 197, 94), inset 0 0 24px 4px rgba(34, 197, 94, 0.45);
 }
 
 @keyframes vehicle-disconnected-pulse {
   0%,
   100% {
-    box-shadow: inset 0 0 0 0 rgba(255, 0, 0, 0);
+    box-shadow: inset 0 0 0 3px rgba(239, 68, 68, 0), inset 0 0 0 0 rgba(239, 68, 68, 0);
   }
   50% {
-    box-shadow: inset 0 0 24px 4px rgba(255, 0, 0, 0.55);
+    box-shadow: inset 0 0 0 3px rgb(239, 68, 68), inset 0 0 32px 6px rgba(239, 68, 68, 0.65);
   }
 }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -44,7 +44,11 @@
       </teleport>
 
       <div ref="routerSection" class="router-view">
-        <div class="main-view" :class="{ 'edit-mode': widgetStore.editingMode }" :style="connectionStatusFeedback">
+        <div
+          class="main-view"
+          :class="{ 'edit-mode': widgetStore.editingMode, 'vehicle-disconnected': !vehicleStore.isVehicleOnline }"
+          :style="connectionStatusFeedback"
+        >
           <WidgetBar
             v-show="showTopBarNow"
             id="mainTopBar"
@@ -233,7 +237,8 @@ onBeforeUnmount(() => {
 /* eslint-disable jsdoc/require-jsdoc  */
 const connectionStatusFeedback = ref<{ border: string; transition?: string }>({ border: '0px' })
 
-const resetConnectionStatusFeedback = (): void => {
+// Fades the border out a few seconds after the vehicle reconnects, so the success feedback is not permanent.
+const fadeOutConnectionStatusFeedback = (): void => {
   setTimeout(() => {
     connectionStatusFeedback.value = {
       border: '0px solid transparent',
@@ -255,14 +260,13 @@ watch(
       })
       connectionStatusFeedback.value = { border: '3px solid red' }
 
-      resetConnectionStatusFeedback()
       return
     }
 
     openSnackbar({ message: 'Vehicle connected', variant: 'success', duration: 3000, closeButton: false })
     connectionStatusFeedback.value = { border: '3px solid green' }
 
-    resetConnectionStatusFeedback()
+    fadeOutConnectionStatusFeedback()
   }
 )
 
@@ -356,6 +360,20 @@ body.hide-cursor {
   transform: scale(0.78);
   right: -11%;
   top: -11%;
+}
+
+.main-view.vehicle-disconnected {
+  animation: vehicle-disconnected-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes vehicle-disconnected-pulse {
+  0%,
+  100% {
+    box-shadow: inset 0 0 0 0 rgba(255, 0, 0, 0);
+  }
+  50% {
+    box-shadow: inset 0 0 24px 4px rgba(255, 0, 0, 0.55);
+  }
 }
 
 .fade-enter-active,

--- a/src/App.vue
+++ b/src/App.vue
@@ -82,7 +82,10 @@
   </v-app>
   <div
     class="vehicle-connection-overlay"
-    :class="{ 'is-disconnected': !vehicleStore.isVehicleOnline, 'is-reconnected': showReconnectedFeedback }"
+    :class="{
+      'is-disconnected': vehicleStore.isVehicleConnectionLost,
+      'is-reconnected': showReconnectedFeedback,
+    }"
     aria-hidden="true"
   />
   <About v-if="showAboutDialog" @update:show-about-dialog="showAboutDialog = $event" />
@@ -236,8 +239,8 @@ onBeforeUnmount(() => {
 })
 
 /* eslint-disable jsdoc/require-jsdoc  */
-// Drives the brief green flash shown right after the vehicle reconnects; the persistent red pulse
-// while disconnected is handled purely via CSS on the overlay element.
+// Drives the brief green flash on reconnect. The red border pulse (when connection was lost) is CSS-only
+// on the overlay; the overlay uses isVehicleConnectionLost so idle sessions without a link stay neutral.
 const showReconnectedFeedback = ref(false)
 let reconnectedFeedbackTimeout: ReturnType<typeof setTimeout> | undefined
 
@@ -248,13 +251,14 @@ watch(
     if (reconnectedFeedbackTimeout) clearTimeout(reconnectedFeedbackTimeout)
 
     if (!isOnline) {
+      showReconnectedFeedback.value = false
+      if (!vehicleStore.isVehicleConnectionLost) return
       openSnackbar({
         message: 'Vehicle connection lost: reestablishing',
         variant: 'error',
         duration: 3000,
         closeButton: false,
       })
-      showReconnectedFeedback.value = false
       return
     }
 

--- a/src/components/mini-widgets/BaseCommIndicator.vue
+++ b/src/components/mini-widgets/BaseCommIndicator.vue
@@ -1,22 +1,36 @@
 <template>
-  <v-tooltip :text="store.isVehicleOnline ? 'Vehicle connected' : 'Vehicle disconnected'" location="top">
+  <v-tooltip :text="commTooltip" location="top">
     <template #activator="{ props: tooltipProps }">
       <div
         class="relative"
-        :class="store.isVehicleOnline ? 'text-slate-50' : 'text-red-500 disconnected-pulse'"
+        :class="
+          store.isVehicleOnline
+            ? 'text-slate-50'
+            : store.isVehicleConnectionLost
+            ? 'text-red-500 disconnected-pulse'
+            : 'text-slate-500'
+        "
         v-bind="tooltipProps"
       >
         <FontAwesomeIcon icon="fa-solid fa-arrow-right-arrow-left" size="xl" />
-        <FontAwesomeIcon v-if="!store.isVehicleOnline" icon="fa-slash" size="xl" class="absolute -left-1" />
+        <FontAwesomeIcon v-if="store.isVehicleConnectionLost" icon="fa-slash" size="xl" class="absolute -left-1" />
       </div>
     </template>
   </v-tooltip>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
+
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 
 const store = useMainVehicleStore()
+
+const commTooltip = computed((): string => {
+  if (store.isVehicleOnline) return 'Vehicle connected'
+  if (store.isVehicleConnectionLost) return 'Vehicle disconnected'
+  return 'No vehicle connected'
+})
 </script>
 
 <style scoped>

--- a/src/components/mini-widgets/BaseCommIndicator.vue
+++ b/src/components/mini-widgets/BaseCommIndicator.vue
@@ -1,7 +1,11 @@
 <template>
   <v-tooltip :text="store.isVehicleOnline ? 'Vehicle connected' : 'Vehicle disconnected'" location="top">
     <template #activator="{ props: tooltipProps }">
-      <div class="relative" :class="store.isVehicleOnline ? 'text-slate-50' : 'text-gray-700'" v-bind="tooltipProps">
+      <div
+        class="relative"
+        :class="store.isVehicleOnline ? 'text-slate-50' : 'text-red-500 disconnected-pulse'"
+        v-bind="tooltipProps"
+      >
         <FontAwesomeIcon icon="fa-solid fa-arrow-right-arrow-left" size="xl" />
         <FontAwesomeIcon v-if="!store.isVehicleOnline" icon="fa-slash" size="xl" class="absolute -left-1" />
       </div>
@@ -14,3 +18,20 @@ import { useMainVehicleStore } from '@/stores/mainVehicle'
 
 const store = useMainVehicleStore()
 </script>
+
+<style scoped>
+.disconnected-pulse {
+  animation: comm-indicator-pulse 1.6s ease-in-out infinite;
+  filter: drop-shadow(0 0 4px rgba(239, 68, 68, 0.8));
+}
+
+@keyframes comm-indicator-pulse {
+  0%,
+  100% {
+    opacity: 0.35;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+</style>

--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -119,6 +119,12 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
   const currentlyConnectedVehicleId = ref<string | undefined>()
 
   const lastHeartbeat = ref<Date>()
+
+  /**
+   * Set to true the first time {@link isVehicleOnline} becomes true in this app session, and not reset
+   * until a full page reload. Used to distinguish "never had a link" from "had a link, now lost".
+   */
+  const hasVehicleBeenOnlineThisSession = ref(false)
   const firmwareType = ref<MavAutopilot>()
   const vehicleType = ref<MavType>()
   const altitude: Altitude = reactive({} as Altitude)
@@ -209,13 +215,22 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     return lastHeartbeat.value !== undefined && new Date(timeNow.value).getTime() - lastHeartbeat.value.getTime() < 5000
   })
 
+  /**
+   * True when a vehicle was online in this session (heartbeats received) and is now offline. Use for
+   * alarming disconnection UI; omit when the user never established a link this session.
+   * @returns {boolean} True if the user should see connection-lost (red border, pulsing comm indicator, etc.)
+   */
+  const isVehicleConnectionLost = computed(() => {
+    return hasVehicleBeenOnlineThisSession.value && !isVehicleOnline.value
+  })
+
   watch(isVehicleOnline, (isOnline) => {
     if (isOnline) {
+      hasVehicleBeenOnlineThisSession.value = true
       dispatchEvent(new CustomEvent('vehicle-online', { detail: { vehicleAddress: globalAddress.value } }))
-    } else {
-      dispatchEvent(new CustomEvent('vehicle-offline'))
+      return
     }
-    if (isOnline) return
+    dispatchEvent(new CustomEvent('vehicle-offline'))
     currentlyConnectedVehicleId.value = undefined
   })
 
@@ -1027,6 +1042,7 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     isArmed,
     flying,
     isVehicleOnline,
+    isVehicleConnectionLost,
     icon,
     configurationPages,
     rtcConfiguration,


### PR DESCRIPTION
Also fixes the problem of the border pushing elements and squeezing the screen space.

https://github.com/user-attachments/assets/68d36f0b-d45b-4396-9892-873fc504f83c


Closes #2616 
Closes #1817
