### PR TITLE
Fix minor bugs in the vehicle discovery system

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -309,6 +309,7 @@ onBeforeUnmount(() => {
 const currentBottomBarHeightPixels = computed(() => `${widgetStore.currentBottomBarHeightPixels}px`)
 
 const showDiscoveryDialog = ref(false)
+const discoveryDialogAutoOpened = ref(false)
 const preventAutoSearch = useStorage('cockpit-prevent-auto-vehicle-discovery-dialog', false)
 
 onMounted(() => {
@@ -317,6 +318,7 @@ onMounted(() => {
     setTimeout(() => {
       if (vehicleStore.isVehicleOnline) return
       showDiscoveryDialog.value = true
+      discoveryDialogAutoOpened.value = true
     }, 5000)
   }
 
@@ -326,6 +328,23 @@ onMounted(() => {
     }, 6000)
   }
 })
+
+watch(showDiscoveryDialog, (isOpen) => {
+  if (!isOpen) discoveryDialogAutoOpened.value = false
+})
+
+// Auto-close the discovery dialog if the vehicle comes online while it's open, but only when the
+// dialog was opened automatically (not when the user explicitly opened it). Handles cases where the
+// first heartbeat arrives late (e.g. slow mDNS resolution of `blueos-avahi.local`), so the dialog
+// gets auto-opened even though the configured address would have connected on its own.
+watch(
+  () => vehicleStore.isVehicleOnline,
+  (isOnline) => {
+    if (isOnline && showDiscoveryDialog.value && discoveryDialogAutoOpened.value) {
+      showDiscoveryDialog.value = false
+    }
+  }
+)
 </script>
 
 <style>

--- a/src/electron/services/network.ts
+++ b/src/electron/services/network.ts
@@ -2,6 +2,38 @@ import { ipcMain } from 'electron'
 import { networkInterfaces } from 'os'
 
 import { NetworkInfo } from '../../types/network'
+
+/**
+ * Interface name prefixes that are virtual / non-physical and should be skipped
+ * during vehicle discovery: VPN tunnels, container/VM bridges, Apple wireless
+ * peer-to-peer interfaces, IPSec, etc. None of these can carry a BlueOS vehicle.
+ */
+const VIRTUAL_INTERFACE_PREFIXES = [
+  'awdl', // Apple Wireless Direct Link
+  'br-', // Docker user-defined bridge
+  'bridge', // macOS bridge
+  'docker', // Docker default bridge
+  'feth', // macOS fake ethernet (Docker / virtualization)
+  'gif', // macOS generic tunnel
+  'ipsec', // IPSec tunnel
+  'llw', // Apple low-latency wifi
+  'lo', // loopback (also caught by `internal`, but keep explicit)
+  'stf', // macOS 6to4 tunnel
+  'tap', // generic TAP device
+  'tun', // generic TUN device
+  'utun', // macOS userland tunnel (VPN)
+  'vboxnet', // VirtualBox host-only
+  'veth', // Linux virtual ethernet pair
+  'vmnet', // VMware host-only / NAT
+  'wg', // WireGuard
+  'zt', // ZeroTier
+]
+
+const isVirtualInterface = (interfaceName: string): boolean => {
+  const lower = interfaceName.toLowerCase()
+  return VIRTUAL_INTERFACE_PREFIXES.some((prefix) => lower.startsWith(prefix))
+}
+
 /**
  * Get the network information
  * @returns {NetworkInfo} The network information
@@ -9,18 +41,40 @@ import { NetworkInfo } from '../../types/network'
 const getInfoOnSubnets = (): NetworkInfo[] => {
   const allSubnets = networkInterfaces()
 
-  const ipv4Subnets = Object.entries(allSubnets)
-    .flatMap(([_, nets]) => {
-      return nets.map((net) => ({ ...net, interfaceName: _ }))
-    })
-    .filter((net) => net.family === 'IPv4')
-    .filter((net) => !net.internal)
+  const rawList = Object.entries(allSubnets).flatMap(([_, nets]) => {
+    return (nets ?? []).map((net) => ({ ...net, interfaceName: _ }))
+  })
+  console.log(
+    `[VehicleDiscovery] Raw network interfaces: ${JSON.stringify(
+      rawList.map((n) => ({
+        iface: n.interfaceName,
+        family: n.family,
+        internal: n.internal,
+        addr: n.address,
+        cidr: n.cidr,
+      }))
+    )}`
+  )
+
+  const ipv4Candidates = rawList.filter((net) => net.family === 'IPv4').filter((net) => !net.internal)
+
+  const skipped = ipv4Candidates.filter((net) => isVirtualInterface(net.interfaceName))
+  const ipv4Subnets = ipv4Candidates.filter((net) => !isVirtualInterface(net.interfaceName))
+
+  if (skipped.length > 0) {
+    console.log(
+      `[VehicleDiscovery] Skipping ${skipped.length} virtual interface(s): ${JSON.stringify(
+        skipped.map((n) => ({ iface: n.interfaceName, addr: n.address }))
+      )}`
+    )
+  }
 
   if (ipv4Subnets.length === 0) {
+    console.warn('[VehicleDiscovery] No external IPv4 interfaces found, aborting.')
     throw new Error('No network interfaces found.')
   }
 
-  return ipv4Subnets.map((subnet) => {
+  const result = ipv4Subnets.map((subnet) => {
     // TODO: Use the mask to calculate the available addresses. The current implementation is not correct for anything else than /24.
     const subnetPrefix = subnet.address.split('.').slice(0, 3).join('.')
     const availableAddresses: string[] = []
@@ -35,6 +89,14 @@ const getInfoOnSubnets = (): NetworkInfo[] => {
       availableAddresses,
     }
   })
+
+  console.log(
+    `[VehicleDiscovery] Subnets to scan: ${JSON.stringify(
+      result.map((s) => ({ iface: s.interfaceName, top: s.topSideAddress, count: s.availableAddresses.length }))
+    )}`
+  )
+
+  return result
 }
 
 /**

--- a/src/libs/electron/vehicle-discovery.ts
+++ b/src/libs/electron/vehicle-discovery.ts
@@ -56,12 +56,23 @@ class VehicleDiscover {
 
       // Check if the vehicle is a BlueOS vehicle
       const beaconResponse = await getBeaconInfo(address)
-      if (!beaconResponse.ok) return null
+      if (!beaconResponse.ok) {
+        console.warn(
+          `[VehicleDiscovery] [${address}] Host responded to /status but /beacon/ returned ${beaconResponse.status}; not a BlueOS vehicle.`
+        )
+        return null
+      }
       const beaconText = await beaconResponse.text()
-      if (!beaconText.toLowerCase().includes('beacon')) return null
+      if (!beaconText.toLowerCase().includes('beacon')) {
+        console.warn(
+          `[VehicleDiscovery] [${address}] Host responded to /beacon/ but body lacks the 'beacon' marker; ignoring.`
+        )
+        return null
+      }
 
       // Try to get the vehicle name
       const name = await getVehicleName(address)
+      console.info(`[VehicleDiscovery] Found vehicle '${name}' at ${address}.`)
       return { address, name }
     } catch {
       // If we can't get the name, it's because it's not a vehicle (or maybe BlueOS's Beacon service is not running)
@@ -84,6 +95,9 @@ class VehicleDiscover {
     }
 
     const search = async (): Promise<NetworkVehicle[]> => {
+      const searchStart = Date.now()
+      console.info('[VehicleDiscovery] Starting vehicle discovery scan...')
+
       if (!isElectron() || !window.electronAPI?.getInfoOnSubnets) {
         const msg = 'For technical reasons, getting information about the local subnet is only available in Electron.'
         throw new Error(msg)
@@ -93,10 +107,12 @@ class VehicleDiscover {
       try {
         localSubnets = await window.electronAPI.getInfoOnSubnets()
       } catch (error) {
+        console.error(`[VehicleDiscovery] Failed to get information about the local subnets: ${error}`)
         throw new Error(`Failed to get information about the local subnets. ${error}`)
       }
 
       if (localSubnets.length === 0) {
+        console.error('[VehicleDiscovery] Got an empty list of subnets from Electron.')
         throw new Error('Failed to get information about the local subnets.')
       }
 
@@ -110,6 +126,10 @@ class VehicleDiscover {
 
       const vehiclesFound: NetworkVehicle[] = []
       const concurrency = Math.min(MAX_CONCURRENT_ADDRESS_CHECKS, addressesToCheck.length)
+      console.info(
+        `[VehicleDiscovery] Scanning ${addressesToCheck.length} address(es) across ${localSubnets.length} subnet(s) ` +
+          `with up to ${concurrency} concurrent checks.`
+      )
 
       let nextIndex = 0
       const worker = async (): Promise<void> => {
@@ -125,6 +145,10 @@ class VehicleDiscover {
       await Promise.all(Array.from({ length: concurrency }, () => worker()))
 
       this.currentSearch = undefined
+
+      console.info(
+        `[VehicleDiscovery] Scan complete in ${Date.now() - searchStart}ms. Found ${vehiclesFound.length} vehicle(s).`
+      )
 
       return vehiclesFound
     }

--- a/src/libs/electron/vehicle-discovery.ts
+++ b/src/libs/electron/vehicle-discovery.ts
@@ -4,6 +4,14 @@ import { getBeaconInfo, getStatus, getVehicleName } from '../blueos'
 import { isElectron } from '../utils'
 
 /**
+ * Maximum number of address checks performed in parallel during discovery.
+ * Firing all addresses at once saturates Chromium's renderer socket pool and
+ * the OS ARP cache, causing legitimate vehicles to time out before their
+ * request gets a socket.
+ */
+const MAX_CONCURRENT_ADDRESS_CHECKS = 100
+
+/**
  * A vehicle found on the network
  */
 export interface NetworkVehicle {
@@ -92,25 +100,30 @@ class VehicleDiscover {
         throw new Error('Failed to get information about the local subnets.')
       }
 
-      const vehiclesFound: NetworkVehicle[] = []
-      const allChecks: Promise<void>[] = []
-
+      const addressesToCheck: string[] = []
       for (const subnet of localSubnets) {
         const topSideAddress = subnet.topSideAddress
-        const possibleAddresses = subnet.availableAddresses.filter((address) => address !== topSideAddress)
-
-        for (const address of possibleAddresses) {
-          const check = this.checkAddress(address).then((vehicle) => {
-            if (vehicle) {
-              vehiclesFound.push(vehicle)
-              onVehicleFound?.(vehicle)
-            }
-          })
-          allChecks.push(check)
+        for (const address of subnet.availableAddresses) {
+          if (address !== topSideAddress) addressesToCheck.push(address)
         }
       }
 
-      await Promise.all(allChecks)
+      const vehiclesFound: NetworkVehicle[] = []
+      const concurrency = Math.min(MAX_CONCURRENT_ADDRESS_CHECKS, addressesToCheck.length)
+
+      let nextIndex = 0
+      const worker = async (): Promise<void> => {
+        while (nextIndex < addressesToCheck.length) {
+          const address = addressesToCheck[nextIndex++]
+          const vehicle = await this.checkAddress(address)
+          if (vehicle) {
+            vehiclesFound.push(vehicle)
+            onVehicleFound?.(vehicle)
+          }
+        }
+      }
+      await Promise.all(Array.from({ length: concurrency }, () => worker()))
+
       this.currentSearch = undefined
 
       return vehiclesFound


### PR DESCRIPTION
There were two main bugs:

1. If the user was using an mDNS address, it would take some time for the IP to be resolved, so the discovery dialog would appear before the vehicle connected. Now the dialog will auto-close if auto-opened and the vehicle connects.
2. If the user's system had too many virtual interfaces, it would fail to scan everything. The solution was to ignore virtual interfaces and limit concurrent checks.

It also adds extra logs to help with any future problems.

Fix #2634 
Fix #2635 
