### PR TITLE
data-lake: Fix persistent variables not surviving reboot

### DIFF
--- a/src/libs/actions/data-lake.ts
+++ b/src/libs/actions/data-lake.ts
@@ -46,7 +46,7 @@ const loadPersistentVariables = (): void => {
 const savePersistentVariables = (): void => {
   const persistentVariables = Object.values(dataLakeVariableInfo).filter((variable) => variable?.persistent)
 
-  settingsManager.setKeyValue(persistentVariablesKey, JSON.stringify(persistentVariables))
+  settingsManager.setKeyValue(persistentVariablesKey, persistentVariables)
 }
 
 // Save persistent values to localStorage
@@ -61,7 +61,7 @@ const savePersistentValues = (): void => {
       }
     })
 
-  settingsManager.setKeyValue(persistentValuesKey, JSON.stringify(persistentValuesObj))
+  settingsManager.setKeyValue(persistentValuesKey, persistentValuesObj)
 }
 
 export const getAllDataLakeVariablesInfo = (): Record<string, DataLakeVariable> => {


### PR DESCRIPTION
The settings manager already serializes the entire settings tree, so pre-stringifying the persistent variables and values was double-encoding them, causing the loader's array/object shape checks to fail on boot. Save the payloads as-is so the loader sees the correct shapes.

Fix #2667 