### PR TITLE
Fix snapshot of RTSP streams failing in Windows

### DIFF
--- a/src/components/mini-widgets/SnapshotTool.vue
+++ b/src/components/mini-widgets/SnapshotTool.vue
@@ -277,7 +277,7 @@ const captureSnapshot = async (): Promise<SnapshotResult> => {
 }
 
 const toInternalName = (externalId: string): string => {
-  return videoStore.streamsCorrespondency.find((c) => c.externalId === externalId)?.name ?? externalId
+  return videoStore.internalStreamNameFromExternal(externalId) ?? externalId
 }
 
 const handleSnapshotResult = (result: SnapshotResult): void => {
@@ -386,8 +386,7 @@ const migrateSelectedStreamsToInternalNames = (): void => {
   const streams = miniWidget.value.options.selectedStreams as string[] | undefined
   if (!streams || streams.length === 0) return
   miniWidget.value.options.selectedStreams = streams.map((name: string) => {
-    const corr = videoStore.streamsCorrespondency.find((c) => c.externalId === name)
-    return corr ? corr.name : name
+    return videoStore.internalStreamNameFromExternal(name) ?? name
   })
 }
 

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -220,6 +220,25 @@ export const machinizeString = (str: string): string => {
 }
 
 /**
+ * Sanitizes a value for use as a filename component on every supported platform.
+ * Windows is the strictest target: it forbids `<`, `>`, `:`, `"`, `/`, `\`, `|`, `?`, `*`
+ * and control characters, and disallows trailing dots/spaces. Without this, values like
+ * RTSP URLs (used as snapshot stream names) or mission names containing colons produce
+ * paths that fail with ENOENT on NTFS.
+ * @param {string} value
+ * @returns {string} Filesystem-safe representation of the value
+ */
+export const sanitizeFilenameComponent = (value: string): string => {
+  return (
+    value
+      // eslint-disable-next-line no-control-regex
+      .replace(/[<>:"/\\|?*\u0000-\u001F]/g, '_')
+      .replace(/_+/g, '_')
+      .replace(/^[. ]+|[. ]+$/g, '')
+  )
+}
+
+/**
  * Get an unindented string
  * Trims all lines by the same amount of whitespace, so that the string is not indented
  * @param {string} str The string to unindent

--- a/src/stores/snapshot.ts
+++ b/src/stores/snapshot.ts
@@ -9,7 +9,7 @@ import { useInteractionDialog } from '@/composables/interactionDialog'
 import { useBlueOsStorage } from '@/composables/settingsSyncer'
 import { app_version } from '@/libs/cosmos'
 import { availableCockpitActions, registerActionCallback } from '@/libs/joystick/protocols/cockpit-actions'
-import { isElectron } from '@/libs/utils'
+import { isElectron, sanitizeFilenameComponent } from '@/libs/utils'
 import { snapshotStorage, snapshotThumbStorage } from '@/libs/videoStorage'
 import { StorageDB } from '@/types/general'
 import { EIXFType, SnapshotExif, SnapshotFileDescriptor, SnapshotResult } from '@/types/snapshot'
@@ -159,7 +159,8 @@ export const useSnapshotStore = defineStore('snapshot', () => {
 
   const snapshotFilename = (streamName: string): string => {
     const timestamp = format(new Date(), 'LLL dd, yyyy - HH꞉mm꞉ss O')
-    return `(${timestamp})_Cockpit_${streamName}.jpeg`
+    const safeName = sanitizeFilenameComponent(streamName) || 'workspace'
+    return `(${timestamp})_Cockpit_${safeName}.jpeg`
   }
 
   const createThumbnail = (blob: Blob, width: number, height: number): Promise<Blob> => {
@@ -240,8 +241,8 @@ export const useSnapshotStore = defineStore('snapshot', () => {
         const { width, height } = videoStore.getMediaStream(streamName)?.getVideoTracks()[0].getSettings() || {}
         const stExif = buildExif({ latitude, longitude, yaw, pitch, roll, width, height })
         stBlob = await maybeEmbedExif(stBlob, stExif)
-        const filename = snapshotFilename(streamName.replace(/[\\/]/g, '_') || 'workspace')
-        const thumbFilename = snapshotFilename(streamName.replace(/[\\/]/g, '_') || 'workspace') + '-thumb'
+        const filename = snapshotFilename(streamName)
+        const thumbFilename = filename + '-thumb'
 
         await snapshotStorage.setItem(filename, stBlob)
         await snapshotThumbStorage.setItem(thumbFilename, thumbBlob)

--- a/src/stores/snapshot.ts
+++ b/src/stores/snapshot.ts
@@ -245,7 +245,8 @@ export const useSnapshotStore = defineStore('snapshot', () => {
         const { width, height } = videoStore.getMediaStream(streamName)?.getVideoTracks()[0].getSettings() || {}
         const stExif = buildExif({ latitude, longitude, yaw, pitch, roll, width, height })
         stBlob = await maybeEmbedExif(stBlob, stExif)
-        const filename = snapshotFilename(streamName, missionName)
+        const internalStreamName = videoStore.internalStreamNameFromExternal(streamName) ?? streamName
+        const filename = snapshotFilename(internalStreamName, missionName)
         const thumbFilename = filename + '-thumb'
 
         await snapshotStorage.setItem(filename, stBlob)

--- a/src/stores/snapshot.ts
+++ b/src/stores/snapshot.ts
@@ -11,6 +11,7 @@ import { app_version } from '@/libs/cosmos'
 import { availableCockpitActions, registerActionCallback } from '@/libs/joystick/protocols/cockpit-actions'
 import { isElectron, sanitizeFilenameComponent } from '@/libs/utils'
 import { snapshotStorage, snapshotThumbStorage } from '@/libs/videoStorage'
+import { useMissionStore } from '@/stores/mission'
 import { StorageDB } from '@/types/general'
 import { EIXFType, SnapshotExif, SnapshotFileDescriptor, SnapshotResult } from '@/types/snapshot'
 import { DownloadProgressCallback, FileDescriptor } from '@/types/video'
@@ -21,6 +22,7 @@ import { useVideoStore } from './video'
 export const useSnapshotStore = defineStore('snapshot', () => {
   const videoStore = useVideoStore()
   const vehicleStore = useMainVehicleStore()
+  const missionStore = useMissionStore()
   const { showDialog } = useInteractionDialog()
 
   const zipMultipleFiles = useBlueOsStorage('cockpit-zip-multiple-video-files', false)
@@ -157,10 +159,11 @@ export const useSnapshotStore = defineStore('snapshot', () => {
     return new Blob([pngBuffer], { type: 'image/png' })
   }
 
-  const snapshotFilename = (streamName: string): string => {
-    const timestamp = format(new Date(), 'LLL dd, yyyy - HH꞉mm꞉ss O')
-    const safeName = sanitizeFilenameComponent(streamName) || 'workspace'
-    return `(${timestamp})_Cockpit_${safeName}.jpeg`
+  const snapshotFilename = (streamName: string, missionName = 'Cockpit'): string => {
+    const timeString = format(new Date(), 'LLL dd, yyyy - HH꞉mm꞉ss O')
+    const safeMissionName = sanitizeFilenameComponent(missionName) || 'Cockpit'
+    const safeStreamName = sanitizeFilenameComponent(streamName) || 'workspace'
+    return `${safeMissionName} (${timeString}) #${safeStreamName}.jpeg`
   }
 
   const createThumbnail = (blob: Blob, width: number, height: number): Promise<Blob> => {
@@ -203,6 +206,7 @@ export const useSnapshotStore = defineStore('snapshot', () => {
   const takeSnapshot = async (streamNames: string[], captureWorkspace?: boolean): Promise<SnapshotResult> => {
     const { yaw, pitch, roll } = vehicleStore.attitude
     const { latitude, longitude } = vehicleStore.coordinates
+    const missionName = missionStore.missionName || 'Cockpit'
 
     const succeeded: string[] = []
     const failed: string[] = []
@@ -222,7 +226,7 @@ export const useSnapshotStore = defineStore('snapshot', () => {
           })
           wsBlob = await maybeEmbedExif(wsBlob, wsExif)
           const thumbBlob = await createThumbnail(wsBlob, 200, 113)
-          const filename = snapshotFilename('workspace')
+          const filename = snapshotFilename('workspace', missionName)
           const thumbFilename = filename + '-thumb'
           await snapshotStorage.setItem(filename, wsBlob)
           await snapshotThumbStorage.setItem(thumbFilename, thumbBlob)
@@ -241,7 +245,7 @@ export const useSnapshotStore = defineStore('snapshot', () => {
         const { width, height } = videoStore.getMediaStream(streamName)?.getVideoTracks()[0].getSettings() || {}
         const stExif = buildExif({ latitude, longitude, yaw, pitch, roll, width, height })
         stBlob = await maybeEmbedExif(stBlob, stExif)
-        const filename = snapshotFilename(streamName)
+        const filename = snapshotFilename(streamName, missionName)
         const thumbFilename = filename + '-thumb'
 
         await snapshotStorage.setItem(filename, stBlob)

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -21,7 +21,7 @@ import {
   LiveVideoProcessorInitializationError,
 } from '@/libs/live-video-processor'
 import { datalogger } from '@/libs/sensors-logging'
-import { isElectron, isEqual, sleep } from '@/libs/utils'
+import { isElectron, isEqual, sanitizeFilenameComponent, sleep } from '@/libs/utils'
 import { tempVideoStorage, videoStorage } from '@/libs/videoStorage'
 import type { Stream } from '@/libs/webrtc/signalling_protocol'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
@@ -620,7 +620,8 @@ export const useVideoStore = defineStore('video', () => {
       refreshHash = hashOnDB || hashOnRegistry
     }
 
-    const fileName = videoFilename(recordingHash, streamData.timeRecordingStart!, missionStore.missionName || 'Cockpit')
+    const safeMissionName = sanitizeFilenameComponent(missionStore.missionName) || 'Cockpit'
+    const fileName = videoFilename(recordingHash, streamData.timeRecordingStart!, safeMissionName)
     activeStreams.value[streamName]!.mediaRecorder = new MediaRecorder(streamData.mediaStream!)
 
     const videoTrack = streamData.mediaStream!.getVideoTracks()[0]

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -118,6 +118,11 @@ export const useVideoStore = defineStore('video', () => {
     return corr ? corr.externalId : undefined
   }
 
+  const internalStreamNameFromExternal = (externalId: string): string | undefined => {
+    const corr = streamsCorrespondency.value.find((stream) => stream.externalId === externalId)
+    return corr ? corr.name : undefined
+  }
+
   const getStreamCorrespondency = (externalId: string): VideoStreamCorrespondency | undefined => {
     return streamsCorrespondency.value.find((stream) => stream.externalId === externalId)
   }
@@ -1263,6 +1268,7 @@ export const useVideoStore = defineStore('video', () => {
     ignoredStreamExternalIds,
     namessAvailableAbstractedStreams,
     externalStreamId,
+    internalStreamNameFromExternal,
     getStreamProtocol,
     getStreamDisplayInfo,
     getRtspUrl,


### PR DESCRIPTION
The snapshot of RTSP streams was failing on Windows machines because the filenames for the snapshots was using the external stream name, which for the RTSP cases has a `:`, which is a reserved character on Windows. 

To solve the problem, the snapshot filename is being sanitized. Also, to be closer to the filename format used for video recordings, we are replacing the external stream name with the mission name (or Cockpit as a fallback) plus the datetime plus the internal stream name.

Fix #2629 