### PR TITLE
Add go-to functionality to POI markers

### DIFF
--- a/src/components/poi/PoiActionPopup.vue
+++ b/src/components/poi/PoiActionPopup.vue
@@ -1,0 +1,200 @@
+<template>
+  <Teleport to="body">
+    <div
+      v-if="visible && selectedPoi"
+      class="poi-popup-menu fixed z-[99999] flex flex-col rounded-md text-white"
+      :style="[
+        interfaceStore.globalGlassMenuStyles,
+        { background: '#333333EE', border: '1px solid #FFFFFF44' },
+        { top: `${position.y}px`, left: `${position.x}px`, width: `${POI_POPUP_WIDTH}px` },
+      ]"
+      @click.stop
+      @contextmenu.stop.prevent
+    >
+      <div class="flex justify-between items-center pt-1 pb-2 px-2">
+        <p class="text-[14px] truncate mr-2">{{ selectedPoi.name }}</p>
+        <div class="flex shrink-0 items-center gap-x-3">
+          <v-icon
+            v-tooltip="{ text: 'Delete Point of Interest', zIndex: POI_POPUP_TOOLTIP_Z_INDEX }"
+            variant="text"
+            icon="mdi-trash-can"
+            rounded="full"
+            size="x-small"
+            color="white"
+            class="text-[17px] cursor-pointer mt-1"
+            @click="onDeleteClick"
+          ></v-icon>
+          <v-icon
+            v-tooltip="{ text: 'Edit Point of Interest', zIndex: POI_POPUP_TOOLTIP_Z_INDEX }"
+            variant="text"
+            icon="mdi-pencil"
+            rounded="full"
+            size="x-small"
+            color="white"
+            class="text-[17px] cursor-pointer mt-1"
+            @click="onEditClick"
+          ></v-icon>
+        </div>
+      </div>
+
+      <v-divider />
+
+      <div
+        class="flex flex-col justify-center w-full items-center py-1 px-2 bg-[#EEEEEE] text-black rounded-bl-md rounded-br-md"
+      >
+        <div class="flex w-full items-center gap-x-2 text-[10px] py-[1px] mb-[2px]">
+          <v-icon
+            v-tooltip="{ text: 'Copy latitude to clipboard', zIndex: POI_POPUP_TOOLTIP_Z_INDEX }"
+            variant="text"
+            icon="mdi-content-copy"
+            size="x-small"
+            color="black"
+            class="text-[12px] cursor-pointer shrink-0"
+            @click="onCopyCoordinate(0)"
+          ></v-icon>
+          <p class="flex-1">Lat.:</p>
+          <p>{{ selectedPoi.coordinates[0].toFixed(7) }}</p>
+        </div>
+        <v-divider class="border-black w-full" />
+        <div class="flex w-full items-center gap-x-2 text-[10px] py-[1px]">
+          <v-icon
+            v-tooltip="{ text: 'Copy longitude to clipboard', zIndex: POI_POPUP_TOOLTIP_Z_INDEX }"
+            variant="text"
+            icon="mdi-content-copy"
+            size="x-small"
+            color="black"
+            class="text-[12px] cursor-pointer shrink-0"
+            @click="onCopyCoordinate(1)"
+          ></v-icon>
+          <p class="flex-1">Long.:</p>
+          <p>{{ selectedPoi.coordinates[1].toFixed(7) }}</p>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+
+import { useInteractionDialog } from '@/composables/interactionDialog'
+import { openSnackbar } from '@/composables/snackbar'
+import { copyToClipboard } from '@/libs/utils'
+import { useAppInterfaceStore } from '@/stores/appInterface'
+import { useMissionStore } from '@/stores/mission'
+import { type DialogActions } from '@/types/general'
+import type { PointOfInterest } from '@/types/mission'
+
+const emit = defineEmits<{
+  /**
+   * Emitted when the user requests to edit the selected PoI.
+   */
+  (event: 'edit', poi: PointOfInterest): void
+  /**
+   * Emitted after the user confirms deletion of the selected PoI.
+   */
+  (event: 'delete', poi: PointOfInterest): void
+}>()
+
+const interfaceStore = useAppInterfaceStore()
+const missionStore = useMissionStore()
+const { showDialog, closeDialog } = useInteractionDialog()
+
+const POI_POPUP_WIDTH = 221
+// Used to keep the popup clamped inside the viewport; bump this if the popup grows taller.
+const POI_POPUP_HEIGHT = 110
+const POI_POPUP_TOOLTIP_Z_INDEX = 100000
+
+const visible = ref(false)
+const position = ref({ x: 0, y: 0 })
+const selectedId = ref<string | null>(null)
+const selectedPoi = computed(() =>
+  selectedId.value === null ? null : missionStore.pointsOfInterest.find((p) => p.id === selectedId.value) ?? null
+)
+
+const open = (poi: PointOfInterest, event: MouseEvent): void => {
+  const margin = 8
+  let x = event.clientX
+  let y = event.clientY
+  if (x + POI_POPUP_WIDTH > window.innerWidth - margin) x = window.innerWidth - POI_POPUP_WIDTH - margin
+  if (y + POI_POPUP_HEIGHT > window.innerHeight - margin) y = window.innerHeight - POI_POPUP_HEIGHT - margin
+  if (x < margin) x = margin
+  if (y < margin) y = margin
+
+  position.value = { x, y }
+  selectedId.value = poi.id
+  visible.value = true
+  logUserAction(`Opened PoI context menu for "${poi.name}"`)
+}
+
+const close = (): void => {
+  visible.value = false
+  selectedId.value = null
+}
+
+const onEditClick = (): void => {
+  const poi = selectedPoi.value
+  if (!poi) return
+  close()
+  logUserAction(`Opened edit dialog for PoI "${poi.name}"`)
+  emit('edit', poi)
+}
+
+const onDeleteClick = (): void => {
+  const poi = selectedPoi.value
+  if (!poi) return
+  close()
+  logUserAction(`Opened delete confirmation for PoI "${poi.name}"`)
+  showDialog({
+    variant: 'warning',
+    message: `Delete "${poi.name}"?`,
+    persistent: false,
+    maxWidth: '350px',
+    actions: [
+      { text: 'Cancel', color: 'white', action: closeDialog },
+      {
+        text: 'Delete',
+        color: 'white',
+        action: () => {
+          logUserAction(`Deleted PoI "${poi.name}"`)
+          emit('delete', poi)
+          closeDialog()
+        },
+      },
+    ] as DialogActions[],
+  })
+}
+
+const onCopyCoordinate = async (index: 0 | 1): Promise<void> => {
+  const poi = selectedPoi.value
+  if (!poi) return
+  const label = index === 0 ? 'Latitude' : 'Longitude'
+  logUserAction(`Copied ${label} of PoI "${poi.name}" to clipboard`)
+  try {
+    await copyToClipboard(`${poi.coordinates[index]}`)
+    openSnackbar({ message: `${label} copied to clipboard.`, variant: 'success' })
+  } catch (error) {
+    openSnackbar({ message: `Failed to copy ${label.toLowerCase()}: ${(error as Error).message}`, variant: 'error' })
+  }
+}
+
+const onDocumentClick = (): void => {
+  if (visible.value) close()
+}
+
+const onKeydown = (event: KeyboardEvent): void => {
+  if (event.key === 'Escape') close()
+}
+
+onMounted(() => {
+  document.addEventListener('click', onDocumentClick)
+  window.addEventListener('keydown', onKeydown)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('click', onDocumentClick)
+  window.removeEventListener('keydown', onKeydown)
+})
+
+defineExpose({ open, close })
+</script>

--- a/src/components/poi/PoiActionPopup.vue
+++ b/src/components/poi/PoiActionPopup.vue
@@ -15,6 +15,31 @@
         <p class="text-[14px] truncate mr-2">{{ selectedPoi.name }}</p>
         <div class="flex shrink-0 items-center gap-x-3">
           <v-icon
+            v-if="!isGotoTarget"
+            v-tooltip="{ text: 'GoTo Point of Interest', zIndex: POI_POPUP_TOOLTIP_Z_INDEX }"
+            variant="text"
+            icon="mdi-crosshairs-gps"
+            rounded="full"
+            size="x-small"
+            color="white"
+            class="text-[17px] cursor-pointer mt-1"
+            @click="onGotoClick"
+          ></v-icon>
+          <v-icon
+            v-else
+            v-tooltip="{
+              text: 'Cancel GoTo command (vehicle will hold at current position)',
+              zIndex: POI_POPUP_TOOLTIP_Z_INDEX,
+            }"
+            variant="text"
+            icon="mdi-close-circle-multiple-outline"
+            rounded="full"
+            size="x-small"
+            color="white"
+            class="text-[17px] cursor-pointer mt-1"
+            @click="onCancelGotoClick"
+          ></v-icon>
+          <v-icon
             v-tooltip="{ text: 'Delete Point of Interest', zIndex: POI_POPUP_TOOLTIP_Z_INDEX }"
             variant="text"
             icon="mdi-trash-can"
@@ -85,7 +110,26 @@ import { useMissionStore } from '@/stores/mission'
 import { type DialogActions } from '@/types/general'
 import type { PointOfInterest } from '@/types/mission'
 
+const props = withDefaults(
+  defineProps<{
+    /**
+     * Id of the PoI currently flagged as the active GoTo target, or null/undefined when none. Used to
+     * decide whether this popup shows the "GoTo" or the "Cancel GoTo" action for the selected PoI.
+     */
+    gotoTargetId?: string | null
+  }>(),
+  { gotoTargetId: null }
+)
+
 const emit = defineEmits<{
+  /**
+   * Emitted when the user requests a GoTo to the selected PoI.
+   */
+  (event: 'goto', poi: PointOfInterest): void
+  /**
+   * Emitted when the user cancels the active GoTo for the selected PoI.
+   */
+  (event: 'cancelGoto', poi: PointOfInterest): void
   /**
    * Emitted when the user requests to edit the selected PoI.
    */
@@ -111,6 +155,7 @@ const selectedId = ref<string | null>(null)
 const selectedPoi = computed(() =>
   selectedId.value === null ? null : missionStore.pointsOfInterest.find((p) => p.id === selectedId.value) ?? null
 )
+const isGotoTarget = computed(() => selectedId.value !== null && selectedId.value === props.gotoTargetId)
 
 const open = (poi: PointOfInterest, event: MouseEvent): void => {
   const margin = 8
@@ -130,6 +175,22 @@ const open = (poi: PointOfInterest, event: MouseEvent): void => {
 const close = (): void => {
   visible.value = false
   selectedId.value = null
+}
+
+const onGotoClick = (): void => {
+  const poi = selectedPoi.value
+  if (!poi) return
+  close()
+  logUserAction(`Requested GoTo to PoI "${poi.name}"`)
+  emit('goto', poi)
+}
+
+const onCancelGotoClick = (): void => {
+  const poi = selectedPoi.value
+  if (!poi) return
+  close()
+  logUserAction(`Cancelled GoTo to PoI "${poi.name}"`)
+  emit('cancelGoto', poi)
 }
 
 const onEditClick = (): void => {

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -154,6 +154,8 @@
   >
   </ContextMenu>
 
+  <PoiActionPopup ref="poiPopupRef" @edit="onPoiEdit" @delete="onPoiDelete" />
+
   <v-dialog v-model="widgetStore.widgetManagerVars(widget.hash).configMenuOpen" width="auto">
     <v-card class="pa-2" :style="interfaceStore.globalGlassMenuStyles">
       <v-card-title class="text-center">Map widget settings</v-card-title>
@@ -287,6 +289,7 @@ import GlobalOriginDialog from '@/components/GlobalOriginDialog.vue'
 import MapNorthIndicator from '@/components/map/MapNorthIndicator.vue'
 import MapOverlaysDialog from '@/components/map/MapOverlaysDialog.vue'
 import MissionChecklist from '@/components/MissionChecklist.vue'
+import PoiActionPopup from '@/components/poi/PoiActionPopup.vue'
 import PoiManager from '@/components/poi/PoiManager.vue'
 import PoiMapArrows from '@/components/poi/PoiMapArrows.vue'
 import { useInteractionDialog } from '@/composables/interactionDialog'
@@ -314,7 +317,7 @@ import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useMissionStore } from '@/stores/mission'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
-import type { IconDimensions, MarkerSizes, Waypoint, WaypointCoordinates } from '@/types/mission'
+import type { IconDimensions, MarkerSizes, PointOfInterest, Waypoint, WaypointCoordinates } from '@/types/mission'
 import type { Widget } from '@/types/widgets'
 
 import ContextMenu from '../ContextMenu.vue'
@@ -413,6 +416,7 @@ const onTouchStart = (e: TouchEvent): void => {
   if (e.touches.length > 1) {
     isPinching.value = true
     if (contextMenuVisible.value) hideContextMenuAndMarker()
+    poiPopupRef.value?.close()
     clearTimeout(pinchTimeout)
   }
 }
@@ -526,11 +530,28 @@ const refreshReachedWaypointMarkerStyles = (): void => {
 }
 
 const poiManagerMapWidgetRef = ref<typeof PoiManager | null>(null)
+const poiPopupRef = ref<InstanceType<typeof PoiActionPopup> | null>(null)
+
 const poiMarkers = useMapPoiMarkers(map, {
   iconClassName: 'poi-marker-icon-widget',
   tooltipClassName: 'poi-tooltip-widget',
-  onClick: (poi) => poiManagerMapWidgetRef.value?.openDialog(undefined, poi),
+  onContextMenu: (poi, event) => {
+    if (contextMenuVisible.value) hideContextMenuAndMarker()
+    poiPopupRef.value?.open(poi, event)
+  },
 })
+
+const onPoiEdit = (poi: PointOfInterest): void => {
+  if (!poiManagerMapWidgetRef.value) {
+    openSnackbar({ message: 'POI Manager (map widget) is not available.', variant: 'error' })
+    return
+  }
+  poiManagerMapWidgetRef.value.openDialog(undefined, poi)
+}
+
+const onPoiDelete = (poi: PointOfInterest): void => {
+  missionStore.removePointOfInterest(poi.id)
+}
 
 // Register the usage of the coordinate variables for logging
 datalogger.registerUsage(DatalogVariable.latitude)
@@ -729,6 +750,7 @@ onMounted(async () => {
 
   map.value.on('click', (event: LeafletMouseEvent) => {
     clickedLocation.value = [event.latlng.lat, event.latlng.lng]
+    poiPopupRef.value?.close()
   })
 
   // Update center value after panning
@@ -893,6 +915,8 @@ const handleContextMenu = {
     if (!map.value || isPinching.value || isDragging.value) return
     event.preventDefault()
     event.stopPropagation()
+
+    poiPopupRef.value?.close()
 
     const pt = map.value.mouseEventToContainerPoint(event)
     const ll = map.value.containerPointToLatLng(pt)
@@ -1693,6 +1717,7 @@ const onGlobalOriginSet = (latitude: number, longitude: number): void => {
 const onKeydown = (event: KeyboardEvent): void => {
   if (event.key === 'Escape') {
     hideContextMenuAndMarker()
+    poiPopupRef.value?.close()
     return
   }
 }

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -154,7 +154,14 @@
   >
   </ContextMenu>
 
-  <PoiActionPopup ref="poiPopupRef" @edit="onPoiEdit" @delete="onPoiDelete" />
+  <PoiActionPopup
+    ref="poiPopupRef"
+    :goto-target-id="poiGotoTargetId"
+    @goto="poiGoTo.onPoiGoTo"
+    @cancel-goto="poiGoTo.onPoiCancelGoTo"
+    @edit="onPoiEdit"
+    @delete="onPoiDelete"
+  />
 
   <v-dialog v-model="widgetStore.widgetManagerVars(widget.hash).configMenuOpen" width="auto">
     <v-card class="pa-2" :style="interfaceStore.globalGlassMenuStyles">
@@ -295,6 +302,7 @@ import PoiMapArrows from '@/components/poi/PoiMapArrows.vue'
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { provideMapContext } from '@/composables/map/useMapContext'
 import { useMapOverlays } from '@/composables/map/useMapOverlays'
+import { useMapPoiGoTo } from '@/composables/map/useMapPoiGoTo'
 import { useMapPoiMarkers } from '@/composables/map/useMapPoiMarkers'
 import { useMapTileLayers } from '@/composables/map/useMapTileLayers'
 import { useMapTileLayerSelection } from '@/composables/map/useMapTileLayerSelection'
@@ -540,6 +548,25 @@ const poiMarkers = useMapPoiMarkers(map, {
     poiPopupRef.value?.open(poi, event)
   },
 })
+const poiGotoTargetId = poiMarkers.gotoTargetId
+
+// Sends the GoTo MAVLink command to the vehicle. Shared between the regular map-click GoTo flow and
+// PoI GoTo, which only issue the command and never both place a goto marker AND target a PoI at once.
+const issueGoto = async (coordinates: WaypointCoordinates): Promise<void> => {
+  const hold = 0
+  const acceptanceRadius = 0
+  const passRadius = 0
+  const yaw = 0
+  const altitude = vehicleStore.coordinates.altitude ?? 0
+
+  try {
+    await vehicleStore.goTo(hold, acceptanceRadius, passRadius, yaw, coordinates[0], coordinates[1], altitude)
+  } catch (error) {
+    openSnackbar({ message: `GoTo request failed: ${(error as Error).message}`, variant: 'error' })
+  }
+}
+
+const poiGoTo = useMapPoiGoTo(poiMarkers, { issueGoto })
 
 const onPoiEdit = (poi: PointOfInterest): void => {
   if (!poiManagerMapWidgetRef.value) {
@@ -549,7 +576,10 @@ const onPoiEdit = (poi: PointOfInterest): void => {
   poiManagerMapWidgetRef.value.openDialog(undefined, poi)
 }
 
-const onPoiDelete = (poi: PointOfInterest): void => {
+const onPoiDelete = async (poi: PointOfInterest): Promise<void> => {
+  if (poiMarkers.gotoTargetId.value === poi.id) {
+    await poiGoTo.onPoiCancelGoTo()
+  }
   missionStore.removePointOfInterest(poi.id)
 }
 
@@ -1556,15 +1586,20 @@ const setDefaultMapPosition = async (): Promise<void> => {
   }
 }
 
-const executeGoToOption = async (): Promise<void> => {
-  if (!clickedLocation.value || !map.value) return
+const clearGotoMarker = (): void => {
+  if (!map.value || !gotoMarker.value) return
+  map.value.removeLayer(gotoMarker.value)
+  gotoMarker.value = undefined
+}
 
-  if (gotoMarker.value) {
-    map.value.removeLayer(gotoMarker.value)
-    gotoMarker.value = undefined
-  }
+// Places the regular GoTo marker on the map. Not used for PoI GoTo targets, which show the active state
+// via a pulsating border on the PoI marker itself (see useMapPoiMarkers and .poi-marker-goto-target styles).
+const placeGotoMarker = (coordinates: WaypointCoordinates): void => {
+  if (!map.value) return
 
-  gotoMarker.value = L.marker(clickedLocation.value as LatLngTuple, {
+  clearGotoMarker()
+
+  gotoMarker.value = L.marker(coordinates as LatLngTuple, {
     icon: L.divIcon({
       className: 'marker-icon',
       iconSize: [24, 24],
@@ -1580,31 +1615,16 @@ const executeGoToOption = async (): Promise<void> => {
     opacity: 1,
   })
   gotoMarker.value.bindTooltip(gotoTooltip)
-
-  if (clickedLocation.value) {
-    // Define default values
-    const hold = 0
-    const acceptanceRadius = 0
-    const passRadius = 0
-    const yaw = 0
-    const altitude = vehicleStore.coordinates.altitude ?? 0
-
-    const latitude = clickedLocation.value[0]
-    const longitude = clickedLocation.value[1]
-
-    try {
-      await vehicleStore.goTo(hold, acceptanceRadius, passRadius, yaw, latitude, longitude, altitude)
-    } catch (error) {
-      openSnackbar({ message: `GoTo request failed: ${(error as Error).message}`, variant: 'error' })
-    }
-  }
 }
 
 const onMenuOptionSelect = async (option: string): Promise<void> => {
   logUserAction(`Selected map context-menu action '${option}'`)
   switch (option) {
     case 'goto': {
-      executeGoToOption()
+      if (!clickedLocation.value) break
+      poiGoTo.clearTarget()
+      placeGotoMarker(clickedLocation.value)
+      await issueGoto(clickedLocation.value)
       break
     }
 
@@ -2163,6 +2183,26 @@ const centerOnMission = (): void => {
 </style>
 
 <style>
+/* Unscoped because Leaflet creates the marker DOM imperatively (no scope attribute applied).
+   Uses box-shadow with a positive spread for the active border so the effect is drawn outside
+   the bg circle (revealing the map when transparent) and follows the circular border-radius.
+   The static 1px border is hidden during the active state so only the pulsating ring remains. */
+.poi-marker-background.poi-marker-goto-target {
+  border-color: transparent;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 0 0 3px rgba(255, 255, 255, 1);
+  animation: poi-marker-goto-target-pulse 1s ease-in-out infinite;
+}
+
+@keyframes poi-marker-goto-target-pulse {
+  0%,
+  100% {
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 0 0 3px rgba(255, 255, 255, 1);
+  }
+  50% {
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 0 0 3px rgba(255, 255, 255, 0);
+  }
+}
+
 .speed-dial-glow {
   isolation: isolate;
 }

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -292,6 +292,7 @@ import PoiMapArrows from '@/components/poi/PoiMapArrows.vue'
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { provideMapContext } from '@/composables/map/useMapContext'
 import { useMapOverlays } from '@/composables/map/useMapOverlays'
+import { useMapPoiMarkers } from '@/composables/map/useMapPoiMarkers'
 import { useMapTileLayers } from '@/composables/map/useMapTileLayers'
 import { useMapTileLayerSelection } from '@/composables/map/useMapTileLayerSelection'
 import { openSnackbar } from '@/composables/snackbar'
@@ -313,7 +314,7 @@ import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useMissionStore } from '@/stores/mission'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
-import type { IconDimensions, MarkerSizes, PointOfInterest, Waypoint, WaypointCoordinates } from '@/types/mission'
+import type { IconDimensions, MarkerSizes, Waypoint, WaypointCoordinates } from '@/types/mission'
 import type { Widget } from '@/types/widgets'
 
 import ContextMenu from '../ContextMenu.vue'
@@ -525,7 +526,11 @@ const refreshReachedWaypointMarkerStyles = (): void => {
 }
 
 const poiManagerMapWidgetRef = ref<typeof PoiManager | null>(null)
-const mapWidgetPoiMarkers = shallowRef<{ [id: string]: L.Marker }>({})
+const poiMarkers = useMapPoiMarkers(map, {
+  iconClassName: 'poi-marker-icon-widget',
+  tooltipClassName: 'poi-tooltip-widget',
+  onClick: (poi) => poiManagerMapWidgetRef.value?.openDialog(undefined, poi),
+})
 
 // Register the usage of the coordinate variables for logging
 datalogger.registerUsage(DatalogVariable.latitude)
@@ -899,11 +904,11 @@ const handleContextMenu = {
 }
 
 const clearMapDrawing = (): void => {
-  const poiMarkers = new Set(Object.values(mapWidgetPoiMarkers.value))
+  const poiMarkerSet = new Set(Object.values(poiMarkers.markers.value))
 
   map.value?.eachLayer((l) => {
     if (l instanceof L.Marker || (l instanceof L.Polyline && l.options.color === '#358AC3')) {
-      if (poiMarkers.has(l as L.Marker)) return
+      if (poiMarkerSet.has(l as L.Marker)) return
       map.value!.removeLayer(l)
     }
   })
@@ -1055,9 +1060,6 @@ onBeforeUnmount(() => {
 
   if (map.value) {
     map.value.off('contextmenu')
-    // Clean up POI markers
-    Object.values(mapWidgetPoiMarkers.value).forEach((marker) => marker.remove())
-    mapWidgetPoiMarkers.value = {}
   }
 
   mapBase.value?.removeEventListener('touchstart', onTouchStart)
@@ -1858,140 +1860,6 @@ const centerOnMission = (): void => {
   targetFollower.unFollow()
   fitMapToWaypoints(map.value, missionFitCoordinates.value)
 }
-
-// POI Marker Management Functions for Map Widget
-const poiIconConfig = (poi: PointOfInterest): L.DivIconOptions => {
-  const poiIconHtml = `
-    <div class="poi-marker-container">
-      <div class="poi-marker-background" style="background-color: ${poi.color}80;"></div>
-      <i class="v-icon notranslate mdi ${poi.icon}" style="color: rgba(255, 255, 255, 0.7); position: relative; z-index: 2;"></i>
-    </div>
-  `
-
-  return {
-    html: poiIconHtml,
-    className: 'poi-marker-icon-widget',
-    iconSize: [32, 32], // Match the actual container size
-    iconAnchor: [16, 32], // Center horizontally, bottom vertically (like a pin)
-  }
-}
-
-const addPoiMarkerToMapWidget = (poi: PointOfInterest): void => {
-  if (!map.value || !map.value.getContainer()) return
-
-  const poiMarkerIcon = L.divIcon(poiIconConfig(poi))
-
-  const marker = L.marker(poi.coordinates as LatLngTuple, { icon: poiMarkerIcon, draggable: true }).addTo(map.value)
-
-  const tooltipContent = `
-    <strong>${poi.name}</strong><br>
-    ${poi.description ? poi.description + '<br>' : ''}
-    Lat: ${poi.coordinates[0].toFixed(8)}, Lng: ${poi.coordinates[1].toFixed(8)}
-  `
-  const tooltipConfig = { permanent: false, direction: 'top', offset: [0, -40], className: 'poi-tooltip-widget' }
-  marker.bindTooltip(tooltipContent, tooltipConfig)
-
-  marker.on('drag', (event) => {
-    const newCoords = event.target.getLatLng()
-    const updatedTooltipContent = `
-      <strong>${poi.name}</strong><br>
-      ${poi.description ? poi.description + '<br>' : ''}
-      Lat: ${newCoords.lat.toFixed(8)}, Lng: ${newCoords.lng.toFixed(8)}
-    `
-    marker.getTooltip()?.setContent(updatedTooltipContent)
-  })
-
-  marker.on('dragend', (event) => {
-    const newCoords = event.target.getLatLng()
-    missionStore.movePointOfInterest(poi.id, [newCoords.lat, newCoords.lng])
-  })
-
-  marker.on('click', (event) => {
-    L.DomEvent.stopPropagation(event)
-    if (poiManagerMapWidgetRef.value) {
-      // Get fresh POI data from store instead of using potentially stale poi object
-      const freshPoi = missionStore.pointsOfInterest.find((p) => p.id === poi.id)
-      if (freshPoi) {
-        poiManagerMapWidgetRef.value.openDialog(undefined, freshPoi)
-      } else {
-        console.warn('POI not found in store:', poi.id)
-      }
-    }
-  })
-
-  mapWidgetPoiMarkers.value[poi.id] = marker
-}
-
-const updatePoiMarkerOnMapWidget = (poi: PointOfInterest): void => {
-  if (!map.value || !map.value.getContainer() || !mapWidgetPoiMarkers.value[poi.id]) return
-
-  const marker = mapWidgetPoiMarkers.value[poi.id]
-  marker.setLatLng(poi.coordinates as LatLngTuple)
-
-  marker.setIcon(L.divIcon(poiIconConfig(poi)))
-
-  const updatedTooltipContent = `
-    <strong>${poi.name}</strong><br>
-    ${poi.description ? poi.description + '<br>' : ''}
-    Lat: ${poi.coordinates[0].toFixed(8)}, Lng: ${poi.coordinates[1].toFixed(8)}
-  `
-  marker.getTooltip()?.setContent(updatedTooltipContent)
-}
-
-const removePoiMarkerFromMapWidget = (poiId: string): void => {
-  if (!map.value || !mapWidgetPoiMarkers.value[poiId]) return
-
-  mapWidgetPoiMarkers.value[poiId].remove()
-  delete mapWidgetPoiMarkers.value[poiId]
-}
-
-// Watch for changes in POIs from the store and update markers on this map widget
-watch(
-  () => missionStore.pointsOfInterest,
-  async (newPois) => {
-    if (!map.value || !map.value.getContainer()) {
-      await nextTick() // Wait for map to potentially become available
-      if (!map.value || !map.value.getContainer()) {
-        console.warn('Map.vue: POI watcher - map not ready after nextTick.')
-        return
-      }
-    }
-
-    const newPoiIds = new Set(newPois.map((p) => p.id))
-
-    Object.keys(mapWidgetPoiMarkers.value).forEach((poiId) => {
-      if (!newPoiIds.has(poiId)) {
-        removePoiMarkerFromMapWidget(poiId)
-      }
-    })
-
-    newPois.forEach((poi) => {
-      if (mapWidgetPoiMarkers.value[poi.id]) {
-        updatePoiMarkerOnMapWidget(poi)
-      } else {
-        addPoiMarkerToMapWidget(poi)
-      }
-    })
-  },
-  { deep: true, immediate: true }
-)
-
-// Ensure POIs are drawn when the map instance becomes available
-watch(
-  map,
-  (currentMapInstance) => {
-    if (currentMapInstance && currentMapInstance.getContainer()) {
-      missionStore.pointsOfInterest.forEach((poi) => {
-        if (!mapWidgetPoiMarkers.value[poi.id]) {
-          addPoiMarkerToMapWidget(poi)
-        } else {
-          updatePoiMarkerOnMapWidget(poi) // Update if already exists, in case details changed
-        }
-      })
-    }
-  },
-  { immediate: true }
-)
 </script>
 
 <style scoped>

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -550,9 +550,13 @@ const poiMarkers = useMapPoiMarkers(map, {
 })
 const poiGotoTargetId = poiMarkers.gotoTargetId
 
-// Sends the GoTo MAVLink command to the vehicle. Shared between the regular map-click GoTo flow and
-// PoI GoTo, which only issue the command and never both place a goto marker AND target a PoI at once.
-const issueGoto = async (coordinates: WaypointCoordinates): Promise<void> => {
+// Sends a GoTo-family MAVLink command to the vehicle for the given coordinates, reporting failures via
+// the given message. Shared by the regular map-click GoTo flow, PoI GoTo, and PoI-follow target updates.
+const sendGoToCommand = async (
+  coordinates: WaypointCoordinates,
+  failureMessage: string,
+  skipConfirmation = false
+): Promise<void> => {
   const hold = 0
   const acceptanceRadius = 0
   const passRadius = 0
@@ -560,13 +564,29 @@ const issueGoto = async (coordinates: WaypointCoordinates): Promise<void> => {
   const altitude = vehicleStore.coordinates.altitude ?? 0
 
   try {
-    await vehicleStore.goTo(hold, acceptanceRadius, passRadius, yaw, coordinates[0], coordinates[1], altitude)
+    await vehicleStore.goTo(
+      hold,
+      acceptanceRadius,
+      passRadius,
+      yaw,
+      coordinates[0],
+      coordinates[1],
+      altitude,
+      skipConfirmation
+    )
   } catch (error) {
-    openSnackbar({ message: `GoTo request failed: ${(error as Error).message}`, variant: 'error' })
+    openSnackbar({ message: `${failureMessage}: ${(error as Error).message}`, variant: 'error' })
+    throw error
   }
 }
 
-const poiGoTo = useMapPoiGoTo(poiMarkers, { issueGoto })
+const issueGoto = (coordinates: WaypointCoordinates): Promise<void> =>
+  sendGoToCommand(coordinates, 'GoTo request failed')
+
+const updateGotoTarget = (coordinates: WaypointCoordinates): Promise<void> =>
+  sendGoToCommand(coordinates, 'Failed to update GoTo target', true)
+
+const poiGoTo = useMapPoiGoTo(poiMarkers, { issueGoto, updateGotoTarget })
 
 const onPoiEdit = (poi: PointOfInterest): void => {
   if (!poiManagerMapWidgetRef.value) {

--- a/src/composables/map/useMapPoiGoTo.ts
+++ b/src/composables/map/useMapPoiGoTo.ts
@@ -1,10 +1,22 @@
+import { useThrottleFn } from '@vueuse/core'
 import { onBeforeUnmount, ref, watch } from 'vue'
 
 import { openSnackbar } from '@/composables/snackbar'
+import { distanceInMeters } from '@/libs/map/utils-map'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
+import { useMissionStore } from '@/stores/mission'
 import type { PointOfInterest, WaypointCoordinates } from '@/types/mission'
 
 import type { UseMapPoiMarkersReturn } from './useMapPoiMarkers'
+
+// Minimum movement, in meters, a followed PoI must travel before its GoTo target is updated; filters
+// out drag and storage jitter that shouldn't reroute the vehicle.
+const followMinDistanceMeters = 1
+// Minimum interval, in milliseconds, between target updates while following a moving PoI.
+const followThrottleMs = 2000
+// Delay, in milliseconds, before the GoTo starts watching for user-initiated mode changes, giving the
+// arm + GUIDED transitions caused by issuing the GoTo itself time to settle so it doesn't cancel itself.
+const modeTrackingSettleMs = 2000
 
 /**
  * Dependencies a surface must provide for {@link useMapPoiGoTo} to issue GoTo commands.
@@ -17,6 +29,13 @@ export interface UseMapPoiGoToOptions {
    * @returns {Promise<void>} Resolves once the command has been sent (or failed and been reported).
    */
   issueGoto: (coordinates: WaypointCoordinates) => Promise<void>
+  /**
+   * Updates the destination of an already-active GoTo, without the confirmation prompt `issueGoto` may
+   * show. Used to follow the target PoI while it moves, so the user isn't re-prompted on every move.
+   * @param {WaypointCoordinates} coordinates - The PoI's new coordinates to redirect the vehicle to.
+   * @returns {Promise<void>} Resolves once the command has been sent (or failed and been reported).
+   */
+  updateGotoTarget: (coordinates: WaypointCoordinates) => Promise<void>
 }
 
 /**
@@ -56,6 +75,7 @@ export const useMapPoiGoTo = (
   options: UseMapPoiGoToOptions
 ): UseMapPoiGoToReturn => {
   const vehicleStore = useMainVehicleStore()
+  const missionStore = useMissionStore()
 
   // Vehicle state an active PoI GoTo expects, used to drop the highlight when the user disarms or
   // changes flight mode outside of the GoTo flow. Mode tracking only starts once the arm + GUIDED
@@ -63,6 +83,9 @@ export const useMapPoiGoTo = (
   const poiGotoBaselineMode = ref<string | undefined>(undefined)
   const poiGotoModeTracking = ref(false)
   let poiGotoSettleTimeout: ReturnType<typeof setTimeout> | undefined
+
+  // Coordinates last sent to the vehicle for the active target, used to tell how far a followed PoI has moved.
+  let lastIssuedCoordinates: WaypointCoordinates | undefined
 
   const resetPoiGotoTracking = (): void => {
     if (poiGotoSettleTimeout !== undefined) clearTimeout(poiGotoSettleTimeout)
@@ -74,6 +97,7 @@ export const useMapPoiGoTo = (
   const clearTarget = (): void => {
     poiMarkers.setGotoTarget(null)
     resetPoiGotoTracking()
+    lastIssuedCoordinates = undefined
   }
 
   const cancelPoiGotoTarget = (message: string): void => {
@@ -84,14 +108,39 @@ export const useMapPoiGoTo = (
   const onPoiGoTo = async (poi: PointOfInterest): Promise<void> => {
     poiMarkers.setGotoTarget(poi.id)
     resetPoiGotoTracking()
+    lastIssuedCoordinates = poi.coordinates
     await options.issueGoto(poi.coordinates)
     if (poiMarkers.gotoTargetId.value !== poi.id) return
     poiGotoSettleTimeout = setTimeout(() => {
       if (poiMarkers.gotoTargetId.value !== poi.id) return
       poiGotoBaselineMode.value = vehicleStore.mode
       poiGotoModeTracking.value = true
-    }, 2000)
+    }, modeTrackingSettleMs)
   }
+
+  // Re-issues the GoTo whenever the followed PoI moves far enough, so the vehicle keeps heading to its
+  // current position instead of the now-stale one it had when the GoTo was first issued.
+  const followMovedTarget = useThrottleFn(
+    async (coordinates: WaypointCoordinates): Promise<void> => {
+      // The target can be cleared (e.g. by the disarm watcher) while a throttled trailing call is
+      // pending; bail out so we don't re-issue — and thus re-arm — a GoTo the user just cancelled.
+      if (!poiMarkers.gotoTargetId.value) return
+      await options.updateGotoTarget(coordinates)
+      lastIssuedCoordinates = coordinates
+    },
+    followThrottleMs,
+    true,
+    true
+  )
+
+  watch(
+    () => missionStore.pointsOfInterest.find((poi) => poi.id === poiMarkers.gotoTargetId.value)?.coordinates,
+    (coordinates) => {
+      if (!coordinates || !lastIssuedCoordinates) return
+      if (distanceInMeters(lastIssuedCoordinates, coordinates) < followMinDistanceMeters) return
+      followMovedTarget(coordinates)
+    }
+  )
 
   const onPoiCancelGoTo = async (): Promise<void> => {
     try {

--- a/src/composables/map/useMapPoiGoTo.ts
+++ b/src/composables/map/useMapPoiGoTo.ts
@@ -1,0 +1,135 @@
+import { onBeforeUnmount, ref, watch } from 'vue'
+
+import { openSnackbar } from '@/composables/snackbar'
+import { useMainVehicleStore } from '@/stores/mainVehicle'
+import type { PointOfInterest, WaypointCoordinates } from '@/types/mission'
+
+import type { UseMapPoiMarkersReturn } from './useMapPoiMarkers'
+
+/**
+ * Dependencies a surface must provide for {@link useMapPoiGoTo} to issue GoTo commands.
+ */
+export interface UseMapPoiGoToOptions {
+  /**
+   * Sends the GoTo MAVLink command to the vehicle for the given coordinates. Shared with the surface's
+   * regular (non-PoI) map-click GoTo flow so both pipelines issue the exact same command.
+   * @param {WaypointCoordinates} coordinates - The coordinates to send the vehicle to.
+   * @returns {Promise<void>} Resolves once the command has been sent (or failed and been reported).
+   */
+  issueGoto: (coordinates: WaypointCoordinates) => Promise<void>
+}
+
+/**
+ * Handlers exposed by {@link useMapPoiGoTo} to wire up a PoI action popup or menu.
+ */
+export interface UseMapPoiGoToReturn {
+  /**
+   * Issues a GoTo to the given PoI and flags it as the active target until it's reached, cancelled, or
+   * the vehicle leaves the GoTo state on its own (disarm or flight mode change).
+   * @param {PointOfInterest} poi - The PoI to send the vehicle to.
+   * @returns {Promise<void>} Resolves once the GoTo command has been issued.
+   */
+  onPoiGoTo: (poi: PointOfInterest) => Promise<void>
+  /**
+   * Cancels the active PoI GoTo by switching the vehicle to its position-hold flight mode.
+   * @returns {Promise<void>} Resolves once the cancel command has been issued (or failed and been reported).
+   */
+  onPoiCancelGoTo: () => Promise<void>
+  /**
+   * Clears the active PoI GoTo target (if any) without sending any command to the vehicle. Used when a
+   * different GoTo (e.g. a regular map-click GoTo) takes over as the map's active destination.
+   * @returns {void}
+   */
+  clearTarget: () => void
+}
+
+/**
+ * Owns the GoTo-to-PoI lifecycle for a single map: issuing the command, flagging the target PoI on the
+ * given marker registry, and tracking the vehicle's arm state and flight mode so the highlight is dropped
+ * if the GoTo is interrupted outside of this flow (disarm or mode change caused by something else).
+ * @param {UseMapPoiMarkersReturn} poiMarkers - The PoI marker registry to flag the active target on.
+ * @param {UseMapPoiGoToOptions} options - Dependencies needed to issue the GoTo command.
+ * @returns {UseMapPoiGoToReturn} Handlers to wire up a PoI action popup or menu.
+ */
+export const useMapPoiGoTo = (
+  poiMarkers: UseMapPoiMarkersReturn,
+  options: UseMapPoiGoToOptions
+): UseMapPoiGoToReturn => {
+  const vehicleStore = useMainVehicleStore()
+
+  // Vehicle state an active PoI GoTo expects, used to drop the highlight when the user disarms or
+  // changes flight mode outside of the GoTo flow. Mode tracking only starts once the arm + GUIDED
+  // transitions caused by issuing the GoTo itself have settled, so the GoTo does not cancel itself.
+  const poiGotoBaselineMode = ref<string | undefined>(undefined)
+  const poiGotoModeTracking = ref(false)
+  let poiGotoSettleTimeout: ReturnType<typeof setTimeout> | undefined
+
+  const resetPoiGotoTracking = (): void => {
+    if (poiGotoSettleTimeout !== undefined) clearTimeout(poiGotoSettleTimeout)
+    poiGotoSettleTimeout = undefined
+    poiGotoModeTracking.value = false
+    poiGotoBaselineMode.value = undefined
+  }
+
+  const clearTarget = (): void => {
+    poiMarkers.setGotoTarget(null)
+    resetPoiGotoTracking()
+  }
+
+  const cancelPoiGotoTarget = (message: string): void => {
+    clearTarget()
+    openSnackbar({ message, variant: 'info' })
+  }
+
+  const onPoiGoTo = async (poi: PointOfInterest): Promise<void> => {
+    poiMarkers.setGotoTarget(poi.id)
+    resetPoiGotoTracking()
+    await options.issueGoto(poi.coordinates)
+    if (poiMarkers.gotoTargetId.value !== poi.id) return
+    poiGotoSettleTimeout = setTimeout(() => {
+      if (poiMarkers.gotoTargetId.value !== poi.id) return
+      poiGotoBaselineMode.value = vehicleStore.mode
+      poiGotoModeTracking.value = true
+    }, 2000)
+  }
+
+  const onPoiCancelGoTo = async (): Promise<void> => {
+    try {
+      await vehicleStore.pauseMission()
+      clearTarget()
+      openSnackbar({
+        message: 'GoTo command cancelled. Vehicle will hold at its current position.',
+        variant: 'success',
+      })
+    } catch (error) {
+      openSnackbar({ message: `Cancel GoTo failed: ${(error as Error).message}`, variant: 'error' })
+    }
+  }
+
+  // Drop the GoTo highlight when the vehicle leaves the GoTo state on its own (disarm or mode change).
+  watch(
+    () => vehicleStore.isArmed,
+    (isNowArmed, wasArmed) => {
+      if (!poiMarkers.gotoTargetId.value) return
+      if (wasArmed && isNowArmed === false) {
+        cancelPoiGotoTarget('GoTo cancelled: the vehicle was disarmed.')
+      }
+    }
+  )
+
+  watch(
+    () => vehicleStore.mode,
+    (newMode) => {
+      if (!poiMarkers.gotoTargetId.value || !poiGotoModeTracking.value) return
+      if (newMode !== poiGotoBaselineMode.value) {
+        cancelPoiGotoTarget('GoTo cancelled: the vehicle flight mode changed.')
+      }
+    }
+  )
+
+  onBeforeUnmount(() => {
+    resetPoiGotoTracking()
+  })
+
+  return { onPoiGoTo, onPoiCancelGoTo, clearTarget }
+}

--- a/src/composables/map/useMapPoiMarkers.ts
+++ b/src/composables/map/useMapPoiMarkers.ts
@@ -24,6 +24,10 @@ export interface UseMapPoiMarkersOptions {
    * Called when a marker is left-clicked, with the up-to-date PoI from the store and the originating event.
    */
   onClick?: (poi: PointOfInterest, event: MouseEvent) => void
+  /**
+   * Called when a marker is right-clicked, with the up-to-date PoI from the store and the originating event.
+   */
+  onContextMenu?: (poi: PointOfInterest, event: MouseEvent) => void
 }
 
 /**
@@ -116,6 +120,18 @@ export const useMapPoiMarkers = (
         return
       }
       options.onClick?.(freshPoi, event.originalEvent)
+    })
+
+    marker.on('contextmenu', (event: LeafletMouseEvent) => {
+      L.DomEvent.stopPropagation(event)
+      event.originalEvent.stopPropagation()
+      event.originalEvent.preventDefault()
+      const freshPoi = missionStore.pointsOfInterest.find((p) => p.id === poi.id)
+      if (!freshPoi) {
+        console.warn('POI not found in store:', poi.id)
+        return
+      }
+      options.onContextMenu?.(freshPoi, event.originalEvent)
     })
 
     markers.value[poi.id] = marker

--- a/src/composables/map/useMapPoiMarkers.ts
+++ b/src/composables/map/useMapPoiMarkers.ts
@@ -1,5 +1,5 @@
 import L, { type LatLngTuple, type LeafletEvent, type LeafletMouseEvent, type Map, type Marker } from 'leaflet'
-import { type ShallowRef, nextTick, onBeforeUnmount, shallowRef, watch } from 'vue'
+import { type Ref, type ShallowRef, nextTick, onBeforeUnmount, ref, shallowRef, watch } from 'vue'
 
 import { useMissionStore } from '@/stores/mission'
 import type { PointOfInterest } from '@/types/mission'
@@ -38,15 +38,25 @@ export interface UseMapPoiMarkersReturn {
    * Markers currently on the map, keyed by PoI id.
    */
   markers: ShallowRef<Record<string, Marker>>
+  /**
+   * Id of the PoI currently flagged as the active GoTo target, or null when none.
+   */
+  gotoTargetId: Ref<string | null>
+  /**
+   * Flags a PoI as the active GoTo target (or clears it with null), updating the pulsating marker style.
+   * @param {string | null} poiId - The PoI to highlight, or null to clear the current target.
+   * @returns {void}
+   */
+  setGotoTarget: (poiId: string | null) => void
 }
 
 /**
  * Mirrors the mission store's points of interest as draggable Leaflet markers on the given map, keeping them
- * in sync as PoIs are added, edited, moved or removed. Markers are torn down automatically when the owning
- * component unmounts.
+ * in sync as PoIs are added, edited, moved or removed, and exposing GoTo-target highlighting. Markers are torn
+ * down automatically when the owning component unmounts.
  * @param {ShallowRef<Map | undefined>} map - The Leaflet map to draw on; markers (re)draw once it becomes available.
  * @param {UseMapPoiMarkersOptions} options - Rendering classes and interaction callbacks.
- * @returns {UseMapPoiMarkersReturn} The reactive marker registry.
+ * @returns {UseMapPoiMarkersReturn} The reactive marker registry and GoTo-target controls.
  */
 export const useMapPoiMarkers = (
   map: ShallowRef<Map | undefined>,
@@ -54,6 +64,7 @@ export const useMapPoiMarkers = (
 ): UseMapPoiMarkersReturn => {
   const missionStore = useMissionStore()
   const markers = shallowRef<Record<string, Marker>>({})
+  const gotoTargetId = ref<string | null>(null)
   const draggable = options.draggable ?? true
 
   // Snapshot of the fields each marker was last rendered with, keyed by PoI id. Lets syncMarkers skip
@@ -86,6 +97,20 @@ export const useMapPoiMarkers = (
     ${poi.description ? poi.description + '<br>' : ''}
     Lat: ${coordinates[0].toFixed(8)}, Lng: ${coordinates[1].toFixed(8)}
   `
+
+  const applyGotoTargetStyle = (poiId: string, active: boolean): void => {
+    const bg = markers.value[poiId]?.getElement()?.querySelector('.poi-marker-background') as HTMLElement | null
+    bg?.classList.toggle('poi-marker-goto-target', active)
+  }
+
+  const setGotoTarget = (poiId: string | null): void => {
+    gotoTargetId.value = poiId
+  }
+
+  watch(gotoTargetId, (newId, oldId) => {
+    if (oldId && oldId !== newId) applyGotoTargetStyle(oldId, false)
+    if (newId) applyGotoTargetStyle(newId, true)
+  })
 
   const addMarker = (poi: PointOfInterest): void => {
     if (!isMapReady(map.value)) return
@@ -136,6 +161,8 @@ export const useMapPoiMarkers = (
 
     markers.value[poi.id] = marker
     lastRenderedSignatures[poi.id] = poiSignature(poi)
+
+    if (gotoTargetId.value === poi.id) applyGotoTargetStyle(poi.id, true)
   }
 
   const updateMarker = (poi: PointOfInterest): void => {
@@ -150,6 +177,10 @@ export const useMapPoiMarkers = (
 
     marker.setLatLng(poi.coordinates as LatLngTuple)
     marker.setIcon(L.divIcon(poiIconConfig(poi)))
+
+    // setIcon replaces the marker's DOM element, so the goto-target class needs to be re-applied.
+    if (gotoTargetId.value === poi.id) applyGotoTargetStyle(poi.id, true)
+
     marker.getTooltip()?.setContent(tooltipContent(poi, poi.coordinates as LatLngTuple))
   }
 
@@ -158,6 +189,7 @@ export const useMapPoiMarkers = (
     markers.value[poiId].remove()
     delete markers.value[poiId]
     delete lastRenderedSignatures[poiId]
+    if (gotoTargetId.value === poiId) gotoTargetId.value = null
   }
 
   const syncMarkers = (pois: PointOfInterest[]): void => {
@@ -195,5 +227,5 @@ export const useMapPoiMarkers = (
     Object.keys(lastRenderedSignatures).forEach((id) => delete lastRenderedSignatures[id])
   })
 
-  return { markers }
+  return { markers, gotoTargetId, setGotoTarget }
 }

--- a/src/composables/map/useMapPoiMarkers.ts
+++ b/src/composables/map/useMapPoiMarkers.ts
@@ -1,0 +1,183 @@
+import L, { type LatLngTuple, type LeafletEvent, type LeafletMouseEvent, type Map, type Marker } from 'leaflet'
+import { type ShallowRef, nextTick, onBeforeUnmount, shallowRef, watch } from 'vue'
+
+import { useMissionStore } from '@/stores/mission'
+import type { PointOfInterest } from '@/types/mission'
+
+/**
+ * Rendering classes and interaction callbacks for the PoI markers of a single map.
+ */
+export interface UseMapPoiMarkersOptions {
+  /**
+   * CSS class applied to each marker's Leaflet divIcon, so each surface can keep its own marker styles.
+   */
+  iconClassName: string
+  /**
+   * CSS class applied to each marker's tooltip.
+   */
+  tooltipClassName: string
+  /**
+   * Whether markers can be dragged to move the underlying PoI. Defaults to true.
+   */
+  draggable?: boolean
+  /**
+   * Called when a marker is left-clicked, with the up-to-date PoI from the store and the originating event.
+   */
+  onClick?: (poi: PointOfInterest, event: MouseEvent) => void
+}
+
+/**
+ * Reactive handles to the PoI markers managed on a given map.
+ */
+export interface UseMapPoiMarkersReturn {
+  /**
+   * Markers currently on the map, keyed by PoI id.
+   */
+  markers: ShallowRef<Record<string, Marker>>
+}
+
+/**
+ * Mirrors the mission store's points of interest as draggable Leaflet markers on the given map, keeping them
+ * in sync as PoIs are added, edited, moved or removed. Markers are torn down automatically when the owning
+ * component unmounts.
+ * @param {ShallowRef<Map | undefined>} map - The Leaflet map to draw on; markers (re)draw once it becomes available.
+ * @param {UseMapPoiMarkersOptions} options - Rendering classes and interaction callbacks.
+ * @returns {UseMapPoiMarkersReturn} The reactive marker registry.
+ */
+export const useMapPoiMarkers = (
+  map: ShallowRef<Map | undefined>,
+  options: UseMapPoiMarkersOptions
+): UseMapPoiMarkersReturn => {
+  const missionStore = useMissionStore()
+  const markers = shallowRef<Record<string, Marker>>({})
+  const draggable = options.draggable ?? true
+
+  // Snapshot of the fields each marker was last rendered with, keyed by PoI id. Lets syncMarkers skip
+  // markers whose data hasn't changed, instead of rebuilding every marker's icon (and Leaflet Draggable
+  // instance) whenever any single PoI in the store is edited or dragged. A plain record (rather than an
+  // ES Map) to avoid shadowing the Leaflet `Map` type already imported in this file.
+  const lastRenderedSignatures: Record<string, string> = {}
+  const poiSignature = (poi: PointOfInterest): string =>
+    JSON.stringify([poi.coordinates, poi.icon, poi.color, poi.name, poi.description])
+
+  // The map ref can momentarily hold a template-ref DOM element before the Leaflet instance is
+  // assigned (consumers reuse the same ref name for the container and the map), so guard on the API.
+  const isMapReady = (instance: Map | undefined): instance is Map =>
+    !!instance && typeof instance.getContainer === 'function' && !!instance.getContainer()
+
+  const poiIconConfig = (poi: PointOfInterest): L.DivIconOptions => ({
+    html: `
+    <div class="poi-marker-container">
+      <div class="poi-marker-background" style="background-color: ${poi.color}80;"></div>
+      <i class="v-icon notranslate mdi ${poi.icon}" style="color: rgba(255, 255, 255, 0.7); position: relative; z-index: 2;"></i>
+    </div>
+  `,
+    className: options.iconClassName,
+    iconSize: [32, 32],
+    iconAnchor: [16, 32],
+  })
+
+  const tooltipContent = (poi: PointOfInterest, coordinates: LatLngTuple): string => `
+    <strong>${poi.name}</strong><br>
+    ${poi.description ? poi.description + '<br>' : ''}
+    Lat: ${coordinates[0].toFixed(8)}, Lng: ${coordinates[1].toFixed(8)}
+  `
+
+  const addMarker = (poi: PointOfInterest): void => {
+    if (!isMapReady(map.value)) return
+
+    const marker = L.marker(poi.coordinates as LatLngTuple, {
+      icon: L.divIcon(poiIconConfig(poi)),
+      draggable,
+    }).addTo(map.value)
+
+    marker.bindTooltip(tooltipContent(poi, poi.coordinates as LatLngTuple), {
+      permanent: false,
+      direction: 'top',
+      offset: [0, -40],
+      className: options.tooltipClassName,
+    })
+
+    marker.on('drag', (event: LeafletEvent) => {
+      const coords = event.target.getLatLng()
+      marker.getTooltip()?.setContent(tooltipContent(poi, [coords.lat, coords.lng]))
+    })
+
+    marker.on('dragend', (event: LeafletEvent) => {
+      const coords = event.target.getLatLng()
+      missionStore.movePointOfInterest(poi.id, [coords.lat, coords.lng])
+    })
+
+    marker.on('click', (event: LeafletMouseEvent) => {
+      L.DomEvent.stopPropagation(event)
+      const freshPoi = missionStore.pointsOfInterest.find((p) => p.id === poi.id)
+      if (!freshPoi) {
+        console.warn('POI not found in store:', poi.id)
+        return
+      }
+      options.onClick?.(freshPoi, event.originalEvent)
+    })
+
+    markers.value[poi.id] = marker
+    lastRenderedSignatures[poi.id] = poiSignature(poi)
+  }
+
+  const updateMarker = (poi: PointOfInterest): void => {
+    const marker = markers.value[poi.id]
+    if (!isMapReady(map.value) || !marker) return
+
+    // Skip markers whose data hasn't changed since last render, so editing or dragging one PoI doesn't
+    // rebuild every other marker's icon and tear down its Leaflet Draggable instance mid-interaction.
+    const signature = poiSignature(poi)
+    if (lastRenderedSignatures[poi.id] === signature) return
+    lastRenderedSignatures[poi.id] = signature
+
+    marker.setLatLng(poi.coordinates as LatLngTuple)
+    marker.setIcon(L.divIcon(poiIconConfig(poi)))
+    marker.getTooltip()?.setContent(tooltipContent(poi, poi.coordinates as LatLngTuple))
+  }
+
+  const removeMarker = (poiId: string): void => {
+    if (!markers.value[poiId]) return
+    markers.value[poiId].remove()
+    delete markers.value[poiId]
+    delete lastRenderedSignatures[poiId]
+  }
+
+  const syncMarkers = (pois: PointOfInterest[]): void => {
+    const liveIds = new Set(pois.map((p) => p.id))
+    Object.keys(markers.value).forEach((id) => {
+      if (!liveIds.has(id)) removeMarker(id)
+    })
+    pois.forEach((poi) => (markers.value[poi.id] ? updateMarker(poi) : addMarker(poi)))
+  }
+
+  watch(
+    () => missionStore.pointsOfInterest,
+    async (pois) => {
+      if (!isMapReady(map.value)) {
+        await nextTick()
+        if (!isMapReady(map.value)) return
+      }
+      syncMarkers(pois)
+    },
+    { deep: true, immediate: true }
+  )
+
+  // Draw any PoIs that loaded before the map instance was ready.
+  watch(
+    map,
+    (instance) => {
+      if (isMapReady(instance)) syncMarkers(missionStore.pointsOfInterest)
+    },
+    { immediate: true }
+  )
+
+  onBeforeUnmount(() => {
+    Object.values(markers.value).forEach((marker) => marker.remove())
+    markers.value = {}
+    Object.keys(lastRenderedSignatures).forEach((id) => delete lastRenderedSignatures[id])
+  })
+
+  return { markers }
+}

--- a/src/libs/map/utils-map.ts
+++ b/src/libs/map/utils-map.ts
@@ -27,6 +27,15 @@ export const singleStepZoomMapOptions: Pick<
 }
 
 /**
+ * Great-circle distance between two coordinates.
+ * @param {WaypointCoordinates} from - The first coordinate pair ([latitude, longitude]).
+ * @param {WaypointCoordinates} to - The second coordinate pair ([latitude, longitude]).
+ * @returns {number} The distance between the two coordinates, in meters.
+ */
+export const distanceInMeters = (from: WaypointCoordinates, to: WaypointCoordinates): number =>
+  L.latLng(from[0], from[1]).distanceTo(L.latLng(to[0], to[1]))
+
+/**
  * Enum for the different types of targets that can be followed.
  * @enum {string}
  */

--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -387,6 +387,9 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
    * @param {number} latitude Latitude in degrees.
    * @param {number} longitude Longitude in degrees.
    * @param {number} alt Altitude in meters.
+   * @param {boolean} skipConfirmation Skip the slide-to-confirm prompt (the arm and GUIDED-mode setup
+   * still run), used when retargeting an already-active GoTo so the user isn't re-prompted on every
+   * update (e.g. following a moving target).
    * @returns {Promise<void>}
    */
   async function goTo(
@@ -396,7 +399,8 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     yaw: number,
     latitude: number,
     longitude: number,
-    alt: number
+    alt: number,
+    skipConfirmation = false
   ): Promise<void> {
     if (!mainVehicle.value) {
       throw new Error('No vehicle available to execute go to command.')
@@ -409,7 +413,7 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     const askArmConfirm = !mainVehicle.value.isArmed() && !canByPassCategory(EventCategory.ARM)
     const askGoToConfirm = !canByPassCategory(EventCategory.GOTO)
 
-    if (askArmConfirm || askGoToConfirm) {
+    if (!skipConfirmation && (askArmConfirm || askGoToConfirm)) {
       const command = askArmConfirm && askGoToConfirm ? 'Arm and GoTo' : askArmConfirm ? 'Arm' : 'GoTo'
       try {
         await slideToConfirm({ command })

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -749,6 +749,7 @@ import { useInteractionDialog } from '@/composables/interactionDialog'
 import { useDragMeasureOverlay } from '@/composables/map/useDragMeasureOverlay'
 import { provideMapContext } from '@/composables/map/useMapContext'
 import { useMapOverlays } from '@/composables/map/useMapOverlays'
+import { useMapPoiMarkers } from '@/composables/map/useMapPoiMarkers'
 import { useMapTileLayers } from '@/composables/map/useMapTileLayers'
 import { useMapTileLayerSelection } from '@/composables/map/useMapTileLayerSelection'
 import { useVertexAngleOverlay } from '@/composables/map/useVertexAngleOverlay'
@@ -801,7 +802,6 @@ import {
   MarkerSizes,
   MissionCommand,
   MissionCommandType,
-  PointOfInterest,
   Survey,
   SurveyPath,
 } from '@/types/mission'
@@ -1429,7 +1429,11 @@ const handleOpenMissionSettings = (): void => {
 }
 
 const poiManagerRef = ref<InstanceType<typeof PoiManager> | null>(null)
-const planningPoiMarkers = shallowRef<{ [id: string]: L.Marker }>({})
+useMapPoiMarkers(planningMap, {
+  iconClassName: 'poi-marker-icon',
+  tooltipClassName: 'poi-tooltip',
+  onClick: (poi) => poiManagerRef.value?.openDialog(undefined, poi),
+})
 
 const clearCurrentMission = (): void => {
   missionStore.clearMission()
@@ -4526,144 +4530,6 @@ const openPoiDialog = (): void => {
   }
   hideContextMenu()
 }
-
-// POI Marker Management Functions for MissionPlanningView
-const poiIconConfig = (poi: PointOfInterest): L.DivIconOptions => {
-  const poiIconHtml = `
-    <div class="poi-marker-container">
-      <div class="poi-marker-background" style="background-color: ${poi.color}80;"></div>
-      <i class="v-icon notranslate mdi ${poi.icon}" style="color: rgba(255, 255, 255, 0.7); position: relative; z-index: 2;"></i>
-    </div>
-  `
-
-  return {
-    html: poiIconHtml,
-    className: 'poi-marker-icon',
-    iconSize: [32, 32], // Match the actual container size
-    iconAnchor: [16, 32], // Center horizontally, bottom vertically (like a pin)
-  }
-}
-
-// POI Marker Management Functions for MissionPlanningView
-const addPoiMarkerToPlanningMap = (poi: PointOfInterest): void => {
-  if (!planningMap.value || !planningMap.value.getContainer()) return
-
-  const poiMarkerIcon = L.divIcon(poiIconConfig(poi))
-
-  const marker = L.marker(poi.coordinates as LatLngTuple, { icon: poiMarkerIcon, draggable: true }).addTo(
-    planningMap.value
-  )
-
-  const tooltipContent = `
-    <strong>${poi.name}</strong><br>
-    ${poi.description ? poi.description + '<br>' : ''}
-    Lat: ${poi.coordinates[0].toFixed(8)}, Lng: ${poi.coordinates[1].toFixed(8)}
-  `
-  const tooltipConfig = { permanent: false, direction: 'top', offset: [0, -40], className: 'poi-tooltip' }
-  marker.bindTooltip(tooltipContent, tooltipConfig)
-
-  marker.on('drag', (event) => {
-    const newCoords = event.target.getLatLng()
-    const updatedTooltipContent = `
-      <strong>${poi.name}</strong><br>
-      ${poi.description ? poi.description + '<br>' : ''}
-      Lat: ${newCoords.lat.toFixed(8)}, Lng: ${newCoords.lng.toFixed(8)}
-    `
-    marker.getTooltip()?.setContent(updatedTooltipContent)
-  })
-
-  marker.on('dragend', (event) => {
-    const newCoords = event.target.getLatLng()
-    missionStore.movePointOfInterest(poi.id, [newCoords.lat, newCoords.lng])
-  })
-
-  marker.on('click', (event) => {
-    L.DomEvent.stopPropagation(event)
-    if (poiManagerRef.value) {
-      poiManagerRef.value.openDialog(undefined, poi)
-    }
-  })
-
-  planningPoiMarkers.value[poi.id] = marker
-}
-
-const updatePoiMarkerOnPlanningMap = (poi: PointOfInterest): void => {
-  if (!planningMap.value || !planningMap.value.getContainer() || !planningPoiMarkers.value[poi.id]) return
-
-  const marker = planningPoiMarkers.value[poi.id]
-  marker.setLatLng(poi.coordinates as LatLngTuple)
-
-  marker.setIcon(L.divIcon(poiIconConfig(poi)))
-
-  const updatedTooltipContent = `
-    <strong>${poi.name}</strong><br>
-    ${poi.description ? poi.description + '<br>' : ''}
-    Lat: ${poi.coordinates[0].toFixed(8)}, Lng: ${poi.coordinates[1].toFixed(8)}
-  `
-  marker.getTooltip()?.setContent(updatedTooltipContent)
-}
-
-const removePoiMarkerFromPlanningMap = (poiId: string): void => {
-  if (!planningMap.value || !planningPoiMarkers.value[poiId]) return
-
-  planningPoiMarkers.value[poiId].remove()
-  delete planningPoiMarkers.value[poiId]
-}
-
-// Watch for changes in POIs from the store and update markers
-watch(
-  () => missionStore.pointsOfInterest,
-  async (newPois) => {
-    if (!planningMap.value || !planningMap.value.getContainer()) {
-      // Defer if map not ready, try again on next tick or when map becomes available
-      await nextTick()
-      if (!planningMap.value || !planningMap.value.getContainer()) {
-        console.warn('MissionPlanningView: POI watcher - planningMap not ready after nextTick.')
-        return
-      }
-    }
-
-    const newPoiIds = new Set(newPois.map((p) => p.id))
-
-    // Remove markers for POIs that no longer exist
-    Object.keys(planningPoiMarkers.value).forEach((poiId) => {
-      if (!newPoiIds.has(poiId)) {
-        removePoiMarkerFromPlanningMap(poiId)
-      }
-    })
-
-    // Add or update markers
-    newPois.forEach((poi) => {
-      if (planningPoiMarkers.value[poi.id]) {
-        updatePoiMarkerOnPlanningMap(poi)
-      } else {
-        addPoiMarkerToPlanningMap(poi)
-      }
-    })
-  },
-  { deep: true, immediate: true }
-)
-
-// Ensure POIs are drawn when the map becomes available, if not already handled by immediate watcher
-watch(
-  planningMap,
-  (currentMap) => {
-    if (currentMap && currentMap.getContainer()) {
-      // Map is ready, ensure all POIs from the store are drawn
-      // This helps if POIs loaded from store before mapInstance was fully initialized
-      // or if the immediate watcher for pointsOfInterest ran too early.
-      missionStore.pointsOfInterest.forEach((poi) => {
-        if (!planningPoiMarkers.value[poi.id]) {
-          addPoiMarkerToPlanningMap(poi)
-        } else {
-          // Potentially update if details changed while map was not ready
-          updatePoiMarkerOnPlanningMap(poi)
-        }
-      })
-    }
-  },
-  { immediate: true }
-) // Immediate to catch initial map state
 </script>
 
 <style>


### PR DESCRIPTION
* Added a context menu to the POI markers on the map
* Users can edit, delete, copy coordinates and go-to POIs from the context menu;
* Added a go-to functionality to Points of Interest Markers

https://github.com/user-attachments/assets/6d4c0811-92d2-4347-8a0a-281e509bedaa

Closes #2689 