### PR TITLE
Fix automatic creation of views and mapping defaults and allow later importing

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -95,6 +95,9 @@
   <VehicleDiscoveryDialog v-model="showDiscoveryDialog" show-auto-search-option />
   <CameraReplacementDialog />
   <ExternalFeaturesDiscoveryModal auto-check-on-mount />
+  <VehicleDefaultsAutoImportModal />
+  <VehicleDefaultsViewsImportModal />
+  <VehicleDefaultsJoystickImportModal />
   <UpdateNotification v-if="isElectron()" />
   <ArchitectureWarning v-if="isElectron()" />
   <SnackbarContainer />
@@ -124,6 +127,9 @@ import SkullAnimation from '@/components/SkullAnimation.vue'
 import SnackbarContainer from '@/components/SnackbarContainer.vue'
 import Tutorial from '@/components/Tutorial.vue'
 import UpdateNotification from '@/components/UpdateNotification.vue'
+import VehicleDefaultsAutoImportModal from '@/components/vehicle-defaults/VehicleDefaultsAutoImportModal.vue'
+import VehicleDefaultsJoystickImportModal from '@/components/vehicle-defaults/VehicleDefaultsJoystickImportModal.vue'
+import VehicleDefaultsViewsImportModal from '@/components/vehicle-defaults/VehicleDefaultsViewsImportModal.vue'
 import VehicleDiscoveryDialog from '@/components/VehicleDiscoveryDialog.vue'
 import VideoLibraryModal from '@/components/VideoLibraryModal.vue'
 import {
@@ -143,6 +149,7 @@ import SplashScreen from './components/SplashScreen.vue'
 import WidgetBar from './components/WidgetBar.vue'
 import { openMainMenuIfSafeOrDesired } from './composables/armSafetyDialog'
 import { useSnackbar } from './composables/snackbar'
+import { useVehicleDefaultsAutoImport } from './composables/vehicleDefaults/vehicleDefaultsAutoImport'
 import { checkBlueOsUserDataSimilarity } from './libs/blueos'
 import { useAppInterfaceStore } from './stores/appInterface'
 import { useDevelopmentStore } from './stores/development'
@@ -160,6 +167,10 @@ const missionStore = useMissionStore()
 
 // Initialize the snapshot store to register action callbacks
 useSnapshotStore()
+
+// Listen for `vehicle-sync-complete` events to auto-import vehicle-type defaults or open the
+// VehicleDefaultsAutoImportModal when the user still needs to make a decision.
+useVehicleDefaultsAutoImport()
 
 const showAboutDialog = ref(false)
 const currentSubMenuComponent = ref<SubMenuComponent>(null)

--- a/src/components/EditMenu.vue
+++ b/src/components/EditMenu.vue
@@ -47,6 +47,12 @@
                   <v-icon size="20">mdi-download</v-icon>
                 </div>
               </v-list-item>
+              <v-list-item @click="openVehicleDefaultsImportModal">
+                <div class="flex w-full justify-between">
+                  <v-list-item-title class="mr-6">Import vehicle defaults</v-list-item-title>
+                  <v-icon size="20">mdi-import</v-icon>
+                </div>
+              </v-list-item>
               <v-list-item @click="store.snapToGrid = !store.snapToGrid">
                 <div class="flex w-full justify-between mt-[6px]">
                   <v-list-item-title>{{ store.snapToGrid ? 'Disable grid' : 'Enable grid' }}</v-list-item-title>
@@ -598,6 +604,10 @@ const { showDialog, closeDialog } = useInteractionDialog()
 const interfaceStore = useAppInterfaceStore()
 const store = useWidgetManagerStore()
 const mainVehicleStore = useMainVehicleStore()
+
+const openVehicleDefaultsImportModal = (): void => {
+  interfaceStore.openVehicleDefaultsViewsImport()
+}
 
 const miniWidgetsBars = computed(() => {
   let regularContainers = store.miniWidgetContainersInCurrentView.filter(

--- a/src/components/vehicle-defaults/VehicleDefaultsAutoImportModal.vue
+++ b/src/components/vehicle-defaults/VehicleDefaultsAutoImportModal.vue
@@ -1,0 +1,165 @@
+<template>
+  <teleport to="body">
+    <GlassModal :is-visible="isVisible" position="center" no-close-on-outside-click @outside-click="requestCloseModal">
+      <div class="relative w-[740px] max-w-[95vw] p-4">
+        <div class="mb-2 flex flex-col items-center justify-center gap-1">
+          <h2 class="text-xl font-semibold">{{ modalTitle }}</h2>
+          <p v-if="evaluation" class="text-xs opacity-60">Step {{ autoWizardStepNumber }} of 4</p>
+        </div>
+        <v-btn
+          icon="mdi-close"
+          size="small"
+          variant="text"
+          class="absolute right-1 top-1 text-lg"
+          @click="requestCloseModal"
+        />
+
+        <p v-if="!evaluation" class="py-8 text-center opacity-70">
+          Connect a vehicle so Cockpit can identify which defaults are available.
+        </p>
+
+        <template v-else>
+          <div class="mt-6">
+            <VehicleDefaultsAutoWizardIntroPanel v-if="autoWizardStep === 'intro'" />
+            <VehicleDefaultsJoystickMappingContent v-else-if="autoWizardStep === 'joystick'" variant="wizard" />
+            <VehicleDefaultsViewsGroupContent v-else-if="autoWizardStep === 'views'" variant="wizard" />
+            <VehicleDefaultsAutoWizardDonePanel v-else-if="autoWizardStep === 'done'" />
+          </div>
+
+          <div v-if="autoWizardStep !== 'done'" class="mt-4 flex justify-space-between">
+            <v-btn v-if="wizardShowSecondaryButton" variant="text" @click="onWizardSecondaryAction">
+              {{ wizardSecondaryLabel }}
+            </v-btn>
+            <div v-else />
+            <v-btn variant="text" :disabled="wizardPrimaryDisabled" @click="onWizardPrimaryAction">
+              {{ wizardPrimaryLabel }}
+            </v-btn>
+          </div>
+          <div v-else class="mt-4 flex justify-end">
+            <v-btn variant="text" @click="onWizardPrimaryAction">{{ wizardPrimaryLabel }}</v-btn>
+          </div>
+        </template>
+      </div>
+    </GlassModal>
+  </teleport>
+
+  <VehicleDefaultsReplaceConfirmationDialog
+    :model-value="replaceConfirmationVisible"
+    :views-count="currentViewsCount"
+    :vehicle-type-name="evaluation?.vehicleTypeName"
+    @confirm="confirmViewsReplace"
+    @cancel="cancelReplace"
+  />
+
+  <v-dialog v-if="isVisible" v-model="ignoreConfirmationVisible" max-width="500px" persistent>
+    <v-card class="rounded-lg" :style="interfaceStore.globalGlassMenuStyles">
+      <v-card-title class="pb-0 pt-4 text-center">
+        <h2 class="text-xl font-semibold">Ignore all defaults?</h2>
+      </v-card-title>
+
+      <v-card-text class="px-6 pb-2">
+        <p class="mb-3 text-center text-sm">
+          You will keep your current views group and joystick mapping for {{ evaluation?.vehicleTypeName }}. This
+          walkthrough will not open automatically again for this vehicle.
+        </p>
+        <p class="mb-3 text-center text-sm opacity-80">You can still import defaults later:</p>
+        <ul class="space-y-2 text-sm">
+          <li>
+            <strong>Default views</strong> — open the <strong>Edit menu</strong> and choose
+            <strong>Import vehicle defaults</strong>
+          </li>
+          <li>
+            <strong>Default joystick mapping</strong> — open <strong>Joystick configuration</strong> and use the import
+            button on the mapping toolbar
+          </li>
+        </ul>
+      </v-card-text>
+
+      <v-card-actions class="justify-space-between px-6 pb-4">
+        <v-btn variant="text" @click="cancelIgnoreAll">Keep reviewing</v-btn>
+        <v-btn variant="text" @click="confirmIgnoreAll">Ignore</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+
+  <v-dialog v-if="isVisible" v-model="closeConfirmationVisible" max-width="500px" persistent>
+    <v-card class="rounded-lg" :style="interfaceStore.globalGlassMenuStyles">
+      <v-card-title class="pb-0 pt-4 text-center">
+        <div class="flex items-center justify-center gap-2">
+          <v-icon color="warning" size="24">mdi-alert</v-icon>
+          <h2 class="text-xl font-semibold">Finish the walkthrough first</h2>
+        </div>
+      </v-card-title>
+
+      <v-card-text class="px-6 pb-2">
+        <p class="mb-3 text-center text-sm">Please complete or ignore all steps before closing.</p>
+        <p class="text-center text-xs opacity-80">
+          Having a correct joystick mapping for your vehicle type is important: a mismatched mapping can cause motors to
+          spin unexpectedly the moment the vehicle is armed.
+        </p>
+      </v-card-text>
+
+      <v-card-actions class="justify-center px-6 pb-4">
+        <v-btn @click="closeConfirmationVisible = false">Keep reviewing</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+import { onUnmounted, provide, watch } from 'vue'
+
+import GlassModal from '@/components/GlassModal.vue'
+import VehicleDefaultsAutoWizardDonePanel from '@/components/vehicle-defaults/VehicleDefaultsAutoWizardDonePanel.vue'
+import VehicleDefaultsAutoWizardIntroPanel from '@/components/vehicle-defaults/VehicleDefaultsAutoWizardIntroPanel.vue'
+import VehicleDefaultsJoystickMappingContent from '@/components/vehicle-defaults/VehicleDefaultsJoystickMappingContent.vue'
+import VehicleDefaultsReplaceConfirmationDialog from '@/components/vehicle-defaults/VehicleDefaultsReplaceConfirmationDialog.vue'
+import VehicleDefaultsViewsGroupContent from '@/components/vehicle-defaults/VehicleDefaultsViewsGroupContent.vue'
+import {
+  useVehicleDefaultsAutoImportWizard,
+  vehicleDefaultsAutoImportWizardKey,
+} from '@/composables/vehicleDefaults/useVehicleDefaultsAutoImportWizard'
+import { vehicleDefaultsJoystickImportKey } from '@/composables/vehicleDefaults/useVehicleDefaultsJoystickImport'
+import { vehicleDefaultsViewsImportKey } from '@/composables/vehicleDefaults/useVehicleDefaultsViewsImport'
+
+const wizard = useVehicleDefaultsAutoImportWizard()
+provide(vehicleDefaultsAutoImportWizardKey, wizard)
+provide(vehicleDefaultsViewsImportKey, wizard.viewsImport)
+provide(vehicleDefaultsJoystickImportKey, wizard.joystickImport)
+
+const {
+  interfaceStore,
+  isVisible,
+  evaluation,
+  autoWizardStep,
+  autoWizardStepNumber,
+  modalTitle,
+  closeConfirmationVisible,
+  ignoreConfirmationVisible,
+  wizardSecondaryLabel,
+  wizardPrimaryLabel,
+  wizardShowSecondaryButton,
+  wizardPrimaryDisabled,
+  onWizardPrimaryAction,
+  onWizardSecondaryAction,
+  confirmIgnoreAll,
+  cancelIgnoreAll,
+  confirmViewsReplace,
+  requestCloseModal,
+  viewsImport,
+} = wizard
+
+const { replaceConfirmationVisible, currentViewsCount, cancelReplace } = viewsImport
+
+watch(
+  [isVisible, replaceConfirmationVisible],
+  ([modalVisible, replaceOpen]) => {
+    interfaceStore.isGlassModalAlwaysOnTop = modalVisible && !replaceOpen
+  },
+  { immediate: true }
+)
+
+onUnmounted(() => {
+  interfaceStore.isGlassModalAlwaysOnTop = false
+})
+</script>

--- a/src/components/vehicle-defaults/VehicleDefaultsAutoWizardDonePanel.vue
+++ b/src/components/vehicle-defaults/VehicleDefaultsAutoWizardDonePanel.vue
@@ -1,0 +1,18 @@
+<template>
+  <div class="space-y-3 py-4 text-center text-sm opacity-80">
+    <p>
+      You have finished reviewing the default configuration for {{ evaluation?.vehicleTypeName }}. This dialog will not
+      open automatically again for this vehicle.
+    </p>
+    <p>
+      If you want to import default views or joystick mapping later, use <strong>Import vehicle defaults</strong> in the
+      <strong>Edit menu</strong>, or the import button in <strong>Joystick configuration</strong>.
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useVehicleDefaultsAutoImportWizardInject } from '@/composables/vehicleDefaults/useVehicleDefaultsAutoImportWizard'
+
+const { evaluation } = useVehicleDefaultsAutoImportWizardInject()
+</script>

--- a/src/components/vehicle-defaults/VehicleDefaultsAutoWizardIntroPanel.vue
+++ b/src/components/vehicle-defaults/VehicleDefaultsAutoWizardIntroPanel.vue
@@ -1,0 +1,30 @@
+<template>
+  <div class="space-y-3">
+    <div class="space-y-2 text-center text-sm opacity-80">
+      <p v-for="(paragraph, index) in introParagraphs" :key="index">
+        {{ paragraph }}
+      </p>
+    </div>
+
+    <div class="mt-6 grid grid-cols-2 gap-6 px-2">
+      <div class="flex flex-col items-start text-left">
+        <p class="max-w-[220px] text-xs leading-snug opacity-80">
+          Click <strong>Ignore</strong> if you are happy with your current views group and joystick mapping.
+        </p>
+        <v-icon size="42" color="white" class="mt-3 -rotate-[25deg]">mdi-arrow-down-left-bold</v-icon>
+      </div>
+      <div class="flex flex-col items-end text-right">
+        <p class="max-w-[220px] text-xs leading-snug opacity-80">
+          Click <strong>Next</strong> to review the defaults and decide whether to import them.
+        </p>
+        <v-icon size="48" color="white" class="mt-4 rotate-[25deg]">mdi-arrow-down-right-bold</v-icon>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useVehicleDefaultsAutoImportWizardInject } from '@/composables/vehicleDefaults/useVehicleDefaultsAutoImportWizard'
+
+const { introParagraphs } = useVehicleDefaultsAutoImportWizardInject()
+</script>

--- a/src/components/vehicle-defaults/VehicleDefaultsJoystickImportModal.vue
+++ b/src/components/vehicle-defaults/VehicleDefaultsJoystickImportModal.vue
@@ -1,0 +1,73 @@
+<template>
+  <teleport to="body">
+    <GlassModal :is-visible="isVisible" position="center" no-close-on-outside-click @outside-click="close">
+      <div class="relative w-[640px] max-w-[95vw] p-4">
+        <div class="mb-2 flex flex-col items-center justify-center gap-1">
+          <h2 class="text-xl font-semibold">Default Joystick Mapping</h2>
+        </div>
+        <v-btn icon="mdi-close" size="small" variant="text" class="absolute right-1 top-1 text-lg" @click="close" />
+
+        <p v-if="!evaluation" class="py-8 text-center opacity-70">
+          Connect a vehicle so Cockpit can identify which defaults are available.
+        </p>
+
+        <template v-else>
+          <p v-if="hasImportOffer" class="mt-6 mb-4 text-center text-sm opacity-80">
+            Connected to a {{ evaluation.vehicleTypeName }}. Select which default bindings to import.
+          </p>
+
+          <VehicleDefaultsJoystickMappingContent variant="standalone" />
+
+          <div class="mt-4 flex justify-space-between">
+            <v-btn variant="text" @click="close">Cancel</v-btn>
+            <v-btn :disabled="!hasImportOffer || selectedJoystickRowsCount === 0" variant="text" @click="onImportClick">
+              Import selected
+            </v-btn>
+          </div>
+        </template>
+      </div>
+    </GlassModal>
+  </teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, onUnmounted, provide, watch } from 'vue'
+
+import GlassModal from '@/components/GlassModal.vue'
+import VehicleDefaultsJoystickMappingContent from '@/components/vehicle-defaults/VehicleDefaultsJoystickMappingContent.vue'
+import {
+  useVehicleDefaultsJoystickImport,
+  vehicleDefaultsJoystickImportKey,
+} from '@/composables/vehicleDefaults/useVehicleDefaultsJoystickImport'
+import { useAppInterfaceStore } from '@/stores/appInterface'
+
+const interfaceStore = useAppInterfaceStore()
+const joystickImport = useVehicleDefaultsJoystickImport()
+provide(vehicleDefaultsJoystickImportKey, joystickImport)
+
+const { evaluation, hasImportOffer, selectedJoystickRowsCount, applyImport, refresh } = joystickImport
+
+const isVisible = computed({
+  get: () => interfaceStore.isVehicleDefaultsJoystickImportModalVisible,
+  set: (v) => {
+    interfaceStore.isVehicleDefaultsJoystickImportModalVisible = v
+  },
+})
+
+const close = (): void => {
+  isVisible.value = false
+}
+
+const onImportClick = (): void => {
+  if (applyImport()) close()
+}
+
+watch(isVisible, (visible, wasVisible) => {
+  if (visible && !wasVisible) refresh()
+  interfaceStore.isGlassModalAlwaysOnTop = visible
+})
+
+onUnmounted(() => {
+  interfaceStore.isGlassModalAlwaysOnTop = false
+})
+</script>

--- a/src/components/vehicle-defaults/VehicleDefaultsJoystickMappingContent.vue
+++ b/src/components/vehicle-defaults/VehicleDefaultsJoystickMappingContent.vue
@@ -1,0 +1,125 @@
+<template>
+  <div>
+    <div v-if="evaluation?.joystick.defaultMapping && hasImportOffer" class="space-y-3">
+      <div class="space-y-1.5 text-sm opacity-80">
+        <p class="pl-2 mb-2">
+          Cockpit has a default joystick mapping for {{ evaluation.vehicleTypeName }} with
+          {{ defaultMappingAxisCount }} axis function(s)
+        </p>
+        <ul v-if="!isCurrentMappingBlank" class="list-none space-y-1.5 pl-2">
+          <li class="flex items-start gap-2">
+            <v-icon color="white" size="16" class="mt-0.5 shrink-0">
+              {{ evaluation.joystick.missingAxisFunctions === 0 ? 'mdi-check' : 'mdi-close' }}
+            </v-icon>
+            <span>
+              Your current mapping is missing {{ evaluation.joystick.missingAxisFunctions }} default axis function(s).
+            </span>
+          </li>
+          <li class="flex items-start gap-2">
+            <v-icon color="white" size="16" class="mt-0.5 shrink-0">
+              {{ evaluation.joystick.axisFunctionsWithRangeMismatch === 0 ? 'mdi-check' : 'mdi-close' }}
+            </v-icon>
+            <span>
+              Your current mapping has {{ evaluation.joystick.axisFunctionsWithRangeMismatch }} axis function(s) with a
+              range that differs from the default by more than 5%.
+            </span>
+          </li>
+        </ul>
+      </div>
+
+      <div class="rounded-lg border border-white/10 px-2.5 py-2">
+        <div class="mb-1 flex items-center justify-between">
+          <span class="text-sm font-semibold">Bindings to import ({{ joystickImportRows.length }})</span>
+          <div class="flex gap-1">
+            <v-btn size="x-small" variant="text" @click="selectAllJoystickRows">All</v-btn>
+            <v-btn size="x-small" variant="text" @click="selectNoneJoystickRows">None</v-btn>
+          </div>
+        </div>
+        <div class="max-h-[280px] space-y-1.5 overflow-y-auto pr-0.5">
+          <label
+            v-for="row in joystickImportRows"
+            :key="row.id"
+            class="flex min-h-[52px] cursor-pointer items-center gap-1 rounded-md bg-gray-600/60 px-2 py-1.5"
+          >
+            <v-checkbox
+              v-model="selectedJoystickRowIds"
+              :value="row.id"
+              density="compact"
+              hide-details
+              class="m-0 shrink-0 p-0 [&_.v-label]:hidden [&_.v-selection-control]:min-h-7 [&_.v-selection-control__wrapper]:h-7 [&_.v-selection-control__wrapper]:w-7"
+            />
+            <div class="flex min-h-[52px] min-w-0 flex-1 flex-col">
+              <div class="flex min-h-0 flex-1 flex-col items-center justify-end">
+                <p class="mb-2.5 text-center text-[11px] leading-none text-gray-300/50">{{ row.inputLabel }}</p>
+              </div>
+              <div class="flex w-full shrink-0 items-center justify-center gap-2.5">
+                <span
+                  class="max-w-[42%] flex-[0_1_42%] truncate text-right text-xs leading-snug text-gray-300"
+                  :title="row.fromActionName"
+                >
+                  {{ row.fromActionName }}
+                </span>
+                <v-icon size="16" color="green" class="shrink-0">mdi-arrow-right</v-icon>
+                <span
+                  class="max-w-[42%] flex-[0_1_42%] truncate text-left text-xs leading-snug text-green-400"
+                  :title="row.toActionName"
+                >
+                  {{ row.toActionName }}
+                </span>
+              </div>
+              <div class="min-h-0 flex-1" />
+            </div>
+          </label>
+        </div>
+      </div>
+    </div>
+
+    <div v-else-if="evaluation?.joystick.defaultMapping && !hasImportOffer" class="space-y-3">
+      <p class="my-8 text-sm text-center opacity-80">
+        <template v-if="variant === 'wizard'">
+          Your joystick mapping already matches the default for {{ evaluation.vehicleTypeName }}. Click
+          <strong>Next</strong> to continue to the views group screen.
+        </template>
+        <template v-else-if="!isCurrentMappingBlank">
+          Your joystick mapping matches the default for {{ evaluation.vehicleTypeName }} exactly.
+        </template>
+        <template v-else>
+          Your joystick mapping already matches the default for {{ evaluation.vehicleTypeName }}.
+        </template>
+      </p>
+    </div>
+
+    <div v-else class="py-2 text-center text-sm opacity-80">
+      <template v-if="variant === 'wizard'">
+        No default joystick mapping is available for {{ evaluation?.vehicleTypeName ?? 'this vehicle' }}. Click
+        <strong>Next</strong> to continue.
+      </template>
+      <template v-else>
+        No default joystick mapping is available for {{ evaluation?.vehicleTypeName ?? 'this vehicle' }}.
+      </template>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useVehicleDefaultsJoystickImportInject } from '@/composables/vehicleDefaults/useVehicleDefaultsJoystickImport'
+
+withDefaults(
+  defineProps<{
+    /** Wizard steps reference Next; standalone omits that copy */
+    variant?: 'wizard' | 'standalone'
+  }>(),
+  { variant: 'standalone' }
+)
+
+const {
+  evaluation,
+  hasImportOffer,
+  isCurrentMappingBlank,
+  defaultMappingAxisCount,
+  joystickImportRows,
+  selectedJoystickRowIds,
+  selectAllJoystickRows,
+  selectNoneJoystickRows,
+} = useVehicleDefaultsJoystickImportInject()
+</script>

--- a/src/components/vehicle-defaults/VehicleDefaultsReplaceConfirmationDialog.vue
+++ b/src/components/vehicle-defaults/VehicleDefaultsReplaceConfirmationDialog.vue
@@ -1,0 +1,46 @@
+<template>
+  <v-dialog v-if="modelValue" :model-value="modelValue" max-width="500px" persistent :z-index="5200">
+    <v-card class="rounded-lg" :style="interfaceStore.globalGlassMenuStyles">
+      <v-card-title class="pb-0 pt-4 text-center">
+        <div class="flex items-center justify-center gap-2">
+          <v-icon color="warning" size="24">mdi-alert</v-icon>
+          <h2 class="text-xl font-semibold">Replace existing configuration?</h2>
+        </div>
+      </v-card-title>
+
+      <v-card-text class="px-6 pb-2">
+        <p class="text-center text-sm">
+          This will <strong>permanently delete your current {{ viewsCount }} view(s)</strong> and replace them with the
+          selected default view(s) for {{ vehicleTypeName }}. This action cannot be undone.
+        </p>
+      </v-card-text>
+
+      <v-card-actions class="justify-space-between px-6 pb-4">
+        <v-btn variant="text" @click="$emit('cancel')">Cancel</v-btn>
+        <v-btn color="error" @click="$emit('confirm')">Replace</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+import { useAppInterfaceStore } from '@/stores/appInterface'
+
+defineProps<{
+  /** Whether the confirmation dialog is currently open */
+  modelValue: boolean
+  /** Number of views the user currently has, shown in the warning copy */
+  viewsCount: number
+  /** Friendly vehicle type name shown in the warning copy */
+  vehicleTypeName: string | undefined
+}>()
+
+defineEmits<{
+  /** Emitted when the user confirms the destructive replace */
+  (e: 'confirm'): void
+  /** Emitted when the user cancels the confirmation */
+  (e: 'cancel'): void
+}>()
+
+const interfaceStore = useAppInterfaceStore()
+</script>

--- a/src/components/vehicle-defaults/VehicleDefaultsViewsGroupContent.vue
+++ b/src/components/vehicle-defaults/VehicleDefaultsViewsGroupContent.vue
@@ -1,0 +1,142 @@
+<template>
+  <div>
+    <div v-if="showImportUi" class="space-y-3">
+      <p class="text-sm opacity-80">
+        Cockpit ships with the following default views for {{ evaluation.vehicleTypeName }}. Pick which ones to import,
+        choose how to apply them, then check the preview below.
+      </p>
+
+      <v-card variant="outlined" class="px-3 py-2">
+        <div class="mb-1 flex items-center justify-between">
+          <span class="text-sm font-semibold">
+            Default views ({{ evaluation.views.defaultProfile.views.length }})
+          </span>
+          <div class="flex gap-1">
+            <v-btn size="x-small" variant="text" @click="selectAllDefaultViews">All</v-btn>
+            <v-btn size="x-small" variant="text" @click="selectNoneDefaultViews">None</v-btn>
+          </div>
+        </div>
+        <div class="flex flex-col">
+          <v-checkbox
+            v-for="view in evaluation.views.defaultProfile.views"
+            :key="view.hash"
+            v-model="selectedDefaultViewNames"
+            :value="view.name"
+            density="compact"
+            hide-details
+            class="m-0 p-0"
+          >
+            <template #label>
+              <span class="text-sm">
+                {{ view.name }}
+                <span class="ml-1 text-xs">· {{ view.widgets.length }} widgets</span>
+              </span>
+            </template>
+          </v-checkbox>
+        </div>
+      </v-card>
+
+      <v-card v-if="!isCurrentViewsGroupBlank" variant="outlined" class="px-3 py-2">
+        <div class="mb-1 text-sm font-semibold">How to apply</div>
+        <v-radio-group v-model="viewsMode" hide-details density="compact" class="mt-0">
+          <v-radio value="append">
+            <template #label>
+              <span class="text-sm"> <strong>Append</strong> after your existing view(s) </span>
+            </template>
+          </v-radio>
+          <v-radio value="replace">
+            <template #label>
+              <span class="text-sm"> <strong>Replace</strong> your current view(s) </span>
+            </template>
+          </v-radio>
+        </v-radio-group>
+      </v-card>
+
+      <v-card variant="outlined" class="px-3 py-2">
+        <div class="mb-1 text-sm font-semibold">Views group preview</div>
+        <div class="rounded-md bg-gray-600/60 px-2 py-2">
+          <div class="mb-2 grid grid-cols-[1fr_auto_1fr] gap-x-2.5">
+            <p class="text-right text-[11px] leading-none text-gray-300/50">Before</p>
+            <div class="w-4" />
+            <p class="text-left text-[11px] leading-none text-gray-300/50">After</p>
+          </div>
+          <div class="grid grid-cols-[1fr_auto_1fr] items-center gap-x-2.5">
+            <div class="flex flex-col items-end gap-0.5">
+              <span
+                v-for="(name, index) in viewsPreviewBeforeNames"
+                :key="`before-${index}-${name}`"
+                class="text-right text-xs leading-snug text-gray-300"
+              >
+                {{ name }}
+              </span>
+              <span v-if="viewsPreviewBeforeNames.length === 0" class="text-right text-xs leading-snug text-gray-300">
+                No views
+              </span>
+            </div>
+            <div class="flex self-stretch items-center justify-center px-0.5">
+              <v-icon size="16" color="green" class="shrink-0">mdi-arrow-right</v-icon>
+            </div>
+            <div class="flex flex-col items-start gap-0.5">
+              <span
+                v-for="(name, index) in viewsPreviewAfterNames"
+                :key="`after-${index}-${name}`"
+                class="text-left text-xs leading-snug text-green-400"
+              >
+                {{ name }}
+              </span>
+              <span v-if="viewsPreviewAfterNames.length === 0" class="text-left text-xs leading-snug text-green-400">
+                No views
+              </span>
+            </div>
+          </div>
+        </div>
+      </v-card>
+    </div>
+
+    <div v-else-if="variant === 'wizard' && evaluation?.views.defaultProfile && !hasImportOffer" class="space-y-3">
+      <p class="text-sm text-center opacity-80">
+        Your views group already includes the default views for {{ evaluation.vehicleTypeName }}. Click
+        <strong>Next</strong> to finish.
+      </p>
+    </div>
+
+    <div v-else class="py-2 text-center text-sm opacity-80">
+      <template v-if="variant === 'wizard'">
+        No default views are available for {{ evaluation?.vehicleTypeName ?? 'this vehicle' }}. Click
+        <strong>Next</strong> to finish.
+      </template>
+      <template v-else>
+        No default views are available for {{ evaluation?.vehicleTypeName ?? 'this vehicle' }}.
+      </template>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import { useVehicleDefaultsViewsImportInject } from '@/composables/vehicleDefaults/useVehicleDefaultsViewsImport'
+
+const props = withDefaults(
+  defineProps<{
+    /** Wizard steps reference Next; standalone always shows import UI when defaults exist */
+    variant?: 'wizard' | 'standalone'
+  }>(),
+  { variant: 'standalone' }
+)
+
+const {
+  evaluation,
+  hasDefaultProfile,
+  hasImportOffer,
+  selectedDefaultViewNames,
+  viewsMode,
+  viewsPreviewBeforeNames,
+  viewsPreviewAfterNames,
+  isCurrentViewsGroupBlank,
+  selectAllDefaultViews,
+  selectNoneDefaultViews,
+} = useVehicleDefaultsViewsImportInject()
+
+const showImportUi = computed(() => (props.variant === 'standalone' ? hasDefaultProfile.value : hasImportOffer.value))
+</script>

--- a/src/components/vehicle-defaults/VehicleDefaultsViewsImportModal.vue
+++ b/src/components/vehicle-defaults/VehicleDefaultsViewsImportModal.vue
@@ -1,0 +1,114 @@
+<template>
+  <teleport to="body">
+    <GlassModal :is-visible="isVisible" position="center" no-close-on-outside-click @outside-click="close">
+      <div class="relative w-[640px] max-w-[95vw] p-4">
+        <div class="mb-2 flex flex-col items-center justify-center gap-1">
+          <h2 class="text-xl font-semibold">Default Views</h2>
+        </div>
+        <v-btn icon="mdi-close" size="small" variant="text" class="absolute right-1 top-1 text-lg" @click="close" />
+
+        <p v-if="!evaluation" class="py-8 text-center opacity-70">
+          Connect a vehicle so Cockpit can identify which defaults are available.
+        </p>
+
+        <template v-else>
+          <p v-if="hasDefaultProfile" class="mt-6 mb-4 text-center text-sm opacity-80">
+            Connected to a {{ evaluation.vehicleTypeName }}. Choose which default views to import.
+          </p>
+
+          <VehicleDefaultsViewsGroupContent variant="standalone" />
+
+          <div class="mt-4 flex justify-space-between">
+            <v-btn variant="text" @click="close">Cancel</v-btn>
+            <v-btn
+              :disabled="!hasDefaultProfile || selectedDefaultViewNames.length === 0"
+              variant="text"
+              @click="onImportClick"
+            >
+              Import
+            </v-btn>
+          </div>
+        </template>
+      </div>
+    </GlassModal>
+  </teleport>
+
+  <VehicleDefaultsReplaceConfirmationDialog
+    :model-value="replaceConfirmationVisible"
+    :views-count="currentViewsCount"
+    :vehicle-type-name="evaluation?.vehicleTypeName"
+    @confirm="onConfirmReplace"
+    @cancel="cancelReplace"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed, onUnmounted, provide, watch } from 'vue'
+
+import GlassModal from '@/components/GlassModal.vue'
+import VehicleDefaultsReplaceConfirmationDialog from '@/components/vehicle-defaults/VehicleDefaultsReplaceConfirmationDialog.vue'
+import VehicleDefaultsViewsGroupContent from '@/components/vehicle-defaults/VehicleDefaultsViewsGroupContent.vue'
+import {
+  useVehicleDefaultsViewsImport,
+  vehicleDefaultsViewsImportKey,
+} from '@/composables/vehicleDefaults/useVehicleDefaultsViewsImport'
+import { useAppInterfaceStore } from '@/stores/appInterface'
+
+const interfaceStore = useAppInterfaceStore()
+const viewsImport = useVehicleDefaultsViewsImport()
+provide(vehicleDefaultsViewsImportKey, viewsImport)
+
+const {
+  evaluation,
+  hasDefaultProfile,
+  selectedDefaultViewNames,
+  currentViewsCount,
+  replaceConfirmationVisible,
+  viewsMode,
+  isCurrentViewsGroupBlank,
+  onClickImport,
+  applyImport,
+  confirmReplace,
+  cancelReplace,
+  refresh,
+} = viewsImport
+
+const isVisible = computed({
+  get: () => interfaceStore.isVehicleDefaultsViewsImportModalVisible,
+  set: (v) => {
+    interfaceStore.isVehicleDefaultsViewsImportModalVisible = v
+  },
+})
+
+const close = (): void => {
+  isVisible.value = false
+}
+
+const onImportClick = (): void => {
+  if (viewsMode.value === 'replace' && !isCurrentViewsGroupBlank.value) {
+    onClickImport()
+    return
+  }
+  if (applyImport()) close()
+}
+
+const onConfirmReplace = (): void => {
+  if (confirmReplace()) close()
+}
+
+watch(isVisible, (visible, wasVisible) => {
+  if (visible && !wasVisible) refresh()
+})
+
+watch(
+  [isVisible, replaceConfirmationVisible],
+  ([modalVisible, replaceOpen]) => {
+    interfaceStore.isGlassModalAlwaysOnTop = modalVisible && !replaceOpen
+  },
+  { immediate: true }
+)
+
+onUnmounted(() => {
+  interfaceStore.isGlassModalAlwaysOnTop = false
+})
+</script>

--- a/src/composables/vehicleDefaults/useVehicleDefaultsAutoImportWizard.ts
+++ b/src/composables/vehicleDefaults/useVehicleDefaultsAutoImportWizard.ts
@@ -1,0 +1,234 @@
+import { type InjectionKey, computed, inject, nextTick, ref, watch } from 'vue'
+
+import { useAppInterfaceStore } from '@/stores/appInterface'
+
+import { useVehicleDefaultsJoystickImport } from './useVehicleDefaultsJoystickImport'
+import { useVehicleDefaultsViewsImport } from './useVehicleDefaultsViewsImport'
+import { useVehicleDefaultsHandledFlag } from './vehicleDefaultsAutoImport'
+import { useVehicleDefaultsEvaluation } from './vehicleDefaultsImportShared'
+
+type AutoWizardStep = 'intro' | 'joystick' | 'views' | 'done'
+
+/**
+ * Auto-open vehicle defaults walkthrough: intro, joystick, views, done.
+ * Confirmations (ignore all, finish walkthrough) live in the auto modal only.
+ * @returns {VehicleDefaultsAutoImportWizard} Wizard state and handlers for the auto import modal
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const useVehicleDefaultsAutoImportWizard = () => {
+  const interfaceStore = useAppInterfaceStore()
+  const defaultsHandled = useVehicleDefaultsHandledFlag()
+  const evaluationBundle = useVehicleDefaultsEvaluation()
+  const viewsImport = useVehicleDefaultsViewsImport(evaluationBundle)
+  const joystickImport = useVehicleDefaultsJoystickImport(evaluationBundle)
+
+  const isVisible = computed({
+    get: () => interfaceStore.isVehicleDefaultsAutoImportModalVisible,
+    set: (v) => {
+      interfaceStore.isVehicleDefaultsAutoImportModalVisible = v
+    },
+  })
+
+  const autoWizardStep = ref<AutoWizardStep>('intro')
+  const closeConfirmationVisible = ref(false)
+  const ignoreConfirmationVisible = ref(false)
+
+  const { evaluation } = evaluationBundle
+
+  const hasAnyOffer = computed(() => viewsImport.hasImportOffer.value || joystickImport.hasImportOffer.value)
+
+  const introParagraphs = computed((): string[] => {
+    if (!evaluation.value) return []
+    const vehicleTypeName = evaluation.value.vehicleTypeName
+    return [
+      `Cockpit detected that you are not using the default configuration for your connected ${vehicleTypeName}. ` +
+        `You can import Cockpit's defaults now, or keep your current setup.`,
+      `On the next screens you can review joystick mapping and views group defaults. For views, you may append the ` +
+        `default views after yours or replace your entire views group. For joystick mapping, select which default ` +
+        `bindings to import.`,
+      `This dialog opens automatically only once, the first time we detect this for this vehicle. After you finish ` +
+        `this walkthrough, it will not open on its own again. You can still import defaults later from the Edit menu ` +
+        `(views) or Joystick configuration (import button on the mapping toolbar).`,
+    ]
+  })
+
+  const stepNumbers: Record<AutoWizardStep, number> = { intro: 1, joystick: 2, views: 3, done: 4 }
+  const stepTitles: Record<AutoWizardStep, string> = {
+    intro: 'Default Configuration',
+    joystick: 'Default Joystick Mapping',
+    views: 'Default Views',
+    done: 'All set',
+  }
+
+  const autoWizardStepNumber = computed(() => stepNumbers[autoWizardStep.value])
+  const modalTitle = computed(() => stepTitles[autoWizardStep.value])
+
+  const wizardSecondaryLabel = computed(() => {
+    if (autoWizardStep.value === 'intro') return 'Ignore'
+    if (autoWizardStep.value === 'joystick') {
+      return joystickImport.hasImportOffer.value ? 'Ignore Joystick Mapping defaults' : ''
+    }
+    if (autoWizardStep.value === 'views') {
+      return viewsImport.hasImportOffer.value ? 'Ignore Views Group defaults' : ''
+    }
+    return ''
+  })
+
+  const wizardPrimaryLabel = computed(() => {
+    if (autoWizardStep.value === 'intro') return 'Next'
+    if (autoWizardStep.value === 'joystick') {
+      return joystickImport.hasImportOffer.value ? 'Import Joystick Mapping defaults' : 'Next'
+    }
+    if (autoWizardStep.value === 'views') {
+      return viewsImport.hasImportOffer.value ? 'Import Views Group defaults' : 'Next'
+    }
+    return 'Done'
+  })
+
+  const wizardShowSecondaryButton = computed(() => {
+    if (autoWizardStep.value === 'intro') return true
+    if (autoWizardStep.value === 'joystick') return joystickImport.hasImportOffer.value
+    if (autoWizardStep.value === 'views') return viewsImport.hasImportOffer.value
+    return false
+  })
+
+  const wizardPrimaryDisabled = computed(() => {
+    if (autoWizardStep.value === 'joystick' && joystickImport.hasImportOffer.value) {
+      return joystickImport.selectedJoystickRowsCount.value === 0
+    }
+    if (autoWizardStep.value === 'views' && viewsImport.hasImportOffer.value) {
+      return viewsImport.selectedDefaultViewNames.value.length === 0
+    }
+    return false
+  })
+
+  const resetWizard = (): void => {
+    autoWizardStep.value = 'intro'
+    viewsImport.refresh()
+    joystickImport.refresh()
+  }
+
+  const finishAutoWizard = (): void => {
+    defaultsHandled.value = true
+    nextTick(() => {
+      isVisible.value = false
+    })
+  }
+
+  const onWizardIntroIgnore = (): void => {
+    ignoreConfirmationVisible.value = true
+  }
+
+  const confirmIgnoreAll = (): void => {
+    ignoreConfirmationVisible.value = false
+    finishAutoWizard()
+  }
+
+  const cancelIgnoreAll = (): void => {
+    ignoreConfirmationVisible.value = false
+  }
+
+  const onWizardPrimaryAction = (): void => {
+    switch (autoWizardStep.value) {
+      case 'intro':
+        autoWizardStep.value = 'joystick'
+        break
+      case 'joystick':
+        if (joystickImport.hasImportOffer.value) joystickImport.applyImport()
+        autoWizardStep.value = 'views'
+        break
+      case 'views':
+        if (!viewsImport.hasImportOffer.value) {
+          autoWizardStep.value = 'done'
+          break
+        }
+        if (viewsImport.viewsMode.value === 'replace' && !viewsImport.isCurrentViewsGroupBlank.value) {
+          viewsImport.onClickImport()
+          break
+        }
+        if (viewsImport.applyImport()) autoWizardStep.value = 'done'
+        break
+      case 'done':
+        finishAutoWizard()
+        break
+    }
+  }
+
+  const onWizardSecondaryAction = (): void => {
+    switch (autoWizardStep.value) {
+      case 'intro':
+        onWizardIntroIgnore()
+        break
+      case 'joystick':
+        autoWizardStep.value = 'views'
+        break
+      case 'views':
+        autoWizardStep.value = 'done'
+        break
+      case 'done':
+        break
+    }
+  }
+
+  const confirmViewsReplace = (): void => {
+    if (!viewsImport.confirmReplace()) return
+    if (autoWizardStep.value === 'views') autoWizardStep.value = 'done'
+  }
+
+  watch(isVisible, (visible, wasVisible) => {
+    if (visible && !wasVisible) resetWizard()
+    if (!visible) autoWizardStep.value = 'intro'
+  })
+
+  const requestCloseModal = (): void => {
+    if (!hasAnyOffer.value || autoWizardStep.value === 'done') {
+      if (autoWizardStep.value === 'done') finishAutoWizard()
+      else isVisible.value = false
+      return
+    }
+    closeConfirmationVisible.value = true
+  }
+
+  return {
+    interfaceStore,
+    isVisible,
+    evaluation,
+    introParagraphs,
+    autoWizardStep,
+    autoWizardStepNumber,
+    modalTitle,
+    hasAnyOffer,
+    closeConfirmationVisible,
+    ignoreConfirmationVisible,
+    wizardSecondaryLabel,
+    wizardPrimaryLabel,
+    wizardShowSecondaryButton,
+    wizardPrimaryDisabled,
+    onWizardPrimaryAction,
+    onWizardSecondaryAction,
+    confirmIgnoreAll,
+    cancelIgnoreAll,
+    requestCloseModal,
+    confirmViewsReplace,
+    viewsImport,
+    joystickImport,
+  }
+}
+
+export type VehicleDefaultsAutoImportWizard = ReturnType<typeof useVehicleDefaultsAutoImportWizard>
+
+export const vehicleDefaultsAutoImportWizardKey: InjectionKey<VehicleDefaultsAutoImportWizard> = Symbol(
+  'vehicleDefaultsAutoImportWizard'
+)
+
+/**
+ * Injects the auto defaults walkthrough state provided by the auto import modal.
+ * @returns {VehicleDefaultsAutoImportWizard} Shared auto wizard state
+ */
+export const useVehicleDefaultsAutoImportWizardInject = (): VehicleDefaultsAutoImportWizard => {
+  const context = inject(vehicleDefaultsAutoImportWizardKey)
+  if (!context) {
+    throw new Error('useVehicleDefaultsAutoImportWizardInject must be used within VehicleDefaultsAutoImportModal')
+  }
+  return context
+}

--- a/src/composables/vehicleDefaults/useVehicleDefaultsJoystickImport.ts
+++ b/src/composables/vehicleDefaults/useVehicleDefaultsJoystickImport.ts
@@ -1,0 +1,121 @@
+import { type InjectionKey, computed, inject, ref } from 'vue'
+
+import { openSnackbar } from '@/composables/snackbar'
+import { OtherProtocol } from '@/libs/joystick/protocols/other'
+import { cloneMapping } from '@/migration/default-profile-importer'
+import { useControllerStore } from '@/stores/controller'
+
+import {
+  type VehicleDefaultsEvaluationBundle,
+  buildJoystickImportRows,
+  useVehicleDefaultsEvaluation,
+} from './vehicleDefaultsImportShared'
+
+/**
+ * Joystick defaults import state and actions, shared by the manual modal and auto wizard.
+ * @param {VehicleDefaultsEvaluationBundle} [evaluationBundle] - Optional shared evaluation from the auto wizard
+ * @returns {VehicleDefaultsJoystickImport} Joystick import state and handlers
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const useVehicleDefaultsJoystickImport = (evaluationBundle?: VehicleDefaultsEvaluationBundle) => {
+  const controllerStore = useControllerStore()
+  const bundle = evaluationBundle ?? useVehicleDefaultsEvaluation()
+  const { evaluation, isCurrentMappingBlank, refreshEvaluation } = bundle
+
+  const selectedJoystickRowIds = ref<string[]>([])
+
+  const joystickImportRows = computed(() => {
+    const defaultMapping = evaluation.value?.joystick.defaultMapping
+    if (!defaultMapping) return []
+    return buildJoystickImportRows(controllerStore.protocolMapping, defaultMapping)
+  })
+
+  const hasImportOffer = computed(() => joystickImportRows.value.length > 0)
+
+  const selectedJoystickRows = computed(() =>
+    joystickImportRows.value.filter((row) => selectedJoystickRowIds.value.includes(row.id))
+  )
+
+  const selectedJoystickRowsCount = computed(() => selectedJoystickRows.value.length)
+
+  const defaultMappingAxisCount = computed(() => {
+    const map = evaluation.value?.joystick.defaultMapping
+    if (!map) return 0
+    return Object.values(map.axesCorrespondencies).filter((axis) => axis.action.id !== OtherProtocol.no_function).length
+  })
+
+  const selectAllJoystickRows = (): void => {
+    selectedJoystickRowIds.value = joystickImportRows.value.map((row) => row.id)
+  }
+
+  const selectNoneJoystickRows = (): void => {
+    selectedJoystickRowIds.value = []
+  }
+
+  const refresh = (): void => {
+    refreshEvaluation()
+    selectAllJoystickRows()
+  }
+
+  const applyImport = (): boolean => {
+    const defaultMapping = evaluation.value?.joystick.defaultMapping
+    if (!defaultMapping || selectedJoystickRowsCount.value === 0) return false
+
+    const nextMapping = cloneMapping(controllerStore.protocolMapping)
+    const defaultClone = cloneMapping(defaultMapping)
+    for (const row of selectedJoystickRows.value) {
+      if (row.axisKey !== undefined) {
+        nextMapping.axesCorrespondencies[row.axisKey as unknown as keyof typeof nextMapping.axesCorrespondencies] =
+          defaultClone.axesCorrespondencies[row.axisKey as unknown as keyof typeof defaultClone.axesCorrespondencies]
+        continue
+      }
+      if (row.modifier === undefined || row.buttonKey === undefined) continue
+      nextMapping.buttonsCorrespondencies[row.modifier as keyof typeof nextMapping.buttonsCorrespondencies][
+        row.buttonKey as unknown as number
+      ] =
+        defaultClone.buttonsCorrespondencies[row.modifier as keyof typeof defaultClone.buttonsCorrespondencies][
+          row.buttonKey as unknown as number
+        ]
+    }
+    controllerStore.protocolMapping = nextMapping
+
+    openSnackbar({
+      message: `Imported ${selectedJoystickRowsCount.value} default joystick binding(s) for ${evaluation.value?.vehicleTypeName}.`,
+      variant: 'success',
+      duration: 5000,
+    })
+    return true
+  }
+
+  return {
+    evaluation,
+    isCurrentMappingBlank,
+    selectedJoystickRowIds,
+    joystickImportRows,
+    hasImportOffer,
+    selectedJoystickRowsCount,
+    defaultMappingAxisCount,
+    refresh,
+    selectAllJoystickRows,
+    selectNoneJoystickRows,
+    applyImport,
+  }
+}
+
+export type VehicleDefaultsJoystickImport = ReturnType<typeof useVehicleDefaultsJoystickImport>
+
+export const vehicleDefaultsJoystickImportKey: InjectionKey<VehicleDefaultsJoystickImport> = Symbol(
+  'vehicleDefaultsJoystickImport'
+)
+
+/**
+ * Injects joystick defaults import state provided by a parent modal.
+ * @returns {VehicleDefaultsJoystickImport} Shared joystick import state
+ */
+export const useVehicleDefaultsJoystickImportInject = (): VehicleDefaultsJoystickImport => {
+  const context = inject(vehicleDefaultsJoystickImportKey)
+  if (!context) {
+    throw new Error('useVehicleDefaultsJoystickImportInject must be used within a vehicle defaults joystick provider')
+  }
+  return context
+}

--- a/src/composables/vehicleDefaults/useVehicleDefaultsViewsImport.ts
+++ b/src/composables/vehicleDefaults/useVehicleDefaultsViewsImport.ts
@@ -1,0 +1,155 @@
+import { type InjectionKey, computed, inject, nextTick, ref } from 'vue'
+
+import { openSnackbar } from '@/composables/snackbar'
+import { buildViewsGroupAfterImport } from '@/migration/default-profile-importer'
+import { useWidgetManagerStore } from '@/stores/widgetManager'
+
+import { type VehicleDefaultsEvaluationBundle, useVehicleDefaultsEvaluation } from './vehicleDefaultsImportShared'
+
+/**
+ * Views-group defaults import state and actions, shared by the manual modal and auto wizard.
+ * @param {VehicleDefaultsEvaluationBundle} [evaluationBundle] - Optional shared evaluation from the auto wizard
+ * @returns {VehicleDefaultsViewsImport} Views import state and handlers
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const useVehicleDefaultsViewsImport = (evaluationBundle?: VehicleDefaultsEvaluationBundle) => {
+  const widgetStore = useWidgetManagerStore()
+  const bundle = evaluationBundle ?? useVehicleDefaultsEvaluation()
+  const { evaluation, isCurrentViewsGroupBlank, currentViewsCount, refreshEvaluation } = bundle
+
+  const selectedDefaultViewNames = ref<string[]>([])
+  const viewsMode = ref<'append' | 'replace'>('append')
+  const replaceConfirmationVisible = ref(false)
+
+  const hasDefaultProfile = computed(() => !!evaluation.value?.views.defaultProfile)
+  /** True when the auto wizard should offer import (name-match heuristic may skip). */
+  const hasImportOffer = computed(() => evaluation.value?.views.action === 'offer')
+
+  const effectiveViewsImportMode = computed((): 'append' | 'replace' =>
+    isCurrentViewsGroupBlank.value ? 'replace' : viewsMode.value
+  )
+
+  const previewViewsGroupAfterImport = computed(() => {
+    const defaultProfile = evaluation.value?.views.defaultProfile
+    if (!defaultProfile) return null
+    return buildViewsGroupAfterImport(
+      widgetStore.viewsGroup,
+      defaultProfile,
+      selectedDefaultViewNames.value,
+      viewsMode.value,
+      isCurrentViewsGroupBlank.value
+    )
+  })
+
+  const viewsPreviewBeforeNames = computed(() => widgetStore.viewsGroup.views.map((view) => view.name))
+
+  const viewsPreviewAfterNames = computed((): string[] => {
+    if (selectedDefaultViewNames.value.length === 0) {
+      return effectiveViewsImportMode.value === 'replace' ? [] : viewsPreviewBeforeNames.value
+    }
+    const profile = previewViewsGroupAfterImport.value
+    if (!profile) return []
+    return profile.views.map((view) => view.name)
+  })
+
+  const selectAllDefaultViews = (): void => {
+    selectedDefaultViewNames.value = evaluation.value?.views.defaultProfile?.views.map((view) => view.name) ?? []
+  }
+
+  const selectNoneDefaultViews = (): void => {
+    selectedDefaultViewNames.value = []
+  }
+
+  const refresh = (): void => {
+    refreshEvaluation()
+    selectAllDefaultViews()
+    viewsMode.value = isCurrentViewsGroupBlank.value ? 'replace' : 'append'
+  }
+
+  const selectFirstViewOfCurrentGroup = (): void => {
+    const firstVisible = widgetStore.viewsGroup.views.find((view) => view.visible) ?? widgetStore.viewsGroup.views[0]
+    if (firstVisible) widgetStore.selectView(firstVisible)
+  }
+
+  const applyImport = (): boolean => {
+    const defaultProfile = evaluation.value?.views.defaultProfile
+    if (!defaultProfile || selectedDefaultViewNames.value.length === 0) return false
+
+    const effectiveMode = effectiveViewsImportMode.value
+    widgetStore.viewsGroup = buildViewsGroupAfterImport(
+      widgetStore.viewsGroup,
+      defaultProfile,
+      selectedDefaultViewNames.value,
+      viewsMode.value,
+      isCurrentViewsGroupBlank.value
+    )
+
+    if (effectiveMode === 'replace') {
+      nextTick(() => selectFirstViewOfCurrentGroup())
+    }
+
+    openSnackbar({
+      message:
+        effectiveMode === 'replace'
+          ? `Imported default views for ${evaluation.value?.vehicleTypeName}.`
+          : `Appended ${selectedDefaultViewNames.value.length} default view(s) for ${evaluation.value?.vehicleTypeName}.`,
+      variant: 'success',
+      duration: 5000,
+    })
+    return true
+  }
+
+  const onClickImport = (): void => {
+    if (viewsMode.value === 'replace' && !isCurrentViewsGroupBlank.value) {
+      replaceConfirmationVisible.value = true
+      return
+    }
+    applyImport()
+  }
+
+  const confirmReplace = (): boolean => {
+    replaceConfirmationVisible.value = false
+    return applyImport()
+  }
+
+  const cancelReplace = (): void => {
+    replaceConfirmationVisible.value = false
+  }
+
+  return {
+    evaluation,
+    isCurrentViewsGroupBlank,
+    currentViewsCount,
+    selectedDefaultViewNames,
+    viewsMode,
+    hasDefaultProfile,
+    hasImportOffer,
+    viewsPreviewBeforeNames,
+    viewsPreviewAfterNames,
+    replaceConfirmationVisible,
+    refresh,
+    selectAllDefaultViews,
+    selectNoneDefaultViews,
+    onClickImport,
+    applyImport,
+    confirmReplace,
+    cancelReplace,
+  }
+}
+
+export type VehicleDefaultsViewsImport = ReturnType<typeof useVehicleDefaultsViewsImport>
+
+export const vehicleDefaultsViewsImportKey: InjectionKey<VehicleDefaultsViewsImport> =
+  Symbol('vehicleDefaultsViewsImport')
+
+/**
+ * Injects views defaults import state provided by a parent modal.
+ * @returns {VehicleDefaultsViewsImport} Shared views import state
+ */
+export const useVehicleDefaultsViewsImportInject = (): VehicleDefaultsViewsImport => {
+  const context = inject(vehicleDefaultsViewsImportKey)
+  if (!context) {
+    throw new Error('useVehicleDefaultsViewsImportInject must be used within a vehicle defaults views provider')
+  }
+  return context
+}

--- a/src/composables/vehicleDefaults/vehicleDefaultsAutoImport.ts
+++ b/src/composables/vehicleDefaults/vehicleDefaultsAutoImport.ts
@@ -1,0 +1,94 @@
+import { type Ref, onUnmounted } from 'vue'
+
+import { useBlueOsStorage } from '@/composables/settingsSyncer'
+import { openSnackbar } from '@/composables/snackbar'
+import {
+  buildFreshViewsGroupFromDefault,
+  buildReplacementMapping,
+  evaluateDefaults,
+} from '@/migration/default-profile-importer'
+import { useAppInterfaceStore } from '@/stores/appInterface'
+import { useControllerStore } from '@/stores/controller'
+import { useMainVehicleStore } from '@/stores/mainVehicle'
+import { useWidgetManagerStore } from '@/stores/widgetManager'
+
+/**
+ * Single source for the per-vehicle "the user already handled the defaults walkthrough" flag.
+ * Backed by {@link useBlueOsStorage}, so settings-v2 scopes it per (user, vehicle) automatically.
+ * @returns {Ref<boolean>} Reactive flag; set to true to suppress the auto walkthrough for this vehicle
+ */
+export const useVehicleDefaultsHandledFlag = (): Ref<boolean> =>
+  useBlueOsStorage<boolean>('cockpit-vehicle-defaults-handled', false)
+
+/**
+ * Wires the per-vehicle defaults flow to the `vehicle-sync-complete` event.
+ *
+ * Behaviour, evaluated on every sync-complete event:
+ * - If the per-vehicle `cockpit-vehicle-defaults-handled` flag is set, do nothing.
+ * - Otherwise run the evaluator, silently auto-import any side that comes back as `auto-import`
+ *   (with a per-side success snackbar), then re-evaluate. Open the auto import modal when any side
+ *   still says `offer`; if nothing is left to offer, just persist the handled flag.
+ *
+ * The flag lives in `useBlueOsStorage`, so settings-v2 scopes it automatically to the current
+ * (user, vehicle) pair — no per-vehicle-type bookkeeping is needed.
+ */
+export const useVehicleDefaultsAutoImport = (): void => {
+  const widgetStore = useWidgetManagerStore()
+  const controllerStore = useControllerStore()
+  const interfaceStore = useAppInterfaceStore()
+  const mainVehicleStore = useMainVehicleStore()
+  const defaultsHandled = useVehicleDefaultsHandledFlag()
+
+  const handleSyncComplete = (): void => {
+    try {
+      if (defaultsHandled.value) return
+
+      const vehicleType = mainVehicleStore.vehicleType
+      if (vehicleType === undefined) return
+
+      let evaluation = evaluateDefaults(vehicleType, widgetStore.viewsGroup, controllerStore.protocolMapping)
+
+      if (evaluation.views.action === 'auto-import' && evaluation.views.defaultProfile) {
+        widgetStore.viewsGroup = buildFreshViewsGroupFromDefault(evaluation.views.defaultProfile)
+        openSnackbar({
+          message: `Imported default views for ${evaluation.vehicleTypeName}.`,
+          variant: 'success',
+          duration: 5000,
+        })
+      }
+
+      if (evaluation.joystick.action === 'auto-import' && evaluation.joystick.defaultMapping) {
+        controllerStore.protocolMapping = buildReplacementMapping(evaluation.joystick.defaultMapping)
+        openSnackbar({
+          message: `Imported default joystick mapping for ${evaluation.vehicleTypeName}.`,
+          variant: 'success',
+          duration: 5000,
+        })
+      }
+
+      // Re-evaluate after auto-imports so we don't open the modal for a side we just resolved.
+      evaluation = evaluateDefaults(vehicleType, widgetStore.viewsGroup, controllerStore.protocolMapping)
+
+      const stillNeedsDecision = evaluation.views.action === 'offer' || evaluation.joystick.action === 'offer'
+      if (stillNeedsDecision) {
+        if (
+          interfaceStore.isVehicleDefaultsViewsImportModalVisible ||
+          interfaceStore.isVehicleDefaultsJoystickImportModalVisible
+        ) {
+          return
+        }
+        interfaceStore.openVehicleDefaultsAutoImport()
+      } else {
+        defaultsHandled.value = true
+      }
+    } catch (error) {
+      // A failure in the defaults flow must never wipe the user's current profile or block startup.
+      console.error('Failed to evaluate vehicle defaults after sync.', error)
+    }
+  }
+
+  window.addEventListener('vehicle-sync-complete', handleSyncComplete)
+  onUnmounted(() => {
+    window.removeEventListener('vehicle-sync-complete', handleSyncComplete)
+  })
+}

--- a/src/composables/vehicleDefaults/vehicleDefaultsImportShared.ts
+++ b/src/composables/vehicleDefaults/vehicleDefaultsImportShared.ts
@@ -1,0 +1,167 @@
+import { type Ref, ref } from 'vue'
+
+import { OtherProtocol } from '@/libs/joystick/protocols/other'
+import {
+  type DefaultsEvaluation,
+  evaluateDefaults,
+  isMappingBlank,
+  isViewsGroupBlank,
+} from '@/migration/default-profile-importer'
+import { useControllerStore } from '@/stores/controller'
+import { useMainVehicleStore } from '@/stores/mainVehicle'
+import { useWidgetManagerStore } from '@/stores/widgetManager'
+import type { JoystickProtocolActionsMapping } from '@/types/joystick'
+
+/** One importable joystick binding shown in the defaults import UI */
+export interface JoystickImportRow {
+  /** Unique row identifier (axis or button slot) */
+  id: string
+  /** Axis index when this row describes an axis binding */
+  axisKey?: string
+  /** Button modifier key when this row describes a button binding */
+  modifier?: string
+  /** Button index when this row describes a button binding */
+  buttonKey?: number
+  /** Display label for the input slot (e.g. "Axis 0", "Button 3 (regular)") */
+  inputLabel: string
+  /** Current function name bound to this input */
+  fromActionName: string
+  /** Default function name that would be imported */
+  toActionName: string
+}
+
+type JoystickMappingActionRef = {
+  /**
+   * Protocol action reference
+   */
+  action: {
+    /**
+     * Protocol action ID
+     */
+    id: string
+    /**
+     * Protocol action name
+     */
+    name: string
+  }
+}
+
+const signed = (n: number): string => (n >= 0 ? `+${n}` : `${n}`)
+
+/** Reactive bundle returned by {@link useVehicleDefaultsEvaluation}, shared by the auto wizard and the manual modals. */
+export interface VehicleDefaultsEvaluationBundle {
+  /** Current defaults evaluation for the connected vehicle, or null when no vehicle is connected */
+  evaluation: Ref<DefaultsEvaluation | null>
+  /** True when the user's current views group still matches the blank template */
+  isCurrentViewsGroupBlank: Ref<boolean>
+  /** True when the user's current joystick mapping still matches the blank template */
+  isCurrentMappingBlank: Ref<boolean>
+  /** Number of views currently in the user's group, used for "replace N views" copy */
+  currentViewsCount: Ref<number>
+  /** Re-runs the evaluation against the current stores; call when a modal opens */
+  refreshEvaluation: () => void
+}
+
+/**
+ * Builds the list of joystick bindings that differ from the vehicle default mapping.
+ * @param {JoystickProtocolActionsMapping} currentMapping - The user's current mapping
+ * @param {JoystickProtocolActionsMapping} defaultMapping - The vehicle-type default mapping
+ * @returns {JoystickImportRow[]} Rows to show in the import UI
+ */
+export const buildJoystickImportRows = (
+  currentMapping: JoystickProtocolActionsMapping,
+  defaultMapping: JoystickProtocolActionsMapping
+): JoystickImportRow[] => {
+  const rows: JoystickImportRow[] = []
+
+  const pushAxisDiff = (axisKey: string, defaultCorr: (typeof defaultMapping.axesCorrespondencies)[string]): void => {
+    const currentCorr =
+      currentMapping.axesCorrespondencies[axisKey as unknown as keyof typeof currentMapping.axesCorrespondencies]
+    const defaultId = defaultCorr.action.id
+    const currentId = currentCorr?.action.id ?? OtherProtocol.no_function
+    if (defaultId === currentId && currentCorr) {
+      if (currentCorr.min !== defaultCorr.min || currentCorr.max !== defaultCorr.max) {
+        rows.push({
+          id: `axis-${axisKey}`,
+          axisKey,
+          inputLabel: `Axis ${axisKey}`,
+          fromActionName: `${currentCorr.action.name} (${signed(currentCorr.min)} / ${signed(currentCorr.max)})`,
+          toActionName: `${defaultCorr.action.name} (${signed(defaultCorr.min)} / ${signed(defaultCorr.max)})`,
+        })
+      }
+      return
+    }
+    if (defaultId === OtherProtocol.no_function && currentId === OtherProtocol.no_function) return
+    rows.push({
+      id: `axis-${axisKey}`,
+      axisKey,
+      inputLabel: `Axis ${axisKey}`,
+      fromActionName: currentCorr?.action.name ?? 'Unassigned',
+      toActionName: defaultCorr.action.name,
+    })
+  }
+
+  const pushButtonDiff = (
+    modKey: string,
+    btnKey: string,
+    defaultBtn: JoystickMappingActionRef,
+    currentBtn?: JoystickMappingActionRef
+  ): void => {
+    const defaultId = defaultBtn.action.id
+    const currentId = currentBtn?.action.id ?? OtherProtocol.no_function
+    if (defaultId === currentId) return
+    if (defaultId === OtherProtocol.no_function && currentId === OtherProtocol.no_function) return
+    rows.push({
+      id: `btn-${modKey}-${btnKey}`,
+      modifier: modKey,
+      buttonKey: Number(btnKey),
+      inputLabel: `Button ${btnKey} (${modKey})`,
+      fromActionName: currentBtn?.action.name ?? 'Unassigned',
+      toActionName: defaultBtn.action.name,
+    })
+  }
+
+  for (const [axisKey, defaultCorr] of Object.entries(defaultMapping.axesCorrespondencies)) {
+    pushAxisDiff(axisKey, defaultCorr)
+  }
+
+  for (const [modKey, defaultButtons] of Object.entries(defaultMapping.buttonsCorrespondencies)) {
+    const currentButtons =
+      currentMapping.buttonsCorrespondencies[modKey as keyof typeof currentMapping.buttonsCorrespondencies]
+    for (const [btnKey, defaultBtn] of Object.entries(defaultButtons)) {
+      const currentBtn = currentButtons?.[btnKey as unknown as number]
+      pushButtonDiff(modKey, btnKey, defaultBtn, currentBtn)
+    }
+  }
+
+  return rows
+}
+
+/**
+ * Loads the defaults evaluation for the connected vehicle and related UI flags.
+ * @returns {VehicleDefaultsEvaluationBundle} Evaluation state and a refresh helper for when the modal opens
+ */
+export const useVehicleDefaultsEvaluation = (): VehicleDefaultsEvaluationBundle => {
+  const widgetStore = useWidgetManagerStore()
+  const controllerStore = useControllerStore()
+  const mainVehicleStore = useMainVehicleStore()
+
+  const evaluation = ref<DefaultsEvaluation | null>(null)
+  const isCurrentViewsGroupBlank = ref(false)
+  const isCurrentMappingBlank = ref(false)
+  const currentViewsCount = ref(0)
+
+  const refreshEvaluation = (): void => {
+    const vehicleType = mainVehicleStore.vehicleType
+    if (vehicleType === undefined) {
+      evaluation.value = null
+      return
+    }
+    evaluation.value = evaluateDefaults(vehicleType, widgetStore.viewsGroup, controllerStore.protocolMapping)
+    isCurrentViewsGroupBlank.value = isViewsGroupBlank(widgetStore.viewsGroup)
+    isCurrentMappingBlank.value = isMappingBlank(controllerStore.protocolMapping)
+    currentViewsCount.value = widgetStore.viewsGroup.views.length
+  }
+
+  return { evaluation, isCurrentViewsGroupBlank, isCurrentMappingBlank, currentViewsCount, refreshEvaluation }
+}

--- a/src/migration/default-profile-importer.ts
+++ b/src/migration/default-profile-importer.ts
@@ -7,18 +7,39 @@ import {
   cockpitStandardToProtocols,
   defaultProtocolMappingVehicleCorrespondency,
 } from '@/assets/joystick-profiles'
-import { openSnackbar } from '@/composables/snackbar'
 import { MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import { OtherProtocol } from '@/libs/joystick/protocols/other'
-import { settingsManager } from '@/libs/settings-management'
 import type { JoystickProtocolActionsMapping } from '@/types/joystick'
-import type { Profile } from '@/types/widgets'
+import type { Profile, View } from '@/types/widgets'
 
 // Proxy-safe deep clone; structuredClone can't handle Vue reactivity wrappers or function references that
 // may end up inside the stored mappings/views (seen in the wild when importing defaults crashes the renderer).
 const safeClone = <T>(value: T): T => JSON.parse(JSON.stringify(toRaw(value)))
 
-const defaultsImportedKey = 'cockpit-defaults-imported-for-vehicle-type'
+/**
+ * Proxy-safe deep clone of a joystick mapping. Use this whenever the import flow needs a detached
+ * copy (current or default) before mutating it.
+ * @param {JoystickProtocolActionsMapping} mapping - The mapping to clone
+ * @returns {JoystickProtocolActionsMapping} A detached copy
+ */
+export const cloneMapping = (mapping: JoystickProtocolActionsMapping): JoystickProtocolActionsMapping =>
+  safeClone(mapping)
+
+/**
+ * Assigns fresh hashes to a view and every widget in it so Vue remounts after a profile replace.
+ * @param {View} view - View to re-hash
+ */
+const rehashViewAndWidgets = (view: View): void => {
+  view.hash = uuid4()
+  for (const widget of view.widgets) {
+    widget.hash = uuid4()
+  }
+  for (const container of view.miniWidgetContainers) {
+    for (const miniWidget of container.widgets) {
+      miniWidget.hash = uuid4()
+    }
+  }
+}
 
 const getDefaultViewsGroup = (vehicleType: MavType): Profile | undefined => {
   // @ts-ignore: We know that the value is a string
@@ -60,7 +81,12 @@ export const isMappingBlank = (mapping: JoystickProtocolActionsMapping): boolean
   return true
 }
 
-const vehicleTypeName = (vehicleType: MavType): string => {
+/**
+ * Human-readable label for a vehicle type, used in snackbars and dialog copy.
+ * @param {MavType} vehicleType - The vehicle type
+ * @returns {string} Friendly label, falling back to the raw enum value
+ */
+export const vehicleTypeName = (vehicleType: MavType): string => {
   const names: Partial<Record<MavType, string>> = {
     [MavType.MAV_TYPE_SUBMARINE]: 'Submarine / ROV',
     [MavType.MAV_TYPE_SURFACE_BOAT]: 'Boat',
@@ -70,145 +96,302 @@ const vehicleTypeName = (vehicleType: MavType): string => {
 }
 
 /**
- * Merges a user's modified joystick mapping with the vehicle default.
- * All axis values come from the default. For buttons, user-assigned functions are kept,
- * and remaining no_function slots are filled from the default (if not already assigned).
- * @param {JoystickProtocolActionsMapping} userMapping - The user's current mapping
- * @param {JoystickProtocolActionsMapping} defaultMapping - The vehicle type default
- * @returns {JoystickProtocolActionsMapping} The merged mapping
+ * The action the defaults flow should take for a given side (views or joystick).
+ * - `auto-import`: the user has no real configuration, silently import the defaults.
+ * - `offer`: the user has some configuration but it doesn't sufficiently overlap with the defaults,
+ *   present them with a dialog so they can opt in.
+ * - `skip`: either there is no default for this vehicle type, or the user already has the defaults
+ *   (or something close enough); do nothing.
  */
-const mergeJoystickMappings = (
-  userMapping: JoystickProtocolActionsMapping,
+export type DefaultsAction = 'auto-import' | 'offer' | 'skip'
+
+/**
+ * Evaluation result for the views side of the defaults flow.
+ */
+export interface ViewsDefaultsEvaluation {
+  /** The action to take for the views group */
+  action: DefaultsAction
+  /** The default views group available for this vehicle type, when one exists */
+  defaultProfile?: Profile
+}
+
+/**
+ * Evaluation result for the joystick side of the defaults flow.
+ *
+ * The decision intentionally ignores buttons — only axes are considered, because axes drive motors
+ * and an axis mapping that deviates meaningfully from the vehicle default can be dangerous.
+ */
+export interface JoystickDefaultsEvaluation {
+  /** The action to take for the joystick mapping */
+  action: DefaultsAction
+  /** The default joystick mapping available for this vehicle type, when one exists */
+  defaultMapping?: JoystickProtocolActionsMapping
+  /** Default axis functions (excluding no_function) not present anywhere in the user's axes */
+  missingAxisFunctions: number
+  /** Default axis functions present in the user's axes but with a min or max outside the allowed tolerance of the default */
+  axisFunctionsWithRangeMismatch: number
+}
+
+/**
+ * Combined evaluation describing what the defaults-import flow should do for a vehicle.
+ */
+export interface DefaultsEvaluation {
+  /** The vehicle type that was evaluated */
+  vehicleType: MavType
+  /** Friendly label for the vehicle type, suitable for UI copy */
+  vehicleTypeName: string
+  /** Evaluation for the views side */
+  views: ViewsDefaultsEvaluation
+  /** Evaluation for the joystick side */
+  joystick: JoystickDefaultsEvaluation
+}
+
+/**
+ * Returns true when the user already has at least one view whose name matches one of the default
+ * views' names. Used as a heuristic for "the user already has these defaults (possibly customized)".
+ * @param {Profile} currentViewsGroup - The user's current ViewsGroup
+ * @param {Profile} defaultProfile - The vehicle-type default profile
+ * @returns {boolean} True when at least one name matches
+ */
+export const userViewNamesMatchAnyDefault = (currentViewsGroup: Profile, defaultProfile: Profile): boolean => {
+  const userNames = new Set(currentViewsGroup.views.map((v) => v.name))
+  return defaultProfile.views.some((v) => userNames.has(v.name))
+}
+
+/**
+ * Maximum allowed deviation for either endpoint (min or max) of a user-mapped axis range,
+ * expressed as a fraction of the default's full range `|defaultMax - defaultMin|`. Applied as a
+ * single absolute tolerance to both endpoints, so the comparison stays well-defined even when the
+ * default endpoint is 0 (e.g. the ROV `axis_z` max).
+ *
+ * Example: default min = +1000, max = 0 → range = 1000, tolerance = 50 → the user's min must lie
+ * in [950, 1050] and max in [-50, +50].
+ */
+const axisRangeTolerance = 0.05
+
+/**
+ * Counts the default axis functions (excluding `no_function`) that don't appear on any of the
+ * user's axes. Position is ignored — the user is free to put `axis_x` on whichever physical axis
+ * they prefer, as long as it's present somewhere.
+ * @param {JoystickProtocolActionsMapping} currentMapping - The user's current mapping
+ * @param {JoystickProtocolActionsMapping} defaultMapping - The vehicle-type default mapping
+ * @returns {number} How many default axis functions are not present in the user's mapping
+ */
+export const countMissingDefaultAxisFunctions = (
+  currentMapping: JoystickProtocolActionsMapping,
   defaultMapping: JoystickProtocolActionsMapping
-): JoystickProtocolActionsMapping => {
-  const merged = safeClone(userMapping)
-
-  merged.axesCorrespondencies = safeClone(defaultMapping.axesCorrespondencies)
-
-  for (const modKey of Object.keys(merged.buttonsCorrespondencies)) {
-    const userButtons = merged.buttonsCorrespondencies[modKey as keyof typeof merged.buttonsCorrespondencies]
-    const defaultButtons =
-      defaultMapping.buttonsCorrespondencies[modKey as keyof typeof defaultMapping.buttonsCorrespondencies]
-
-    const usedActionIds = new Set<string>()
-    for (const btn of Object.values(userButtons)) {
-      if (btn.action.id !== OtherProtocol.no_function) {
-        usedActionIds.add(btn.action.id)
-      }
-    }
-
-    for (const [btnIdx, btn] of Object.entries(userButtons)) {
-      if (btn.action.id !== OtherProtocol.no_function) continue
-      const defaultAction = defaultButtons[btnIdx as unknown as number]?.action
-      if (!defaultAction || defaultAction.id === OtherProtocol.no_function) continue
-      if (usedActionIds.has(defaultAction.id)) continue
-      btn.action = safeClone(defaultAction)
-      usedActionIds.add(defaultAction.id)
-    }
+): number => {
+  const currentAxisFunctionIds = new Set(
+    Object.values(currentMapping.axesCorrespondencies)
+      .map((corr) => corr.action.id)
+      .filter((id) => id !== OtherProtocol.no_function)
+  )
+  let missing = 0
+  for (const defaultCorr of Object.values(defaultMapping.axesCorrespondencies)) {
+    if (defaultCorr.action.id === OtherProtocol.no_function) continue
+    if (!currentAxisFunctionIds.has(defaultCorr.action.id)) missing++
   }
-
-  return merged
+  return missing
 }
 
+type AxisCorrespondence =
+  JoystickProtocolActionsMapping['axesCorrespondencies'][keyof JoystickProtocolActionsMapping['axesCorrespondencies']]
+
 /**
- * Merges a user's modified ViewsGroup with the vehicle default by appending default views.
- * User's existing views stay first so they don't see an immediate change.
- * @param {Profile} userProfile - The user's current ViewsGroup
- * @param {Profile} defaultProfile - The vehicle type default profile
- * @returns {Profile} The merged profile
+ * For each default axis function present in the user's mapping, checks whether the user's axis
+ * range (min/max) is within {@link axisRangeTolerance} of the default. Default functions that the
+ * user doesn't have at all are skipped — they're already accounted for by
+ * {@link countMissingDefaultAxisFunctions}.
+ *
+ * When the user has the same function on multiple axes, the first occurrence is used.
+ * @param {JoystickProtocolActionsMapping} currentMapping - The user's current mapping
+ * @param {JoystickProtocolActionsMapping} defaultMapping - The vehicle-type default mapping
+ * @returns {number} How many present-in-both axis functions have a range outside the tolerance
  */
-const mergeViewsGroups = (userProfile: Profile, defaultProfile: Profile): Profile => {
-  const merged = safeClone(userProfile)
-  const defaultViews = safeClone(defaultProfile.views)
-  for (const view of defaultViews) {
-    view.hash = uuid4()
+export const countAxisFunctionRangeMismatches = (
+  currentMapping: JoystickProtocolActionsMapping,
+  defaultMapping: JoystickProtocolActionsMapping
+): number => {
+  const currentCorrByFunctionId = new Map<string, AxisCorrespondence>()
+  for (const corr of Object.values(currentMapping.axesCorrespondencies)) {
+    if (corr.action.id === OtherProtocol.no_function) continue
+    if (!currentCorrByFunctionId.has(corr.action.id)) {
+      currentCorrByFunctionId.set(corr.action.id, corr)
+    }
   }
-  merged.views.push(...defaultViews)
-  return merged
+
+  let mismatches = 0
+  for (const defaultCorr of Object.values(defaultMapping.axesCorrespondencies)) {
+    if (defaultCorr.action.id === OtherProtocol.no_function) continue
+    const currentCorr = currentCorrByFunctionId.get(defaultCorr.action.id)
+    if (!currentCorr) continue
+    const tolerance = axisRangeTolerance * Math.abs(defaultCorr.max - defaultCorr.min)
+    if (
+      Math.abs(currentCorr.min - defaultCorr.min) > tolerance ||
+      Math.abs(currentCorr.max - defaultCorr.max) > tolerance
+    ) {
+      mismatches++
+    }
+  }
+  return mismatches
 }
 
 /**
- * Imports or merges vehicle-type defaults into the current ViewsGroup and joystick mapping.
- * Only runs once per vehicle (tracked via a persisted key).
+ * Decides what the defaults flow should do for the connected vehicle, per side. The decision is
+ * derived from the connected vehicle type, the user's current ViewsGroup, and their current joystick
+ * mapping — not from any stored "have we already done this" flag, which is the caller's
+ * responsibility to track per vehicle.
+ *
+ * Rules:
+ * - Views: blank → `auto-import`; any user view name matches a default view name → `skip`;
+ *   otherwise → `offer`.
+ * - Joystick (buttons are intentionally ignored — only axes are checked, since axes drive motors):
+ *   blank → `auto-import`; user has every default axis function (regardless of which physical axis
+ *   it's mapped to) AND every shared axis function has min and max within
+ *   {@link axisRangeTolerance} of the default → `skip`; otherwise → `offer`.
+ * - Either side becomes `skip` if there is no default available for this vehicle type.
  * @param {MavType} vehicleType - The connected vehicle's type
- * @param {Profile} currentViewsGroup - The current ViewsGroup ref value
- * @param {JoystickProtocolActionsMapping} currentMapping - The current joystick mapping ref value
- * @returns {{ viewsGroup?: Profile; mapping?: JoystickProtocolActionsMapping }} The updated values, if changed
+ * @param {Profile} currentViewsGroup - The user's current ViewsGroup
+ * @param {JoystickProtocolActionsMapping} currentMapping - The user's current joystick mapping
+ * @returns {DefaultsEvaluation} What to do per side, plus the relevant defaults for callers to act on
  */
-export const importDefaultsForVehicle = (
+export const evaluateDefaults = (
   vehicleType: MavType,
   currentViewsGroup: Profile,
   currentMapping: JoystickProtocolActionsMapping
-): {
-  /**
-   * The default views group for the vehicle type
-   */
-  viewsGroup?: Profile
-  /**
-   * The default joystick mapping for the vehicle type
-   */
-  mapping?: JoystickProtocolActionsMapping
-} => {
-  const alreadyImported = settingsManager.getKeyValue<Record<string, boolean>>(defaultsImportedKey)
-  if (alreadyImported?.[vehicleType]) return {}
+): DefaultsEvaluation => {
+  const defaultProfile = getDefaultViewsGroup(vehicleType)
+  const defaultMapping = getDefaultMapping(vehicleType)
 
-  const defaultVG = getDefaultViewsGroup(vehicleType)
-  const defaultMap = getDefaultMapping(vehicleType)
-  if (!defaultVG && !defaultMap) return {}
-
-  const result: {
-    /**
-     * The merged views group for the vehicle type
-     */
-    viewsGroup?: Profile
-    /**
-     * The merged joystick mapping for the vehicle type
-     */
-    mapping?: JoystickProtocolActionsMapping
-  } = {}
-  const name = vehicleTypeName(vehicleType)
-
-  if (defaultVG) {
+  let viewsAction: DefaultsAction = 'skip'
+  if (defaultProfile) {
     if (isViewsGroupBlank(currentViewsGroup)) {
-      const imported = safeClone(defaultVG)
-      imported.hash = uuid4()
-      imported.name = defaultVG.name.replace('default', 'User').replace('Default', 'User')
-      for (const view of imported.views) {
-        view.hash = uuid4()
-      }
-      result.viewsGroup = imported
-      openSnackbar({ message: `Imported default views for ${name}.`, variant: 'success', duration: 5000 })
-    } else {
-      result.viewsGroup = mergeViewsGroups(currentViewsGroup, defaultVG)
-      openSnackbar({
-        message: `Merged default views for ${name} into your existing views.`,
-        variant: 'success',
-        duration: 5000,
-      })
+      viewsAction = 'auto-import'
+    } else if (!userViewNamesMatchAnyDefault(currentViewsGroup, defaultProfile)) {
+      viewsAction = 'offer'
     }
   }
 
-  if (defaultMap) {
+  let joystickAction: DefaultsAction = 'skip'
+  let missingAxisFunctions = 0
+  let axisFunctionsWithRangeMismatch = 0
+  if (defaultMapping) {
     if (isMappingBlank(currentMapping)) {
-      result.mapping = safeClone(defaultMap)
-      openSnackbar({
-        message: `Imported default joystick mapping for ${name}.`,
-        variant: 'success',
-        duration: 5000,
-      })
+      joystickAction = 'auto-import'
     } else {
-      result.mapping = mergeJoystickMappings(currentMapping, defaultMap)
-      openSnackbar({
-        message: `Merged default joystick mapping for ${name} with your custom mapping.`,
-        variant: 'success',
-        duration: 5000,
-      })
+      missingAxisFunctions = countMissingDefaultAxisFunctions(currentMapping, defaultMapping)
+      axisFunctionsWithRangeMismatch = countAxisFunctionRangeMismatches(currentMapping, defaultMapping)
+      if (missingAxisFunctions > 0 || axisFunctionsWithRangeMismatch > 0) joystickAction = 'offer'
     }
   }
 
-  const imported = alreadyImported ?? {}
-  imported[vehicleType] = true
-  settingsManager.setKeyValue(defaultsImportedKey, imported)
-
-  return result
+  return {
+    vehicleType,
+    vehicleTypeName: vehicleTypeName(vehicleType),
+    views: { action: viewsAction, defaultProfile },
+    joystick: {
+      action: joystickAction,
+      defaultMapping,
+      missingAxisFunctions,
+      axisFunctionsWithRangeMismatch,
+    },
+  }
 }
+
+/**
+ * Builds a brand-new ViewsGroup from the vehicle-type default, suitable for replacing a blank or
+ * existing ViewsGroup. Re-hashes the profile and each view so they don't collide with any historical
+ * data, and renames the profile from "... default" to "... User" to match the snackbar messaging.
+ * @param {Profile} defaultProfile - The vehicle-type default profile
+ * @returns {Profile} A fresh ViewsGroup ready to assign to the widget store
+ */
+export const buildFreshViewsGroupFromDefault = (defaultProfile: Profile): Profile => {
+  const fresh = safeClone(defaultProfile)
+  fresh.hash = uuid4()
+  fresh.name = defaultProfile.name.replace('default', 'User').replace('Default', 'User')
+  for (const view of fresh.views) {
+    rehashViewAndWidgets(view)
+  }
+  return fresh
+}
+
+/**
+ * Returns a copy of the user's ViewsGroup with the selected default views appended at the end.
+ * Each appended view receives a fresh hash so it cannot collide with any pre-existing one.
+ * @param {Profile} currentViewsGroup - The user's current ViewsGroup
+ * @param {Profile} defaultProfile - The vehicle-type default profile
+ * @param {string[]} selectedViewNames - Names of the default views the user chose to append
+ * @returns {Profile} The new ViewsGroup with the selected default views appended
+ */
+export const buildAppendedViewsGroup = (
+  currentViewsGroup: Profile,
+  defaultProfile: Profile,
+  selectedViewNames: string[]
+): Profile => {
+  const merged = safeClone(currentViewsGroup)
+  const selected = new Set(selectedViewNames)
+  const viewsToAppend = safeClone(defaultProfile.views).filter((v) => selected.has(v.name))
+  for (const view of viewsToAppend) {
+    rehashViewAndWidgets(view)
+  }
+  merged.views.push(...viewsToAppend)
+  return merged
+}
+
+/**
+ * Returns a fresh ViewsGroup containing only the selected default views, intended to fully replace
+ * the user's current ViewsGroup. The caller must have confirmed the destructive intent already.
+ * @param {Profile} defaultProfile - The vehicle-type default profile
+ * @param {string[]} selectedViewNames - Names of the default views the user chose to keep
+ * @returns {Profile} A new ViewsGroup ready to replace the existing one
+ */
+export const buildReplacementViewsGroup = (defaultProfile: Profile, selectedViewNames: string[]): Profile => {
+  const replacement = safeClone(defaultProfile)
+  const selected = new Set(selectedViewNames)
+  replacement.views = replacement.views.filter((v) => selected.has(v.name))
+  replacement.hash = uuid4()
+  replacement.name = defaultProfile.name.replace('default', 'User').replace('Default', 'User')
+  for (const view of replacement.views) {
+    rehashViewAndWidgets(view)
+  }
+  return replacement
+}
+
+/**
+ * Builds the ViewsGroup that would result from the user's import choices (append or replace).
+ * @param {Profile} currentViewsGroup - The user's current ViewsGroup
+ * @param {Profile} defaultProfile - The vehicle-type default profile
+ * @param {string[]} selectedViewNames - Names of the default views the user chose to import
+ * @param {'append' | 'replace'} mode - Whether to append or replace when the current group is not blank
+ * @param {boolean} currentBlank - Whether the current ViewsGroup is blank
+ * @returns {Profile} The ViewsGroup after applying the import
+ */
+export const buildViewsGroupAfterImport = (
+  currentViewsGroup: Profile,
+  defaultProfile: Profile,
+  selectedViewNames: string[],
+  mode: 'append' | 'replace',
+  currentBlank: boolean
+): Profile => {
+  if (selectedViewNames.length === 0) {
+    return safeClone(currentViewsGroup)
+  }
+  const effectiveMode = currentBlank ? 'replace' : mode
+  if (effectiveMode === 'replace') {
+    if (selectedViewNames.length === defaultProfile.views.length && currentBlank) {
+      return buildFreshViewsGroupFromDefault(defaultProfile)
+    }
+    return buildReplacementViewsGroup(defaultProfile, selectedViewNames)
+  }
+  return buildAppendedViewsGroup(currentViewsGroup, defaultProfile, selectedViewNames)
+}
+
+/**
+ * Returns a clean copy of the vehicle default mapping, intended to fully replace the user's current
+ * mapping. The caller must have confirmed the destructive intent already.
+ * @param {JoystickProtocolActionsMapping} defaultMapping - The vehicle-type default mapping
+ * @returns {JoystickProtocolActionsMapping} A fresh mapping ready to replace the existing one
+ */
+export const buildReplacementMapping = (
+  defaultMapping: JoystickProtocolActionsMapping
+): JoystickProtocolActionsMapping => cloneMapping(defaultMapping)

--- a/src/stores/appInterface.ts
+++ b/src/stores/appInterface.ts
@@ -61,6 +61,9 @@ export const useAppInterfaceStore = defineStore('responsive', {
     isTutorialVisible: false,
     isExternalFeaturesModalVisible: false,
     isDataPrivacyModalVisible: false,
+    isVehicleDefaultsAutoImportModalVisible: false,
+    isVehicleDefaultsViewsImportModalVisible: false,
+    isVehicleDefaultsJoystickImportModalVisible: false,
     userHasSeenTutorial: useBlueOsStorage('cockpit-has-seen-tutorial', false),
     configPanelVisible: false,
     showSplashScreen: true,
@@ -82,6 +85,15 @@ export const useAppInterfaceStore = defineStore('responsive', {
     },
     hideSkullAnimation() {
       this.showSkullAnimation = false
+    },
+    openVehicleDefaultsAutoImport(): void {
+      this.isVehicleDefaultsAutoImportModalVisible = true
+    },
+    openVehicleDefaultsViewsImport(): void {
+      this.isVehicleDefaultsViewsImportModalVisible = true
+    },
+    openVehicleDefaultsJoystickImport(): void {
+      this.isVehicleDefaultsJoystickImportModalVisible = true
     },
   },
   getters: {

--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -49,12 +49,10 @@ import type {
 import { Coordinates } from '@/libs/vehicle/types'
 import * as Vehicle from '@/libs/vehicle/vehicle'
 import { VehicleFactory } from '@/libs/vehicle/vehicle-factory'
-import { importDefaultsForVehicle } from '@/migration/default-profile-importer'
 import type { MissionLoadingCallback, Waypoint } from '@/types/mission'
 
 import { useControllerStore } from './controller'
 import { useMissionStore } from './mission'
-import { useWidgetManagerStore } from './widgetManager'
 /**
  * Custom parameter data description interface
  */
@@ -79,7 +77,6 @@ const { openSnackbar } = useSnackbar()
 
 export const useMainVehicleStore = defineStore('main-vehicle', () => {
   const controllerStore = useControllerStore()
-  const widgetStore = useWidgetManagerStore()
   const missionStore = useMissionStore()
   const ws_protocol = location?.protocol === 'https:' ? 'wss' : 'ws'
   const http_protocol = location?.protocol === 'https:' ? 'https' : 'http'
@@ -670,19 +667,6 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
 
       if (oldVehicleType !== vehicleType.value && vehicleType.value !== undefined) {
         console.log('Vehicle type changed to', vehicleType.value)
-
-        // A failure in the defaults import must never wipe the user's current profile, so we isolate it
-        try {
-          const defaults = importDefaultsForVehicle(
-            vehicleType.value,
-            widgetStore.viewsGroup,
-            controllerStore.protocolMapping
-          )
-          if (defaults.viewsGroup) widgetStore.viewsGroup = defaults.viewsGroup
-          if (defaults.mapping) controllerStore.protocolMapping = defaults.mapping
-        } catch (error) {
-          console.error('Failed to import defaults for vehicle type.', error)
-        }
       }
     })
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/views/ConfigurationJoystickView.vue
+++ b/src/views/ConfigurationJoystickView.vue
@@ -138,6 +138,18 @@
                             </label>
                           </template>
                         </v-tooltip>
+                        <v-divider vertical />
+                        <v-tooltip location="top" text="Import default mapping for this vehicle">
+                          <template #activator="{ props }">
+                            <v-btn
+                              v-bind="props"
+                              icon="mdi-import"
+                              variant="text"
+                              size="24"
+                              class="text-[12px] mx-3 mt-[2px] mb-[1px]"
+                              @click="openVehicleDefaultsImportModal"
+                          /></template>
+                        </v-tooltip>
                       </div>
                     </div>
                   </v-tabs>
@@ -1015,6 +1027,10 @@ const scaledAxisValue = (joystick: Joystick, axisId: JoystickAxis): number => {
   const min = selectedProfileAxesCorrespondencies.value[axisId]?.min ?? -1
   const max = selectedProfileAxesCorrespondencies.value[axisId]?.max ?? +1
   return scale(rawValue, -1, 1, min, max)
+}
+
+const openVehicleDefaultsImportModal = (): void => {
+  interfaceStore.openVehicleDefaultsJoystickImport()
 }
 
 const toggleJoystickEnabling = (joystickModel: string): void => {

--- a/src/views/ConfigurationJoystickView.vue
+++ b/src/views/ConfigurationJoystickView.vue
@@ -8,13 +8,16 @@
         style="scrollbar-gutter: stable"
       >
         <div
-          v-if="controllerStore.joysticks && !controllerStore.joysticks.size"
+          v-if="!controllerStore.joysticks.size"
           class="px-6 pb-2 flex-centered flex-column position-relative"
           :class="interfaceStore.isOnSmallScreen ? 'pt-1' : 'pt-3'"
         >
-          <p class="text-base text-center font-bold mt-6 mb-4">Connect a joystick and press any key.</p>
+          <p class="text-sm text-center opacity-80 mt-2 mb-1">
+            No joystick connected. Live input is unavailable, but you can still configure mappings, import defaults, and
+            import or export joystick configurations below.
+          </p>
         </div>
-        <div v-else>
+        <div>
           <ExpansiblePanel no-top-divider no-bottom-divider :is-expanded="!interfaceStore.isOnPhoneScreen" compact>
             <template #title>General settings</template>
             <template #info>
@@ -141,6 +144,9 @@
                 </div>
               </div>
               <div v-if="currentTabVIew === 'svg'" class="flex flex-col justify-between">
+                <div v-if="!controllerStore.joysticks.size" class="text-center py-12 opacity-70 text-sm">
+                  Connect a joystick to see its visual layout and live input.
+                </div>
                 <div
                   v-for="[key, joystick] in controllerStore.joysticks"
                   :key="key"
@@ -256,11 +262,13 @@
                   </div>
                 </div>
               </div>
-              <div v-if="currentTabVIew === 'table'" class="w-full">
+              <div v-if="currentTabVIew === 'table'" class="w-full flex-centered flex-column position-relative">
+                <!-- Per-joystick header (model name + enable switch). Skipped entirely when no joystick is
+                     connected so the mapping editor below still renders. -->
                 <div
                   v-for="[key, joystick] in controllerStore.joysticks"
                   :key="key"
-                  class="w-full flex-centered flex-column position-relative"
+                  class="w-full flex-centered flex-column"
                 >
                   <span class="text-md font-semibold w-full text-center -mt-8">{{ joystick.model }} controller</span>
                   <div class="flex items-center gap-2">
@@ -272,9 +280,11 @@
                       @update:model-value="toggleJoystickEnabling(joystick.model)"
                     />
                   </div>
+                </div>
+
+                <div class="w-full flex-centered flex-column">
                   <p class="text-start text-sm font-bold w-[93%] mb-1">Axes</p>
                   <v-data-table
-                    v-if="controllerStore.joysticks && controllerStore.joysticks.size"
                     :items="tableItems"
                     class="elevation-1 bg-transparent rounded-lg mb-[20px]"
                     theme="dark"
@@ -304,10 +314,11 @@
                         </td>
                         <td class="w-[120px] text-center">
                           <AxisVisualization
-                            v-if="item.type === 'axis' && joystick.state.axes"
-                            :raw-value="joystick.state.axes[item.id as JoystickAxis] || 0"
-                            :processed-value="scaledAxisValue(joystick, item.id as JoystickAxis)"
+                            v-if="item.type === 'axis' && currentJoystick && currentJoystick.state.axes"
+                            :raw-value="currentJoystick.state.axes[item.id as JoystickAxis] || 0"
+                            :processed-value="scaledAxisValue(currentJoystick, item.id as JoystickAxis)"
                           />
+                          <span v-else class="text-xs opacity-50">—</span>
                         </td>
                         <td class="w-[50px] text-center">
                           <v-icon v-if="item.type === 'axis'">
@@ -371,7 +382,6 @@
 
                   <p class="text-start text-sm font-bold w-[93%] mb-1">Buttons</p>
                   <v-data-table
-                    v-if="currentJoystick && currentJoystick?.gamepadToCockpitMap?.buttons"
                     :headers="headers"
                     :items="tableItems"
                     :items-per-page="128"
@@ -440,7 +450,7 @@
                             icon="mdi-circle-edit-outline"
                             variant="text"
                             class="text-[16px]"
-                            @click="setCurrentInputFromTable(joystick, item as JoystickInput)"
+                            @click="setCurrentInputFromTable(currentJoystick ?? null, item as JoystickInput)"
                           >
                           </v-btn>
                         </td>
@@ -474,13 +484,7 @@
     </template>
   </BaseConfigurationView>
   <teleport to="body">
-    <InteractionDialog
-      v-show="currentJoystick"
-      :show-dialog="inputClickedDialog"
-      max-width="auto"
-      variant="text-only"
-      persistent
-    >
+    <InteractionDialog :show-dialog="inputClickedDialog" max-width="auto" variant="text-only" persistent>
       <template #title>
         <div class="flex justify-center w-full font-bold mt-1">Input mapping</div>
       </template>
@@ -855,15 +859,24 @@ const tableItemsCache = ref<{
 } | null>(null)
 
 /**
- * Optimized table items with memoization to reduce object creation
+ * Optimized table items with memoization to reduce object creation. When a joystick is connected
+ * we use its actual axes/buttons counts; otherwise we fall back to the protocol mapping's known
+ * axes/buttons so the mapping editor still renders and is editable without a joystick.
  */
 const tableItems = computed(() => {
-  if (currentJoystick.value === undefined) {
-    return []
+  let axesLength: number
+  let buttonsLength: number
+
+  if (currentJoystick.value) {
+    axesLength = currentJoystick.value.state.axes.length
+    buttonsLength = currentJoystick.value.state.buttons.length
+  } else {
+    axesLength = Object.keys(selectedProfileAxesCorrespondencies.value).length
+    const buttons =
+      selectedProfileButtonsCorrespondencies.value[currentModifierKey.value.id as CockpitModifierKeyOption]
+    buttonsLength = buttons ? Object.keys(buttons).length : 0
   }
 
-  const axesLength = currentJoystick.value.state.axes.length
-  const buttonsLength = currentJoystick.value.state.buttons.length
   const cacheKey = `${axesLength}-${buttonsLength}`
 
   // Check if we can use cached items
@@ -901,13 +914,15 @@ watch(inputClickedDialog, () => {
   justRemappedAxisInput.value = undefined
 })
 
-const setCurrentInputFromTable = (joystick: Joystick, input: JoystickInput): void => {
+const setCurrentInputFromTable = (joystick: Joystick | null, input: JoystickInput): void => {
   const inputs = [input]
   setCurrentInputs(joystick, inputs)
 }
 
-const setCurrentInputs = (joystick: Joystick, inputs: JoystickInput[]): void => {
-  currentJoystick.value = joystick
+const setCurrentInputs = (joystick: Joystick | null, inputs: JoystickInput[]): void => {
+  // Keep the previously-set currentJoystick (if any) when called without one, so the live joystick
+  // reference is preserved across mapping-editor interactions that don't carry a joystick context.
+  if (joystick) currentJoystick.value = joystick
 
   currentButtonInputs.value = inputs
     .filter((i) => i.type === InputType.Button)


### PR DESCRIPTION
When a user upgraded from Cockpit <= 1.17.x, their legacy widget profiles were migrated into the new ViewsGroup key, but the automatic defaults importing pipeline was kicking in and also adding the default for that vehicle, always, and that was causing users that already had the correct views to have them duplicated.

https://github.com/user-attachments/assets/c73b2d42-b864-4b39-8c9e-759505621bbd



This PR does a bunch of things to completely solve this problem:
1. It only automatically imports the default views if the user has blank views (this is, if they just installed Cockpit and are connecting to a fresh vehicle).
2. It only automatically imports the default joystick mapping if the user has a blank mapping (this is, if they just installed Cockpit and are connecting to a fresh vehicle).
3. If the user has views and/or a joystick mapping that differs from the default ones, a assisting modal in the form a tutorial will open during boot telling them that they have the option to import those.
  3.1. For the joystick mapping, "differs" mean not having one of the default axis functions or having them with min or max differing by more than 10% of the default value (e.g.: for the ROV they should have the `MANUAL_CONTROL` functions X, Y, R and Z, and the mins and maxes should be close to those of the defaults)
  3.2. For the views, "differs" means they don't have any views currently with the same name of any views from the defaults
4. The modal is in the form of a tutorial, so it's easier to understand what to do and pass through all steps
5. The modal allows importing one, both, or to completely ignore everything
6. The user can open a dedicated modal for the views importing from the edit-menu (three dots > import defaults)
7. The user can open a dedicated modal for importing the joystick mapping from the joystick configuration page (button next to the import/export buttons)
8. The automatic modal only appears once during boot, so there are confirmation screens if the user chooses to ignore it making sure they understand and also instructing on how to later use the import default buttons mentioned previously
9. The import defaults modal and automatic routines now runs after the vehicle sync has finished, so we don't face race conditions with the settings management sync
10. I've also modified the joystick config page to show the table view even if the user has no joystick connected (scope creep, but always made sense and I needed that for my tests)


### Joystick mapping import modal opened by the dedicated button in the joystick configuration page:
<img width="816" height="415" alt="image" src="https://github.com/user-attachments/assets/50678c5a-c909-4555-abde-41497c4b8a32" />

### Views importing modal opened by the dedicated button in the edit-menu:
<img width="694" height="595" alt="image" src="https://github.com/user-attachments/assets/5564d800-55e6-4f7c-9f2a-56ebf5b34c35" />







Fixes #2623.