### PR TITLE
Migrate depth widgets to the data-lake and allow source selection

### DIFF
--- a/src/components/mini-widgets/DepthIndicator.vue
+++ b/src/components/mini-widgets/DepthIndicator.vue
@@ -13,16 +13,77 @@
       </span>
     </div>
   </div>
+  <v-dialog v-model="widgetStore.miniWidgetManagerVars(miniWidget.hash).configMenuOpen" width="auto">
+    <v-card class="pa-4 text-white w-[400px]" style="border-radius: 15px" :style="interfaceStore.globalGlassMenuStyles">
+      <v-card-title class="text-center">Depth Indicator Config</v-card-title>
+      <v-card-text class="flex flex-col gap-y-4">
+        <div class="absolute top-2 right-2 z-10">
+          <v-btn
+            icon
+            size="30"
+            variant="text"
+            class="text-white text-[22px]"
+            aria-label="Close"
+            @click="widgetStore.miniWidgetManagerVars(miniWidget.hash).configMenuOpen = false"
+          >
+            <i class="mdi mdi-close"></i>
+          </v-btn>
+        </div>
+        <v-select
+          v-if="!configUseCustomAltitudeVariable"
+          v-model="configAltitudeVariableId"
+          label="Altitude source"
+          :items="altitudeSourceOptions"
+          item-title="title"
+          item-value="value"
+          hide-details
+          theme="dark"
+          variant="outlined"
+          density="compact"
+          @update:model-value="onAltitudeSourceSelected"
+        />
+        <v-autocomplete
+          v-else
+          v-model="configAltitudeVariableId"
+          :items="availableDataLakeNumberVariables"
+          item-title="name"
+          item-value="id"
+          label="Data lake variable"
+          hint="Select any numeric data lake variable"
+          persistent-hint
+          theme="dark"
+          variant="outlined"
+          density="compact"
+          clearable
+          prepend-inner-icon="mdi-magnify"
+          @update:model-value="onAltitudeSourceSelected"
+        />
+        <v-checkbox
+          v-model="configUseCustomAltitudeVariable"
+          label="Use custom data lake variable"
+          hide-details
+          @update:model-value="onUseCustomAltitudeVariableToggled"
+        />
+      </v-card-text>
+    </v-card>
+  </v-dialog>
 </template>
 
 <script setup lang="ts">
 import { unit } from 'mathjs'
-import { computed, onBeforeMount, ref, toRefs, watch } from 'vue'
+import { computed, onBeforeMount, toRefs } from 'vue'
 
+import { mergeAltitudeVariableOptions, useAltitudeSourceConfig } from '@/composables/useAltitudeSourceConfig'
 import { useDataLakeVariable } from '@/composables/useDataLakeVariable'
+import {
+  altitudeSourceOptions,
+  defaultDepthAltitudeVariableId,
+  rawAltitudeToMeters,
+} from '@/libs/data-sources/altitude'
 import { datalogger, DatalogVariable } from '@/libs/sensors-logging'
 import { unitAbbreviation } from '@/libs/units'
 import { useAppInterfaceStore } from '@/stores/appInterface'
+import { useWidgetManagerStore } from '@/stores/widgetManager'
 import type { MiniWidget } from '@/types/widgets'
 
 const props = defineProps<{
@@ -33,31 +94,41 @@ const props = defineProps<{
 }>()
 const miniWidget = toRefs(props).miniWidget
 
+const widgetStore = useWidgetManagerStore()
+const interfaceStore = useAppInterfaceStore()
+const { displayUnitPreferences } = interfaceStore
+datalogger.registerUsage(DatalogVariable.depth)
+
 const defaultOptions = {
-  altitudeVariableId: '/mavlink/1/1/AHRS2/altitude',
+  altitudeVariableId: defaultDepthAltitudeVariableId,
+  useCustomAltitudeVariable: false,
 }
 
 onBeforeMount(() => {
-  miniWidget.value.options = { ...defaultOptions, ...miniWidget.value.options }
+  miniWidget.value.options = mergeAltitudeVariableOptions(defaultOptions, miniWidget.value.options)
 })
 
-const { displayUnitPreferences } = useAppInterfaceStore()
-datalogger.registerUsage(DatalogVariable.depth)
+const {
+  resolvedAltitudeVariableId,
+  configAltitudeVariableId,
+  configUseCustomAltitudeVariable,
+  availableDataLakeNumberVariables,
+  onAltitudeSourceSelected,
+  onUseCustomAltitudeVariableToggled,
+} = useAltitudeSourceConfig({
+  widget: miniWidget,
+  isConfigMenuOpen: () => widgetStore.miniWidgetManagerVars(miniWidget.value.hash).configMenuOpen,
+  defaultAltitudeVariableId: defaultDepthAltitudeVariableId,
+})
 
-const { value: rawAltitude } = useDataLakeVariable(() => miniWidget.value.options.altitudeVariableId)
+const { value: rawAltitude } = useDataLakeVariable(resolvedAltitudeVariableId)
 
-const currentDepth = ref<undefined | number>(undefined)
-watch(rawAltitude, (newAlt) => {
-  if (newAlt === undefined) return
-  const altMeters = newAlt as number
+const currentDepth = computed<number | undefined>(() => {
+  if (resolvedAltitudeVariableId.value === undefined || typeof rawAltitude.value !== 'number') return undefined
+  const altMeters = rawAltitudeToMeters(resolvedAltitudeVariableId.value, rawAltitude.value)
   const depth = unit(-altMeters, 'm')
-  if (depth.value < 0.01) {
-    currentDepth.value = 0
-    return
-  }
-
-  const depthConverted = depth.to(displayUnitPreferences.distance)
-  currentDepth.value = depthConverted.toJSON().value
+  if (depth.value < 0.01) return 0
+  return depth.to(displayUnitPreferences.distance).toJSON().value as number
 })
 
 const parsedState = computed(() => {

--- a/src/components/mini-widgets/DepthIndicator.vue
+++ b/src/components/mini-widgets/DepthIndicator.vue
@@ -17,21 +17,40 @@
 
 <script setup lang="ts">
 import { unit } from 'mathjs'
-import { computed, ref, watch } from 'vue'
+import { computed, onBeforeMount, ref, toRefs, watch } from 'vue'
 
+import { useDataLakeVariable } from '@/composables/useDataLakeVariable'
 import { datalogger, DatalogVariable } from '@/libs/sensors-logging'
 import { unitAbbreviation } from '@/libs/units'
 import { useAppInterfaceStore } from '@/stores/appInterface'
-import { useMainVehicleStore } from '@/stores/mainVehicle'
+import type { MiniWidget } from '@/types/widgets'
 
-const vehicleStore = useMainVehicleStore()
+const props = defineProps<{
+  /**
+   * Configuration of the widget
+   */
+  miniWidget: MiniWidget
+}>()
+const miniWidget = toRefs(props).miniWidget
+
+const defaultOptions = {
+  altitudeVariableId: '/mavlink/1/1/AHRS2/altitude',
+}
+
+onBeforeMount(() => {
+  miniWidget.value.options = { ...defaultOptions, ...miniWidget.value.options }
+})
+
 const { displayUnitPreferences } = useAppInterfaceStore()
 datalogger.registerUsage(DatalogVariable.depth)
 
+const { value: rawAltitude } = useDataLakeVariable(() => miniWidget.value.options.altitudeVariableId)
+
 const currentDepth = ref<undefined | number>(undefined)
-watch(vehicleStore.altitude, () => {
-  const altitude = vehicleStore.altitude.msl
-  const depth = unit(-altitude.value, altitude.toJSON().unit)
+watch(rawAltitude, (newAlt) => {
+  if (newAlt === undefined) return
+  const altMeters = newAlt as number
+  const depth = unit(-altMeters, 'm')
   if (depth.value < 0.01) {
     currentDepth.value = 0
     return
@@ -40,6 +59,7 @@ watch(vehicleStore.altitude, () => {
   const depthConverted = depth.to(displayUnitPreferences.distance)
   currentDepth.value = depthConverted.toJSON().value
 })
+
 const parsedState = computed(() => {
   const fDepth = currentDepth.value
   if (fDepth === undefined) return '--'

--- a/src/components/mini-widgets/RelativeAltitudeIndicator.vue
+++ b/src/components/mini-widgets/RelativeAltitudeIndicator.vue
@@ -3,8 +3,10 @@
     <img src="@/assets/altitude-icon.svg" class="h-full" :draggable="false" />
     <div class="flex flex-col items-start justify-center ml-1 min-w-[4rem] max-w-[6rem] select-none">
       <div>
-        <span class="font-mono text-xl font-semibold leading-6 w-fit">{{ round(altitude, 2).toFixed(2) }}</span>
-        <span class="text-xl font-semibold leading-6 w-fit"> m</span>
+        <span class="font-mono text-xl font-semibold leading-6 w-fit">{{ parsedState }}</span>
+        <span class="text-xl font-semibold leading-6 w-fit">
+          {{ String.fromCharCode(0x20) }} {{ unitAbbreviation[displayUnitPreferences.distance] }}
+        </span>
       </div>
       <span class="w-full text-sm font-semibold leading-4 whitespace-nowrap">Alt (Rel)</span>
     </div>
@@ -12,13 +14,46 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { unit } from 'mathjs'
+import { computed, onBeforeMount, ref, toRefs, watch } from 'vue'
 
-import { round } from '@/libs/utils'
-import { useMainVehicleStore } from '@/stores/mainVehicle'
+import { useDataLakeVariable } from '@/composables/useDataLakeVariable'
+import { unitAbbreviation } from '@/libs/units'
+import { useAppInterfaceStore } from '@/stores/appInterface'
+import type { MiniWidget } from '@/types/widgets'
 
-const store = useMainVehicleStore()
+const props = defineProps<{
+  /**
+   * Configuration of the widget
+   */
+  miniWidget: MiniWidget
+}>()
+const miniWidget = toRefs(props).miniWidget
 
-const altitude = ref(0)
-watch(store.altitude, () => (altitude.value = store.altitude.rel))
+const defaultOptions = {
+  altitudeVariableId: '/mavlink/1/1/GLOBAL_POSITION_INT/relative_alt',
+}
+
+onBeforeMount(() => {
+  miniWidget.value.options = { ...defaultOptions, ...miniWidget.value.options }
+})
+
+const { displayUnitPreferences } = useAppInterfaceStore()
+
+const { value: rawAltitude } = useDataLakeVariable(() => miniWidget.value.options.altitudeVariableId)
+
+const currentAltitude = ref<undefined | number>(undefined)
+watch(rawAltitude, (newAlt) => {
+  if (newAlt === undefined) return
+  const altMeters = (newAlt as number) / 1000
+  const altitude = unit(altMeters, 'm')
+  const altitudeConverted = altitude.to(displayUnitPreferences.distance)
+  currentAltitude.value = altitudeConverted.toJSON().value
+})
+
+const parsedState = computed(() => {
+  const altitude = currentAltitude.value
+  if (altitude === undefined) return '--'
+  return altitude.toFixed(2)
+})
 </script>

--- a/src/components/mini-widgets/RelativeAltitudeIndicator.vue
+++ b/src/components/mini-widgets/RelativeAltitudeIndicator.vue
@@ -11,15 +11,76 @@
       <span class="w-full text-sm font-semibold leading-4 whitespace-nowrap">Alt (Rel)</span>
     </div>
   </div>
+  <v-dialog v-model="widgetStore.miniWidgetManagerVars(miniWidget.hash).configMenuOpen" width="auto">
+    <v-card class="pa-4 text-white w-[400px]" style="border-radius: 15px" :style="interfaceStore.globalGlassMenuStyles">
+      <v-card-title class="text-center">Relative Altitude Indicator Config</v-card-title>
+      <v-card-text class="flex flex-col gap-y-4">
+        <div class="absolute top-2 right-2 z-10">
+          <v-btn
+            icon
+            size="30"
+            variant="text"
+            class="text-white text-[22px]"
+            aria-label="Close"
+            @click="widgetStore.miniWidgetManagerVars(miniWidget.hash).configMenuOpen = false"
+          >
+            <i class="mdi mdi-close"></i>
+          </v-btn>
+        </div>
+        <v-select
+          v-if="!configUseCustomAltitudeVariable"
+          v-model="configAltitudeVariableId"
+          label="Altitude source"
+          :items="altitudeSourceOptions"
+          item-title="title"
+          item-value="value"
+          hide-details
+          theme="dark"
+          variant="outlined"
+          density="compact"
+          @update:model-value="onAltitudeSourceSelected"
+        />
+        <v-autocomplete
+          v-else
+          v-model="configAltitudeVariableId"
+          :items="availableDataLakeNumberVariables"
+          item-title="name"
+          item-value="id"
+          label="Data lake variable"
+          hint="Select any numeric data lake variable"
+          persistent-hint
+          theme="dark"
+          variant="outlined"
+          density="compact"
+          clearable
+          prepend-inner-icon="mdi-magnify"
+          @update:model-value="onAltitudeSourceSelected"
+        />
+        <v-checkbox
+          v-model="configUseCustomAltitudeVariable"
+          label="Use custom data lake variable"
+          hide-details
+          @update:model-value="onUseCustomAltitudeVariableToggled"
+        />
+      </v-card-text>
+    </v-card>
+  </v-dialog>
 </template>
 
 <script setup lang="ts">
 import { unit } from 'mathjs'
-import { computed, onBeforeMount, ref, toRefs, watch } from 'vue'
+import { computed, onBeforeMount, toRefs } from 'vue'
 
+import { mergeAltitudeVariableOptions, useAltitudeSourceConfig } from '@/composables/useAltitudeSourceConfig'
 import { useDataLakeVariable } from '@/composables/useDataLakeVariable'
+import {
+  altitudeSourceOptions,
+  defaultAltitudeIndicatorVariableId,
+  rawAltitudeToMeters,
+} from '@/libs/data-sources/altitude'
 import { unitAbbreviation } from '@/libs/units'
 import { useAppInterfaceStore } from '@/stores/appInterface'
+import { useWidgetManagerStore } from '@/stores/widgetManager'
 import type { MiniWidget } from '@/types/widgets'
 
 const props = defineProps<{
@@ -30,25 +91,38 @@ const props = defineProps<{
 }>()
 const miniWidget = toRefs(props).miniWidget
 
+const widgetStore = useWidgetManagerStore()
+const interfaceStore = useAppInterfaceStore()
+const { displayUnitPreferences } = interfaceStore
+
 const defaultOptions = {
-  altitudeVariableId: '/mavlink/1/1/GLOBAL_POSITION_INT/relative_alt',
+  altitudeVariableId: defaultAltitudeIndicatorVariableId,
+  useCustomAltitudeVariable: false,
 }
 
 onBeforeMount(() => {
-  miniWidget.value.options = { ...defaultOptions, ...miniWidget.value.options }
+  miniWidget.value.options = mergeAltitudeVariableOptions(defaultOptions, miniWidget.value.options)
 })
 
-const { displayUnitPreferences } = useAppInterfaceStore()
+const {
+  resolvedAltitudeVariableId,
+  configAltitudeVariableId,
+  configUseCustomAltitudeVariable,
+  availableDataLakeNumberVariables,
+  onAltitudeSourceSelected,
+  onUseCustomAltitudeVariableToggled,
+} = useAltitudeSourceConfig({
+  widget: miniWidget,
+  isConfigMenuOpen: () => widgetStore.miniWidgetManagerVars(miniWidget.value.hash).configMenuOpen,
+  defaultAltitudeVariableId: defaultAltitudeIndicatorVariableId,
+})
 
-const { value: rawAltitude } = useDataLakeVariable(() => miniWidget.value.options.altitudeVariableId)
+const { value: rawAltitude } = useDataLakeVariable(resolvedAltitudeVariableId)
 
-const currentAltitude = ref<undefined | number>(undefined)
-watch(rawAltitude, (newAlt) => {
-  if (newAlt === undefined) return
-  const altMeters = (newAlt as number) / 1000
-  const altitude = unit(altMeters, 'm')
-  const altitudeConverted = altitude.to(displayUnitPreferences.distance)
-  currentAltitude.value = altitudeConverted.toJSON().value
+const currentAltitude = computed<number | undefined>(() => {
+  if (resolvedAltitudeVariableId.value === undefined || typeof rawAltitude.value !== 'number') return undefined
+  const altMeters = rawAltitudeToMeters(resolvedAltitudeVariableId.value, rawAltitude.value)
+  return unit(altMeters, 'm').to(displayUnitPreferences.distance).toJSON().value as number
 })
 
 const parsedState = computed(() => {

--- a/src/components/widgets/DepthHUD.vue
+++ b/src/components/widgets/DepthHUD.vue
@@ -6,6 +6,44 @@
     <v-card class="pa-2" :style="interfaceStore.globalGlassMenuStyles">
       <v-card-title class="text-center">Depth HUD config</v-card-title>
       <v-card-text>
+        <v-select
+          v-if="!configUseCustomAltitudeVariable"
+          v-model="configAltitudeVariableId"
+          label="Altitude source"
+          :items="altitudeSourceOptions"
+          item-title="title"
+          item-value="value"
+          hide-details
+          theme="dark"
+          variant="outlined"
+          density="compact"
+          class="mb-2"
+          @update:model-value="onAltitudeSourceSelected"
+        />
+        <v-autocomplete
+          v-else
+          v-model="configAltitudeVariableId"
+          :items="availableDataLakeNumberVariables"
+          item-title="name"
+          item-value="id"
+          label="Data lake variable"
+          hint="Select any numeric data lake variable"
+          persistent-hint
+          theme="dark"
+          variant="outlined"
+          density="compact"
+          clearable
+          prepend-inner-icon="mdi-magnify"
+          class="mb-2"
+          @update:model-value="onAltitudeSourceSelected"
+        />
+        <v-checkbox
+          v-model="configUseCustomAltitudeVariable"
+          label="Use custom data lake variable"
+          hide-details
+          class="mb-2"
+          @update:model-value="onUseCustomAltitudeVariableToggled"
+        />
         <v-switch
           class="ma-1"
           label="Show height value"
@@ -40,7 +78,13 @@ import gsap from 'gsap'
 import { unit } from 'mathjs'
 import { computed, nextTick, onBeforeMount, onMounted, reactive, ref, toRefs, watch } from 'vue'
 
+import { mergeAltitudeVariableOptions, useAltitudeSourceConfig } from '@/composables/useAltitudeSourceConfig'
 import { useDataLakeVariable } from '@/composables/useDataLakeVariable'
+import {
+  altitudeSourceOptions,
+  defaultDepthAltitudeVariableId,
+  rawAltitudeToMeters,
+} from '@/libs/data-sources/altitude'
 import { datalogger, DatalogVariable } from '@/libs/sensors-logging'
 import { unitAbbreviation } from '@/libs/units'
 import { range, resetCanvas, round } from '@/libs/utils'
@@ -67,8 +111,22 @@ const colorSwatches = ref([['#FF2D2D'], ['#0ADB0ACC'], ['#FFFFFF']])
 const defaultOptions = {
   showDepthValue: true,
   hudColor: '#FFFFFF',
-  altitudeVariableId: '/mavlink/1/1/AHRS2/altitude',
+  altitudeVariableId: defaultDepthAltitudeVariableId,
+  useCustomAltitudeVariable: false,
 }
+
+const {
+  resolvedAltitudeVariableId,
+  configAltitudeVariableId,
+  configUseCustomAltitudeVariable,
+  availableDataLakeNumberVariables,
+  onAltitudeSourceSelected,
+  onUseCustomAltitudeVariableToggled,
+} = useAltitudeSourceConfig({
+  widget,
+  isConfigMenuOpen: () => widgetStore.widgetManagerVars(widget.value.hash).configMenuOpen,
+  defaultAltitudeVariableId: defaultDepthAltitudeVariableId,
+})
 
 type RenderVariables = {
   /**
@@ -96,7 +154,7 @@ const currentUnit = computed(() => unitAbbreviation[interfaceStore.displayUnitPr
 
 onBeforeMount(() => {
   // Set initial widget options if they don't exist
-  widget.value.options = { ...defaultOptions, ...widget.value.options }
+  widget.value.options = mergeAltitudeVariableOptions(defaultOptions, widget.value.options)
 })
 onMounted(() => {
   depthGraphDistances.value.forEach((distance: number) => (renderVars.depthLinesY[distance] = distanceY(distance)))
@@ -112,11 +170,17 @@ const canvasSize = computed(() => ({
 
 // The implementation below makes sure we don't update the Depth value in the widget whenever
 // the system Depth (from vehicle) updates, preventing unnecessary performance bottlenecks.
-const { value: rawAltitude } = useDataLakeVariable(() => widget.value.options.altitudeVariableId)
+const { value: rawAltitude } = useDataLakeVariable(resolvedAltitudeVariableId)
 
-watch(rawAltitude, (newAlt) => {
-  if (newAlt === undefined) return
-  const altMeters = newAlt as number
+// Reset the depth history when the altitude source changes so the graph scale doesn't carry
+// over the previous source's range while new values are still flowing in.
+watch(resolvedAltitudeVariableId, () => {
+  passedDepths.value = Array(10).fill(0)
+})
+
+watch([rawAltitude, resolvedAltitudeVariableId], ([newAlt, resolvedId]) => {
+  if (resolvedId === undefined || typeof newAlt !== 'number') return
+  const altMeters = rawAltitudeToMeters(resolvedId, newAlt)
   const newDepth = unit(-altMeters, 'm')
 
   const depthDiff = Math.abs(newDepth.value - (depth.value || 0))

--- a/src/components/widgets/DepthHUD.vue
+++ b/src/components/widgets/DepthHUD.vue
@@ -40,19 +40,19 @@ import gsap from 'gsap'
 import { unit } from 'mathjs'
 import { computed, nextTick, onBeforeMount, onMounted, reactive, ref, toRefs, watch } from 'vue'
 
+import { useDataLakeVariable } from '@/composables/useDataLakeVariable'
 import { datalogger, DatalogVariable } from '@/libs/sensors-logging'
 import { unitAbbreviation } from '@/libs/units'
 import { range, resetCanvas, round } from '@/libs/utils'
 import { useAppInterfaceStore } from '@/stores/appInterface'
-import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
 import type { Widget } from '@/types/widgets'
-const interfaceStore = useAppInterfaceStore()
 
+const interfaceStore = useAppInterfaceStore()
 const widgetStore = useWidgetManagerStore()
 
 datalogger.registerUsage(DatalogVariable.depth)
-const store = useMainVehicleStore()
+
 const props = defineProps<{
   /**
    * Widget reference
@@ -63,6 +63,12 @@ const widget = toRefs(props).widget
 
 // Pre-defined HUD colors
 const colorSwatches = ref([['#FF2D2D'], ['#0ADB0ACC'], ['#FFFFFF']])
+
+const defaultOptions = {
+  showDepthValue: true,
+  hudColor: '#FFFFFF',
+  altitudeVariableId: '/mavlink/1/1/AHRS2/altitude',
+}
 
 type RenderVariables = {
   /**
@@ -90,12 +96,7 @@ const currentUnit = computed(() => unitAbbreviation[interfaceStore.displayUnitPr
 
 onBeforeMount(() => {
   // Set initial widget options if they don't exist
-  if (Object.keys(widget.value.options).length === 0) {
-    widget.value.options = {
-      showDepthValue: true,
-      hudColor: colorSwatches.value[2][0],
-    }
-  }
+  widget.value.options = { ...defaultOptions, ...widget.value.options }
 })
 onMounted(() => {
   depthGraphDistances.value.forEach((distance: number) => (renderVars.depthLinesY[distance] = distanceY(distance)))
@@ -111,9 +112,12 @@ const canvasSize = computed(() => ({
 
 // The implementation below makes sure we don't update the Depth value in the widget whenever
 // the system Depth (from vehicle) updates, preventing unnecessary performance bottlenecks.
-watch(store.altitude, () => {
-  const altitude = store.altitude.msl
-  const newDepth = unit(-altitude.value, altitude.toJSON().unit)
+const { value: rawAltitude } = useDataLakeVariable(() => widget.value.options.altitudeVariableId)
+
+watch(rawAltitude, (newAlt) => {
+  if (newAlt === undefined) return
+  const altMeters = newAlt as number
+  const newDepth = unit(-altMeters, 'm')
 
   const depthDiff = Math.abs(newDepth.value - (depth.value || 0))
   if (depthDiff < 0.1) return

--- a/src/composables/useAltitudeSourceConfig.ts
+++ b/src/composables/useAltitudeSourceConfig.ts
@@ -1,0 +1,173 @@
+import { type MaybeRefOrGetter, type Ref, computed, onMounted, onUnmounted, ref, toValue, watch } from 'vue'
+
+import { useResolvedDataLakeTemplate } from '@/composables/useResolvedDataLakeTemplate'
+import {
+  DataLakeVariable,
+  getAllDataLakeVariablesInfo,
+  listenToDataLakeVariablesInfoChanges,
+  unlistenToDataLakeVariablesInfoChanges,
+} from '@/libs/actions/data-lake'
+import { isPresetAltitudeVariableId } from '@/libs/data-sources/altitude'
+
+/** Altitude source selections saved when the config menu opens. */
+type AltitudeConfigSnapshot = {
+  /** Data lake variable ID for the active altitude source. */
+  altitudeVariableId: string
+  /** Whether a custom data lake variable is selected. */
+  useCustomAltitudeVariable: boolean
+}
+
+type AltitudeVariableOptions = {
+  /** Persisted data lake variable ID (templated for presets, concrete for custom variables). */
+  altitudeVariableId?: string
+  /** Whether the user has opted into picking a custom data lake variable. */
+  useCustomAltitudeVariable?: boolean
+}
+
+/**
+ * Merge persisted altitude options with defaults and infer custom mode when needed.
+ * @param {T} defaultOptions - Default widget options
+ * @param {Partial<T>} persistedOptions - Persisted widget options
+ * @returns {T} Merged widget options
+ */
+export const mergeAltitudeVariableOptions = <T extends AltitudeVariableOptions>(
+  defaultOptions: T,
+  persistedOptions: Partial<T>
+): T => {
+  const merged = { ...defaultOptions, ...persistedOptions }
+
+  if (merged.altitudeVariableId && !isPresetAltitudeVariableId(merged.altitudeVariableId)) {
+    merged.useCustomAltitudeVariable = true
+  }
+
+  return merged
+}
+
+/**
+ * Manage draft altitude source config while a widget config menu is open and
+ * expose the resolved data lake variable ID for runtime subscription.
+ * @param {object} params - Configuration parameters
+ * @param {Ref<{ options: AltitudeVariableOptions }>} params.widget - Widget or mini-widget ref
+ * @param {MaybeRefOrGetter<boolean>} params.isConfigMenuOpen - Whether the config menu is open
+ * @param {string} params.defaultAltitudeVariableId - Default preset altitude variable ID (templated)
+ * @returns {object} Draft config state and the resolved variable ID
+ */
+export function useAltitudeSourceConfig(params: {
+  /** Widget (or mini-widget) reference whose `options` hold the altitude selection. */
+  widget: Ref<{
+    /** Altitude selection options stored on the widget. */
+    options: AltitudeVariableOptions
+  }>
+  /** Reactive flag indicating whether the widget config menu is open. */
+  isConfigMenuOpen: MaybeRefOrGetter<boolean>
+  /** Templated data lake variable ID applied when no preset has been chosen yet. */
+  defaultAltitudeVariableId: string
+}): {
+  /** Concrete data lake variable ID for the active source, resolved at runtime. */
+  resolvedAltitudeVariableId: ReturnType<typeof computed<string | undefined>>
+  /** Draft altitude variable ID bound to the config menu controls. */
+  configAltitudeVariableId: Ref<string | undefined>
+  /** Draft "custom data lake variable" toggle bound to the config menu. */
+  configUseCustomAltitudeVariable: Ref<boolean>
+  /** Numeric data lake variables available to pick as a custom altitude source. */
+  availableDataLakeNumberVariables: ReturnType<typeof computed<DataLakeVariable[]>>
+  /** Logs a user-driven altitude source selection; wire to the config control's `@update:model-value`. */
+  onAltitudeSourceSelected: (variableId: string | undefined) => void
+  /** Logs the custom-variable toggle; wire to the checkbox's `@update:model-value`. */
+  onUseCustomAltitudeVariableToggled: (useCustomAltitudeVariable: boolean | null) => void
+} {
+  const availableDataLakeVariables = ref<DataLakeVariable[]>([])
+  let dataLakeVariableInfoListenerId: string | undefined
+
+  const availableDataLakeNumberVariables = computed(() => {
+    return availableDataLakeVariables.value.filter((variable) => variable.type === 'number')
+  })
+
+  const resolvedAltitudeVariableId = useResolvedDataLakeTemplate(() => params.widget.value.options.altitudeVariableId)
+
+  const configAltitudeVariableId = ref<string | undefined>()
+  const configUseCustomAltitudeVariable = ref(false)
+  let altitudeConfigSnapshot: AltitudeConfigSnapshot = {
+    altitudeVariableId: params.defaultAltitudeVariableId,
+    useCustomAltitudeVariable: false,
+  }
+
+  const openAltitudeConfigMenu = (): void => {
+    altitudeConfigSnapshot = {
+      altitudeVariableId: params.widget.value.options.altitudeVariableId ?? params.defaultAltitudeVariableId,
+      useCustomAltitudeVariable: params.widget.value.options.useCustomAltitudeVariable ?? false,
+    }
+    configAltitudeVariableId.value = params.widget.value.options.altitudeVariableId
+    configUseCustomAltitudeVariable.value = params.widget.value.options.useCustomAltitudeVariable ?? false
+  }
+
+  const closeAltitudeConfigMenu = (): void => {
+    const customSelectionMissing = configUseCustomAltitudeVariable.value && !configAltitudeVariableId.value
+
+    if (customSelectionMissing) {
+      params.widget.value.options.altitudeVariableId = altitudeConfigSnapshot.altitudeVariableId
+      params.widget.value.options.useCustomAltitudeVariable = altitudeConfigSnapshot.useCustomAltitudeVariable
+      return
+    }
+
+    params.widget.value.options.altitudeVariableId =
+      configAltitudeVariableId.value ?? altitudeConfigSnapshot.altitudeVariableId
+    params.widget.value.options.useCustomAltitudeVariable = configUseCustomAltitudeVariable.value
+  }
+
+  onMounted(() => {
+    availableDataLakeVariables.value = Object.values(getAllDataLakeVariablesInfo())
+    dataLakeVariableInfoListenerId = listenToDataLakeVariablesInfoChanges((variables) => {
+      availableDataLakeVariables.value = Object.values(variables)
+    })
+  })
+
+  onUnmounted(() => {
+    if (dataLakeVariableInfoListenerId) {
+      unlistenToDataLakeVariablesInfoChanges(dataLakeVariableInfoListenerId)
+    }
+  })
+
+  watch(
+    () => toValue(params.isConfigMenuOpen),
+    (isOpen, wasOpen) => {
+      if (isOpen && !wasOpen) openAltitudeConfigMenu()
+      if (!isOpen && wasOpen) closeAltitudeConfigMenu()
+    }
+  )
+
+  watch(configUseCustomAltitudeVariable, (useCustomAltitudeVariable, wasCustomAltitudeVariable) => {
+    if (useCustomAltitudeVariable && !wasCustomAltitudeVariable) {
+      // Preserve a non-preset id (e.g. when openAltitudeConfigMenu loads a persisted
+      // custom selection), and only clear when the previous draft was a preset.
+      if (configAltitudeVariableId.value && !isPresetAltitudeVariableId(configAltitudeVariableId.value)) {
+        return
+      }
+      configAltitudeVariableId.value = undefined
+      return
+    }
+
+    if (!useCustomAltitudeVariable && wasCustomAltitudeVariable) {
+      if (!configAltitudeVariableId.value || !isPresetAltitudeVariableId(configAltitudeVariableId.value)) {
+        configAltitudeVariableId.value = params.defaultAltitudeVariableId
+      }
+    }
+  })
+
+  const onAltitudeSourceSelected = (variableId: string | undefined): void => {
+    if (variableId) logUserAction(`Selected altitude source '${variableId}'`)
+  }
+
+  const onUseCustomAltitudeVariableToggled = (useCustomAltitudeVariable: boolean | null): void => {
+    logUserAction(`${useCustomAltitudeVariable ? 'Enabled' : 'Disabled'} custom altitude data lake variable`)
+  }
+
+  return {
+    resolvedAltitudeVariableId,
+    configAltitudeVariableId,
+    configUseCustomAltitudeVariable,
+    availableDataLakeNumberVariables,
+    onAltitudeSourceSelected,
+    onUseCustomAltitudeVariableToggled,
+  }
+}

--- a/src/composables/useDataLakeVariable.ts
+++ b/src/composables/useDataLakeVariable.ts
@@ -31,15 +31,8 @@ export function useDataLakeVariable(variableId: MaybeRefOrGetter<string | undefi
     }
 
     currentVariableId = id
-    if (!id) {
-      value.value = undefined
-      return
-    }
-
-    const initialValue = getDataLakeVariableData(id)
-    if (initialValue !== undefined) {
-      value.value = initialValue
-    }
+    value.value = id ? getDataLakeVariableData(id) : undefined
+    if (!id) return
 
     currentListenerId = listenDataLakeVariable(id, (raw) => {
       value.value = raw

--- a/src/composables/useResolvedDataLakeTemplate.ts
+++ b/src/composables/useResolvedDataLakeTemplate.ts
@@ -1,0 +1,56 @@
+import { type MaybeRefOrGetter, computed, onUnmounted, ref, toValue, watch } from 'vue'
+
+import { listenDataLakeVariable, unlistenDataLakeVariable } from '@/libs/actions/data-lake'
+import { findDataLakeVariablesIdsInString, replaceDataLakeInputsInString } from '@/libs/utils-data-lake'
+
+/**
+ * Resolve a string containing mustache-style data lake placeholders
+ * (e.g. '/mavlink/{{autopilotSystemId}}/1/AHRS2/altitude') reactively.
+ * Re-resolves when the template itself changes or when any of the referenced
+ * data lake variables update.
+ * @param {MaybeRefOrGetter<string | undefined>} template - The template string
+ * @returns {ReturnType<typeof computed<string | undefined>>} The resolved string
+ */
+export function useResolvedDataLakeTemplate(
+  template: MaybeRefOrGetter<string | undefined>
+): ReturnType<typeof computed<string | undefined>> {
+  // Bumped by each referenced variable's listener to force re-resolution.
+  const tick = ref(0)
+  let subscriptions: {
+    /** ID of the data lake variable being listened to. */
+    variableId: string
+    /** Listener handle returned by `listenDataLakeVariable` for later cleanup. */
+    listenerId: string
+  }[] = []
+
+  const clearSubscriptions = (): void => {
+    subscriptions.forEach(({ variableId, listenerId }) => {
+      unlistenDataLakeVariable(variableId, listenerId)
+    })
+    subscriptions = []
+  }
+
+  const resubscribe = (currentTemplate: string | undefined): void => {
+    clearSubscriptions()
+    if (!currentTemplate) return
+
+    const referencedIds = Array.from(new Set(findDataLakeVariablesIdsInString(currentTemplate)))
+    referencedIds.forEach((variableId) => {
+      const listenerId = listenDataLakeVariable(variableId, () => {
+        tick.value++
+      })
+      subscriptions.push({ variableId, listenerId })
+    })
+  }
+
+  watch(() => toValue(template), resubscribe, { immediate: true })
+
+  onUnmounted(clearSubscriptions)
+
+  return computed(() => {
+    void tick.value
+    const value = toValue(template)
+    if (!value) return undefined
+    return replaceDataLakeInputsInString(value)
+  })
+}

--- a/src/libs/data-sources/altitude.ts
+++ b/src/libs/data-sources/altitude.ts
@@ -1,0 +1,72 @@
+/** Altitude source entry for widgets that read MAVLink altitude fields. */
+export type AltitudeSourceOption = {
+  /** User-facing source label shown in widget config menus. */
+  title: string
+  /** Templated data lake variable ID; resolved at runtime via the mustache system. */
+  value: string
+  /** Converts the raw data lake altitude value to meters. */
+  toMeters: (rawAltitude: number) => number
+}
+
+/** Altitude source options exposed to widget config menus. */
+export const altitudeSourceOptions: AltitudeSourceOption[] = [
+  {
+    title: 'ahrs2.alt',
+    value: '/mavlink/{{autopilotSystemId}}/1/AHRS2/altitude',
+    toMeters: (rawAltitude) => rawAltitude,
+  },
+  {
+    title: 'vfr_hud.alt',
+    value: '/mavlink/{{autopilotSystemId}}/1/VFR_HUD/alt',
+    toMeters: (rawAltitude) => rawAltitude,
+  },
+  {
+    title: 'global_position_int.alt',
+    value: '/mavlink/{{autopilotSystemId}}/1/GLOBAL_POSITION_INT/alt',
+    toMeters: (rawAltitude) => rawAltitude / 1000,
+  },
+  {
+    title: 'global_position_int.relative_alt',
+    value: '/mavlink/{{autopilotSystemId}}/1/GLOBAL_POSITION_INT/relative_alt',
+    toMeters: (rawAltitude) => rawAltitude / 1000,
+  },
+]
+
+/** Default altitude source for depth widgets (ahrs2.alt). */
+export const defaultDepthAltitudeVariableId = altitudeSourceOptions[0].value
+
+/** Default altitude source for altitude indicators (global_position_int.relative_alt). */
+export const defaultAltitudeIndicatorVariableId = altitudeSourceOptions[3].value
+
+// Captures the suffix from both templated and concrete preset paths.
+const ALTITUDE_PATH_PATTERN = /^\/mavlink\/(?:\d+|\{\{autopilotSystemId\}\})\/\d+\/(.+)$/
+
+const extractAltitudeSuffix = (variableId: string): string | undefined => variableId.match(ALTITUDE_PATH_PATTERN)?.[1]
+
+const findOptionForVariableId = (variableId: string): AltitudeSourceOption | undefined => {
+  const suffix = extractAltitudeSuffix(variableId)
+  if (!suffix) return undefined
+  return altitudeSourceOptions.find((option) => extractAltitudeSuffix(option.value) === suffix)
+}
+
+/**
+ * Whether the given variable ID matches a known altitude source preset
+ * (templated form or a concrete /mavlink/N/N/SUFFIX path).
+ * @param {string} altitudeVariableId - Data lake variable ID or template
+ * @returns {boolean} True if it matches a preset
+ */
+export const isPresetAltitudeVariableId = (altitudeVariableId: string): boolean =>
+  findOptionForVariableId(altitudeVariableId) !== undefined
+
+/**
+ * Convert a raw altitude value from the selected altitude source to meters.
+ * Accepts either the templated or the concrete data lake variable ID. Custom
+ * (non-preset) variables are assumed to already be in meters and pass through unchanged.
+ * @param {string} altitudeVariableId - Data lake variable ID for the altitude source
+ * @param {number} rawAltitude - Raw altitude value from the data lake
+ * @returns {number} Altitude in meters
+ */
+export const rawAltitudeToMeters = (altitudeVariableId: string, rawAltitude: number): number => {
+  const option = findOptionForVariableId(altitudeVariableId)
+  return option ? option.toMeters(rawAltitude) : rawAltitude
+}

--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -893,7 +893,7 @@ export const isMiniWidgetConfigurable: Record<MiniWidgetType, boolean> = {
   [MiniWidgetType.EnterEditMode]: false,
   [MiniWidgetType.DepthIndicator]: true,
   [MiniWidgetType.MissionIdentifier]: true,
-  [MiniWidgetType.RelativeAltitudeIndicator]: false,
+  [MiniWidgetType.RelativeAltitudeIndicator]: true,
   [MiniWidgetType.TakeoffLandCommander]: false,
   [MiniWidgetType.VeryGenericIndicator]: true,
   [MiniWidgetType.JoystickCommIndicator]: true,

--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -891,7 +891,7 @@ export const isMiniWidgetConfigurable: Record<MiniWidgetType, boolean> = {
   [MiniWidgetType.GoFullScreen]: false,
   [MiniWidgetType.EkfStateIndicator]: false,
   [MiniWidgetType.EnterEditMode]: false,
-  [MiniWidgetType.DepthIndicator]: false,
+  [MiniWidgetType.DepthIndicator]: true,
   [MiniWidgetType.MissionIdentifier]: true,
   [MiniWidgetType.RelativeAltitudeIndicator]: false,
   [MiniWidgetType.TakeoffLandCommander]: false,


### PR DESCRIPTION
I'm segregating this one from #2449 because there are problems happening with the depth data that comes from ArduSub and apparently in some cases the current default `AHRS2.altitude` doesn't work well.

<img width="563" height="371" alt="image" src="https://github.com/user-attachments/assets/95b9a5a0-7bb9-4e5a-bd93-8a1bfc4d5872" />


By default the user faces 4 options:
- AHRS2.altitude
- VFR_HUD.alt
- GLOBAL_POSITION_INT.alt
- GLOBAL_POSITION_INT.relative_alt

The user can also click a checkbox to allow choosing any number variable from the data-lake, in case they want to go custom.

Fix #2155 