### PR TITLE
map: Set referrer policy on OSM tile layers

### DIFF
--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -508,7 +508,7 @@ onBeforeMount(() => {
 const tileBufferOptions = { edgeBufferTiles: 2, keepBuffer: 8, updateWhenIdle: false } as const
 
 // Configure the available map tile providers
-const osm = tileLayerOffline('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+const osm = tileLayerOffline('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
   maxZoom: 23,
   maxNativeZoom: 19,
   attribution: '© OpenStreetMap',

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -512,6 +512,9 @@ const osm = tileLayerOffline('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png
   maxZoom: 23,
   maxNativeZoom: 19,
   attribution: '© OpenStreetMap',
+  // Required by the OSM tile usage policy: tiles requested without a Referer are blocked (403R).
+  // See https://wiki.openstreetmap.org/wiki/Referer
+  referrerPolicy: 'strict-origin-when-cross-origin',
   ...tileBufferOptions,
 })
 

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -9,6 +9,7 @@ import { setupHardwareTelemetryService } from './services/hardware-telemetry'
 import { setupJoystickMonitoring } from './services/joystick'
 import { linkService } from './services/link'
 import { setupNetworkService } from './services/network'
+import { setupOsmRefererService } from './services/osm-referer'
 import { setupResourceMonitoringService } from './services/resource-monitoring'
 import { setupFilesystemStorage } from './services/storage'
 import { setupSystemInfoService } from './services/system-info'
@@ -108,6 +109,10 @@ setupGo2RTCService()
 app.whenReady().then(async () => {
   console.log('Electron app is ready.')
   console.log(`Cockpit version: ${app.getVersion()}`)
+
+  // Inject a Referer header for OSM tile requests before the first tile is fetched, so the
+  // standalone build (loaded from file://) complies with the OSM tile usage policy.
+  setupOsmRefererService()
 
   console.log('Creating window...')
   createWindow()

--- a/src/electron/services/osm-referer.ts
+++ b/src/electron/services/osm-referer.ts
@@ -1,0 +1,45 @@
+import { session } from 'electron'
+
+/**
+ * Public-facing URL used as the Referer for OSM tile requests.
+ *
+ * Per the OSM tile usage policy the Referer must be "accurate end-to-end", so we point it at
+ * Cockpit's source repository which is the canonical contact for the application.
+ * @see https://operations.osmfoundation.org/policies/tiles/
+ */
+const COCKPIT_REFERER = 'https://github.com/bluerobotics/cockpit'
+
+/**
+ * URL filter matching every known OSM tile host. The canonical policy-compliant URL is
+ * `https://tile.openstreetmap.org/...`, but the legacy `{s}.tile.openstreetmap.org` subdomains
+ * are still in use inside some offline caches, so we cover both.
+ */
+const OSM_TILE_URL_FILTER = {
+  urls: [
+    'https://tile.openstreetmap.org/*',
+    'https://*.tile.openstreetmap.org/*',
+    'https://tile.osm.org/*',
+    'https://*.tile.osm.org/*',
+  ],
+}
+
+/**
+ * Setup a webRequest interceptor that guarantees an HTTP Referer header on every request to
+ * OpenStreetMap tile servers.
+ *
+ * When Cockpit is loaded from `file://` (standalone/Electron build), the document origin is
+ * `"null"` and Chromium omits the Referer header for cross-origin tile requests regardless of
+ * the `referrerPolicy` set on the tile `<img>` element. Without a Referer, OSM serves a
+ * "403R — Referer is required" blocked-tile placeholder (with a 200 status code and
+ * `X-Blocked` response header) per their tile usage policy.
+ *
+ * This listener injects a Cockpit-identifying Referer only for OSM tile hosts so other
+ * request flows are unaffected.
+ * @returns {void}
+ */
+export const setupOsmRefererService = (): void => {
+  session.defaultSession.webRequest.onBeforeSendHeaders(OSM_TILE_URL_FILTER, (details, callback) => {
+    const requestHeaders = { ...details.requestHeaders, Referer: COCKPIT_REFERER }
+    callback({ requestHeaders })
+  })
+}

--- a/src/electron/services/user-agent.ts
+++ b/src/electron/services/user-agent.ts
@@ -1,60 +1,44 @@
 import { ipcMain, session } from 'electron'
 
 let originalUserAgent: string | null = null
-let currentCustomUserAgent: string | null = null
-let webRequestListener: ((details: any, callback: any) => void) | null = null
 
 /**
- * Set a custom User-Agent for HTTP requests
+ * Set a custom User-Agent for HTTP requests on the default Electron session.
  * @param {string} userAgent The custom User-Agent string
+ * @returns {void}
  */
 const setUserAgent = (userAgent: string): void => {
   if (!originalUserAgent) {
     originalUserAgent = session.defaultSession.getUserAgent()
   }
-
-  currentCustomUserAgent = userAgent
-
-  // Remove any existing listener
-  if (webRequestListener) {
-    session.defaultSession.webRequest.onBeforeSendHeaders(null)
-  }
-
-  // Create a new listener that modifies the User-Agent header
-  webRequestListener = (details, callback) => {
-    if (currentCustomUserAgent) {
-      details.requestHeaders['User-Agent'] = currentCustomUserAgent
-    }
-    callback({ requestHeaders: details.requestHeaders })
-  }
-
-  // Add the listener for all URLs
-  session.defaultSession.webRequest.onBeforeSendHeaders({ urls: ['*://*/*'] }, webRequestListener)
+  session.defaultSession.setUserAgent(userAgent)
 }
 
 /**
- * Restore the original User-Agent
+ * Restore the original User-Agent recorded at the time of the first override.
+ * @returns {void}
  */
 const restoreUserAgent = (): void => {
-  currentCustomUserAgent = null
-
-  // Remove the web request listener
-  if (webRequestListener) {
-    session.defaultSession.webRequest.onBeforeSendHeaders(null)
-    webRequestListener = null
+  if (originalUserAgent) {
+    session.defaultSession.setUserAgent(originalUserAgent)
   }
 }
 
 /**
- * Get the current User-Agent
+ * Get the current User-Agent applied to the default session.
  * @returns {string} The current User-Agent string
  */
 const getCurrentUserAgent = (): string => {
-  return currentCustomUserAgent || originalUserAgent || session.defaultSession.getUserAgent()
+  return session.defaultSession.getUserAgent()
 }
 
 /**
- * Setup the User-Agent service
+ * Setup the User-Agent service.
+ *
+ * Uses `session.setUserAgent` (instead of a webRequest interceptor) so the single
+ * `onBeforeSendHeaders` listener slot stays free for other header manipulations
+ * (e.g. Referer injection for OSM tile requests).
+ * @returns {void}
  */
 export const setupUserAgentService = (): void => {
   ipcMain.handle('set-user-agent', (_event, userAgent: string) => {

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -3666,6 +3666,9 @@ onMounted(async () => {
     maxZoom: 23,
     maxNativeZoom: 19,
     attribution: '© OpenStreetMap',
+    // Required by the OSM tile usage policy: tiles requested without a Referer are blocked (403R).
+    // See https://wiki.openstreetmap.org/wiki/Referer
+    referrerPolicy: 'strict-origin-when-cross-origin',
     ...tileBufferOptions,
   })
   const esri = tileLayerOffline(
@@ -3697,6 +3700,9 @@ onMounted(async () => {
   L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     maxZoom: 19,
     attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+    // Required by the OSM tile usage policy: tiles requested without a Referer are blocked (403R).
+    // See https://wiki.openstreetmap.org/wiki/Referer
+    referrerPolicy: 'strict-origin-when-cross-origin',
     ...tileBufferOptions,
   }).addTo(planningMap.value)
   planningMap.value.zoomControl.setPosition('bottomright')

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -3662,7 +3662,7 @@ const attachOfflineProgress = (layer: any, layerName: string): void => {
 onMounted(async () => {
   const tileBufferOptions = { edgeBufferTiles: 2, keepBuffer: 8, updateWhenIdle: false } as const
 
-  const osm = tileLayerOffline('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  const osm = tileLayerOffline('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
     maxZoom: 23,
     maxNativeZoom: 19,
     attribution: '© OpenStreetMap',
@@ -3697,7 +3697,7 @@ onMounted(async () => {
   mapContext.map.value = planningMap.value
   mapContext.mapReady.value = true
 
-  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
     maxZoom: 19,
     attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
     // Required by the OSM tile usage policy: tiles requested without a Referer are blocked (403R).


### PR DESCRIPTION
Leaflet tiles were requested without a Referer header, triggering OSM's 403R "Referer is required" block per their tile usage policy. Sets the referrerPolicy to strict-origin-when-cross-origin as recommended by the OSM wiki, so tiles load again.

Fix #2613 