### PR TITLE
Add google maps layer as a community map provider

### DIFF
--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -259,7 +259,15 @@ import { openSnackbar } from '@/composables/snackbar'
 import { MavCmd, MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import { datalogger, DatalogVariable } from '@/libs/sensors-logging'
 import { degrees } from '@/libs/utils'
-import { createGridOverlay, TargetFollower, WhoToFollow } from '@/libs/utils-map'
+import {
+  addCommunityProvidersToLayerControl,
+  createGoogleMapsTileLayer,
+  createGoogleSatelliteTileLayer,
+  createGridOverlay,
+  createLayersControlWithCommunityToggle,
+  TargetFollower,
+  WhoToFollow,
+} from '@/libs/utils-map'
 import type { MAVLinkVehicle } from '@/libs/vehicle/mavlink/vehicle'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
@@ -546,9 +554,29 @@ const marineProfile = L.tileLayer.wms('https://geoserver.openseamap.org/geoserve
   ...tileBufferOptions,
 })
 
-const baseMaps = {
+const googleMaps = createGoogleMapsTileLayer(tileBufferOptions)
+const googleSatellite = createGoogleSatelliteTileLayer(tileBufferOptions)
+
+const communityProviders: {
+  /**
+   * Display name of the community map tile provider, used as the entry label in Leaflet's layers control.
+   */
+  name: MapTileProvider
+  /**
+   * Leaflet layer instance to register as a base layer once community providers are enabled.
+   */
+  layer: L.Layer
+}[] = [
+  { name: 'Google Maps', layer: googleMaps },
+  { name: 'Google Satellite', layer: googleSatellite },
+]
+
+const baseMaps: Record<string, L.Layer> = {
   'OpenStreetMap': osm,
   'Esri World Imagery': esri,
+}
+if (missionStore.communityMapProvidersEnabled) {
+  communityProviders.forEach((p) => (baseMaps[p.name] = p.layer))
 }
 
 const overlays = {
@@ -561,7 +589,25 @@ const mapBase = ref<HTMLElement>()
 const isMouseOver = useElementHover(mapBase)
 
 const zoomControl = L.control.zoom({ position: 'bottomright' })
-const layerControl = L.control.layers(baseMaps, overlays)
+const layerControl = createLayersControlWithCommunityToggle({
+  baseMaps,
+  overlays,
+  isEnabled: () => missionStore.communityMapProvidersEnabled,
+  onEnableClick: () => {
+    if (missionStore.communityMapProvidersEnabled) return
+    missionStore.communityMapProvidersEnabled = true
+    openSnackbar({ message: 'Community map layers enabled', variant: 'success', duration: 3000 })
+  },
+})
+
+watch(
+  () => missionStore.communityMapProvidersEnabled,
+  (enabled, prev) => {
+    if (enabled && !prev) {
+      addCommunityProvidersToLayerControl(layerControl, communityProviders)
+    }
+  }
+)
 const gridLayer = shallowRef<L.LayerGroup | undefined>(undefined)
 
 watch(showButtons, () => {
@@ -2181,6 +2227,9 @@ watch(
 
 :deep(.leaflet-control-layers-selector) {
   accent-color: var(--glass-color) !important;
+  vertical-align: middle !important;
+  margin-top: 0 !important;
+  top: 0 !important;
 }
 
 :deep(.leaflet-control-layers label) {

--- a/src/libs/utils-map.ts
+++ b/src/libs/utils-map.ts
@@ -2,7 +2,7 @@ import * as turf from '@turf/turf'
 import type { Feature, Polygon } from 'geojson'
 import * as L from 'leaflet'
 
-import type { SurveyPath, WaypointCoordinates } from '@/types/mission'
+import type { MapTileProvider, SurveyPath, WaypointCoordinates } from '@/types/mission'
 
 /**
  * Default target follower update interval in milliseconds.
@@ -469,4 +469,141 @@ export const createGridOverlay = (map: L.Map, gridLayer?: L.LayerGroup): L.Layer
 
   newGridLayer.addTo(map)
   return newGridLayer
+}
+
+const communityProvidersButtonClass = 'cockpit-leaflet-enable-community-providers-btn'
+
+/**
+ * Builds a Leaflet tile layer for Google Maps' roadmap tiles.
+ *
+ * Google Maps is a community-sourced provider (not officially supported by Google for direct
+ * tile access), so it must be opted-in via the layer selector before being shown.
+ * @param {L.TileLayerOptions} extraOptions - Additional Leaflet options to merge into the layer.
+ * @returns {L.TileLayer} A Leaflet tile layer pointing at Google Maps' roadmap tiles.
+ */
+export const createGoogleMapsTileLayer = (extraOptions: L.TileLayerOptions = {}): L.TileLayer => {
+  return L.tileLayer('https://mt{s}.google.com/vt/lyrs=m&x={x}&y={y}&z={z}', {
+    subdomains: ['0', '1', '2', '3'],
+    maxZoom: 23,
+    maxNativeZoom: 21,
+    attribution: '© Google',
+    ...extraOptions,
+  })
+}
+
+/**
+ * Builds a Leaflet tile layer for Google Satellite (imagery) tiles.
+ *
+ * Like `createGoogleMapsTileLayer`, this is a community-sourced provider and must be opted-in via
+ * the layer selector before being shown.
+ * @param {L.TileLayerOptions} extraOptions - Additional Leaflet options to merge into the layer.
+ * @returns {L.TileLayer} A Leaflet tile layer pointing at Google's satellite imagery tiles.
+ */
+export const createGoogleSatelliteTileLayer = (extraOptions: L.TileLayerOptions = {}): L.TileLayer => {
+  return L.tileLayer('https://mt{s}.google.com/vt/lyrs=s&x={x}&y={y}&z={z}', {
+    subdomains: ['0', '1', '2', '3'],
+    maxZoom: 23,
+    maxNativeZoom: 21,
+    attribution: '© Google',
+    ...extraOptions,
+  })
+}
+
+/**
+ * Options for the community-aware Leaflet layers control factory.
+ */
+interface CommunityLayersControlOptions {
+  /**
+   * Base layers to expose unconditionally in the layers control.
+   */
+  baseMaps: Record<string, L.Layer>
+  /**
+   * Optional overlays for the layers control.
+   */
+  overlays?: Record<string, L.Layer>
+  /**
+   * Reactive accessor that returns whether community providers are currently enabled.
+   */
+  isEnabled: () => boolean
+  /**
+   * Callback invoked when the user clicks the "Enable community map providers" button.
+   */
+  onEnableClick: () => void
+}
+
+/**
+ * Creates a Leaflet `L.Control.Layers` instance that, while community providers are disabled,
+ * renders an "Enable community map providers" button at the bottom of the layer list.
+ *
+ * The button is re-rendered every time the control is added to a map, so it stays in sync with
+ * the latest opt-in state across mouse-hover add/remove cycles.
+ * @param {CommunityLayersControlOptions} options - Configuration for the layers control.
+ * @returns {L.Control.Layers} The configured Leaflet layers control instance.
+ */
+export const createLayersControlWithCommunityToggle = (options: CommunityLayersControlOptions): L.Control.Layers => {
+  const ExtendedLayersControl = L.Control.Layers.extend({
+    onAdd(this: L.Control.Layers, map: L.Map): HTMLElement {
+      const baseOnAdd = L.Control.Layers.prototype.onAdd as (m: L.Map) => HTMLElement
+      const container = baseOnAdd.call(this, map)
+      container.querySelectorAll('.' + communityProvidersButtonClass).forEach((el) => el.remove())
+      if (options.isEnabled()) return container
+
+      // Append below the overlays section so the button only shows while the layers control is expanded.
+      const list = container.querySelector('.leaflet-control-layers-list') as HTMLElement | null
+      if (!list) return container
+
+      const separator = document.createElement('div')
+      separator.className = 'leaflet-control-layers-separator ' + communityProvidersButtonClass
+
+      const btn = document.createElement('button')
+      btn.className = communityProvidersButtonClass
+      btn.type = 'button'
+      btn.textContent = 'Enable community map providers'
+      Object.assign(btn.style, {
+        display: 'block',
+        width: '100%',
+        padding: '6px 8px',
+        margin: '8px 0 0 1px',
+        borderRadius: '4px',
+        background: '#f5f5f522',
+        cursor: 'pointer',
+        font: 'bold',
+        color: '#fff',
+        boxShadow: '1px 1px 2px 0 rgba(0, 0, 0, 0.2)',
+      } satisfies Partial<CSSStyleDeclaration>)
+      L.DomEvent.disableClickPropagation(btn)
+      L.DomEvent.on(btn, 'click', () => options.onEnableClick())
+
+      list.appendChild(separator)
+      list.appendChild(btn)
+      return container
+    },
+  })
+  return new (ExtendedLayersControl as unknown as typeof L.Control.Layers)(options.baseMaps, options.overlays)
+}
+
+/**
+ * Adds the given community providers to an existing Leaflet layers control and removes the
+ * "Enable community map providers" button (if present) from its DOM container.
+ * @param {L.Control.Layers} layerControl - The Leaflet layers control to update.
+ * @param {{ name: MapTileProvider, layer: L.Layer }[]} providers - Community providers to expose
+ * as base layers.
+ * @returns {void}
+ */
+export const addCommunityProvidersToLayerControl = (
+  layerControl: L.Control.Layers,
+  providers: {
+    /**
+     *
+     */
+    name: MapTileProvider
+    /**
+     *
+     */
+    layer: L.Layer
+  }[]
+): void => {
+  providers.forEach((p) => layerControl.addBaseLayer(p.layer, p.name))
+  const container = layerControl.getContainer?.()
+  container?.querySelectorAll('.' + communityProvidersButtonClass).forEach((el) => el.remove())
 }

--- a/src/stores/mission.ts
+++ b/src/stores/mission.ts
@@ -58,6 +58,7 @@ export const useMissionStore = defineStore('mission', () => {
     'cockpit-user-last-map-tile-provider',
     'Esri World Imagery'
   )
+  const communityMapProvidersEnabled = useBlueOsStorage<boolean>('cockpit-community-map-providers-enabled', false)
   const mapDownloadMissionFromVehicle = ref<(() => Promise<void>) | null>(null)
   const mapClearMapDrawing = ref<(() => void) | null>(null)
 
@@ -602,6 +603,7 @@ export const useMissionStore = defineStore('mission', () => {
     updateWaypointCommand,
     defaultCruiseSpeed,
     userLastMapTileProvider,
+    communityMapProvidersEnabled,
     followVehicleOnMap,
     stopMission,
     executeMissionOnVehicle,

--- a/src/types/mission.ts
+++ b/src/types/mission.ts
@@ -475,9 +475,15 @@ export interface VehicleMissionEstimate {
 }
 
 /**
+ * Names of map tile providers that come from community sources and require explicit user opt-in
+ * before being shown in the map layer selector.
+ */
+export const communityMapTileProviders = ['Google Maps', 'Google Satellite'] as const
+
+/**
  * Types of map tile providers supported.
  */
-export type MapTileProvider = 'Esri World Imagery' | 'OpenStreetMap'
+export type MapTileProvider = 'Esri World Imagery' | 'OpenStreetMap' | (typeof communityMapTileProviders)[number]
 
 export type IconDimensions = {
   /**

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -637,7 +637,15 @@ import { MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import { MavCmd } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import { centroidLatLng, polygonAreaSquareMeters } from '@/libs/mission/general-estimates'
 import { degrees } from '@/libs/utils'
-import { createGridOverlay, TargetFollower, WhoToFollow } from '@/libs/utils-map'
+import {
+  addCommunityProvidersToLayerControl,
+  createGoogleMapsTileLayer,
+  createGoogleSatelliteTileLayer,
+  createGridOverlay,
+  createLayersControlWithCommunityToggle,
+  TargetFollower,
+  WhoToFollow,
+} from '@/libs/utils-map'
 import { generateSurveyPath } from '@/libs/utils-map'
 import router from '@/router'
 import { SubMenuComponentName, SubMenuName, useAppInterfaceStore } from '@/stores/appInterface'
@@ -3681,9 +3689,29 @@ onMounted(async () => {
     }
   )
 
-  const baseMaps = {
+  const googleMaps = createGoogleMapsTileLayer(tileBufferOptions)
+  const googleSatellite = createGoogleSatelliteTileLayer(tileBufferOptions)
+
+  const communityProviders: {
+    /**
+     * Display name of the community map tile provider, used as the entry label in Leaflet's layers control.
+     */
+    name: MapTileProvider
+    /**
+     * Leaflet layer instance to register as a base layer once community providers are enabled.
+     */
+    layer: L.Layer
+  }[] = [
+    { name: 'Google Maps', layer: googleMaps },
+    { name: 'Google Satellite', layer: googleSatellite },
+  ]
+
+  const baseMaps: Record<string, L.Layer> = {
     'OpenStreetMap': osm,
     'Esri World Imagery': esri,
+  }
+  if (missionStore.communityMapProvidersEnabled) {
+    communityProviders.forEach((p) => (baseMaps[p.name] = p.layer))
   }
 
   const initialBaseLayer = baseMaps[missionStore.userLastMapTileProvider] || esri
@@ -3786,8 +3814,25 @@ onMounted(async () => {
     onMapClick(e)
   })
 
-  const layerControl = L.control.layers(baseMaps)
+  const layerControl = createLayersControlWithCommunityToggle({
+    baseMaps,
+    isEnabled: () => missionStore.communityMapProvidersEnabled,
+    onEnableClick: () => {
+      if (missionStore.communityMapProvidersEnabled) return
+      missionStore.communityMapProvidersEnabled = true
+      openSnackbar({ message: 'Community map layers enabled', variant: 'success', duration: 3000 })
+    },
+  })
   planningMap.value.addControl(layerControl)
+
+  watch(
+    () => missionStore.communityMapProvidersEnabled,
+    (enabled, prev) => {
+      if (enabled && !prev) {
+        addCommunityProvidersToLayerControl(layerControl, communityProviders)
+      }
+    }
+  )
 
   // Initialize scale control (always show)
   createScaleControl()
@@ -4670,6 +4715,9 @@ watch(
 
 :deep(.leaflet-control-layers-selector) {
   accent-color: var(--glass-color) !important;
+  vertical-align: middle !important;
+  margin-top: 0 !important;
+  top: 0 !important;
 }
 
 :deep(.leaflet-control-layers label) {


### PR DESCRIPTION
* Add a button to enable community map layers on leaflet's layer selector;
* Once enabled, Google maps and Google Satellite are included to the layer list.

https://github.com/user-attachments/assets/033602f4-1dc0-4ea1-a97c-dae02f868143

Close #2630