### PR TITLE
Fix confusing usage of raw and calibrated joystick axes values

### DIFF
--- a/src/components/joysticks/JoystickCalibration.vue
+++ b/src/components/joysticks/JoystickCalibration.vue
@@ -97,14 +97,6 @@
             >
               <div class="flex w-full justify-center text-lg font-bold text-white mb-3">Axis {{ index }}</div>
               <div class="w-full h-40 relative">
-                <!-- Axis labels -->
-                <span class="font-mono text-xs text-gray-400 absolute top-[81px] right-[10px]">
-                  in: {{ numberToTwoDigitsSigned(rawAxisValues[index]) }}
-                </span>
-                <span class="font-mono text-xs text-gray-400 absolute top-[-2px] left-[170px]">
-                  out: {{ numberToTwoDigitsSigned(processedAxisValues[index]) }}
-                </span>
-
                 <svg
                   :id="`deadband-svg-${index}`"
                   class="w-full h-full my-4"
@@ -114,6 +106,14 @@
                   <!-- Grid lines -->
                   <line x1="0" y1="60" x2="200" y2="60" stroke="#e5e7eb" stroke-width="1" />
                   <line x1="100" y1="0" x2="100" y2="120" stroke="#e5e7eb" stroke-width="1" />
+
+                  <!-- Axis labels (rendered inside the viewBox so they always align with the gridlines) -->
+                  <text x="102" y="9" class="font-mono" fill="#9ca3af" font-size="9" text-anchor="start">
+                    out: {{ numberToTwoDigitsSigned(processedAxisValues[index]) }}
+                  </text>
+                  <text x="198" y="56" class="font-mono" fill="#9ca3af" font-size="9" text-anchor="end">
+                    in: {{ numberToTwoDigitsSigned(rawAxisValues[index]) }}
+                  </text>
 
                   <!-- Deadband region -->
                   <rect

--- a/src/components/joysticks/JoystickCalibration.vue
+++ b/src/components/joysticks/JoystickCalibration.vue
@@ -319,9 +319,7 @@ const cancelCalibration = (): void => {
 
 const saveCalibration = (): void => {
   currentCalibration.value.deadband.thresholds.axes = [...deadzoneThresholds.value]
-  currentCalibration.value.deadband.enabled = true
   currentCalibration.value.exponential.factors.axes = [...exponentialFactors.value]
-  currentCalibration.value.exponential.enabled = true
   showCalibrationModal.value = false
 }
 

--- a/src/libs/joystick/manager.ts
+++ b/src/libs/joystick/manager.ts
@@ -120,9 +120,16 @@ export type JoystickStateEvent = {
    */
   index: number
   /**
-   * Gamepad object
+   * Gamepad object holding the raw, un-calibrated axes and buttons.
+   * Consumers that need the actual stick position (e.g. the calibration UI
+   * or the joystick visualizations) should read from here.
    */
   gamepad: Gamepad
+  /**
+   * Joystick state with calibration (deadband, exponential) already applied.
+   * Consumers driving vehicle commands should read from here.
+   */
+  calibratedState: JoystickState
 }
 
 export type JoystickConnectEvent = {
@@ -357,15 +364,8 @@ class JoystickManager {
       const gamepadId = `${data.deviceName} (SDL STANDARD JOYSTICK Vendor: ${data.vendorId} Product: ${data.productId})`
       const gamepadModel = this.getModel(gamepadId)
 
-      const newState: JoystickState = {
-        axes: [...gamepadState.axes],
-        buttons: [...gamepadState.buttons],
-      }
-
-      gamepadState.axes.forEach((value, index) => {
-        const calibratedValue = this.applyCalibrationToValue('axis', index, value ?? 0, gamepadModel)
-        newState.axes[index] = calibratedValue
-      })
+      const rawAxes = gamepadState.axes.map((value) => value ?? 0)
+      const rawButtons = gamepadState.buttons.map((value) => value ?? 0)
 
       const joystickEvent: JoystickStateEvent = {
         index: data.deviceId,
@@ -375,10 +375,10 @@ class JoystickManager {
           connected: true,
           timestamp: Date.now(),
           mapping: 'standard',
-          axes: newState.axes.map((value) => value ?? 0),
-          buttons: newState.buttons.map((value) => ({
-            pressed: (value ?? 0) > 0.5,
-            value: value ?? 0,
+          axes: rawAxes,
+          buttons: rawButtons.map((value) => ({
+            pressed: value > 0.5,
+            value: value,
             touched: false,
           })),
           vibrationActuator: {
@@ -386,6 +386,7 @@ class JoystickManager {
             reset: async () => 'complete' as const,
           },
         },
+        calibratedState: this.buildCalibratedState(rawAxes, rawButtons, gamepadModel),
       }
 
       // Add joystick to the list of joysticks if it is not already there
@@ -481,7 +482,7 @@ class JoystickManager {
   }
 
   /**
-   * Load calibration settings from localStorage
+   * Load calibration settings from local storage
    */
   private loadCalibrationSettings(): void {
     try {
@@ -496,21 +497,21 @@ class JoystickManager {
   }
 
   /**
-   * Apply calibration to a joystick value
-   * @param {string} inputType The type of input ('button' or 'axis')
-   * @param {number} inputIndex The index of the input
-   * @param {number} originalValue The original value of the input
-   * @param {JoystickModel} joystickModel The joystick model
-   * @returns {number} The calibrated value
+   * Build a calibrated `JoystickState` from raw axes and buttons.
+   * Calibration is per-axis: deadband and exponential scaling are applied
+   * using the thresholds/factors stored for the given joystick model.
+   * Buttons are passed through untouched, matching the previous behavior.
+   * @param {number[]} rawAxes Raw axis values straight from the device
+   * @param {number[]} rawButtons Raw button values straight from the device
+   * @param {JoystickModel} model Joystick model used to look up calibration
+   * @returns {JoystickState} The calibrated joystick state
    */
-  private applyCalibrationToValue(
-    inputType: 'button' | 'axis',
-    inputIndex: number,
-    originalValue: number,
-    joystickModel: JoystickModel
-  ): number {
-    const calibration = this.calibrationOptions.get(joystickModel) ?? defaultJoystickCalibration
-    return applyCalibration(inputType, inputIndex, originalValue, calibration)
+  private buildCalibratedState(rawAxes: number[], rawButtons: number[], model: JoystickModel): JoystickState {
+    const calibration = this.calibrationOptions.get(model) ?? defaultJoystickCalibration
+    return {
+      axes: rawAxes.map((value, index) => applyCalibration('axis', index, value, calibration)),
+      buttons: [...rawButtons],
+    }
   }
 
   /**
@@ -529,42 +530,33 @@ class JoystickManager {
 
       const previousState = this.previousGamepadState.get(gamepad.index)
 
-      const newState: JoystickState = {
-        axes: [...gamepad.axes],
-        buttons: [...(gamepad.buttons.map((button) => button.value) as number[])],
-      }
+      const rawAxes = [...gamepad.axes]
+      const rawButtons = gamepad.buttons.map((button) => button.value)
       let shouldEmitStateEvent = false
 
-      // Check axes
       if (previousState) {
-        // Check for axis changes
-        gamepad.axes.forEach((value, index) => {
-          if (previousState.axes[index] !== value) {
-            const calibratedValue = this.applyCalibrationToValue('axis', index, value, joystickModel)
-            newState.axes[index] = calibratedValue
-          }
+        rawAxes.forEach((value, index) => {
           if (previousState.axes[index] !== value) {
             shouldEmitStateEvent = true
           }
         })
 
-        // Check for button changes
-        gamepad.buttons.forEach((button, index) => {
-          const previousButton = previousState.buttons[index]
-          if (previousButton !== button.value) {
-            newState.buttons[index] = button.value
-          }
-          if (previousButton !== button.value) {
+        rawButtons.forEach((value, index) => {
+          if (previousState.buttons[index] !== value) {
             shouldEmitStateEvent = true
           }
         })
       }
 
       // Update previous state
-      this.previousGamepadState.set(gamepad.index, newState)
+      this.previousGamepadState.set(gamepad.index, { axes: rawAxes, buttons: rawButtons })
 
       if (shouldEmitStateEvent) {
-        this.emitStateEvent({ index: gamepad.index, gamepad: gamepad })
+        this.emitStateEvent({
+          index: gamepad.index,
+          gamepad: gamepad,
+          calibratedState: this.buildCalibratedState(rawAxes, rawButtons, joystickModel),
+        })
       }
     }
 

--- a/src/stores/controller.ts
+++ b/src/stores/controller.ts
@@ -271,8 +271,8 @@ export const useControllerStore = defineStore('controller', () => {
     const joystickModel = joystick.model || JoystickModel.Unknown
     joystick.gamepadToCockpitMap = cockpitStdMappings.value[joystickModel]
     const currentState = {
-      axes: [...event.gamepad.axes],
-      buttons: [...event.gamepad.buttons.map((button) => button.value)],
+      axes: [...event.calibratedState.axes],
+      buttons: [...event.calibratedState.buttons],
     }
 
     // If joystick forwarding is disabled, disable the callback processing


### PR DESCRIPTION
The SDL/Electron pipeline was applying calibration to the emitted gamepad's `axes`, so consumers reading `Joystick.state.axes` as the raw stick position (the calibration UI's "in" indicator and the joystick visualizations) actually saw the deadband-compensated output. Opening the calibration dialog on a stick that already had a deadband configured made the "in" value behave like the "out": pinned to 0 inside the deadband and showing the remapped curve outside of it.

Keep all calibration knowledge inside `JoystickManager` but stop folding the calibrated values into `gamepad.axes`. `JoystickStateEvent` now carries both:

- `gamepad`:         raw, un-calibrated axes/buttons (for UI /
                     visualizations);
- `calibratedState`: `JoystickState` with deadband + exponential
                     already applied (for control consumers).

Both pipelines (SDL and Gamepad API) now produce the same shape via a shared `buildCalibratedState` helper, which also fixes a latent bug where the Gamepad API path was computing calibrated values into a local `newState` that never reached the emitted gamepad — meaning calibration was effectively a no-op in browser mode.

The controller store consumes `event.calibratedState` directly instead of running its own calibration pass, leaving the manager as the single owner of calibration logic.

Fix #2662 