### PR TITLE
Retry the check for external features (e.g.: widgets, actions, joystick suggestions) when vehicle connects

### DIFF
--- a/src/components/EditMenu.vue
+++ b/src/components/EditMenu.vue
@@ -850,10 +850,23 @@ const getExternalWidgetSetupInfos = async (): Promise<void> => {
     const vehicleAddress = await mainVehicleStore.getVehicleAddress()
     ExternalWidgetSetupInfos.value = await getWidgetsFromBlueOS(vehicleAddress)
   } catch (error) {
-    const errorMessage = 'Error getting info around external widgets from BlueOS.'
-    openSnackbar({ message: errorMessage, variant: 'error', closeButton: true })
+    console.error('Could not fetch external widgets from BlueOS:', error)
+    // Only surface the error to the user when the vehicle is reachable; while it is offline we
+    // expect the fetch to fail and a retry will run automatically once it comes online (issue #2650).
+    if (mainVehicleStore.isVehicleOnline) {
+      const errorMessage = 'Error getting info around external widgets from BlueOS.'
+      openSnackbar({ message: errorMessage, variant: 'error', closeButton: true })
+    }
   }
 }
+
+watch(
+  () => mainVehicleStore.isVehicleOnline,
+  (isOnline) => {
+    if (!isOnline) return
+    getExternalWidgetSetupInfos()
+  }
+)
 
 // @ts-ignore: Documentation is not clear on what generic should be passed to 'UseDraggableOptions'
 const customWidgetElementContainerOptions = ref<UseDraggableOptions>({

--- a/src/components/ExternalFeaturesDiscoveryModal.vue
+++ b/src/components/ExternalFeaturesDiscoveryModal.vue
@@ -1614,23 +1614,47 @@ const checkForBlueOSJoystickSuggestions = async (): Promise<void> => {
 let isAutoOpening = false
 
 /**
+ * Whether the modal has already been auto-opened in this session, so transient
+ * vehicle reconnections don't re-pop the modal after the user has dismissed it.
+ */
+let hasAutoOpened = false
+
+/**
  * Fetch features from BlueOS without changing modal visibility
  */
 const fetchBlueOSFeatures = async (): Promise<void> => {
   await Promise.all([checkForBlueOSActions(), checkForBlueOSJoystickSuggestions()])
 }
 
+/**
+ * Auto-open the modal if there are pending features and it has not been auto-opened yet
+ */
+const autoOpenIfPending = (): void => {
+  if (hasAutoOpened || !hasPendingBlueOSFeatures.value) return
+  hasAutoOpened = true
+  isAutoOpening = true
+  isVisible.value = true
+  if (filteredJoystickSuggestionsByExtension.value.length > 0 && filteredActions.value.length === 0) {
+    activeTab.value = 'joystick-suggestions'
+  }
+}
+
 onMounted(async () => {
   if (!props.autoCheckOnMount) return
   await fetchBlueOSFeatures()
-  if (hasPendingBlueOSFeatures.value) {
-    isAutoOpening = true
-    isVisible.value = true
-    if (filteredJoystickSuggestionsByExtension.value.length > 0 && filteredActions.value.length === 0) {
-      activeTab.value = 'joystick-suggestions'
-    }
-  }
+  autoOpenIfPending()
 })
+
+// Retry fetching BlueOS features when the vehicle becomes reachable, since the
+// initial fetch on app boot may have failed if BlueOS was not yet up (issue #2650).
+watch(
+  () => mainVehicleStore.isVehicleOnline,
+  async (isOnline) => {
+    if (!isOnline) return
+    await fetchBlueOSFeatures()
+    if (props.autoCheckOnMount) autoOpenIfPending()
+  }
+)
 
 watch(isVisible, (visible, oldVisible) => {
   if (!visible) return


### PR DESCRIPTION
Fix #2650 