### PR TITLE
Maps: keep last selected map provider

### DIFF
--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -720,7 +720,11 @@ onMounted(async () => {
 
   mapBase.value?.addEventListener('touchstart', onTouchStart, { passive: true })
   mapBase.value?.addEventListener('touchend', onTouchEnd, { passive: true })
-  const initialBaseLayer = baseMaps[missionStore.userLastMapTileProvider] || esri
+  const preferredProvider =
+    missionStore.defaultMapTileProvider === 'Use last selected'
+      ? missionStore.userLastMapTileProvider
+      : missionStore.defaultMapTileProvider
+  const initialBaseLayer = baseMaps[preferredProvider] || esri
 
   // Bind leaflet instance to map element
   map.value = L.map(mapId.value, {
@@ -740,6 +744,24 @@ onMounted(async () => {
     }
     missionStore.userLastMapTileProvider = event.name as MapTileProvider
   })
+
+  // React to changes on the default tile provider preference
+  watch(
+    () => missionStore.defaultMapTileProvider,
+    (newPref) => {
+      if (!map.value || newPref === 'Use last selected') return
+      const targetLayer = baseMaps[newPref]
+      if (!targetLayer) return
+      Object.values(baseMaps).forEach((layer) => {
+        if (layer !== targetLayer && map.value?.hasLayer(layer)) {
+          map.value.removeLayer(layer)
+        }
+      })
+      if (!map.value.hasLayer(targetLayer)) {
+        map.value.addLayer(targetLayer)
+      }
+    }
+  )
 
   // Remove default zoom control
   map.value.removeControl(map.value.zoomControl)

--- a/src/stores/mission.ts
+++ b/src/stores/mission.ts
@@ -11,6 +11,7 @@ import { eventCategoriesDefaultMapping } from '@/libs/slide-to-confirm'
 import {
   AltitudeReferenceType,
   MapTileProvider,
+  MapTileProviderPreference,
   MissionCommand,
   PointOfInterest,
   PointOfInterestCoordinates,
@@ -57,6 +58,10 @@ export const useMissionStore = defineStore('mission', () => {
   const userLastMapTileProvider = useBlueOsStorage<MapTileProvider>(
     'cockpit-user-last-map-tile-provider',
     'Esri World Imagery'
+  )
+  const defaultMapTileProvider = useBlueOsStorage<MapTileProviderPreference>(
+    'cockpit-default-map-tile-provider',
+    'Use last selected'
   )
   const mapDownloadMissionFromVehicle = ref<(() => Promise<void>) | null>(null)
   const mapClearMapDrawing = ref<(() => void) | null>(null)
@@ -602,6 +607,7 @@ export const useMissionStore = defineStore('mission', () => {
     updateWaypointCommand,
     defaultCruiseSpeed,
     userLastMapTileProvider,
+    defaultMapTileProvider,
     followVehicleOnMap,
     stopMission,
     executeMissionOnVehicle,

--- a/src/types/mission.ts
+++ b/src/types/mission.ts
@@ -479,6 +479,13 @@ export interface VehicleMissionEstimate {
  */
 export type MapTileProvider = 'Esri World Imagery' | 'OpenStreetMap'
 
+/**
+ * User preference for the default map tile provider.
+ * When set to 'Use last selected', the map opens with the last provider the user picked via the map's layer control.
+ * Otherwise, the map is forced to open with the specified provider.
+ */
+export type MapTileProviderPreference = MapTileProvider | 'Use last selected'
+
 export type IconDimensions = {
   /**
    * The size of the icon in pixels

--- a/src/views/ConfigurationMissionView.vue
+++ b/src/views/ConfigurationMissionView.vue
@@ -85,7 +85,10 @@
           <template #info>
             <strong>Default map position:</strong> Defines the initial center and zoom level for the map. <br />
             <strong>Max. vehicle position update rate:</strong> Limits how often the vehicle's position is updated on
-            the map to reduce CPU usage.
+            the map to reduce CPU usage. <br />
+            <strong>Map tile provider:</strong> Sets which tile layer is used when the dashboard map and mission
+            planning view open. Choose <em>Use last selected</em> to keep the provider last picked from the map's layer
+            control, or pick a specific provider to always open with it.
           </template>
           <template #content>
             <div class="flex flex-wrap gap-4 px-4 pb-4">
@@ -122,17 +125,32 @@
                 <div class="flex-grow-1" />
                 <v-btn class="mt-7 bg-[#FFFFFF22]" variant="plain" size="small" @click="saveMapPosition">Save</v-btn>
               </div>
-              <div class="flex w-[63%] justify-between items-center mt-4">
-                <p class="w-full text-md">Max. vehicle position update rate</p>
-                <div class="flex flex-col max-w-[118px]">
-                  <input
-                    v-model.number="vehicleStore.vehiclePositionMaxSampleRate"
-                    type="number"
-                    min="0"
-                    class="px-2 py-1 rounded-sm bg-[#FFFFFF22]"
+              <v-divider class="mb-4 mt-1 opacity-5" />
+              <div class="flex w-full items-center -mt-4 gap-4">
+                <div class="flex w-1/2 items-center justify-start pr-2">
+                  <p class="text-md">Max. vehicle position update rate</p>
+                  <div class="flex items-center">
+                    <input
+                      v-model.number="vehicleStore.vehiclePositionMaxSampleRate"
+                      type="number"
+                      min="0"
+                      class="px-2 py-1 w-[80px] rounded-sm bg-[#FFFFFF22] ml-4"
+                    />
+                    <p class="ml-2">ms</p>
+                  </div>
+                </div>
+                <div class="flex w-1/2 items-center justify-between pl-2">
+                  <p class="text-md mr-4">Default map tile provider</p>
+                  <v-select
+                    v-model="missionStore.defaultMapTileProvider"
+                    :items="mapTileProviderOptions"
+                    density="compact"
+                    variant="outlined"
+                    hide-details
+                    class="w-[180px]"
+                    theme="dark"
                   />
                 </div>
-                <p class="ml-2">ms</p>
               </div>
             </div>
           </template>
@@ -141,9 +159,9 @@
         <ExpansiblePanel no-bottom-divider :is-expanded="!interfaceStore.isOnPhoneScreen">
           <template #title>Vehicle options</template>
           <template #info>
-            <strong>Max. displayed path points:</strong> Once the limit is reached, the last third of the mission trail
-            will be simplified. Keep this value reasonable — larger histories use more memory and may affect performance
-            over long missions, especially when using high frequency positioning data (e.g. from a DVL or RTK setup).
+            <strong>Max. path points:</strong> Once the limit is reached, the last third of the mission trail will be
+            simplified. Keep this value reasonable — larger histories use more memory and may affect performance over
+            long missions, specially when using DVL or RTK positioning data.
           </template>
           <template #content>
             <div class="flex flex-col gap-y-3 px-4 pb-4 pt-2">
@@ -192,13 +210,15 @@ import { EventCategory } from '@/libs/slide-to-confirm'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { DEFAULT_MAX_POSITION_HISTORY_SIZE, MIN_MAX_POSITION_HISTORY_SIZE, useMissionStore } from '@/stores/mission'
-import type { WaypointCoordinates } from '@/types/mission'
+import type { MapTileProviderPreference, WaypointCoordinates } from '@/types/mission'
 
 import BaseConfigurationView from './BaseConfigurationView.vue'
 
 const missionStore = useMissionStore()
 const interfaceStore = useAppInterfaceStore()
 const vehicleStore = useMainVehicleStore()
+
+const mapTileProviderOptions: MapTileProviderPreference[] = ['Use last selected', 'OpenStreetMap', 'Esri World Imagery']
 
 // Create local reactive copies of the map settings
 const defaultMapCenter = ref<WaypointCoordinates>([...missionStore.defaultMapCenter])

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -3769,7 +3769,11 @@ onMounted(async () => {
     'Esri World Imagery': esri,
   }
 
-  const initialBaseLayer = baseMaps[missionStore.userLastMapTileProvider] || esri
+  const preferredProvider =
+    missionStore.defaultMapTileProvider === 'Use last selected'
+      ? missionStore.userLastMapTileProvider
+      : missionStore.defaultMapTileProvider
+  const initialBaseLayer = baseMaps[preferredProvider] || esri
 
   planningMap.value = L.map('planningMap', { layers: [initialBaseLayer] }).setView(
     mapCenter.value as LatLngTuple,
@@ -3803,6 +3807,24 @@ onMounted(async () => {
     }
     missionStore.userLastMapTileProvider = event.name as MapTileProvider
   })
+
+  // React to changes on the default tile provider preference
+  watch(
+    () => missionStore.defaultMapTileProvider,
+    (newPref) => {
+      if (!planningMap.value || newPref === 'Use last selected') return
+      const targetLayer = baseMaps[newPref]
+      if (!targetLayer) return
+      Object.values(baseMaps).forEach((layer) => {
+        if (layer !== targetLayer && planningMap.value?.hasLayer(layer)) {
+          planningMap.value.removeLayer(layer)
+        }
+      })
+      if (!planningMap.value.hasLayer(targetLayer)) {
+        planningMap.value.addLayer(targetLayer)
+      }
+    }
+  )
 
   planningMap.value.on('moveend', () => {
     if (planningMap.value === undefined) return


### PR DESCRIPTION
* Maps now open with the last selected map provided, unless a default provider is specified on the mission settings.
* Added a selector on `Settings -> Mission` on which the user can define the default map provider, or use the last selected one.

<img width="1909" height="1023" alt="image" src="https://github.com/user-attachments/assets/68ee0692-79c7-463d-8452-2690c05949d3" />

Closes #2683 