### PR TITLE
vehicle: allow configuring heartbeat connection timeout

### DIFF
--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -188,6 +188,10 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
   // Enabled by default for backward compatibility reasons - users with old devices may want to disable this to improve performance
   const enableLegacyDataLakeVariableNames = useBlueOsStorage('cockpit-enable-legacy-datalake-variable-names', true)
 
+  // Maximum time without heartbeats before the vehicle is considered offline. Configurable so users on
+  // high-latency or lossy links (e.g. cellular modems) can extend the window beyond the 5 s default.
+  const vehicleConnectionTimeoutMs = useBlueOsStorage('cockpit-vehicle-connection-timeout-ms', 5000)
+
   const MAVLink2RestWebsocketURI = computed(() => {
     const queryURI = new URLSearchParams(window.location.search).get('MAVLink2RestWebsocketURI')
     const customURI = customMAVLink2RestWebsocketURI.value.enabled
@@ -208,11 +212,14 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
   })
 
   /**
-   * Check if vehicle is online (no more than 5 seconds passed since last heartbeat)
+   * Check if vehicle is online (no more than {@link vehicleConnectionTimeoutMs} passed since last heartbeat)
    * @returns { boolean } True if vehicle is online
    */
   const isVehicleOnline = computed(() => {
-    return lastHeartbeat.value !== undefined && new Date(timeNow.value).getTime() - lastHeartbeat.value.getTime() < 5000
+    return (
+      lastHeartbeat.value !== undefined &&
+      new Date(timeNow.value).getTime() - lastHeartbeat.value.getTime() < vehicleConnectionTimeoutMs.value
+    )
   })
 
   /**
@@ -1059,6 +1066,7 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     setHomeWaypoint,
     vehiclePayloadParameters,
     vehiclePositionMaxSampleRate,
+    vehicleConnectionTimeoutMs,
     enableDatalakeVariablesFromOtherSystems,
     enableLegacyDataLakeVariableNames,
     getVehicleAddress,

--- a/src/views/ConfigurationGeneralView.vue
+++ b/src/views/ConfigurationGeneralView.vue
@@ -364,7 +364,7 @@
             </div>
           </template>
         </ExpansiblePanel>
-        <ExpansiblePanel no-bottom-divider :is-expanded="!interfaceStore.isOnPhoneScreen">
+        <ExpansiblePanel :is-expanded="!interfaceStore.isOnPhoneScreen">
           <template #title>Generic WebSocket connections</template>
           <template #info>
             <div class="w-full">
@@ -426,6 +426,59 @@
             </div>
           </template>
         </ExpansiblePanel>
+        <ExpansiblePanel no-bottom-divider :is-expanded="!interfaceStore.isOnPhoneScreen">
+          <template #title>Vehicle connection timeout</template>
+          <template #subtitle>Current value: {{ vehicleConnectionTimeoutSeconds }} s</template>
+          <template #info>
+            <p class="w-full">
+              Time without heartbeats before Cockpit considers the vehicle offline. Increase this value when using
+              high-latency or lossy links (e.g. cellular modems) where heartbeat packets may take longer than the
+              default 5 seconds to arrive.
+            </p>
+          </template>
+          <template #content>
+            <v-form
+              ref="connectionTimeoutForm"
+              v-model="connectionTimeoutFormValid"
+              class="flex w-full mt-2 mb-2"
+              @submit.prevent="setConnectionTimeout"
+            >
+              <div
+                class="flex justify-start items-center w-[86%] mb-4"
+                :class="interfaceStore.isOnSmallScreen ? 'scale-80' : 'scale-100'"
+              >
+                <v-text-field
+                  v-model.number="newVehicleConnectionTimeoutSeconds"
+                  variant="filled"
+                  type="number"
+                  density="compact"
+                  theme="dark"
+                  hint="Heartbeat timeout in seconds (minimum 1)"
+                  hide-details
+                  class="w-[80%]"
+                  suffix="s"
+                  :rules="[isValidConnectionTimeout]"
+                >
+                  <template #append-inner>
+                    <v-icon v-tooltip.bottom="'Reset to default'" color="white" @click="resetConnectionTimeout">
+                      mdi-restore
+                    </v-icon>
+                  </template>
+                </v-text-field>
+                <v-btn
+                  :size="interfaceStore.isOnSmallScreen ? 'small' : 'default'"
+                  :disabled="!connectionTimeoutFormValid"
+                  class="bg-transparent"
+                  :class="interfaceStore.isOnSmallScreen ? 'ml-1' : 'ml-5'"
+                  variant="text"
+                  type="submit"
+                >
+                  Apply
+                </v-btn>
+              </div>
+            </v-form>
+          </template>
+        </ExpansiblePanel>
       </div>
     </template>
   </BaseConfigurationView>
@@ -434,7 +487,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 
 import { defaultGlobalAddress } from '@/assets/defaults'
 import ManageCockpitSettings from '@/components/configuration/CockpitSettingsManager.vue'
@@ -672,6 +725,41 @@ const resetWebRTCSignallingURI = (): void => {
     enabled: false,
     data: mainVehicleStore.defaultWebRTCSignallingURI.toString(),
   }
+}
+
+/** Vehicle connection timeout */
+
+const defaultVehicleConnectionTimeoutSeconds = 5
+const minVehicleConnectionTimeoutSeconds = 1
+
+const connectionTimeoutForm = ref()
+const connectionTimeoutFormValid = ref(true)
+const vehicleConnectionTimeoutSeconds = computed(
+  () => Math.round(mainVehicleStore.vehicleConnectionTimeoutMs / 100) / 10
+)
+const newVehicleConnectionTimeoutSeconds = ref<number>(vehicleConnectionTimeoutSeconds.value)
+
+watch(vehicleConnectionTimeoutSeconds, (value) => (newVehicleConnectionTimeoutSeconds.value = value))
+
+const isValidConnectionTimeout = (value: number | string): boolean | string => {
+  const numericValue = typeof value === 'string' ? Number(value) : value
+  if (!Number.isFinite(numericValue)) return 'Timeout must be a valid number.'
+  if (numericValue < minVehicleConnectionTimeoutSeconds) {
+    return `Timeout must be at least ${minVehicleConnectionTimeoutSeconds} second.`
+  }
+  return true
+}
+
+const setConnectionTimeout = async (): Promise<void> => {
+  const validation = await connectionTimeoutForm.value.validate()
+  if (!validation.valid) return
+
+  mainVehicleStore.vehicleConnectionTimeoutMs = Math.round(newVehicleConnectionTimeoutSeconds.value * 1000)
+}
+
+const resetConnectionTimeout = (): void => {
+  newVehicleConnectionTimeoutSeconds.value = defaultVehicleConnectionTimeoutSeconds
+  mainVehicleStore.vehicleConnectionTimeoutMs = defaultVehicleConnectionTimeoutSeconds * 1000
 }
 
 const isValidHostAddress = (value: string): boolean | string => {


### PR DESCRIPTION
Replaces the hardcoded 5 s heartbeat timeout used to flag the vehicle as offline with a user-configurable, persistent setting exposed in the General configuration menu, so operators on high-latency or lossy links (e.g. cellular modems) can extend the window as needed.