### PR TITLE
Add mission and vehicle path history odometer

### DIFF
--- a/src/assets/defaults.ts
+++ b/src/assets/defaults.ts
@@ -314,8 +314,8 @@ export const widgetProfiles: Profile[] = [
               y: 0.804823,
             },
             size: {
-              width: 0.134754,
-              height: 0.09353,
+              width: 0.152,
+              height: 0.11,
             },
             options: {},
           },

--- a/src/components/mini-widgets/MiniMissionControlPanel.vue
+++ b/src/components/mini-widgets/MiniMissionControlPanel.vue
@@ -65,26 +65,84 @@
         </template>
       </v-tooltip>
       <v-divider vertical class="h-[25px] mt-[5px]" />
-      <div class="flex flex-col justify-between w-[46px] h-[33px] text-[8px] ml-1 mt-[4px]">
-        <div class="w-full text-nowrap text-center">Current WP</div>
-        <div class="mb-1 text-[12px] font-bold">{{ currentWaypointOnMission }}</div>
-      </div>
+      <v-menu
+        v-model="areDistancesVisible"
+        :open-on-hover="true"
+        :open-on-click="true"
+        :close-on-content-click="false"
+        location="top"
+        offset="6"
+        theme="dark"
+      >
+        <template #activator="{ props: wpProps }">
+          <div
+            v-bind="wpProps"
+            role="button"
+            tabindex="0"
+            aria-haspopup="true"
+            :aria-expanded="areDistancesVisible"
+            class="flex flex-col justify-between w-[46px] h-[33px] text-[8px] ml-1 mt-[4px] cursor-pointer"
+            @keydown.enter.prevent="areDistancesVisible = !areDistancesVisible"
+            @keydown.space.prevent="areDistancesVisible = !areDistancesVisible"
+          >
+            <div class="w-full text-nowrap text-center">Current WP</div>
+            <div class="mb-1 text-[12px] font-bold">{{ currentWaypointOnMission }}</div>
+          </div>
+        </template>
+        <div
+          class="flex flex-col gap-1 px-3 py-2 rounded-md text-[11px] tabular-nums select-none"
+          :style="interfaceStore.globalGlassMenuStyles"
+        >
+          <div class="flex items-center justify-between gap-3 text-odometer">
+            <div class="flex items-center gap-1">
+              <v-icon size="14" class="opacity-80">mdi-counter</v-icon>
+              <span class="opacity-80">Total:</span>
+            </div>
+            <span class="font-bold">{{ formattedTotalDistance }}</span>
+          </div>
+          <div class="flex items-center justify-between gap-3 text-odometer">
+            <span class="opacity-80">Mission:</span>
+            <div class="flex items-center gap-[3px]">
+              <v-tooltip location="top" open-delay="600" text="Reset mission distance">
+                <template #activator="{ props: resetProps }">
+                  <v-btn
+                    v-bind="resetProps"
+                    variant="text"
+                    density="compact"
+                    aria-label="Reset mission distance"
+                    class="w-[16px] h-[16px] min-w-0 opacity-70 hover:opacity-100"
+                    @click.stop="missionStore.resetMissionDistance()"
+                  >
+                    <v-icon size="11">mdi-restore</v-icon>
+                  </v-btn>
+                </template>
+              </v-tooltip>
+              <span class="font-bold">{{ formattedMissionDistance }}</span>
+            </div>
+          </div>
+        </div>
+      </v-menu>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 
 import CruiseSpeedControl from '@/components/mission-planning/CruiseSpeedControl.vue'
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { openSnackbar } from '@/composables/snackbar'
+import { useTraveledDistances } from '@/composables/useTraveledDistances'
+import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useMissionStore } from '@/stores/mission'
 
 const { showDialog, closeDialog } = useInteractionDialog()
+const interfaceStore = useAppInterfaceStore()
 const missionStore = useMissionStore()
 const vehicleStore = useMainVehicleStore()
+
+const areDistancesVisible = ref(false)
 
 const currentWaypointOnMission = computed<string>((): string => {
   const wpIndex = missionStore.currentWaypointOnMission
@@ -100,6 +158,8 @@ const skipToNextWaypoint = (): void => {
   logUserAction('Skipped to next mission waypoint')
   missionStore.skipToWaypoint(1)
 }
+
+const { formattedTotalDistance, formattedMissionDistance } = useTraveledDistances()
 
 const handleReturnHome = (): void => {
   showDialog({

--- a/src/components/mini-widgets/MiniMissionControlPanel.vue
+++ b/src/components/mini-widgets/MiniMissionControlPanel.vue
@@ -65,10 +65,54 @@
         </template>
       </v-tooltip>
       <v-divider vertical class="h-[25px] mt-[5px]" />
-      <div class="flex flex-col justify-between w-[46px] h-[33px] text-[8px] ml-1 mt-[4px]">
-        <div class="w-full text-nowrap text-center">Current WP</div>
-        <div class="mb-1 text-[12px] font-bold">{{ currentWaypointOnMission }}</div>
-      </div>
+      <v-menu
+        :open-on-hover="true"
+        :open-on-click="true"
+        :close-on-content-click="false"
+        location="top"
+        offset="6"
+        theme="dark"
+      >
+        <template #activator="{ props: wpProps }">
+          <div
+            v-bind="wpProps"
+            class="flex flex-col justify-between w-[46px] h-[33px] text-[8px] ml-1 mt-[4px] cursor-pointer"
+          >
+            <div class="w-full text-nowrap text-center">Current WP</div>
+            <div class="mb-1 text-[12px] font-bold">{{ currentWaypointOnMission }}</div>
+          </div>
+        </template>
+        <div
+          class="flex flex-col gap-1 px-3 py-2 rounded-md text-[11px] tabular-nums select-none"
+          :style="interfaceStore.globalGlassMenuStyles"
+        >
+          <div class="flex items-center justify-between gap-3 text-[#ffb85b]">
+            <div class="flex items-center gap-1">
+              <v-icon size="14" class="opacity-80">mdi-counter</v-icon>
+              <span class="opacity-80">Total:</span>
+            </div>
+            <span class="font-bold">{{ formattedTotalDistance }}</span>
+          </div>
+          <div class="flex items-center justify-between gap-3 text-[#ffb85b]">
+            <span class="opacity-80">Mission:</span>
+            <div class="flex items-center gap-[3px]">
+              <v-tooltip location="top" open-delay="600" text="Reset mission distance">
+                <template #activator="{ props: resetProps }">
+                  <v-icon
+                    v-bind="resetProps"
+                    size="11"
+                    class="cursor-pointer opacity-70 hover:opacity-100"
+                    @click.stop="missionStore.resetMissionDistance()"
+                  >
+                    mdi-restore
+                  </v-icon>
+                </template>
+              </v-tooltip>
+              <span class="font-bold">{{ formattedMissionDistance }}</span>
+            </div>
+          </div>
+        </div>
+      </v-menu>
     </div>
   </div>
 </template>
@@ -79,10 +123,13 @@ import { computed } from 'vue'
 import CruiseSpeedControl from '@/components/mission-planning/CruiseSpeedControl.vue'
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { openSnackbar } from '@/composables/snackbar'
+import { useTraveledDistances } from '@/composables/useTraveledDistances'
+import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useMissionStore } from '@/stores/mission'
 
 const { showDialog, closeDialog } = useInteractionDialog()
+const interfaceStore = useAppInterfaceStore()
 const missionStore = useMissionStore()
 const vehicleStore = useMainVehicleStore()
 
@@ -100,6 +147,8 @@ const skipToNextWaypoint = (): void => {
   logUserAction('Skipped to next mission waypoint')
   missionStore.skipToWaypoint(1)
 }
+
+const { formattedTotalDistance, formattedMissionDistance } = useTraveledDistances()
 
 const handleReturnHome = (): void => {
   showDialog({

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -240,6 +240,7 @@ import { useMapPoiGoTo } from '@/composables/map/useMapPoiGoTo'
 import { useMapPoiMarkers } from '@/composables/map/useMapPoiMarkers'
 import { useMapTileLayers } from '@/composables/map/useMapTileLayers'
 import { useMapTileLayerSelection } from '@/composables/map/useMapTileLayerSelection'
+import { useVehicleHistoryOverlay } from '@/composables/map/useVehicleHistoryOverlay'
 import { openSnackbar } from '@/composables/snackbar'
 import { useOfflineTiles } from '@/composables/useOfflineTiles'
 import { usePointsOfInterest } from '@/composables/usePointsOfInterest'
@@ -589,6 +590,9 @@ const mapOverlays = useMapOverlays()
 const overlayLoadingIds = mapOverlays.loadingIds
 const overlaysDialogOpen = ref(false)
 
+// Draws the vehicle trail and its traveled-distance tooltip
+const { initVehicleHistory, destroyVehicleHistory } = useVehicleHistoryOverlay()
+
 // Replace failed tiles with a procedural noise background sampled by lat/lon
 const getTileFallbackOptions = (): NoiseTileOptions => ({
   baseColor: missionStore.mapFallbackBaseColor,
@@ -873,16 +877,7 @@ onMounted(async () => {
   }
   await refreshMission()
 
-  // Initialize vehicle history polyline if vehicle marker is on screen
-  if (map.value && vehicleMarker.value && missionStore.vehiclePositionHistory.length > 0) {
-    if (vehicleHistoryPolyline.value === undefined) {
-      vehicleHistoryPolyline.value = L.polyline([], { color: '#ffff00', renderer: vehicleHistoryRenderer }).addTo(
-        map.value
-      )
-    }
-    vehicleHistoryPolyline.value.setLatLngs(missionStore.vehiclePositionHistory as L.LatLngExpression[])
-    lastDrawnHistoryLen = missionStore.vehiclePositionHistory.length
-  }
+  if (map.value) initVehicleHistory(map.value, () => vehicleMarker.value !== undefined)
 })
 
 // React to clear/download requests from any mission-control widget.
@@ -1083,6 +1078,7 @@ onBeforeUnmount(() => {
 
   detachTileFallbacks.forEach((detach) => detach())
   mapOverlays.destroyOverlays()
+  destroyVehicleHistory()
 
   if (map.value) {
     map.value.off('contextmenu')
@@ -1387,44 +1383,6 @@ watch([getReachedWaypointIndices, currentMapWpIndex], () => {
     }
   })
 })
-
-// Create polyline for the vehicle path using a dedicated Canvas renderer to prevent performance issues
-const vehicleHistoryRenderer = L.canvas()
-const vehicleHistoryPolyline = shallowRef<L.Polyline>()
-let lastDrawnHistoryLen = 0
-watch(
-  () => missionStore.vehiclePositionHistoryRevision,
-  () => {
-    const newPoints = missionStore.vehiclePositionHistory
-    if (map.value === undefined || !vehicleMarker.value || !newPoints || newPoints.length === 0) {
-      if (vehicleHistoryPolyline.value && map.value) {
-        map.value.removeLayer(vehicleHistoryPolyline.value)
-        vehicleHistoryPolyline.value = undefined
-      }
-      lastDrawnHistoryLen = 0
-      return
-    }
-
-    if (vehicleHistoryPolyline.value === undefined) {
-      vehicleHistoryPolyline.value = L.polyline([], { color: '#ffff00', renderer: vehicleHistoryRenderer }).addTo(
-        map.value
-      )
-      lastDrawnHistoryLen = 0
-    }
-
-    if (newPoints.length > lastDrawnHistoryLen && lastDrawnHistoryLen > 0) {
-      // Append only the new points — O(1) per fire instead of O(N) full rebuild.
-      for (let i = lastDrawnHistoryLen; i < newPoints.length; i++) {
-        vehicleHistoryPolyline.value.addLatLng(newPoints[i] as L.LatLngExpression)
-      }
-    } else {
-      // First draw, or the history shrank (clear/simplify) / stayed same length (push+shift):
-      // fall back to a full rebuild to stay correct.
-      vehicleHistoryPolyline.value.setLatLngs(newPoints as L.LatLngExpression[])
-    }
-    lastDrawnHistoryLen = newPoints.length
-  }
-)
 
 // Handle context menu toggling and selection
 const contextMenuVisible = ref(false)
@@ -1937,6 +1895,75 @@ const centerOnMission = (): void => {
 
 :deep(.vehicle-tooltip::before) {
   border-right-color: var(--glass-background) !important;
+}
+
+/* Clicking the trail to pin its tooltip would otherwise leave a focus ring on the canvas. */
+:deep(.leaflet-interactive:focus:not(:focus-visible)) {
+  outline: none;
+}
+
+:deep(.history-polyline-tooltip) {
+  background-color: var(--glass-background) !important;
+  backdrop-filter: var(--glass-filter);
+  border: var(--glass-border) !important;
+  box-shadow: var(--glass-box-shadow);
+  color: #ffb85b;
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  z-index: 100;
+}
+
+:deep(.history-polyline-tooltip::before) {
+  border-top-color: var(--glass-background) !important;
+}
+
+:deep(.history-tooltip-row) {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  line-height: 1.4;
+}
+
+:deep(.history-tooltip-label) {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  opacity: 0.8;
+}
+
+:deep(.history-tooltip-value) {
+  font-weight: bold;
+}
+
+:deep(.history-tooltip-row-value-group) {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+}
+
+:deep(.history-tooltip-reset) {
+  pointer-events: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  color: #ffb85b;
+  cursor: pointer;
+  opacity: 0.7;
+  padding: 0 1px;
+  font-size: 9px;
+  line-height: 1;
+  border-radius: 3px;
+  transition: opacity 0.15s ease, background-color 0.15s ease;
+}
+
+:deep(.history-tooltip-reset:hover) {
+  opacity: 1;
+  background-color: rgba(255, 184, 91, 0.15);
 }
 
 :deep(.waypoint-tooltip--current-waypoint) {

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -278,6 +278,7 @@ import { useMapPoiGoTo } from '@/composables/map/useMapPoiGoTo'
 import { useMapPoiMarkers } from '@/composables/map/useMapPoiMarkers'
 import { useMapTileLayers } from '@/composables/map/useMapTileLayers'
 import { useMapTileLayerSelection } from '@/composables/map/useMapTileLayerSelection'
+import { useVehicleHistoryOverlay } from '@/composables/map/useVehicleHistoryOverlay'
 import { useWaypointMarkerSize } from '@/composables/map/useWaypointMarkerSize'
 import { openSnackbar } from '@/composables/snackbar'
 import { useOfflineTiles } from '@/composables/useOfflineTiles'
@@ -628,6 +629,9 @@ const overlaysDialogOpen = ref(false)
 // Registers user-defined custom tile providers (URL templates and imported archives) as selectable base layers
 const { init: initCustomTileProviders, destroy: destroyCustomTileProviders } = useCustomTileProviders()
 
+// Draws the vehicle trail and its traveled-distance tooltip
+const { initVehicleHistory, destroyVehicleHistory } = useVehicleHistoryOverlay()
+
 // Replace failed tiles with a procedural noise background sampled by lat/lon
 const getTileFallbackOptions = (): NoiseTileOptions => ({
   baseColor: missionStore.mapFallbackBaseColor,
@@ -916,16 +920,7 @@ onMounted(async () => {
   }
   await refreshMission()
 
-  // Initialize vehicle history polyline if vehicle marker is on screen
-  if (map.value && vehicleMarker.value && missionStore.vehiclePositionHistory.length > 0) {
-    if (vehicleHistoryPolyline.value === undefined) {
-      vehicleHistoryPolyline.value = L.polyline([], { color: '#ffff00', renderer: vehicleHistoryRenderer }).addTo(
-        map.value
-      )
-    }
-    vehicleHistoryPolyline.value.setLatLngs(missionStore.vehiclePositionHistory as L.LatLngExpression[])
-    lastDrawnHistoryLen = missionStore.vehiclePositionHistory.length
-  }
+  if (map.value) initVehicleHistory(map.value, () => vehicleMarker.value !== undefined)
 })
 
 // React to clear/download requests from any mission-control widget.
@@ -1130,6 +1125,7 @@ onBeforeUnmount(() => {
   detachTileFallbacks.forEach((detach) => detach())
   mapOverlays.destroyOverlays()
   destroyCustomTileProviders()
+  destroyVehicleHistory()
 
   if (map.value) {
     map.value.off('contextmenu')
@@ -1434,44 +1430,6 @@ watch([getReachedWaypointIndices, currentMapWpIndex], () => {
     }
   })
 })
-
-// Create polyline for the vehicle path using a dedicated Canvas renderer to prevent performance issues
-const vehicleHistoryRenderer = L.canvas()
-const vehicleHistoryPolyline = shallowRef<L.Polyline>()
-let lastDrawnHistoryLen = 0
-watch(
-  () => missionStore.vehiclePositionHistoryRevision,
-  () => {
-    const newPoints = missionStore.vehiclePositionHistory
-    if (map.value === undefined || !vehicleMarker.value || !newPoints || newPoints.length === 0) {
-      if (vehicleHistoryPolyline.value && map.value) {
-        map.value.removeLayer(vehicleHistoryPolyline.value)
-        vehicleHistoryPolyline.value = undefined
-      }
-      lastDrawnHistoryLen = 0
-      return
-    }
-
-    if (vehicleHistoryPolyline.value === undefined) {
-      vehicleHistoryPolyline.value = L.polyline([], { color: '#ffff00', renderer: vehicleHistoryRenderer }).addTo(
-        map.value
-      )
-      lastDrawnHistoryLen = 0
-    }
-
-    if (newPoints.length > lastDrawnHistoryLen && lastDrawnHistoryLen > 0) {
-      // Append only the new points — O(1) per fire instead of O(N) full rebuild.
-      for (let i = lastDrawnHistoryLen; i < newPoints.length; i++) {
-        vehicleHistoryPolyline.value.addLatLng(newPoints[i] as L.LatLngExpression)
-      }
-    } else {
-      // First draw, or the history shrank (clear/simplify) / stayed same length (push+shift):
-      // fall back to a full rebuild to stay correct.
-      vehicleHistoryPolyline.value.setLatLngs(newPoints as L.LatLngExpression[])
-    }
-    lastDrawnHistoryLen = newPoints.length
-  }
-)
 
 // Handle context menu toggling and selection
 const contextMenuVisible = ref(false)
@@ -2037,6 +1995,75 @@ const centerOnMission = (): void => {
 
 :deep(.vehicle-tooltip::before) {
   border-right-color: var(--glass-background) !important;
+}
+
+/* Clicking the trail to pin its tooltip would otherwise leave a focus ring on the canvas. */
+:deep(.leaflet-interactive:focus:not(:focus-visible)) {
+  outline: none;
+}
+
+:deep(.history-polyline-tooltip) {
+  background-color: var(--glass-background) !important;
+  backdrop-filter: var(--glass-filter);
+  border: var(--glass-border) !important;
+  box-shadow: var(--glass-box-shadow);
+  color: theme('colors.odometer');
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  z-index: 100;
+}
+
+:deep(.history-polyline-tooltip::before) {
+  border-top-color: var(--glass-background) !important;
+}
+
+:deep(.history-tooltip-row) {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  line-height: 1.4;
+}
+
+:deep(.history-tooltip-label) {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  opacity: 0.8;
+}
+
+:deep(.history-tooltip-value) {
+  font-weight: bold;
+}
+
+:deep(.history-tooltip-row-value-group) {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+}
+
+:deep(.history-tooltip-reset) {
+  pointer-events: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  color: theme('colors.odometer');
+  cursor: pointer;
+  opacity: 0.7;
+  padding: 0 1px;
+  font-size: 9px;
+  line-height: 1;
+  border-radius: 3px;
+  transition: opacity 0.15s ease, background-color 0.15s ease;
+}
+
+:deep(.history-tooltip-reset:hover) {
+  opacity: 1;
+  background-color: theme('colors.odometer / 15%');
 }
 
 :deep(.waypoint-tooltip--current-waypoint) {

--- a/src/components/widgets/MissionControlPanel.vue
+++ b/src/components/widgets/MissionControlPanel.vue
@@ -1,26 +1,29 @@
 <template>
-  <div class="min-w-[290px] min-h-[95px] flex items-end">
+  <div class="min-w-[290px] min-h-[115px] flex items-end">
     <div
       class="w-full rounded-lg overflow-hidden -mt-2"
-      :class="[isWrapped ? 'h-[42px]' : 'h-full']"
+      :class="[isWrapped ? 'h-[38px]' : 'h-full']"
       :style="interfaceStore.globalGlassMenuStyles"
     >
-      <div class="flex flex-col justify-start items-center h-full pt-2 cursor-pointer">
-        <div class="flex justify-between w-full px-2 pb-[2px] border-b-[1px] border-[#FFFFFF15]">
+      <div class="flex flex-col justify-start items-center h-full pt-1 cursor-pointer">
+        <div class="flex items-center justify-between w-full px-2 pb-[2px] border-b-[1px] border-[#FFFFFF15]">
           <v-icon class="cursor-grab opacity-40" @mousedown="enableMovingOnDrag" @mouseup="disableMovingOnDrag">
             mdi-drag
           </v-icon>
-          <div class="select-none text-[14px] font-bold mt-[1px]">Mission control panel</div>
+          <div class="select-none text-[14px] font-bold mb-[2px]">Mission control panel</div>
           <v-btn
             :icon="isWrapped ? 'mdi-chevron-up' : 'mdi-chevron-down'"
             variant="text"
-            size="36"
-            class="mt-[-6px] opacity-60 -mr-1"
+            size="30"
+            class="opacity-60 -mr-1"
             @click="toggleWrapContainer"
           />
         </div>
         <v-divider v-if="!isWrapped" />
-        <div v-show="!isWrapped" class="flex justify-center items-center w-full h-full">
+        <div
+          v-show="!isWrapped"
+          class="flex justify-center items-center w-full h-full bg-[#00000022] shadow-[inset_0_2px_3px_-1px_rgba(0,0,0,0.45)]"
+        >
           <div
             class="flex w-full h-full justify-start items-center overflow-hidden px-1"
             :class="!vehicleStore.isVehicleOnline ? 'active-events-on-disabled' : ''"
@@ -104,22 +107,63 @@
                   />
                 </template>
 
-                <v-list>
+                <v-list class="py-0">
                   <v-list-item
                     :disabled="!vehicleStore.isVehicleOnline"
                     class="cursor-pointer"
                     @click="handleDownloadMissionOnMap"
                   >
-                    <v-list-item-title>Download mission from vehicle</v-list-item-title>
+                    <v-list-item-title class="text-[14px]">Download mission from vehicle</v-list-item-title>
                   </v-list-item>
-
-                  <v-list-item class="cursor-pointer" @click="handleClearMissionOnMap">
-                    <v-list-item-title>Clear mission on map</v-list-item-title>
+                  <v-divider class="opacity-10" />
+                  <v-list-item
+                    :disabled="!vehicleStore.isVehicleOnline"
+                    class="cursor-pointer py-0"
+                    @click="handleClearMissionOnMap"
+                  >
+                    <v-list-item-title class="text-[14px]">Clear mission on map</v-list-item-title>
+                  </v-list-item>
+                  <v-divider class="opacity-10" />
+                  <v-list-item class="cursor-pointer" @click="missionStore.resetMissionDistance()">
+                    <v-list-item-title class="text-[14px]">Reset mission distance</v-list-item-title>
+                  </v-list-item>
+                  <v-divider class="opacity-10" />
+                  <v-list-item class="cursor-pointer" @click="handleResetTotalDistance">
+                    <v-list-item-title class="text-[14px]">Reset total distance</v-list-item-title>
                   </v-list-item>
                 </v-list>
               </v-menu>
             </div>
           </div>
+        </div>
+        <v-divider v-if="!isWrapped" class="w-full opacity-10" />
+        <div
+          v-if="!isWrapped"
+          class="flex justify-center items-center gap-4 w-full px-2 py-[2px] text-[11px] tabular-nums select-none"
+        >
+          <div class="relative left-[-10px] flex items-center gap-4">
+            <v-icon size="14" class="opacity-80 text-[#ffb85b]">mdi-map-marker-distance</v-icon>
+            <v-tooltip location="bottom" open-delay="800" text="Total distance the vehicle has traveled">
+              <template #activator="{ props: totalProps }">
+                <div v-bind="totalProps" class="flex items-center gap-1 text-[#ffb85b] -ml-[10px]">
+                  <span class="opacity-80">Total:</span>
+                  <span class="font-bold">{{ formattedTotalDistance }}</span>
+                </div>
+              </template>
+            </v-tooltip>
+          </div>
+          <v-tooltip
+            location="bottom"
+            open-delay="800"
+            text="Distance traveled during the current mission, since waypoint 1"
+          >
+            <template #activator="{ props: missionProps }">
+              <div v-bind="missionProps" class="flex items-center gap-1 text-[#ffb85b]">
+                <span class="opacity-80">Mission:</span>
+                <span class="font-bold">{{ formattedMissionDistance }}</span>
+              </div>
+            </template>
+          </v-tooltip>
         </div>
       </div>
     </div>
@@ -132,6 +176,7 @@ import { computed, onBeforeMount, ref, toRefs } from 'vue'
 import CruiseSpeedControl from '@/components/mission-planning/CruiseSpeedControl.vue'
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { openSnackbar } from '@/composables/snackbar'
+import { useTraveledDistances } from '@/composables/useTraveledDistances'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useMissionStore } from '@/stores/mission'
@@ -176,8 +221,8 @@ const disableMovingOnDrag = (): void => {
 }
 
 const widgetSize = {
-  width: 0.14638572402097255,
-  height: 0.09641222207770606,
+  width: 0.152,
+  height: 0.11,
 }
 
 const skipToPreviousWaypoint = (): void => {
@@ -190,6 +235,8 @@ const skipToNextWaypoint = (): void => {
   missionStore.skipToWaypoint(1)
 }
 
+const { formattedTotalDistance, formattedMissionDistance } = useTraveledDistances()
+
 const handleDownloadMissionOnMap = async (): Promise<void> => {
   logUserAction('Requested mission download from vehicle to map')
   missionStore.requestMapMissionDownload()
@@ -198,6 +245,26 @@ const handleDownloadMissionOnMap = async (): Promise<void> => {
 const handleClearMissionOnMap = (): void => {
   logUserAction('Cleared mission drawn on map')
   missionStore.requestMapClear()
+}
+
+const handleResetTotalDistance = (): void => {
+  showDialog({
+    title: 'Reset total distance',
+    message: `The total distance traveled by this vehicle (${formattedTotalDistance.value}) will be discarded and start counting from zero. This cannot be undone.`,
+    variant: 'warning',
+    actions: [
+      { text: 'Cancel', size: 'small', action: closeDialog },
+      {
+        text: 'Reset',
+        size: 'small',
+        action: () => {
+          closeDialog()
+          missionStore.resetTotalDistance()
+          openSnackbar({ message: 'Total traveled distance reset', variant: 'success' })
+        },
+      },
+    ],
+  })
 }
 
 onBeforeMount(() => {

--- a/src/components/widgets/MissionControlPanel.vue
+++ b/src/components/widgets/MissionControlPanel.vue
@@ -1,21 +1,21 @@
 <template>
-  <div class="min-w-[290px] min-h-[95px] flex items-end">
+  <div class="min-w-[290px] min-h-[115px] flex items-end">
     <div
       class="w-full rounded-lg overflow-hidden -mt-2"
       :class="[isWrapped ? 'h-[38px]' : 'h-full']"
       :style="interfaceStore.globalGlassMenuStyles"
     >
-      <div class="flex flex-col justify-start items-center h-full pt-2 cursor-pointer">
-        <div class="flex justify-between w-full px-2 pb-[2px] border-b-[1px] border-[#FFFFFF15]">
+      <div class="flex flex-col justify-start items-center h-full pt-1 cursor-pointer">
+        <div class="flex items-center justify-between w-full px-2 pb-[2px] border-b-[1px] border-[#FFFFFF15]">
           <v-icon class="cursor-grab opacity-40" @mousedown="enableMovingOnDrag" @mouseup="disableMovingOnDrag">
             mdi-drag
           </v-icon>
-          <div class="select-none text-[14px] font-bold mt-[1px]">Mission control panel</div>
+          <div class="select-none text-[14px] font-bold mb-[2px]">Mission control panel</div>
           <v-btn
             :icon="isWrapped ? 'mdi-chevron-up' : 'mdi-chevron-down'"
             variant="text"
-            size="36"
-            class="mt-[-6px] opacity-60 -mr-1"
+            size="30"
+            class="opacity-60 -mr-1"
             @click="toggleWrapContainer"
           />
         </div>
@@ -119,10 +119,45 @@
                   <v-list-item class="cursor-pointer py-0" @click="handleClearMissionOnMap">
                     <v-list-item-title class="text-[14px]">Clear mission on map</v-list-item-title>
                   </v-list-item>
+                  <v-divider class="opacity-10" />
+                  <v-list-item class="cursor-pointer" @click="missionStore.resetMissionDistance()">
+                    <v-list-item-title class="text-[14px]">Reset mission distance</v-list-item-title>
+                  </v-list-item>
+                  <v-divider class="opacity-10" />
+                  <v-list-item class="cursor-pointer" @click="handleResetTotalDistance">
+                    <v-list-item-title class="text-[14px]">Reset total distance</v-list-item-title>
+                  </v-list-item>
                 </v-list>
               </v-menu>
             </div>
           </div>
+        </div>
+        <v-divider v-if="!isWrapped" class="w-full opacity-10" />
+        <div
+          v-if="!isWrapped"
+          class="flex justify-center items-center gap-4 w-full px-2 py-[2px] text-[11px] tabular-nums select-none"
+        >
+          <v-icon size="14" class="opacity-80 text-odometer">mdi-map-marker-distance</v-icon>
+          <v-tooltip location="bottom" open-delay="800" text="Total distance the vehicle has traveled">
+            <template #activator="{ props: totalProps }">
+              <div v-bind="totalProps" class="flex items-center gap-1 text-odometer">
+                <span class="opacity-80">Total:</span>
+                <span class="font-bold">{{ formattedTotalDistance }}</span>
+              </div>
+            </template>
+          </v-tooltip>
+          <v-tooltip
+            location="bottom"
+            open-delay="800"
+            text="Distance traveled during the current mission, since waypoint 1"
+          >
+            <template #activator="{ props: missionProps }">
+              <div v-bind="missionProps" class="flex items-center gap-1 text-odometer">
+                <span class="opacity-80">Mission:</span>
+                <span class="font-bold">{{ formattedMissionDistance }}</span>
+              </div>
+            </template>
+          </v-tooltip>
         </div>
       </div>
     </div>
@@ -135,6 +170,7 @@ import { computed, onBeforeMount, ref, toRefs } from 'vue'
 import CruiseSpeedControl from '@/components/mission-planning/CruiseSpeedControl.vue'
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { openSnackbar } from '@/composables/snackbar'
+import { useTraveledDistances } from '@/composables/useTraveledDistances'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useMissionStore } from '@/stores/mission'
@@ -179,8 +215,8 @@ const disableMovingOnDrag = (): void => {
 }
 
 const widgetSize = {
-  width: 0.14638572402097255,
-  height: 0.09641222207770606,
+  width: 0.152,
+  height: 0.11,
 }
 
 const skipToPreviousWaypoint = (): void => {
@@ -193,6 +229,8 @@ const skipToNextWaypoint = (): void => {
   missionStore.skipToWaypoint(1)
 }
 
+const { formattedTotalDistance, formattedMissionDistance } = useTraveledDistances()
+
 const handleDownloadMissionOnMap = async (): Promise<void> => {
   logUserAction('Requested mission download from vehicle to map')
   missionStore.requestMapMissionDownload()
@@ -201,6 +239,26 @@ const handleDownloadMissionOnMap = async (): Promise<void> => {
 const handleClearMissionOnMap = (): void => {
   logUserAction('Cleared mission drawn on map')
   missionStore.requestMapClear()
+}
+
+const handleResetTotalDistance = (): void => {
+  showDialog({
+    title: 'Reset total distance',
+    message: `The total distance traveled by this vehicle (${formattedTotalDistance.value}) will be discarded and start counting from zero. This cannot be undone.`,
+    variant: 'warning',
+    actions: [
+      { text: 'Cancel', size: 'small', action: closeDialog },
+      {
+        text: 'Reset',
+        size: 'small',
+        action: () => {
+          closeDialog()
+          missionStore.resetTotalDistance()
+          openSnackbar({ message: 'Total traveled distance reset', variant: 'success' })
+        },
+      },
+    ],
+  })
 }
 
 onBeforeMount(() => {

--- a/src/components/widgets/MissionControlPanel.vue
+++ b/src/components/widgets/MissionControlPanel.vue
@@ -2,7 +2,7 @@
   <div class="min-w-[290px] min-h-[95px] flex items-end">
     <div
       class="w-full rounded-lg overflow-hidden -mt-2"
-      :class="[isWrapped ? 'h-[42px]' : 'h-full']"
+      :class="[isWrapped ? 'h-[38px]' : 'h-full']"
       :style="interfaceStore.globalGlassMenuStyles"
     >
       <div class="flex flex-col justify-start items-center h-full pt-2 cursor-pointer">
@@ -20,7 +20,10 @@
           />
         </div>
         <v-divider v-if="!isWrapped" />
-        <div v-show="!isWrapped" class="flex justify-center items-center w-full h-full">
+        <div
+          v-show="!isWrapped"
+          class="flex justify-center items-center w-full h-full bg-[#00000022] shadow-[inset_0_2px_3px_-1px_rgba(0,0,0,0.45)]"
+        >
           <div
             class="flex w-full h-full justify-start items-center overflow-hidden px-1"
             :class="!vehicleStore.isVehicleOnline ? 'active-events-on-disabled' : ''"
@@ -104,17 +107,17 @@
                   />
                 </template>
 
-                <v-list>
+                <v-list class="py-0">
                   <v-list-item
                     :disabled="!vehicleStore.isVehicleOnline"
                     class="cursor-pointer"
                     @click="handleDownloadMissionOnMap"
                   >
-                    <v-list-item-title>Download mission from vehicle</v-list-item-title>
+                    <v-list-item-title class="text-[14px]">Download mission from vehicle</v-list-item-title>
                   </v-list-item>
-
-                  <v-list-item class="cursor-pointer" @click="handleClearMissionOnMap">
-                    <v-list-item-title>Clear mission on map</v-list-item-title>
+                  <v-divider class="opacity-10" />
+                  <v-list-item class="cursor-pointer py-0" @click="handleClearMissionOnMap">
+                    <v-list-item-title class="text-[14px]">Clear mission on map</v-list-item-title>
                   </v-list-item>
                 </v-list>
               </v-menu>

--- a/src/composables/map/useVehicleHistoryOverlay.ts
+++ b/src/composables/map/useVehicleHistoryOverlay.ts
@@ -1,0 +1,138 @@
+import L, { type Map as LeafletMap } from 'leaflet'
+import { computed, watch } from 'vue'
+
+import { useTraveledDistances } from '@/composables/useTraveledDistances'
+import { useMissionStore } from '@/stores/mission'
+
+/**
+ * Return type of {@link useVehicleHistoryOverlay}.
+ */
+export interface UseVehicleHistoryOverlayReturn {
+  /** Binds the trail to a Leaflet map and starts following the vehicle position history. */
+  initVehicleHistory: (map: LeafletMap, isDrawable: () => boolean) => void
+  /** Removes the trail and stops following the history. */
+  destroyVehicleHistory: () => void
+}
+
+/**
+ * Draws the vehicle position history as a polyline on a Leaflet map, with a tooltip reporting the total
+ * and current-mission traveled distances and a button to reset the mission odometer. Shared by the Map
+ * widget and the Mission Planning view, which both render the same trail.
+ * @returns {UseVehicleHistoryOverlayReturn} Methods to initialize, refresh, and tear down the trail.
+ */
+export const useVehicleHistoryOverlay = (): UseVehicleHistoryOverlayReturn => {
+  const missionStore = useMissionStore()
+  const { formattedTotalDistance, formattedMissionDistance } = useTraveledDistances()
+
+  // Dedicated Canvas renderer to prevent performance issues, since the trail can reach hundreds of
+  // thousands of points.
+  const renderer = L.canvas()
+
+  let mapRef: LeafletMap | undefined
+  let isDrawable: () => boolean = () => true
+  let polyline: L.Polyline | undefined
+  let lastDrawnLength = 0
+  let stopHistoryWatch: (() => void) | undefined
+  let stopTooltipWatch: (() => void) | undefined
+
+  const tooltipContent = computed<string>(
+    () => `
+    <div class="history-tooltip-row">
+      <span class="history-tooltip-label">
+        <i class="mdi mdi-counter"></i>
+        Total:
+      </span>
+      <span class="history-tooltip-value">${formattedTotalDistance.value}</span>
+    </div>
+    <div class="history-tooltip-row">
+      <span class="history-tooltip-label">Mission:</span>
+      <span class="history-tooltip-row-value-group">
+        <button
+          type="button"
+          class="history-tooltip-reset"
+          title="Reset mission distance"
+          aria-label="Reset mission distance"
+        >
+          <i class="mdi mdi-restore"></i>
+        </button>
+        <span class="history-tooltip-value">${formattedMissionDistance.value}</span>
+      </span>
+    </div>
+  `
+  )
+
+  const attachTooltip = (trail: L.Polyline): void => {
+    // Pass content as a function so every Leaflet re-evaluation reads the latest reactive value.
+    // The watcher in `initVehicleHistory` complements this by pushing live updates while the tooltip
+    // is already open.
+    trail.bindTooltip(() => tooltipContent.value, {
+      sticky: true,
+      direction: 'top',
+      className: 'history-polyline-tooltip',
+      opacity: 1,
+    })
+    trail.on('click', (event: L.LeafletMouseEvent) => trail.openTooltip(event.latlng))
+  }
+
+  const removeTrail = (): void => {
+    if (polyline && mapRef) mapRef.removeLayer(polyline)
+    polyline = undefined
+    lastDrawnLength = 0
+  }
+
+  const draw = (): void => {
+    const points = missionStore.vehiclePositionHistory
+    if (!mapRef || !isDrawable() || points.length === 0) {
+      removeTrail()
+      return
+    }
+
+    if (polyline === undefined) {
+      polyline = L.polyline([], { color: '#ffff00', renderer }).addTo(mapRef)
+      lastDrawnLength = 0
+      attachTooltip(polyline)
+    }
+
+    if (points.length > lastDrawnLength && lastDrawnLength > 0) {
+      // Append only the new points — O(1) per fire instead of O(N) full rebuild.
+      for (let i = lastDrawnLength; i < points.length; i++) {
+        polyline.addLatLng(points[i] as L.LatLngExpression)
+      }
+    } else {
+      // First draw, or the history shrank (clear/simplify) / stayed same length (push+shift):
+      // fall back to a full rebuild to stay correct.
+      polyline.setLatLngs(points as L.LatLngExpression[])
+    }
+    lastDrawnLength = points.length
+  }
+
+  // The tooltip's inner DOM is replaced on every setContent, so the reset-button click is delegated on
+  // document instead of bound to the button element.
+  const onResetClick = (event: MouseEvent): void => {
+    const target = event.target as HTMLElement | null
+    if (!target?.closest('.history-tooltip-reset')) return
+    event.stopPropagation()
+    missionStore.resetMissionDistance()
+  }
+
+  const initVehicleHistory = (map: LeafletMap, drawable: () => boolean): void => {
+    mapRef = map
+    isDrawable = drawable
+    stopHistoryWatch = watch(() => missionStore.vehiclePositionHistoryRevision, draw)
+    stopTooltipWatch = watch(tooltipContent, (content) => polyline?.getTooltip()?.setContent(content))
+    document.addEventListener('click', onResetClick, true)
+    draw()
+  }
+
+  const destroyVehicleHistory = (): void => {
+    stopHistoryWatch?.()
+    stopTooltipWatch?.()
+    stopHistoryWatch = undefined
+    stopTooltipWatch = undefined
+    document.removeEventListener('click', onResetClick, true)
+    removeTrail()
+    mapRef = undefined
+  }
+
+  return { initVehicleHistory, destroyVehicleHistory }
+}

--- a/src/composables/map/useVehicleHistoryOverlay.ts
+++ b/src/composables/map/useVehicleHistoryOverlay.ts
@@ -1,0 +1,140 @@
+import L, { type Map as LeafletMap } from 'leaflet'
+import { computed, watch } from 'vue'
+
+import { useTraveledDistances } from '@/composables/useTraveledDistances'
+import { useMissionStore } from '@/stores/mission'
+
+/**
+ * Return type of {@link useVehicleHistoryOverlay}.
+ */
+export interface UseVehicleHistoryOverlayReturn {
+  /** Binds the trail to a Leaflet map and starts following the vehicle position history. */
+  initVehicleHistory: (map: LeafletMap, isDrawable: () => boolean) => void
+  /** Removes the trail and stops following the history. */
+  destroyVehicleHistory: () => void
+}
+
+/**
+ * Draws the vehicle position history as a polyline on a Leaflet map, with a tooltip reporting the total
+ * and current-mission traveled distances and a button to reset the mission odometer. Consumed by the Map
+ * widget; the Mission Planning view still keeps its own trail renderer.
+ * @returns {UseVehicleHistoryOverlayReturn} Methods to initialize and tear down the trail.
+ */
+export const useVehicleHistoryOverlay = (): UseVehicleHistoryOverlayReturn => {
+  const missionStore = useMissionStore()
+  const { formattedTotalDistance, formattedMissionDistance } = useTraveledDistances()
+
+  // Dedicated Canvas renderer to prevent performance issues, since the trail can reach hundreds of
+  // thousands of points.
+  const renderer = L.canvas()
+
+  let mapRef: LeafletMap | undefined
+  let isDrawable: () => boolean = () => true
+  let polyline: L.Polyline | undefined
+  let lastDrawnLength = 0
+  let stopHistoryWatch: (() => void) | undefined
+  let stopTooltipWatch: (() => void) | undefined
+
+  const tooltipContent = computed<string>(
+    () => `
+    <div class="history-tooltip-row">
+      <span class="history-tooltip-label">
+        <i class="mdi mdi-counter"></i>
+        Total:
+      </span>
+      <span class="history-tooltip-value">${formattedTotalDistance.value}</span>
+    </div>
+    <div class="history-tooltip-row">
+      <span class="history-tooltip-label">Mission:</span>
+      <span class="history-tooltip-row-value-group">
+        <button
+          type="button"
+          class="history-tooltip-reset"
+          title="Reset mission distance"
+          aria-label="Reset mission distance"
+        >
+          <i class="mdi mdi-restore"></i>
+        </button>
+        <span class="history-tooltip-value">${formattedMissionDistance.value}</span>
+      </span>
+    </div>
+  `
+  )
+
+  const attachTooltip = (trail: L.Polyline): void => {
+    // Pass content as a function so every Leaflet re-evaluation reads the latest reactive value.
+    // The watcher in `initVehicleHistory` complements this by pushing live updates while the tooltip
+    // is already open.
+    trail.bindTooltip(() => tooltipContent.value, {
+      sticky: true,
+      direction: 'top',
+      className: 'history-polyline-tooltip',
+      opacity: 1,
+    })
+    trail.on('click', (event: L.LeafletMouseEvent) => trail.openTooltip(event.latlng))
+  }
+
+  const removeTrail = (): void => {
+    if (polyline && mapRef) mapRef.removeLayer(polyline)
+    polyline = undefined
+    lastDrawnLength = 0
+  }
+
+  const draw = (): void => {
+    const points = missionStore.vehiclePositionHistory
+    if (!mapRef || !isDrawable() || points.length === 0) {
+      removeTrail()
+      return
+    }
+
+    if (polyline === undefined) {
+      polyline = L.polyline([], { color: '#ffff00', renderer }).addTo(mapRef)
+      lastDrawnLength = 0
+      attachTooltip(polyline)
+    }
+
+    if (points.length > lastDrawnLength && lastDrawnLength > 0) {
+      // Append only the new points — O(1) per fire instead of O(N) full rebuild.
+      for (let i = lastDrawnLength; i < points.length; i++) {
+        polyline.addLatLng(points[i] as L.LatLngExpression)
+      }
+    } else {
+      // First draw, or the history shrank (clear/simplify) / stayed same length (push+shift):
+      // fall back to a full rebuild to stay correct.
+      polyline.setLatLngs(points as L.LatLngExpression[])
+    }
+    lastDrawnLength = points.length
+  }
+
+  // The tooltip's inner DOM is replaced on every setContent, so the reset-button click is delegated on
+  // the map container instead of bound to the button element.
+  const onResetClick = (event: MouseEvent): void => {
+    const target = event.target as HTMLElement | null
+    if (!target?.closest('.history-tooltip-reset')) return
+    event.stopPropagation()
+    missionStore.resetMissionDistance()
+  }
+
+  const initVehicleHistory = (map: LeafletMap, drawable: () => boolean): void => {
+    mapRef = map
+    isDrawable = drawable
+    stopHistoryWatch = watch(() => missionStore.vehiclePositionHistoryRevision, draw)
+    stopTooltipWatch = watch(tooltipContent, (content) => {
+      if (polyline?.isTooltipOpen()) polyline.getTooltip()?.setContent(content)
+    })
+    map.getContainer().addEventListener('click', onResetClick, true)
+    draw()
+  }
+
+  const destroyVehicleHistory = (): void => {
+    stopHistoryWatch?.()
+    stopTooltipWatch?.()
+    stopHistoryWatch = undefined
+    stopTooltipWatch = undefined
+    mapRef?.getContainer().removeEventListener('click', onResetClick, true)
+    removeTrail()
+    mapRef = undefined
+  }
+
+  return { initVehicleHistory, destroyVehicleHistory }
+}

--- a/src/composables/useTraveledDistances.ts
+++ b/src/composables/useTraveledDistances.ts
@@ -1,0 +1,38 @@
+import { type ComputedRef, computed } from 'vue'
+
+import { formatDistance } from '@/libs/units'
+import { useAppInterfaceStore } from '@/stores/appInterface'
+import { useMissionStore } from '@/stores/mission'
+
+type TraveledDistances = {
+  /**
+   * Total distance the vehicle has traveled across its whole history, pre-formatted in the user's
+   * preferred distance unit.
+   */
+  formattedTotalDistance: ComputedRef<string>
+  /**
+   * Distance traveled during the current mission (since waypoint 1), pre-formatted in the user's
+   * preferred distance unit.
+   */
+  formattedMissionDistance: ComputedRef<string>
+}
+
+/**
+ * Exposes the total and mission traveled distances pre-formatted with the user's preferred distance
+ * unit, so widgets, mini-widgets, and map overlays can share a single formatting funnel instead of
+ * duplicating the mission-store + interface-store wiring at each call site.
+ * @returns {TraveledDistances} Reactive formatted-distance strings for the total and mission odometers
+ */
+export const useTraveledDistances = (): TraveledDistances => {
+  const missionStore = useMissionStore()
+  const interfaceStore = useAppInterfaceStore()
+
+  const formattedTotalDistance = computed(() =>
+    formatDistance(missionStore.totalTraveledDistanceMeters, interfaceStore.displayUnitPreferences.distance)
+  )
+  const formattedMissionDistance = computed(() =>
+    formatDistance(missionStore.missionTraveledDistanceMeters, interfaceStore.displayUnitPreferences.distance)
+  )
+
+  return { formattedTotalDistance, formattedMissionDistance }
+}

--- a/src/libs/units.ts
+++ b/src/libs/units.ts
@@ -1,3 +1,5 @@
+import { unit } from 'mathjs'
+
 /**
  * Possible distance units.
  * Meters is the default unit, from which all other units are converted.
@@ -15,4 +17,23 @@ export const unitPrettyName = {
 export const unitAbbreviation = {
   [DistanceDisplayUnit.Meters]: 'm',
   [DistanceDisplayUnit.Feet]: 'ft',
+}
+
+/**
+ * Formats a distance value (in meters) for display in the user's preferred unit, automatically
+ * promoting to a larger unit (km / mi) once the value crosses the conventional threshold.
+ * @param {number} meters - The distance to format, expressed in meters
+ * @param {DistanceDisplayUnit} displayUnit - The user's preferred display unit
+ * @returns {string} A localized string such as `"312.5 m"`, `"1.23 km"`, `"850 ft"` or `"2.41 mi"`
+ */
+export const formatDistance = (meters: number, displayUnit: DistanceDisplayUnit): string => {
+  const distance = unit(meters, 'm')
+  if (displayUnit === DistanceDisplayUnit.Feet) {
+    const miles = distance.toNumber('mi')
+    if (miles >= 1) return `${miles.toFixed(2)} mi`
+    return `${distance.toNumber('ft').toFixed(0)} ${unitAbbreviation[DistanceDisplayUnit.Feet]}`
+  }
+  const kilometers = distance.toNumber('km')
+  if (kilometers >= 1) return `${kilometers.toFixed(2)} km`
+  return `${meters.toFixed(1)} ${unitAbbreviation[DistanceDisplayUnit.Meters]}`
 }

--- a/src/libs/units.ts
+++ b/src/libs/units.ts
@@ -1,3 +1,5 @@
+import { unit } from 'mathjs'
+
 /**
  * Possible distance units.
  * Meters is the default unit, from which all other units are converted.
@@ -15,4 +17,25 @@ export const unitPrettyName = {
 export const unitAbbreviation = {
   [DistanceDisplayUnit.Meters]: 'm',
   [DistanceDisplayUnit.Feet]: 'ft',
+}
+
+/**
+ * Formats a distance value (in meters) for display in the user's preferred unit, automatically
+ * promoting to a larger unit (km / mi) once the value crosses the conventional threshold.
+ * @param {number} meters - The distance to format, expressed in meters
+ * @param {DistanceDisplayUnit} displayUnit - The user's preferred display unit
+ * @returns {string} A localized string such as `"312.5 m"`, `"1.23 km"`, `"850 ft"` or `"2.41 mi"`, or
+ * `"—"` when the value cannot represent a distance
+ */
+export const formatDistance = (meters: number, displayUnit: DistanceDisplayUnit): string => {
+  if (!Number.isFinite(meters) || meters < 0) return '—'
+  const distance = unit(meters, 'm')
+  if (displayUnit === DistanceDisplayUnit.Feet) {
+    const miles = distance.toNumber('mi')
+    if (miles >= 1) return `${miles.toFixed(2)} mi`
+    return `${distance.toNumber('ft').toFixed(0)} ${unitAbbreviation[DistanceDisplayUnit.Feet]}`
+  }
+  const kilometers = distance.toNumber('km')
+  if (kilometers >= 1) return `${kilometers.toFixed(2)} km`
+  return `${meters.toFixed(1)} ${unitAbbreviation[DistanceDisplayUnit.Meters]}`
 }

--- a/src/stores/mission.ts
+++ b/src/stores/mission.ts
@@ -11,6 +11,7 @@ import { useMissionThumbnails } from '@/composables/useMissionThumbnails'
 import { askForUsername } from '@/composables/usernamePrompDialog'
 import { MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import { generateSessionSeed } from '@/libs/map/map-tile-fallback'
+import { distanceInMeters } from '@/libs/map/utils-map'
 import {
   AUTOMATIC_MISSION_NAME_MIN_IDLE_MS,
   generateAutomaticMissionName,
@@ -44,6 +45,11 @@ const DEFAULT_MAP_ZOOM = 15
 // Default cap on the vehicle position history. At 5Hz (default sampling rate), 500k samples is about 30 hours.
 export const DEFAULT_MAX_POSITION_HISTORY_SIZE = 500000
 export const MIN_MAX_POSITION_HISTORY_SIZE = 100
+
+// Minimum movement, in meters, between two odometer samples for the distance to be counted; keeps GPS
+// jitter from racking up kilometers while the vehicle sits still. The reference point holds until the
+// threshold is crossed, so genuinely slow travel still adds up.
+const minOdometerSegmentMeters = 1
 
 export const useMissionStore = defineStore('mission', () => {
   const username = useStorage<string>('cockpit-username', fallbackUsername)
@@ -302,6 +308,41 @@ export const useMissionStore = defineStore('mission', () => {
   const vehiclePositionHistory = ref<WaypointCoordinates[]>([...persistedPositionHistory.value])
   // Revision counter for `vehiclePositionHistory` mutations.
   const vehiclePositionHistoryRevision = ref(0)
+  const totalTraveledDistanceMeters = useBlueOsStorage<number>('cockpit-odometer-total-distance-meters', 0)
+  const missionTraveledDistanceMeters = useBlueOsStorage<number>('cockpit-odometer-mission-distance-meters', 0)
+
+  let lastOdometerPoint: WaypointCoordinates | null = null
+
+  type ResetMissionDistanceOptions = {
+    /**
+     * When `true`, skip the `logUserAction` entry. Used by telemetry-driven callers (e.g. the
+     * auto-reset watcher on `currentMissionSeq`) so those resets don't appear as user actions
+     * in the system log. Defaults to `false`.
+     */
+    silent?: boolean
+  }
+
+  /**
+   * Resets the mission odometer back to zero, so it starts counting again from the vehicle's
+   * current position.
+   * @param {ResetMissionDistanceOptions} [options] - Reset options; see the type for details.
+   * @returns {void}
+   */
+  const resetMissionDistance = (options: ResetMissionDistanceOptions = {}): void => {
+    if (!options.silent) logUserAction('Reset the mission traveled-distance odometer')
+    missionTraveledDistanceMeters.value = 0
+  }
+
+  /**
+   * Resets the total odometer back to zero, so it starts counting again from the vehicle's current
+   * position. Unlike the mission odometer this is never reset automatically, so it only ever happens
+   * on an explicit user request.
+   * @returns {void}
+   */
+  const resetTotalDistance = (): void => {
+    logUserAction('Reset the total traveled-distance odometer')
+    totalTraveledDistanceMeters.value = 0
+  }
 
   let positionHistoryDirty = false
   let simplifiedBoundary = 0
@@ -728,7 +769,8 @@ export const useMissionStore = defineStore('mission', () => {
     () => [mainVehicleStore.coordinates?.latitude, mainVehicleStore.coordinates?.longitude] as const,
     ([lat, lng]) => {
       if (!lat || !lng) return
-      vehiclePositionHistory.value.push([lat, lng] as WaypointCoordinates)
+      const newPoint: WaypointCoordinates = [lat, lng]
+      vehiclePositionHistory.value.push(newPoint)
       if (vehiclePositionHistory.value.length > maxPositionHistorySize.value) {
         const didSimplify = simplifyNextChunk()
         // Fallback: if no unsimplified chunk was available or RDP freed nothing, drop oldest point
@@ -739,6 +781,27 @@ export const useMissionStore = defineStore('mission', () => {
       }
       vehiclePositionHistoryRevision.value += 1
       positionHistoryDirty = true
+
+      const segmentMeters = lastOdometerPoint === null ? 0 : distanceInMeters(lastOdometerPoint, newPoint)
+      if (lastOdometerPoint !== null && segmentMeters < minOdometerSegmentMeters) return
+      lastOdometerPoint = newPoint
+      totalTraveledDistanceMeters.value += segmentMeters
+
+      // Mission distance must only accumulate while running an actual waypoint mission (AUTO).
+      // GUIDED is also a "running" mode for the play/pause control but is used for ad-hoc GoTo
+      // commands that should not contribute to the mission odometer.
+      if (mainVehicleStore.mode === 'AUTO' && (mainVehicleStore.currentMissionSeq ?? 0) >= 1) {
+        missionTraveledDistanceMeters.value += segmentMeters
+      }
+    }
+  )
+
+  // Reset the mission odometer whenever the vehicle (re)starts the mission from the first waypoint.
+  watch(
+    () => mainVehicleStore.currentMissionSeq,
+    (newSeq, oldSeq) => {
+      // Telemetry-driven, not a user gesture, so the [UserAction] log is suppressed.
+      if (newSeq === 1 && oldSeq !== 1) resetMissionDistance({ silent: true })
     }
   )
 
@@ -897,6 +960,10 @@ export const useMissionStore = defineStore('mission', () => {
     isVehiclePositionHistoryPersistent,
     maxPositionHistorySize,
     clearVehicleHistory,
+    totalTraveledDistanceMeters,
+    missionTraveledDistanceMeters,
+    resetMissionDistance,
+    resetTotalDistance,
     pushUndoSnapshot,
     popUndoSnapshot,
     popRedoSnapshot,

--- a/src/stores/mission.ts
+++ b/src/stores/mission.ts
@@ -1,5 +1,5 @@
 import * as turf from '@turf/turf'
-import { useStorage } from '@vueuse/core'
+import { type RemovableRef, useStorage } from '@vueuse/core'
 import { defineStore } from 'pinia'
 import { v4 as uuid } from 'uuid'
 import { computed, reactive, ref, watch } from 'vue'
@@ -11,12 +11,14 @@ import { useMissionThumbnails } from '@/composables/useMissionThumbnails'
 import { askForUsername } from '@/composables/usernamePrompDialog'
 import { MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import { generateSessionSeed } from '@/libs/map/map-tile-fallback'
+import { distanceInMeters } from '@/libs/map/utils-map'
 import {
   AUTOMATIC_MISSION_NAME_MIN_IDLE_MS,
   generateAutomaticMissionName,
   shouldRenewAutomaticMissionName,
 } from '@/libs/mission/automatic-name'
 import { generateMissionThumbnailSvg } from '@/libs/mission/library'
+import { settingsManager } from '@/libs/settings-management'
 import { eventCategoriesDefaultMapping } from '@/libs/slide-to-confirm'
 import { toPlain } from '@/libs/utils'
 import {
@@ -46,6 +48,11 @@ const DEFAULT_MAP_ZOOM = 15
 // Default cap on the vehicle position history. At 5Hz (default sampling rate), 500k samples is about 30 hours.
 export const DEFAULT_MAX_POSITION_HISTORY_SIZE = 500000
 export const MIN_MAX_POSITION_HISTORY_SIZE = 100
+
+// Minimum movement, in meters, between two odometer samples for the distance to be counted; keeps GPS
+// jitter from racking up kilometers while the vehicle sits still. The reference point holds until the
+// threshold is crossed, so genuinely slow travel still adds up.
+const minOdometerSegmentMeters = 1
 
 export const useMissionStore = defineStore('mission', () => {
   const username = useStorage<string>('cockpit-username', fallbackUsername)
@@ -336,6 +343,63 @@ export const useMissionStore = defineStore('mission', () => {
   const vehiclePositionHistory = ref<WaypointCoordinates[]>([...persistedPositionHistory.value])
   // Revision counter for `vehiclePositionHistory` mutations.
   const vehiclePositionHistoryRevision = ref(0)
+  const totalDistanceKey = 'cockpit-odometer-total-distance-meters'
+  const missionDistanceKey = 'cockpit-odometer-mission-distance-meters'
+  const totalTraveledDistanceMeters = useBlueOsStorage<number>(totalDistanceKey, 0)
+  const missionTraveledDistanceMeters = useBlueOsStorage<number>(missionDistanceKey, 0)
+
+  // Both odometers are vehicle-synced, so a value pushed by another topside computer, or by one whose
+  // link dropped mid-accumulation, is assigned straight onto the ref and would replace a higher
+  // reading with a stale lower one. They only ever grow, except when a reset takes them to zero.
+  const keepOdometerMonotonic = (odometer: RemovableRef<number>): void => {
+    watch(odometer, (newValue, oldValue) => {
+      if (newValue !== 0 && newValue < oldValue) odometer.value = oldValue
+    })
+  }
+  keepOdometerMonotonic(totalTraveledDistanceMeters)
+  keepOdometerMonotonic(missionTraveledDistanceMeters)
+
+  // The settings sync writes whatever the odometer holds when its debounce fires, which on a moving
+  // vehicle is already a small non-zero number, and the clamp above refuses every decrease that is
+  // not zero. Publishing the zero as the reset happens is what lets it reach the other clients.
+  const publishOdometerReset = (key: string): void => {
+    settingsManager.setKeyValue(key, 0)
+  }
+
+  let lastOdometerPoint: WaypointCoordinates | null = null
+
+  type ResetMissionDistanceOptions = {
+    /**
+     * When `true`, skip the `logUserAction` entry. Used by telemetry-driven callers (e.g. the
+     * auto-reset watcher on `currentMissionSeq`) so those resets don't appear as user actions
+     * in the system log. Defaults to `false`.
+     */
+    silent?: boolean
+  }
+
+  /**
+   * Resets the mission odometer back to zero, so it starts counting again from the vehicle's
+   * current position.
+   * @param {ResetMissionDistanceOptions} [options] - Reset options; see the type for details.
+   * @returns {void}
+   */
+  const resetMissionDistance = (options: ResetMissionDistanceOptions = {}): void => {
+    if (!options.silent) logUserAction('Reset the mission traveled-distance odometer')
+    missionTraveledDistanceMeters.value = 0
+    publishOdometerReset(missionDistanceKey)
+  }
+
+  /**
+   * Resets the total odometer back to zero, so it starts counting again from the vehicle's current
+   * position. Unlike the mission odometer this is never reset automatically, so it only ever happens
+   * on an explicit user request.
+   * @returns {void}
+   */
+  const resetTotalDistance = (): void => {
+    logUserAction('Reset the total traveled-distance odometer')
+    totalTraveledDistanceMeters.value = 0
+    publishOdometerReset(totalDistanceKey)
+  }
 
   let positionHistoryDirty = false
   let simplifiedBoundary = 0
@@ -766,7 +830,8 @@ export const useMissionStore = defineStore('mission', () => {
     () => [mainVehicleStore.coordinates?.latitude, mainVehicleStore.coordinates?.longitude] as const,
     ([lat, lng]) => {
       if (!lat || !lng) return
-      vehiclePositionHistory.value.push([lat, lng] as WaypointCoordinates)
+      const newPoint: WaypointCoordinates = [lat, lng]
+      vehiclePositionHistory.value.push(newPoint)
       if (vehiclePositionHistory.value.length > maxPositionHistorySize.value) {
         const didSimplify = simplifyNextChunk()
         // Fallback: if no unsimplified chunk was available or RDP freed nothing, drop oldest point
@@ -777,6 +842,29 @@ export const useMissionStore = defineStore('mission', () => {
       }
       vehiclePositionHistoryRevision.value += 1
       positionHistoryDirty = true
+
+      const segmentMeters = lastOdometerPoint === null ? 0 : distanceInMeters(lastOdometerPoint, newPoint)
+      if (lastOdometerPoint !== null && segmentMeters < minOdometerSegmentMeters) return
+      lastOdometerPoint = newPoint
+      totalTraveledDistanceMeters.value += segmentMeters
+
+      // Mission distance must only accumulate while running an actual waypoint mission (AUTO).
+      // GUIDED is also a "running" mode for the play/pause control but is used for ad-hoc GoTo
+      // commands that should not contribute to the mission odometer.
+      if (mainVehicleStore.mode === 'AUTO' && (mainVehicleStore.currentMissionSeq ?? 0) >= 1) {
+        missionTraveledDistanceMeters.value += segmentMeters
+      }
+    }
+  )
+
+  // Reset the mission odometer whenever the vehicle (re)starts the mission from the first waypoint.
+  watch(
+    () => mainVehicleStore.currentMissionSeq,
+    (newSeq, oldSeq) => {
+      // Telemetry-driven, not a user gesture, so the [UserAction] log is suppressed. An unknown
+      // previous sequence means the first message after a page load or a reconnect, which is not the
+      // vehicle moving onto the first waypoint.
+      if (newSeq === 1 && oldSeq !== undefined && oldSeq !== 1) resetMissionDistance({ silent: true })
     }
   )
 
@@ -956,6 +1044,10 @@ export const useMissionStore = defineStore('mission', () => {
     isVehiclePositionHistoryPersistent,
     maxPositionHistorySize,
     clearVehicleHistory,
+    totalTraveledDistanceMeters,
+    missionTraveledDistanceMeters,
+    resetMissionDistance,
+    resetTotalDistance,
     pushUndoSnapshot,
     popUndoSnapshot,
     popRedoSnapshot,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,7 @@ module.exports = {
     extend: {
       colors: {
         critical: '#7F34CF',
+        odometer: '#ffb85b',
       },
       transitionProperty: {
         height: 'height',


### PR DESCRIPTION
* Mission and vehicle path history odometers;
* Can be accessed by the Mission control Panel widget (1), clicking or hovering the WP number on the Mini Mission Control Panel mini widget (2) or hovering/clicking the vehicle history line on the map.
* Mission history can be reset on all three surfaces: the widget's three-dots menu, the mini widget's popover and the map tooltip.
* Mission history also resets itself whenever the vehicle reports it is back on the first waypoint.
* Total history is reset only from the widget's three-dots menu, behind a confirmation, since it is a lifetime counter.

<img width="1723" height="1020" alt="image" src="https://github.com/user-attachments/assets/2bf41383-aeef-4211-a93a-560ab608d314" />

<img width="571" height="497" alt="image" src="https://github.com/user-attachments/assets/5f5d8069-e85c-4867-a2f2-847835471e26" />

<img width="657" height="643" alt="image" src="https://github.com/user-attachments/assets/f1ae67b6-1bda-4fe5-b73e-edbb386bcba5" />

Close #2675
