### PR TITLE
Fix main menu not opening on some situations

### DIFF
--- a/src/composables/armSafetyDialog.ts
+++ b/src/composables/armSafetyDialog.ts
@@ -3,6 +3,7 @@ import { createApp } from 'vue'
 
 import ArmSafetyDialog from '@/components/ArmSafetyDialog.vue'
 import vuetify from '@/plugins/vuetify'
+import router from '@/router'
 import { useAlertStore } from '@/stores/alert'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
@@ -43,5 +44,6 @@ export const openMainMenuIfSafeOrDesired = (): void => {
     },
   })
   dialogApp.use(vuetify)
+  dialogApp.use(router)
   dialogApp.mount(mountPoint)
 }

--- a/src/composables/usernamePrompDialog.ts
+++ b/src/composables/usernamePrompDialog.ts
@@ -3,6 +3,7 @@ import { createApp } from 'vue'
 
 import UserNameInputDialog from '@/components/UserNameInputDialog.vue'
 import vuetify from '@/plugins/vuetify'
+import router from '@/router'
 
 export const askForUsername = (): Promise<string | undefined> => {
   return new Promise((resolve, reject) => {
@@ -22,6 +23,7 @@ export const askForUsername = (): Promise<string | undefined> => {
       },
     })
     dialogApp.use(vuetify)
+    dialogApp.use(router)
     dialogApp.mount(mountPoint)
   })
 }


### PR DESCRIPTION
Vuetify VBtn uses vue-router useLink; detached createApp mounts lacked router injection, breaking armed main-menu warning and username dialog.

I was able to reproduce it 1/1 here, both the bug and fix. The best way to test it is to open Cockpit with the vehicle already armed. The arm safety menu should open, but won't.

Fix #2713 