### PR TITLE
Add persistent option for user-dismissed snackbars

### DIFF
--- a/src/components/Snackbar.vue
+++ b/src/components/Snackbar.vue
@@ -21,18 +21,22 @@
 <script setup lang="ts">
 import { onMounted, ref, watch } from 'vue'
 
+import { closeSnackbar as removeSnackbar } from '@/composables/snackbar'
+
 const props = defineProps({
+  id: { type: Number, default: undefined },
   showSnackbar: { type: Boolean, default: true },
   closeButton: { type: Boolean, default: true },
   message: { type: String, default: '' },
   duration: { type: Number, default: 3000 },
   variant: { type: String, default: 'info' },
+  persistent: { type: Boolean, default: false },
 })
 
 const emits = defineEmits(['update:showSnackbar'])
 
 const visibility = ref(props.showSnackbar)
-const messageDuration = ref(props.duration || 3000)
+const messageDuration = ref(props.persistent ? -1 : props.duration || 3000)
 const selectedVariantColor = ref('')
 
 const setVariantColor = (variant: string): void => {
@@ -65,6 +69,7 @@ watch(
 const closeSnackbar = (): void => {
   visibility.value = false
   emits('update:showSnackbar', false)
+  if (props.id !== undefined) removeSnackbar(props.id)
 }
 
 watch(

--- a/src/composables/snackbar.ts
+++ b/src/composables/snackbar.ts
@@ -9,7 +9,8 @@ interface SnackbarOptions {
    */
   message: string
   /**
-   * The duration in milliseconds to show the snackbar
+   * The duration in milliseconds to show the snackbar.
+   * Ignored when {@link SnackbarOptions.persistent} is `true`.
    */
   duration?: number
   /**
@@ -20,6 +21,11 @@ interface SnackbarOptions {
    * Whether to show the close button
    */
   closeButton?: boolean
+  /**
+   * When `true`, the snackbar stays visible until the user dismisses it via the close button.
+   * Overrides {@link SnackbarOptions.duration} when set.
+   */
+  persistent?: boolean
 }
 
 type SnackbarType = SnackbarOptions & {
@@ -35,15 +41,20 @@ const state = reactive({
 
 let idCounter = 0
 
-export const openSnackbar = (options: SnackbarOptions): void => {
+export const closeSnackbar = (id: number): void => {
+  const index = state.snackbars.findIndex((s): boolean => s.id === id)
+  if (index !== -1) state.snackbars.splice(index, 1)
+}
+
+export const openSnackbar = (options: SnackbarOptions): number => {
   const snackbar: SnackbarType = { ...options, id: idCounter++ }
+  // Persistent snackbars have no timeout, so the close button is the only way to dismiss them.
+  if (snackbar.persistent) snackbar.closeButton = true
   state.snackbars.push(snackbar)
-  if (snackbar.duration) {
-    setTimeout((): void => {
-      const index = state.snackbars.findIndex((s): boolean => s.id === snackbar.id)
-      if (index !== -1) state.snackbars.splice(index, 1)
-    }, snackbar.duration)
+  if (!snackbar.persistent && snackbar.duration && snackbar.duration > 0) {
+    setTimeout((): void => closeSnackbar(snackbar.id), snackbar.duration)
   }
+  return snackbar.id
 }
 
 export const useSnackbar = (): {
@@ -53,11 +64,17 @@ export const useSnackbar = (): {
   snackbars: SnackbarType[]
   /**
    * Opens a snackbar with the given options
+   * @returns {number} The id of the snackbar that was opened, for later programmatic dismissal.
    */
-  openSnackbar: (options: SnackbarOptions) => void
+  openSnackbar: (options: SnackbarOptions) => number
+  /**
+   * Removes the snackbar with the given id from the list
+   */
+  closeSnackbar: (id: number) => void
 } => {
   return {
     snackbars: state.snackbars,
     openSnackbar,
+    closeSnackbar,
   }
 }


### PR DESCRIPTION
When persistent, the snackbars will only be dismissed by user action, clicking on a X button