### PR TITLE
Mission runtime: Fix current waypoint mismatch between mission control panel and map

### DIFF
--- a/src/components/mini-widgets/MiniMissionControlPanel.vue
+++ b/src/components/mini-widgets/MiniMissionControlPanel.vue
@@ -85,13 +85,8 @@ const missionStore = useMissionStore()
 const vehicleStore = useMainVehicleStore()
 
 const currentWaypointOnMission = computed<string>((): string => {
-  if (
-    vehicleStore.currentMissionSeq === undefined ||
-    vehicleStore.currentMissionSeq === null ||
-    vehicleStore.currentMissionSeq === 0
-  )
-    return '--'
-  return vehicleStore.currentMissionSeq.toString()
+  const wpIndex = missionStore.currentWaypointOnMission
+  return wpIndex > 0 ? wpIndex.toString() : '--'
 })
 
 const handleReturnHome = (): void => {

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -388,13 +388,10 @@ const contextMenuSelectedWpIndex = ref<number | null>(null)
 const contextMenuVersion = ref(0)
 const mapWaypointMarkers = ref<L.Marker[]>([])
 
-const currentVehicleWpIndex = computed<number>(() => {
-  return vehicleStore.currentMissionSeq ?? -1
-})
-
-const currentMapWpIndex = computed(() => {
-  if (currentVehicleWpIndex.value === -1 || currentVehicleWpIndex.value === undefined) return -1
-  return Math.max(0, currentVehicleWpIndex.value - 1)
+const currentMapWpIndex = computed<number>(() => {
+  const wpIdx = missionStore.currentWpIndex
+  if (wpIdx === undefined || wpIdx <= 0) return -1
+  return wpIdx - 1
 })
 
 const onTouchStart = (e: TouchEvent): void => {
@@ -1403,7 +1400,7 @@ watch(
 )
 
 // Keep an eye on the current mission status and update the waypoint markers accordingly
-watch([vehicleStore.currentMissionSeq, currentVehicleWpIndex, getReachedWaypointIndices, currentMapWpIndex], () => {
+watch([getReachedWaypointIndices, currentMapWpIndex], () => {
   Object.entries(reachedWaypoints.value).forEach(([seqStr, marker]) => {
     const seq = Number(seqStr)
     const idx = seq - 1

--- a/src/components/widgets/MissionControlPanel.vue
+++ b/src/components/widgets/MissionControlPanel.vue
@@ -157,13 +157,8 @@ const widget = toRefs(props).widget
 const isWrapped = ref(false)
 
 const currentWaypointOnMission = computed<string>((): string => {
-  if (
-    vehicleStore.currentMissionSeq === undefined ||
-    vehicleStore.currentMissionSeq === null ||
-    vehicleStore.currentMissionSeq === 0
-  )
-    return '--'
-  return vehicleStore.currentMissionSeq.toString()
+  const wpIndex = missionStore.currentWaypointOnMission
+  return wpIndex > 0 ? wpIndex.toString() : '--'
 })
 
 const toggleWrapContainer = (): void => {


### PR DESCRIPTION
* Fixed a state desync that caused conflicting waypoint numbers to render on the map markers and mission control panels.

* Refactored the current waypoint state to act as a single source of truth across the mission planning, execution, and control components.
