### PR TITLE
Fix list of usernames not always showing the correct values

### DIFF
--- a/src/components/UserNameInputDialog.vue
+++ b/src/components/UserNameInputDialog.vue
@@ -15,6 +15,13 @@
         <p class="-mt-4 mb-2 w-full text-center"></p>
         <div class="flex flex-col align-center justify-center font-light text-slate-200 w-full h-full transition-all">
           <div
+            v-if="localOnlyNotice"
+            class="mb-3 mx-auto max-w-[560px] rounded-md border border-yellow-400 border-opacity-60 bg-yellow-400 bg-opacity-10 px-3 py-2 text-sm text-yellow-200 flex items-start gap-2"
+          >
+            <v-icon size="18" color="yellow">mdi-alert-circle-outline</v-icon>
+            <span>{{ localOnlyNotice }}</span>
+          </div>
+          <div
             v-if="!isUsernamesEmpty && !showNewUsernamePrompt"
             class="w-full h-full flex flex-col align-center justify-center text-center"
           >
@@ -94,7 +101,7 @@
 
 <script setup lang="ts">
 import slugify from 'slugify'
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { openSnackbar } from '@/composables/snackbar'
@@ -111,6 +118,8 @@ const missionStore = useMissionStore()
 const mainVehicleStore = useMainVehicleStore()
 const { showDialog, closeDialog } = useInteractionDialog()
 
+type BlueOsLoadState = 'idle' | 'loading' | 'loaded' | 'failed' | 'offline'
+
 const showUserDialog = ref(true)
 const showNewUsernamePrompt = ref(false)
 const validationError = ref('')
@@ -119,6 +128,7 @@ const usernamesStoredOnBlueOS = ref<string[] | null>(null)
 const isLoading = ref(true)
 const isOnEditMode = ref(false)
 const currentVehicleName = ref<string | undefined>(undefined)
+const blueOsLoadState = ref<BlueOsLoadState>('idle')
 
 const deleteUser = async (username: string): Promise<void> => {
   if (username === missionStore.username) {
@@ -193,7 +203,14 @@ const loadLocalUsernames = (): void => {
 }
 
 const loadUsernamesFromBlueOS = async (): Promise<void> => {
+  if (!mainVehicleStore.isVehicleOnline) {
+    blueOsLoadState.value = 'offline'
+    isLoading.value = false
+    return
+  }
+
   isLoading.value = true
+  blueOsLoadState.value = 'loading'
 
   try {
     const vehicleAddress = await mainVehicleStore.getVehicleAddress()
@@ -201,20 +218,21 @@ const loadUsernamesFromBlueOS = async (): Promise<void> => {
     if (blueOSUsernames && blueOSUsernames.length) {
       usernamesStoredOnBlueOS.value = [...new Set([...(usernamesStoredOnBlueOS.value ?? []), ...blueOSUsernames])]
     }
+    blueOsLoadState.value = 'loaded'
   } catch (error) {
-    console.error('Failed to load usernames from BlueOS.')
+    console.error('Failed to load usernames from BlueOS.', error)
+    blueOsLoadState.value = 'failed'
   } finally {
     isLoading.value = false
   }
 }
 
 const getVehicleName = async (): Promise<void> => {
-  if (mainVehicleStore.isVehicleOnline) {
-    try {
-      currentVehicleName.value = await mainVehicleStore.getCurrentVehicleName()
-    } catch (error) {
-      console.error('Failed to get vehicle name:', error)
-    }
+  if (!mainVehicleStore.isVehicleOnline) return
+  try {
+    currentVehicleName.value = await mainVehicleStore.getCurrentVehicleName()
+  } catch (error) {
+    console.error('Failed to get vehicle name:', error)
   }
 }
 
@@ -227,13 +245,25 @@ const handleEsc = (e: KeyboardEvent): void => {
 onMounted(() => {
   window.addEventListener('keydown', handleEsc)
   loadLocalUsernames()
-  if (mainVehicleStore.isVehicleOnline) {
-    loadUsernamesFromBlueOS()
-    getVehicleName()
-  } else {
-    isLoading.value = false
-  }
+  loadUsernamesFromBlueOS()
+  getVehicleName()
 })
+
+// Retry fetching vehicle data whenever the vehicle (re)comes online and the previous attempt
+// hasn't succeeded yet. Without this the dialog would forever show only the locally cached users
+// if it was opened while the vehicle was offline.
+watch(
+  () => mainVehicleStore.isVehicleOnline,
+  (isOnline) => {
+    if (!isOnline) return
+    if (blueOsLoadState.value === 'offline' || blueOsLoadState.value === 'failed') {
+      loadUsernamesFromBlueOS()
+    }
+    if (!currentVehicleName.value) {
+      getVehicleName()
+    }
+  }
+)
 
 onBeforeUnmount(() => {
   window.removeEventListener('keydown', handleEsc)
@@ -242,6 +272,15 @@ const isUsernamesEmpty = computed(() => !usernamesStoredOnBlueOS.value || userna
 const dialogTitle = computed(() =>
   currentVehicleName.value ? `Manage users on: ${currentVehicleName.value}` : 'Manage users'
 )
+const localOnlyNotice = computed(() => {
+  if (blueOsLoadState.value === 'offline') {
+    return 'Vehicle is offline. Showing locally cached users only - other users saved on the vehicle may not appear here.'
+  }
+  if (blueOsLoadState.value === 'failed') {
+    return "Couldn't load users from the vehicle. Showing locally cached users only - any users saved on the vehicle still exist."
+  }
+  return ''
+})
 
 const validateUsername = (username: string): true | string => {
   if (username.includes(' ')) {

--- a/src/components/UserNameInputDialog.vue
+++ b/src/components/UserNameInputDialog.vue
@@ -3,7 +3,7 @@
     variant="text-only"
     persistent
     :show-dialog="showUserDialog"
-    :title="`Manage users on: ${currentVehicleName}`"
+    :title="dialogTitle"
     :actions="showNewUsernamePrompt || isUsernamesEmpty ? inputDialogActions : regularDialogActions"
     :max-width="700"
   >
@@ -239,6 +239,9 @@ onBeforeUnmount(() => {
   window.removeEventListener('keydown', handleEsc)
 })
 const isUsernamesEmpty = computed(() => !usernamesStoredOnBlueOS.value || usernamesStoredOnBlueOS.value.length === 0)
+const dialogTitle = computed(() =>
+  currentVehicleName.value ? `Manage users on: ${currentVehicleName.value}` : 'Manage users'
+)
 
 const validateUsername = (username: string): true | string => {
   if (username.includes(' ')) {

--- a/src/components/configuration/CockpitSettingsManager.vue
+++ b/src/components/configuration/CockpitSettingsManager.vue
@@ -294,20 +294,21 @@ import { computed, onMounted, onUnmounted, reactive, ref, watch } from 'vue'
 
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { useSnackbar } from '@/composables/snackbar'
-import {
-  cockpitLastConnectedUserKey,
-  cockpitLastConnectedVehicleKey,
-  localOldStyleSettingsKey,
-  localSyncedSettingsKey,
-  settingsManager,
-  vehicleIdKey,
-} from '@/libs/settings-management'
+import { settingsManager } from '@/libs/settings-management'
 import { isEqual } from '@/libs/utils'
 import { reloadCockpitAndWarnUser } from '@/libs/utils-vue'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMissionStore } from '@/stores/mission'
 import { Settings } from '@/types/general'
-import { LocalSyncedSettings, SettingsPackage } from '@/types/settings-management'
+import {
+  cockpitLastConnectedUserKey,
+  cockpitLastConnectedVehicleKey,
+  localOldStyleSettingsKey,
+  LocalSyncedSettings,
+  localSyncedSettingsKey,
+  SettingsPackage,
+  vehicleIdKey,
+} from '@/types/settings-management'
 
 type SettingsRowSource = 'v2' | 'legacy' | 'all-local-storage'
 type SettingsRow = {

--- a/src/libs/blueos.ts
+++ b/src/libs/blueos.ts
@@ -370,7 +370,15 @@ export const checkBlueOsUserDataSimilarity = async (vehicleAddress: string, user
 
 export const getSettingsUsernamesFromBlueOS = async (vehicleAddress: string): Promise<string[]> => {
   const usernames = await getKeyDataFromCockpitVehicleStorage(vehicleAddress, vehicleNewStyleSettingsKey)
-  return Object.keys(usernames as string[])
+  // `getKeyDataFromCockpitVehicleStorage` returns `undefined` when the bag does not exist yet
+  // (fresh vehicle, never written to). That is a legitimate "no users yet" state, not a failure.
+  if (usernames === undefined) return []
+  // Anything else that isn't a plain object is an unexpected payload shape; surface it as an
+  // error so the caller can distinguish it from a real empty result.
+  if (typeof usernames !== 'object' || usernames === null || Array.isArray(usernames)) {
+    throw new Error(`Unexpected '${vehicleNewStyleSettingsKey}' payload shape on vehicle '${vehicleAddress}'.`)
+  }
+  return Object.keys(usernames)
 }
 
 export const deleteUsernameOnBlueOS = async (vehicleAddress: string, username: string): Promise<void> => {

--- a/src/libs/blueos.ts
+++ b/src/libs/blueos.ts
@@ -14,6 +14,7 @@ import {
   JoystickMapSuggestionGroupsFromExtension,
   NoPathInBlueOsErrorName,
 } from '@/types/blueos'
+import { vehicleNewStyleSettingsKey } from '@/types/settings-management'
 import { ExternalWidgetSetupInfo } from '@/types/widgets'
 
 const defaultTimeout = 10000
@@ -368,14 +369,17 @@ export const checkBlueOsUserDataSimilarity = async (vehicleAddress: string, user
 }
 
 export const getSettingsUsernamesFromBlueOS = async (vehicleAddress: string): Promise<string[]> => {
-  const usernames = await getKeyDataFromCockpitVehicleStorage(vehicleAddress, 'settings')
+  const usernames = await getKeyDataFromCockpitVehicleStorage(vehicleAddress, vehicleNewStyleSettingsKey)
   return Object.keys(usernames as string[])
 }
 
 export const deleteUsernameOnBlueOS = async (vehicleAddress: string, username: string): Promise<void> => {
   let allSettings: Record<string, any> = {}
   try {
-    allSettings = (await getKeyDataFromCockpitVehicleStorage(vehicleAddress, 'settings')) as Record<string, any>
+    allSettings = (await getKeyDataFromCockpitVehicleStorage(vehicleAddress, vehicleNewStyleSettingsKey)) as Record<
+      string,
+      any
+    >
   } catch (err) {
     if ((err as Error).name === NoPathInBlueOsErrorName) return
     throw err
@@ -384,7 +388,7 @@ export const deleteUsernameOnBlueOS = async (vehicleAddress: string, username: s
   if (!(username in allSettings)) return
   delete allSettings[username]
 
-  await setKeyDataOnCockpitVehicleStorage(vehicleAddress, 'settings', allSettings)
+  await setKeyDataOnCockpitVehicleStorage(vehicleAddress, vehicleNewStyleSettingsKey, allSettings)
 }
 
 /**

--- a/src/libs/settings-management.ts
+++ b/src/libs/settings-management.ts
@@ -3,9 +3,15 @@ import { v4 as uuidv4 } from 'uuid'
 
 import { NoPathInBlueOsErrorName } from '@/types/blueos'
 import {
+  cockpitLastConnectedUserKey,
+  cockpitLastConnectedVehicleKey,
   CockpitSetting,
+  fallbackUsername,
+  fallbackVehicleId,
   KeyValueVehicleUpdateQueue,
+  localOldStyleSettingsKey,
   LocalSyncedSettings,
+  localSyncedSettingsKey,
   NoVehicleIdErrorName,
   OldCockpitSettingsPackage,
   SettingsListener,
@@ -13,6 +19,10 @@ import {
   SettingsPackage,
   UserChangedEvent,
   UserSettings,
+  vehicleIdKey,
+  vehicleNewStyleSettingsKey,
+  vehicleOldStyleSettingsBackupKey,
+  vehicleOldStyleSettingsKey,
   VehicleOnlineEvent,
   VehicleSettings,
 } from '@/types/settings-management'
@@ -20,16 +30,6 @@ import {
 import { getKeyDataFromCockpitVehicleStorage, setKeyDataOnCockpitVehicleStorage } from './blueos'
 import { deserialize, isEqual, sleep, tryACoupleOfTimes } from './utils'
 
-export const localOldStyleSettingsKey = 'cockpit-settings-v1-backup'
-export const vehicleOldStyleSettingsKey = 'settings'
-export const vehicleOldStyleSettingsBackupKey = 'settings-v1-backup'
-export const vehicleNewStyleSettingsKey = 'settings-v2'
-export const localSyncedSettingsKey = 'cockpit-settings-v2'
-export const cockpitLastConnectedVehicleKey = 'cockpit-last-connected-vehicle-id'
-export const cockpitLastConnectedUserKey = 'cockpit-last-connected-user'
-export const vehicleIdKey = 'cockpit-vehicle-id'
-export const fallbackUsername = 'fallback-user'
-export const fallbackVehicleId = 'fallback-vehicle'
 const nullValue = 'null'
 const possibleNullValues = [fallbackUsername, fallbackVehicleId, nullValue, null, undefined, '']
 const keyValueUpdateDebounceTime = 100

--- a/src/stores/mission.ts
+++ b/src/stores/mission.ts
@@ -6,7 +6,6 @@ import { computed, reactive, ref, watch } from 'vue'
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { useBlueOsStorage } from '@/composables/settingsSyncer'
 import { askForUsername } from '@/composables/usernamePrompDialog'
-import { cockpitLastConnectedUserKey, fallbackUsername } from '@/libs/settings-management'
 import { eventCategoriesDefaultMapping } from '@/libs/slide-to-confirm'
 import {
   AltitudeReferenceType,
@@ -19,6 +18,7 @@ import {
   Waypoint,
   WaypointCoordinates,
 } from '@/types/mission'
+import { cockpitLastConnectedUserKey, fallbackUsername } from '@/types/settings-management'
 
 import { useMainVehicleStore } from './mainVehicle'
 

--- a/src/types/settings-management.ts
+++ b/src/types/settings-management.ts
@@ -1,3 +1,14 @@
+export const localOldStyleSettingsKey = 'cockpit-settings-v1-backup'
+export const vehicleOldStyleSettingsKey = 'settings'
+export const vehicleOldStyleSettingsBackupKey = 'settings-v1-backup'
+export const vehicleNewStyleSettingsKey = 'settings-v2'
+export const localSyncedSettingsKey = 'cockpit-settings-v2'
+export const cockpitLastConnectedVehicleKey = 'cockpit-last-connected-vehicle-id'
+export const cockpitLastConnectedUserKey = 'cockpit-last-connected-user'
+export const vehicleIdKey = 'cockpit-vehicle-id'
+export const fallbackUsername = 'fallback-user'
+export const fallbackVehicleId = 'fallback-vehicle'
+
 /**
  * An individual setting for a vehicle/user pair
  * Stores the value as well as the epoch time of the last change. The epoch is used to compare with remote values and determine which one is newer.


### PR DESCRIPTION
This PR could have been a 3 characters changing, as in the end the bug was that we were getting the list of users on the vehicle from the "settings" key, instead of the new "settings-v2" key, but I decided to do also fix the cases where fails in fetching the list of users from BlueOS would lead to only local users being shown, without a retry or warn.

To reproduce you basically need your bag of holding to have a different set of users on the old and new key. It's rare to occurred since the migration moves all at the same time, but probably happened to @vshie because he is a beta tester so he comes and goes between versions, and could have deleted an user from the 1.17 after having used 1.18 (so migration already done).

Before and after:
<img width="720" height="308" alt="SCR-20260514-ozlx" src="https://github.com/user-attachments/assets/26c91037-a7ef-4805-bfb2-a4bc00520353" />
<img width="735" height="313" alt="SCR-20260514-ozgs" src="https://github.com/user-attachments/assets/8e9bc99f-9a62-4af4-93b5-7c0e48ee6f99" />



Fix #2704 