### PR TITLE
snapshot: Rename "electron" to "desktop" on instructions

### DIFF
--- a/src/components/mini-widgets/SnapshotTool.vue
+++ b/src/components/mini-widgets/SnapshotTool.vue
@@ -53,7 +53,7 @@
       @click="isTakingTimedSnapshot = !isTakingTimedSnapshot"
     />
   </div>
-  <v-dialog v-model="widgetStore.miniWidgetManagerVars(miniWidget.hash).configMenuOpen" width="450">
+  <v-dialog v-model="widgetStore.miniWidgetManagerVars(miniWidget.hash).configMenuOpen" width="500">
     <div
       class="flex flex-col items-center p-2 px-4 pt-1 m-5 rounded-md gap-y-4"
       :style="interfaceStore.globalGlassMenuStyles"
@@ -154,7 +154,7 @@
           @update:model-value="(val) => (miniWidget.options.captureWorkspace = val)"
         />
         <p class="ml-[4px] -mb-[2px] text-sm" :class="{ 'opacity-20 pointer-events-none': !isElectronEnv }">
-          Capture Cockpit work area (Electron only)
+          Capture Cockpit work area (Desktop-only feature)
         </p>
       </div>
       <v-text-field


### PR DESCRIPTION
As Daniel noticed, most users don't know what Electron is.

<img width="496" height="395" alt="image" src="https://github.com/user-attachments/assets/db33f871-94a1-4f84-81fa-f870b04eafc9" />
