### PR TITLE
Video: Fix the record-all joystick button dropping the first press

### DIFF
--- a/src/components/mini-widgets/MiniVideoRecorder.vue
+++ b/src/components/mini-widgets/MiniVideoRecorder.vue
@@ -363,7 +363,9 @@ const startRecording = (): void => {
 
   assertStreamIsSelectedAndAvailable(nameSelectedStream.value)
   logUserAction(`Started video recording of stream '${nameSelectedStream.value}'`)
-  videoStore.startRecording(selectedExternalId.value)
+  videoStore.startRecording(selectedExternalId.value).catch((error: Error) => {
+    showDialog({ title: 'Recording did not start yet', message: error.message, variant: 'error' })
+  })
   widgetStore.miniWidgetManagerVars(miniWidget.value.hash).configMenuOpen = false
 }
 

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -1,4 +1,4 @@
-import { useStorage, useThrottleFn } from '@vueuse/core'
+import { until, useStorage, useThrottleFn } from '@vueuse/core'
 import { BlobReader, BlobWriter, ZipWriter } from '@zip.js/zip.js'
 import { differenceInSeconds } from 'date-fns'
 import { saveAs } from 'file-saver'
@@ -103,10 +103,17 @@ export const useVideoStore = defineStore('video', () => {
   )
 
   const namesAvailableStreams = computed(() => {
-    const rtspStreams = streamsCorrespondency.value
-      .filter((stream) => (stream.protocol ?? 'webrtc') === 'rtsp')
-      .map((stream) => stream.externalId)
-    return [...new Set([...namesAvailableWebRTCStreams.value, ...rtspStreams])]
+    const rtspCorrespondencies = streamsCorrespondency.value.filter(
+      (stream) => (stream.protocol ?? 'webrtc') === 'rtsp'
+    )
+    const rtspStreams = rtspCorrespondencies.map((stream) => stream.externalId)
+    // Drop the `Stream <rtspUrl>` WebRTC aliases the vehicle re-advertises for already-mapped RTSP
+    // cameras; otherwise record-all spawns a phantom WebRTCManager that hangs waiting for a track.
+    const rtspWebRtcAliases = new Set(
+      rtspCorrespondencies.filter((stream) => stream.rtspUrl).map((stream) => `Stream ${stream.rtspUrl!}`)
+    )
+    const webrtcStreams = namesAvailableWebRTCStreams.value.filter((name) => !rtspWebRtcAliases.has(name))
+    return [...new Set([...webrtcStreams, ...rtspStreams])]
   })
 
   const namessAvailableAbstractedStreams = computed(() => {
@@ -349,6 +356,13 @@ export const useVideoStore = defineStore('video', () => {
 
       const oldStream = activeStreams.value[streamName]!.stream
       const updatedStream = mainWebRTCManager.availableStreams.value.find((s) => s.name === streamName)
+
+      // First-attach: bind to the existing WebRTCManager instead of recreating it, otherwise
+      // a concurrent `startRecording` races against the manager teardown and silently drops.
+      if (oldStream === undefined && updatedStream !== undefined) {
+        activeStreams.value[streamName]!.stream = updatedStream
+        return
+      }
 
       // If the stream configuration has not changed, skip the update
       if (!hasStreamConfigChanged(oldStream, updatedStream)) return
@@ -608,17 +622,37 @@ export const useVideoStore = defineStore('video', () => {
     if (activeStreams.value[streamName] === undefined) activateStream(streamName)
 
     if (namesAvailableStreams.value.isEmpty()) {
-      showDialog({ message: 'No streams available.', variant: 'error' })
-      return
+      openSnackbar({ message: 'No streams available to be recorded.', variant: 'error', duration: 5000 })
+      throw new Error(`Cannot start recording for stream '${streamName}': no streams available.`)
     }
 
-    if (activeStreams.value[streamName]!.mediaStream === undefined) {
-      showDialog({ message: 'Media stream not defined.', variant: 'error' })
-      return
-    }
-    if (!activeStreams.value[streamName]!.mediaStream!.active) {
-      showDialog({ message: 'Media stream not yet active. Wait a second and try again.', variant: 'error' })
-      return
+    // Wait reactively for the remote track; a fresh WebRTC handshake can take several seconds.
+    const mediaReadyTimeoutMs = 30000
+    const isMediaStreamReady = (): boolean => Boolean(activeStreams.value[streamName]?.mediaStream?.active)
+
+    if (!isMediaStreamReady()) {
+      openSnackbar({
+        message: `Waiting for stream '${streamName}' to start...`,
+        variant: 'warning',
+        duration: 5000,
+      })
+      try {
+        await until(isMediaStreamReady).toBe(true, { timeout: mediaReadyTimeoutMs, throwOnTimeout: true })
+      } catch {
+        openSnackbar({
+          message: `Stream '${streamName}' did not become ready in time. Recording aborted.`,
+          variant: 'error',
+          duration: 5000,
+        })
+        throw new Error(
+          `Cannot start recording for stream '${streamName}': media stream did not become ready within ${mediaReadyTimeoutMs}ms.`
+        )
+      }
+      openSnackbar({
+        message: `Stream '${streamName}' is ready. Starting recording...`,
+        variant: 'success',
+        duration: 3000,
+      })
     }
 
     await sleep(100)
@@ -1043,18 +1077,22 @@ export const useVideoStore = defineStore('video', () => {
   }
 
   // Video recording actions
-  const startRecordingAllStreams = (): void => {
-    const streamsThatStarted: string[] = []
+  const startRecordingAllStreams = async (): Promise<void> => {
     isRecordingAllStreams.value = true
 
-    namesAvailableStreams.value.forEach((streamName) => {
-      if (!isRecording(streamName)) {
-        startRecording(streamName)
-        streamsThatStarted.push(streamName)
-      }
-    })
+    const streamsToStart = namesAvailableStreams.value.filter((streamName) => !isRecording(streamName))
+    const startResults = await Promise.allSettled(
+      streamsToStart.map(async (streamName) => {
+        await startRecording(streamName)
+        return streamName
+      })
+    )
+    const streamsThatStarted = startResults
+      .filter((r): r is PromiseFulfilledResult<string> => r.status === 'fulfilled')
+      .map((r) => r.value)
 
     if (streamsThatStarted.isEmpty()) {
+      isRecordingAllStreams.value = false
       alertStore.pushAlert(new Alert(AlertLevel.Error, 'No streams available to be recorded.'))
       return
     }

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -1,4 +1,4 @@
-import { useStorage, useThrottleFn } from '@vueuse/core'
+import { until, useStorage, useThrottleFn } from '@vueuse/core'
 import { BlobReader, BlobWriter, ZipWriter } from '@zip.js/zip.js'
 import { differenceInSeconds } from 'date-fns'
 import { saveAs } from 'file-saver'
@@ -83,6 +83,9 @@ export const useVideoStore = defineStore('video', () => {
   const unprocessedVideos = useStorage<{ [key in string]: UnprocessedVideoInfo }>('cockpit-unprocessed-video-info', {})
   const lastRenamedStreamName = ref('')
   const isRecordingAllStreams = ref(false)
+  // Streams whose recording is waiting for their media to start flowing. Membership doubles as the pending start's
+  // cancellation token: dropping a name aborts the start still waiting on it.
+  const streamsStartingRecording = new Set<string>()
   const liveProcessors = ref<{ [key: string]: LiveVideoProcessor }>({})
   const enableLiveProcessing = useBlueOsStorage('cockpit-enable-live-processing', true)
   const keepRawVideoChunksAsBackup = useBlueOsStorage('cockpit-keep-raw-video-chunks-as-backup', true)
@@ -704,6 +707,10 @@ export const useVideoStore = defineStore('video', () => {
     // set through recording and the async stop() finalizer (telemetry/processing), and onstop clears it when done.
     if (activeStreams.value[externalId]?.mediaRecorder !== undefined) return
 
+    // A recording waiting for this stream's media has no recorder to show for it yet, and tearing the stream down
+    // now would leave that start waiting on media that can never arrive.
+    if (streamsStartingRecording.has(externalId)) return
+
     teardownStreamResources(externalId, `External stream '${externalId}' is no longer used by any consumer`)
   }
 
@@ -867,6 +874,12 @@ export const useVideoStore = defineStore('video', () => {
    * @param {string} streamName - Name of the stream
    */
   const stopRecording = (streamName: string): void => {
+    // Cancels a start still waiting for this stream's media, so a stop is never overtaken by the very recording it
+    // was meant to stop.
+    if (streamsStartingRecording.delete(streamName)) {
+      console.info(`Cancelled the recording of stream '${streamName}', which was still waiting for its media.`)
+    }
+
     // Stop the recording monitor so there's no risk of receiving alerts after the recording is stopped.
     console.info(`Stopping recording monitor for stream '${streamName}'.`)
     clearInterval(recordingMonitors[streamName])
@@ -898,26 +911,55 @@ export const useVideoStore = defineStore('video', () => {
     return thumbnail || null
   }
 
+  // Generous ceiling for how long a recording waits for its stream, well above a typical WebRTC negotiation so a
+  // merely slow camera is not cut off.
+  const streamMediaTimeoutMs = 20000
+
   /**
-   * Start recording the stream
+   * Start recording the stream, waiting for its media to start flowing when it is not connected yet
    * @param {string} streamName - Name of the stream
+   * @returns {Promise<void>} Resolves once the recorder is running
+   * @throws {Error} When no stream is available, when another start is already waiting on this stream, or when its
+   * media does not start flowing in time
    */
   const startRecording = async (streamName: string): Promise<void> => {
     eventTracker.capture('Video recording start', { streamName: streamName })
-    const streamData = getStreamData(streamName)
 
     if (namesAvailableStreams.value.isEmpty()) {
-      showDialog({ message: 'No streams available.', variant: 'error' })
-      return
+      throw new Error('No streams available to be recorded.')
     }
 
-    if (streamData?.mediaStream === undefined) {
-      showDialog({ message: 'Media stream not defined.', variant: 'error' })
-      return
+    if (streamsStartingRecording.has(streamName)) {
+      throw new Error(`Recording of stream '${streamName}' is already starting. Wait for it to connect.`)
     }
-    if (!streamData.mediaStream.active) {
-      showDialog({ message: 'Media stream not yet active. Wait a second and try again.', variant: 'error' })
-      return
+
+    // Activates the stream when nothing else holds it, which is the usual case for one no widget is showing. RTSP
+    // activation only writes its entry a couple of awaits later, so the wait below tolerates it missing.
+    getStreamData(streamName)
+
+    const isMediaFlowing = (): boolean => Boolean(activeStreams.value[streamName]?.mediaStream?.active)
+
+    if (!isMediaFlowing()) {
+      streamsStartingRecording.add(streamName)
+      try {
+        await until(isMediaFlowing).toBe(true, { timeout: streamMediaTimeoutMs, throwOnTimeout: true })
+      } catch {
+        streamsStartingRecording.delete(streamName)
+        const seconds = streamMediaTimeoutMs / 1000
+        throw new Error(
+          `Stream '${streamName}' did not start streaming within ${seconds} seconds.` +
+            ' Check the stream source and try again.'
+        )
+      }
+
+      // A stop requested while we waited drops the name from the set, which is how it cancels this start
+      if (!streamsStartingRecording.delete(streamName)) return
+    }
+
+    // Read back only now: a stream that reconnected while we waited is a whole new entry in the active streams
+    const streamData = getStreamData(streamName)
+    if (streamData?.mediaStream === undefined) {
+      throw new Error(`Media stream of '${streamName}' is not available anymore. Try again once it reconnects.`)
     }
 
     await sleep(100)
@@ -1385,21 +1427,50 @@ export const useVideoStore = defineStore('video', () => {
   }
 
   // Video recording actions
-  const startRecordingAllStreams = (): void => {
-    const streamsThatStarted: string[] = []
-    isRecordingAllStreams.value = true
+  // Both joystick entry points fire the batch and forget it, so a failure of the batch itself, as opposed to one of
+  // a single stream, has nowhere else to surface.
+  const reportFailureToRecordAllStreams = (error: unknown): void => {
+    const reason = error instanceof Error ? error.message : String(error)
+    openSnackbar({ message: `Could not start recording all streams: ${reason}`, variant: 'error', duration: 5000 })
+  }
 
-    namesAvailableStreams.value.forEach((streamName) => {
-      if (!isRecording(streamName)) {
-        startRecording(streamName)
-        streamsThatStarted.push(streamName)
-      }
-    })
+  /**
+   * Start recording every available stream, waiting for the ones that are not streaming yet
+   * @returns {Promise<void>} Resolves once every stream has either started recording or failed to
+   */
+  const startRecordingAllStreams = async (): Promise<void> => {
+    // RTSP is Standalone-only, so on Lite those streams never start flowing and would only stall the batch. They
+    // reach Lite anyway, since the correspondency list is synced from whichever client mapped them.
+    const isRecordable = (streamName: string): boolean => isElectron() || getStreamProtocol(streamName) !== 'rtsp'
+    const streamsToStart = namesAvailableStreams.value.filter(
+      (streamName) => isRecordable(streamName) && !isRecording(streamName)
+    )
 
-    if (streamsThatStarted.isEmpty()) {
+    if (streamsToStart.isEmpty()) {
       alertStore.pushAlert(new Alert(AlertLevel.Error, 'No streams available to be recorded.'))
       return
     }
+
+    // Starting takes as long as the slowest stream needs to connect, so the press is answered right away
+    openSnackbar({ message: `Starting to record ${streamsToStart.length} stream(s)...`, variant: 'info' })
+
+    const results = await Promise.allSettled(streamsToStart.map((streamName) => startRecording(streamName)))
+
+    // A start that a stop cancelled while it was connecting resolves without a recorder to show for it, so what
+    // started is read from the streams themselves rather than from what did not fail.
+    const streamsThatStarted = streamsToStart.filter((streamName) => isRecording(streamName))
+    const reasonsTheyFailed = results
+      .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
+      .map((result) => (result.reason instanceof Error ? result.reason.message : String(result.reason)))
+
+    // One message for the whole batch, so a handful of failing streams cannot bury the screen in dialogs
+    if (!reasonsTheyFailed.isEmpty()) {
+      openSnackbar({ message: [...new Set(reasonsTheyFailed)].join(' '), variant: 'error', duration: 5000 })
+    }
+
+    if (streamsThatStarted.isEmpty()) return
+
+    isRecordingAllStreams.value = true
     const msg = `Started recording all ${streamsThatStarted.length} streams: ${streamsThatStarted.join(', ')}.`
     alertStore.pushAlert(new Alert(AlertLevel.Success, msg))
   }
@@ -1415,8 +1486,16 @@ export const useVideoStore = defineStore('video', () => {
       }
     })
 
+    // stopRecording already dropped every stream it was called for, so what is left are the ones still connecting
+    const cancelledStarts = streamsStartingRecording.size
+    streamsStartingRecording.clear()
+
     if (streamsThatStopped.isEmpty()) {
-      alertStore.pushAlert(new Alert(AlertLevel.Error, 'No streams were being recorded.'))
+      const msg =
+        cancelledStarts > 0
+          ? `Cancelled the recording of ${cancelledStarts} stream(s) that were still connecting.`
+          : 'No streams were being recorded.'
+      alertStore.pushAlert(new Alert(cancelledStarts > 0 ? AlertLevel.Info : AlertLevel.Error, msg))
       return
     }
     const msg = `Stopped recording all ${streamsThatStopped.length} streams: ${streamsThatStopped.join(', ')}.`
@@ -1426,9 +1505,17 @@ export const useVideoStore = defineStore('video', () => {
   const toggleRecordingAllStreams = (): void => {
     if (isRecordingAllStreams.value) {
       stopRecordingAllStreams()
-    } else {
-      startRecordingAllStreams()
+      return
     }
+
+    // Starting is not instantaneous, so the toggle has a third state: a press while the streams are still
+    // connecting reads as impatience rather than as a request to stop the recordings already on their way.
+    if (streamsStartingRecording.size > 0) {
+      openSnackbar({ message: 'Already starting to record. Waiting for the streams to connect.', variant: 'warning' })
+      return
+    }
+
+    startRecordingAllStreams().catch(reportFailureToRecordAllStreams)
   }
 
   const renameStreamInternalNameById = (streamID: string, newInternalName: string): void => {
@@ -1549,7 +1636,7 @@ export const useVideoStore = defineStore('video', () => {
 
   registerActionCallback(
     availableCockpitActions.start_recording_all_streams,
-    useThrottleFn(startRecordingAllStreams, 3000)
+    useThrottleFn(() => startRecordingAllStreams().catch(reportFailureToRecordAllStreams), 3000)
   )
   registerActionCallback(
     availableCockpitActions.stop_recording_all_streams,

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -474,6 +474,13 @@ export const useVideoStore = defineStore('video', () => {
       const oldStream = activeStreams.value[streamName]!.stream
       const updatedStream = mainWebRTCManager.availableStreams.value.find((s) => s.name === streamName)
 
+      // A stream this routine never bound yet still holds the manager activateStream just created, so hand the
+      // stream over to it. The recreation below would drop that manager without closing it and start over.
+      if (oldStream === undefined && updatedStream !== undefined) {
+        activeStreams.value[streamName]!.stream = updatedStream
+        return
+      }
+
       // If the stream configuration has not changed, skip the update
       if (!hasStreamConfigChanged(oldStream, updatedStream)) return
 


### PR DESCRIPTION
**Problem:**

- `startRecording` (`src/stores/video.ts:907`) bailed with a `Media stream not defined` dialog whenever the stream was not connected yet, dropping the first joystick press.
- A stream no widget is showing is only activated by the recording itself, and its WebRTC handshake takes seconds.
- Streams are released when their last consumer disconnects (559f3a74e) and when a recording stops (a36ef861), so a stream that is not connected yet is the normal case rather than an occasional one.
- `startRecordingAllStreams` fire-and-forgot the async `startRecording` and counted every stream as started, so `isRecordingAllStreams` stayed `true` with nothing recording.
- The next press then took the stop branch, stopped nothing, and reported "No streams were being recorded" while the recordings started right after it.
- The streams update routine recreated the `WebRTCManager` that `activateStream` had just built, without closing it.

**Fix:**

- `startRecording` waits for the media to flow, bounded at 20s, re-reads the stream entry afterwards, and throws instead of opening one modal per stream.
- A pending-starts set rejects duplicate starts, blocks teardown mid-wait, and doubles as the start's cancellation token, so a stop is never overtaken by a late recording.
- `startRecordingAllStreams` awaits the batch, reports only what is actually recording, and aggregates failures into a single message.
- Record-all skips RTSP streams on Cockpit Lite, which can never flow there.
- `toggleRecordingAllStreams` answers a press made while the streams are still connecting instead of reading it as a stop.
- The update routine hands a freshly activated stream to the manager already in place.

Closes #2688
