### PR TITLE
map: use dedicated renderer for vehicle path history

### DIFF
--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -923,7 +923,9 @@ onMounted(async () => {
   // Initialize vehicle history polyline if vehicle marker is on screen
   if (map.value && vehicleMarker.value && missionStore.vehiclePositionHistory.length > 0) {
     if (vehicleHistoryPolyline.value === undefined) {
-      vehicleHistoryPolyline.value = L.polyline([], { color: '#ffff00' }).addTo(map.value)
+      vehicleHistoryPolyline.value = L.polyline([], { color: '#ffff00', renderer: vehicleHistoryRenderer }).addTo(
+        map.value
+      )
     }
     vehicleHistoryPolyline.value.setLatLngs(missionStore.vehiclePositionHistory as L.LatLngExpression[])
     lastDrawnHistoryLen = missionStore.vehiclePositionHistory.length
@@ -1479,8 +1481,8 @@ watch([getReachedWaypointIndices, currentMapWpIndex], () => {
   })
 })
 
-// Create polyline for the vehicle path
-// Watch a revision counter instead of the array itself so we avoid Vue's deep-walk on every mutation.
+// Create polyline for the vehicle path using a dedicated Canvas renderer to prevent performance issues
+const vehicleHistoryRenderer = L.canvas()
 const vehicleHistoryPolyline = shallowRef<L.Polyline>()
 let lastDrawnHistoryLen = 0
 watch(
@@ -1497,7 +1499,9 @@ watch(
     }
 
     if (vehicleHistoryPolyline.value === undefined) {
-      vehicleHistoryPolyline.value = L.polyline([], { color: '#ffff00' }).addTo(map.value)
+      vehicleHistoryPolyline.value = L.polyline([], { color: '#ffff00', renderer: vehicleHistoryRenderer }).addTo(
+        map.value
+      )
       lastDrawnHistoryLen = 0
     }
 

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -4179,8 +4179,8 @@ watch(
   { immediate: true, deep: true }
 )
 
-// Create polyline for the vehicle history path (only shown when vehicle marker is on screen)
-// Watch a revision counter instead of the array itself so we avoid Vue's deep-walk on every mutation.
+// Create polyline for the vehicle path using a dedicated Canvas renderer to prevent performance issues
+const vehicleHistoryRenderer = L.canvas()
 const vehicleHistoryPolyline = shallowRef<L.Polyline>()
 let lastDrawnHistoryLen = 0
 watch(
@@ -4198,7 +4198,9 @@ watch(
     }
 
     if (vehicleHistoryPolyline.value === undefined) {
-      vehicleHistoryPolyline.value = L.polyline([], { color: '#ffff00' }).addTo(planningMap.value)
+      vehicleHistoryPolyline.value = L.polyline([], { color: '#ffff00', renderer: vehicleHistoryRenderer }).addTo(
+        planningMap.value
+      )
       lastDrawnHistoryLen = 0
     }
 


### PR DESCRIPTION
* Created a dedicated canvas to render the vehicle's history line;
* Image below shows where the history line has been deleted (1).
  
<img width="1975" height="1100" alt="image" src="https://github.com/user-attachments/assets/8270ee04-3789-4e9f-b127-0b244f7c9ec2" />

Close #2718 