### PR TITLE
Harden vehicle reconnection routine

### DIFF
--- a/src/libs/connection/connection-manager.ts
+++ b/src/libs/connection/connection-manager.ts
@@ -3,7 +3,18 @@ import * as Protocol from '@/libs/vehicle/protocol/protocol'
 
 import * as Connection from './connection'
 import { ElectronConnection } from './electron-connection'
-import { WebSocketConnection } from './websocket-connection'
+import { WebSocketConnection, WebSocketConnectionOptions } from './websocket-connection'
+
+/**
+ * Optional, transport-specific configuration accepted by {@link ConnectionManager.addConnection}.
+ */
+export interface AddConnectionOptions {
+  /**
+   * Configuration forwarded to {@link WebSocketConnection} when the connection's URI uses a
+   * websocket scheme. Ignored for other transports.
+   */
+  websocket?: WebSocketConnectionOptions
+}
 
 /**
  * Manager to handle multiple connections
@@ -30,12 +41,13 @@ export class ConnectionManager {
    * Add a specific connection
    * @param  {Connection.URI} uri
    * @param  {Protocol.Type} vehicleProtocol
+   * @param  {AddConnectionOptions} options Optional transport-specific configuration.
    */
-  static addConnection(uri: Connection.URI, vehicleProtocol: Protocol.Type): void {
+  static addConnection(uri: Connection.URI, vehicleProtocol: Protocol.Type, options: AddConnectionOptions = {}): void {
     let connection = undefined
     switch (uri.type()) {
       case Connection.Type.WebSocket:
-        connection = new WebSocketConnection(uri, vehicleProtocol)
+        connection = new WebSocketConnection(uri, vehicleProtocol, options.websocket)
         break
       case Connection.Type.Serial:
       case Connection.Type.TcpIn:
@@ -81,6 +93,10 @@ export class ConnectionManager {
 
     previousConnection?.onRead?.clear()
     previousConnection?.onWrite?.clear()
+    // Stop background activity (watchdog interval, reconnect timer, underlying socket) on the
+    // replaced connection. Otherwise a URI change leaks a ghost connection that keeps reconnecting
+    // and ticking its watchdog forever in the background.
+    previousConnection?.disconnect()
     connection.onRead.add((data: Uint8Array) => this.onRead.emit_value(data))
     connection.onWrite.add((data: Uint8Array) => this.onWrite.emit_value(data))
     ConnectionManager._mainConnection = new WeakRef(connection)

--- a/src/libs/connection/websocket-connection.ts
+++ b/src/libs/connection/websocket-connection.ts
@@ -3,85 +3,355 @@ import * as Protocol from '@/libs/vehicle/protocol/protocol'
 import * as Connection from './connection'
 
 /**
- * Connection abstraction for websocket communication
+ * Options for {@link WebSocketConnection}.
+ */
+export interface WebSocketConnectionOptions {
+  /**
+   * Returns the user-configured watchdog timeout in milliseconds: how long the socket may stay
+   * `OPEN` without receiving any message before the connection is considered stuck and forcibly
+   * recycled. Decoupled from the UI-facing heartbeat timeout so users can pick each independently.
+   * @returns {number} Current watchdog timeout in milliseconds.
+   */
+  getWatchdogTimeoutMs?: () => number
+}
+
+const DEFAULT_WATCHDOG_TIMEOUT_MS = 4_000
+
+// Initial delay before retrying after a close, doubled on each consecutive failure up to the cap.
+// Keeps quick-recovery cases snappy while avoiding a tight loop when the link is down for long.
+const RECONNECT_INITIAL_DELAY_MS = 500
+const RECONNECT_MAX_DELAY_MS = 5_000
+
+const WATCHDOG_INTERVAL_MS = 1_000
+
+// Absolute floor for the idle window, protecting against pathological configuration. Anything
+// shorter than this would cause spurious recycles even on healthy links where the normal
+// inter-message gap (e.g. 1 Hz heartbeats on a low-traffic vehicle) is around a second.
+const MIN_IDLE_TIMEOUT_MS = 1_000
+
+// Maximum time a new socket is allowed to remain in the `CONNECTING` state before we give up and
+// recycle. A real TCP+TLS+upgrade handshake should comfortably complete inside this on any link
+// Cockpit is usable on; longer means something at the network layer is permanently lost.
+const CONNECTING_TIMEOUT_MS = 10_000
+
+const LOG_PREFIX = '[WebSocketConnection]'
+
+/**
+ * Connection abstraction for websocket communication, with auto-reconnect, error handling, and a
+ * watchdog that recovers from sockets stuck in `CONNECTING` or `OPEN`-but-silent states (which
+ * Chromium can hold for over a minute on a half-dead TCP connection before firing `onclose`).
  */
 export class WebSocketConnection extends Connection.Abstract {
-  _socket: WebSocket
+  private _socket: WebSocket | null = null
   private _textEncoder = new TextEncoder()
   private _textDecoder = new TextDecoder()
 
+  private _getWatchdogTimeoutMs: () => number
+  private _connectingSince: number | undefined
+  private _openedAt: number | undefined
+  private _lastMessageAt = 0
+  private _reconnectAttempts = 0
+  private _reconnectTimer: ReturnType<typeof setTimeout> | undefined
+  private _watchdogInterval: ReturnType<typeof setInterval> | undefined
+  private _disposed = false
+
   /**
    * Websocket constructor
-   * @param  {Connection.URI} uri
-   * @param  {Protocol.Type} vehicleProtocol
+   * @param {Connection.URI} uri - URI to connect to.
+   * @param {Protocol.Type} vehicleProtocol - Vehicle communication protocol carried over the socket.
+   * @param {WebSocketConnectionOptions} options - Optional configuration for reconnect behavior.
    */
-  constructor(uri: Connection.URI, vehicleProtocol: Protocol.Type) {
+  constructor(uri: Connection.URI, vehicleProtocol: Protocol.Type, options: WebSocketConnectionOptions = {}) {
     super(uri, vehicleProtocol)
 
-    this._socket = this.createSocket(uri)
+    this._getWatchdogTimeoutMs = options.getWatchdogTimeoutMs ?? (() => DEFAULT_WATCHDOG_TIMEOUT_MS)
+
+    this._openSocket()
+    this._startWatchdog()
   }
 
   /**
-   * Disconnect the websocket
-   * @returns {boolean}
+   * Permanently disconnect this websocket and stop all background activity. After calling this the
+   * connection cannot be reused.
+   * @returns {boolean} Always true.
    */
   disconnect(): boolean {
-    unimplemented()
+    this._disposed = true
+    this._stopWatchdog()
+    this._cancelPendingReconnect()
+    this._detachSocket()
     return true
   }
 
   /**
-   * Do the websocket connection
-   * @returns {boolean}
+   * Ensure the websocket is being established. If it was disposed this is a no-op; otherwise it
+   * triggers an immediate reconnect attempt when the socket is missing or already closed.
+   * @returns {boolean} Always true.
    */
   connect(): boolean {
-    unimplemented()
+    if (this._disposed) return true
+    if (this._socket === null || this._socket.readyState === WebSocket.CLOSED) {
+      this._scheduleReconnect(0)
+    }
     return true
   }
 
   /**
-   * Check if connection is still alive
-   * @returns {boolean}
+   * Whether the underlying socket is currently in the `OPEN` state.
+   * @returns {boolean} True when the socket is open and ready to send/receive.
    */
   isConnected(): boolean {
-    unimplemented()
-    return true
+    return this._socket?.readyState === WebSocket.OPEN
   }
 
   /**
-   * Write data to websocket
-   * @param  {Uint8Array} data
-   * @returns {boolean}
+   * Write data to the websocket. Silently drops the message if the socket is not currently `OPEN`,
+   * since attempting to send on a `CONNECTING` socket throws and we already detect missing data via
+   * the watchdog.
+   * @param {Uint8Array} data - Bytes to send (will be decoded to a UTF-8 string for the socket).
+   * @returns {boolean} True if the message was handed to the socket, false if it was dropped.
    */
   write(data: Uint8Array): boolean {
-    this._socket?.send(this._textDecoder.decode(data))
-    return true
+    const socket = this._socket
+    if (!socket || socket.readyState !== WebSocket.OPEN) return false
+
+    try {
+      socket.send(this._textDecoder.decode(data))
+      return true
+    } catch (error) {
+      console.error(`${LOG_PREFIX} Failed to send data:`, error)
+      return false
+    }
   }
 
   /**
-   * Create internal websocket connection
-   * @param  {Connection.URI} uri
-   * @returns {WebSocket}
+   * Detach the current socket (if any) and start a new connection attempt.
    */
-  protected createSocket(uri: Connection.URI): WebSocket {
-    const socket = new WebSocket(uri)
+  private _openSocket(): void {
+    if (this._disposed) return
 
-    // TODO:
-    // We need to parse the websocket message to a simple string and let the one that
-    // receives do the json parsing
-    // We need to have the same abstraction for all onRead
-    socket.onmessage = (message: MessageEvent) => {
+    this._detachSocket()
+
+    const uri = this.uri()
+    // Stamp the CONNECTING start before the WebSocket is constructed: in environments where the
+    // socket can open synchronously (e.g. some test mocks) `_onOpen` runs inside this call and
+    // would otherwise see an undefined `_connectingSince`.
+    this._connectingSince = Date.now()
+
+    let socket: WebSocket
+    try {
+      socket = new WebSocket(uri)
+    } catch (error) {
+      console.error(`${LOG_PREFIX} Failed to construct socket for ${uri.toString()}:`, error)
+      this._connectingSince = undefined
+      this._scheduleReconnect()
+      return
+    }
+
+    this._socket = socket
+    console.info(`${LOG_PREFIX} Connecting to ${uri.toString()}...`)
+
+    socket.onopen = () => this._onOpen()
+    socket.onmessage = (event: MessageEvent) => this._onMessage(event)
+    socket.onerror = (event: Event) => this._onError(event)
+    socket.onclose = (event: CloseEvent) => this._onClose(event)
+  }
+
+  /**
+   * Mark the connection as healthy and reset reconnect state when the socket opens.
+   */
+  private _onOpen(): void {
+    this._connectingSince = undefined
+    this._openedAt = Date.now()
+    this._reconnectAttempts = 0
+    this._lastMessageAt = Date.now()
+    console.info(`${LOG_PREFIX} Connected to ${this.uri().toString()}.`)
+  }
+
+  /**
+   * @param {MessageEvent} event Message event from the underlying socket.
+   */
+  private _onMessage(event: MessageEvent): void {
+    this._lastMessageAt = Date.now()
+    try {
+      this.onRead.emit_value(this._textEncoder.encode(event.data))
+    } catch (error) {
+      // Render the error inline as a string: many native errors thrown from downstream parsers
+      // have no enumerable own properties, which made earlier syslogs show a useless `{}` here.
+      const reason = error instanceof Error ? error.message || String(error) : String(error)
+      const preview = typeof event.data === 'string' ? event.data.slice(0, 200) : '[non-string payload]'
+      console.error(`${LOG_PREFIX} Error reading websocket message: ${reason}. Payload (truncated): ${preview}`)
+    }
+  }
+
+  /**
+   * @param {Event} event Error event from the underlying socket.
+   */
+  private _onError(event: Event): void {
+    console.warn(`${LOG_PREFIX} Socket error on ${this.uri().toString()}:`, event)
+  }
+
+  /**
+   * @param {CloseEvent} event Close event from the underlying socket.
+   */
+  private _onClose(event: CloseEvent): void {
+    const uptime = this._openUptimeDescription()
+    if (event.wasClean) {
+      console.info(
+        `${LOG_PREFIX} Socket closed (code=${event.code}, reason="${event.reason || 'n/a'}", clean=true). ${uptime}`
+      )
+    } else {
+      console.warn(
+        `${LOG_PREFIX} Socket closed unexpectedly (code=${event.code}, reason="${event.reason || 'n/a'}"). ${uptime}`
+      )
+    }
+    this._connectingSince = undefined
+    this._openedAt = undefined
+    this._scheduleReconnect()
+  }
+
+  /**
+   * @param {number} [forcedDelayMs] If provided, override the backoff schedule with this delay.
+   */
+  private _scheduleReconnect(forcedDelayMs?: number): void {
+    if (this._disposed) return
+    if (this._reconnectTimer !== undefined) return
+
+    const delay = forcedDelayMs ?? this._nextBackoffDelayMs()
+    this._reconnectAttempts += 1
+
+    if (delay > 0) {
+      console.info(
+        `${LOG_PREFIX} Reconnecting in ${delay} ms (attempt #${this._reconnectAttempts}) to ${this.uri().toString()}.`
+      )
+    }
+
+    this._reconnectTimer = setTimeout(() => {
+      this._reconnectTimer = undefined
+      this._openSocket()
+    }, delay)
+  }
+
+  /**
+   * Cancel a pending reconnect timer, if one is scheduled.
+   */
+  private _cancelPendingReconnect(): void {
+    if (this._reconnectTimer === undefined) return
+    clearTimeout(this._reconnectTimer)
+    this._reconnectTimer = undefined
+  }
+
+  /**
+   * @returns {number} Capped exponential backoff delay (in ms) for the next reconnect attempt.
+   */
+  private _nextBackoffDelayMs(): number {
+    const exp = Math.min(this._reconnectAttempts, 10)
+    const delay = RECONNECT_INITIAL_DELAY_MS * 2 ** exp
+    return Math.min(delay, RECONNECT_MAX_DELAY_MS)
+  }
+
+  /**
+   * Remove all handlers from the current socket and close it. Safe to call when no socket exists.
+   */
+  private _detachSocket(): void {
+    const socket = this._socket
+    if (!socket) return
+
+    socket.onopen = null
+    socket.onmessage = null
+    socket.onerror = null
+    socket.onclose = null
+
+    if (socket.readyState !== WebSocket.CLOSED && socket.readyState !== WebSocket.CLOSING) {
       try {
-        this.onRead.emit_value(this._textEncoder.encode(message.data))
+        socket.close()
       } catch (error) {
-        console.error('Error reading websocket message: ', error)
+        console.warn(`${LOG_PREFIX} Error while closing socket:`, error)
       }
     }
-    socket.onclose = () => {
-      setTimeout(() => {
-        this._socket = this.createSocket(uri)
-      }, 2000)
+
+    this._socket = null
+    this._connectingSince = undefined
+    this._openedAt = undefined
+  }
+
+  /**
+   * Start the periodic watchdog that recycles sockets stuck in `CONNECTING` or `OPEN`-but-silent.
+   */
+  private _startWatchdog(): void {
+    if (this._watchdogInterval !== undefined) return
+    this._watchdogInterval = setInterval(() => this._runWatchdog(), WATCHDOG_INTERVAL_MS)
+  }
+
+  /**
+   * Stop the periodic watchdog. Safe to call when no watchdog is running.
+   */
+  private _stopWatchdog(): void {
+    if (this._watchdogInterval === undefined) return
+    clearInterval(this._watchdogInterval)
+    this._watchdogInterval = undefined
+  }
+
+  /**
+   * Single watchdog tick. Recycles the socket if it has been stuck for too long, or schedules a
+   * reconnect if the socket is missing entirely.
+   */
+  private _runWatchdog(): void {
+    if (this._disposed) return
+
+    const socket = this._socket
+    const idleTimeoutMs = Math.max(MIN_IDLE_TIMEOUT_MS, this._getWatchdogTimeoutMs())
+
+    // No socket and no pending reconnect: failsafe path that recovers from any state where we lost
+    // track of the socket without scheduling its replacement (e.g. an exception during _openSocket).
+    if (!socket) {
+      if (this._reconnectTimer === undefined) this._scheduleReconnect()
+      return
     }
-    return socket
+
+    if (socket.readyState === WebSocket.CONNECTING) {
+      const connectingFor = Date.now() - (this._connectingSince ?? Date.now())
+      if (connectingFor > CONNECTING_TIMEOUT_MS) {
+        console.warn(
+          `${LOG_PREFIX} Socket stuck in CONNECTING for ${connectingFor} ms (limit ${CONNECTING_TIMEOUT_MS} ms). Recycling.`
+        )
+        this._detachSocket()
+        this._scheduleReconnect()
+      }
+      return
+    }
+
+    if (socket.readyState === WebSocket.OPEN) {
+      const idleFor = Date.now() - this._lastMessageAt
+      if (idleFor > idleTimeoutMs) {
+        const uptime = this._openUptimeDescription()
+        console.warn(
+          `${LOG_PREFIX} No data received for ${idleFor} ms (limit ${idleTimeoutMs} ms). Recycling socket. ${uptime}`
+        )
+        this._detachSocket()
+        this._scheduleReconnect()
+      }
+    }
+  }
+
+  /**
+   * @returns {string} Human-readable description of how long the socket has been (or was) `OPEN`,
+   *   suitable for appending to a log line. Distinguishes "never reached OPEN" so a CONNECTING
+   *   stuck/timed-out path can also use this without lying.
+   */
+  private _openUptimeDescription(): string {
+    if (this._openedAt === undefined) return 'never reached OPEN'
+
+    const elapsedMs = Date.now() - this._openedAt
+    if (elapsedMs < 60_000) return `was OPEN for ${(elapsedMs / 1000).toFixed(1)} s`
+
+    const totalSeconds = Math.floor(elapsedMs / 1000)
+    const seconds = totalSeconds % 60
+    const totalMinutes = Math.floor(totalSeconds / 60)
+    const minutes = totalMinutes % 60
+    const hours = Math.floor(totalMinutes / 60)
+
+    if (hours === 0) return `was OPEN for ${minutes}m ${seconds}s`
+    return `was OPEN for ${hours}h ${minutes}m ${seconds}s`
   }
 }

--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -188,6 +188,10 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
   // Enabled by default for backward compatibility reasons - users with old devices may want to disable this to improve performance
   const enableLegacyDataLakeVariableNames = useBlueOsStorage('cockpit-enable-legacy-datalake-variable-names', true)
 
+  // Maximum time without heartbeats before the vehicle is considered offline. Configurable so users on
+  // high-latency or lossy links (e.g. cellular modems) can extend the window beyond the 5 s default.
+  const vehicleConnectionTimeoutMs = useBlueOsStorage('cockpit-vehicle-connection-timeout-ms', 5000)
+
   const MAVLink2RestWebsocketURI = computed(() => {
     const queryURI = new URLSearchParams(window.location.search).get('MAVLink2RestWebsocketURI')
     const customURI = customMAVLink2RestWebsocketURI.value.enabled
@@ -208,11 +212,14 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
   })
 
   /**
-   * Check if vehicle is online (no more than 5 seconds passed since last heartbeat)
+   * Check if vehicle is online (no more than {@link vehicleConnectionTimeoutMs} passed since last heartbeat)
    * @returns { boolean } True if vehicle is online
    */
   const isVehicleOnline = computed(() => {
-    return lastHeartbeat.value !== undefined && new Date(timeNow.value).getTime() - lastHeartbeat.value.getTime() < 5000
+    return (
+      lastHeartbeat.value !== undefined &&
+      new Date(timeNow.value).getTime() - lastHeartbeat.value.getTime() < vehicleConnectionTimeoutMs.value
+    )
   })
 
   /**
@@ -1059,6 +1066,7 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     setHomeWaypoint,
     vehiclePayloadParameters,
     vehiclePositionMaxSampleRate,
+    vehicleConnectionTimeoutMs,
     enableDatalakeVariablesFromOtherSystems,
     enableLegacyDataLakeVariableNames,
     getVehicleAddress,

--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -192,6 +192,12 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
   // high-latency or lossy links (e.g. cellular modems) can extend the window beyond the 5 s default.
   const vehicleConnectionTimeoutMs = useBlueOsStorage('cockpit-vehicle-connection-timeout-ms', 5000)
 
+  // Maximum time the MAVLink websocket may stay open without receiving any message before it is
+  // forcibly recycled. Decoupled from the heartbeat timeout: keeping it shorter than the heartbeat
+  // window lets the socket recover silently before the UI ever flips to "offline" on a brief drop;
+  // keeping it longer trades responsiveness for fewer recycles on high-latency links.
+  const vehicleConnectionWatchdogTimeoutMs = useBlueOsStorage('cockpit-vehicle-connection-watchdog-timeout-ms', 4000)
+
   const MAVLink2RestWebsocketURI = computed(() => {
     const queryURI = new URLSearchParams(window.location.search).get('MAVLink2RestWebsocketURI')
     const customURI = customMAVLink2RestWebsocketURI.value.enabled
@@ -579,7 +585,9 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     }
   })
 
-  ConnectionManager.addConnection(MAVLink2RestWebsocketURI.value, Protocol.Type.MAVLink)
+  ConnectionManager.addConnection(MAVLink2RestWebsocketURI.value, Protocol.Type.MAVLink, {
+    websocket: { getWatchdogTimeoutMs: () => vehicleConnectionWatchdogTimeoutMs.value },
+  })
 
   let applyThrottledCoordinates = useThrottleFn(
     (nc: Coordinates) => Object.assign(coordinates, nc),
@@ -1067,6 +1075,7 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     vehiclePayloadParameters,
     vehiclePositionMaxSampleRate,
     vehicleConnectionTimeoutMs,
+    vehicleConnectionWatchdogTimeoutMs,
     enableDatalakeVariablesFromOtherSystems,
     enableLegacyDataLakeVariableNames,
     getVehicleAddress,

--- a/src/views/ConfigurationGeneralView.vue
+++ b/src/views/ConfigurationGeneralView.vue
@@ -427,56 +427,102 @@
           </template>
         </ExpansiblePanel>
         <ExpansiblePanel no-bottom-divider :is-expanded="!interfaceStore.isOnPhoneScreen">
-          <template #title>Vehicle connection timeout</template>
-          <template #subtitle>Current value: {{ vehicleConnectionTimeoutSeconds }} s</template>
+          <template #title>Vehicle connection timeouts</template>
           <template #info>
             <p class="w-full">
-              Time without heartbeats before Cockpit considers the vehicle offline. Increase this value when using
-              high-latency or lossy links (e.g. cellular modems) where heartbeat packets may take longer than the
-              default 5 seconds to arrive. Unrelated to the autopilot's GCS (heartbeat) failsafe.
+              Heartbeat timeout: Time without heartbeats before Cockpit considers the vehicle offline. Increase this
+              value when using high-latency or lossy links (e.g. cellular modems) where heartbeat packets may take
+              longer than the default 5 seconds to arrive. Unrelated to the autopilot's GCS (heartbeat) failsafe.
+            </p>
+            <br />
+            <p class="w-full">
+              Watchdog timeout: Time the MAVLink websocket may stay open without receiving any message before Cockpit
+              forcibly recycles it and reconnects. This is the recovery threshold, not the offline indicator: setting it
+              lower than the heartbeat timeout (above) means a brief link drop can be silently recovered before Cockpit
+              ever flips to "vehicle offline". On high-latency links where short stalls are normal, raise this value so
+              the socket is not torn down on every minor delivery delay.
             </p>
           </template>
           <template #content>
-            <v-form
-              ref="connectionTimeoutForm"
-              v-model="connectionTimeoutFormValid"
-              class="flex w-full mt-2 mb-2"
-              @submit.prevent="setConnectionTimeout"
+            <div
+              class="grid w-full mt-2 pb-2 gap-12"
+              :class="interfaceStore.isOnPhoneScreen ? 'grid-cols-1' : 'grid-cols-2'"
             >
-              <div
-                class="flex justify-start items-center w-[86%] mb-4"
-                :class="interfaceStore.isOnSmallScreen ? 'scale-80' : 'scale-100'"
-              >
-                <v-text-field
-                  v-model.number="newVehicleConnectionTimeoutSeconds"
-                  variant="filled"
-                  type="number"
-                  density="compact"
-                  theme="dark"
-                  hint="Heartbeat timeout in seconds (minimum 1)"
-                  hide-details="auto"
-                  class="w-[80%]"
-                  suffix="s"
-                  :rules="[isValidConnectionTimeout]"
+              <div class="min-w-0">
+                <div class="mb-1 text-sm">Heartbeat timeout</div>
+                <v-form
+                  ref="connectionTimeoutForm"
+                  v-model="connectionTimeoutFormValid"
+                  class="w-full"
+                  @submit.prevent="setConnectionTimeout"
                 >
-                  <template #append-inner>
-                    <v-icon v-tooltip.bottom="'Reset to default'" color="white" @click="resetConnectionTimeout">
-                      mdi-restore
-                    </v-icon>
-                  </template>
-                </v-text-field>
-                <v-btn
-                  :size="interfaceStore.isOnSmallScreen ? 'small' : 'default'"
-                  :disabled="!connectionTimeoutFormValid"
-                  class="bg-transparent"
-                  :class="interfaceStore.isOnSmallScreen ? 'ml-1' : 'ml-5'"
-                  variant="text"
-                  type="submit"
-                >
-                  Apply
-                </v-btn>
+                  <div class="flex items-start gap-2">
+                    <v-text-field
+                      v-model.number="newVehicleConnectionTimeoutSeconds"
+                      variant="filled"
+                      type="number"
+                      density="compact"
+                      theme="dark"
+                      class="flex-1"
+                      suffix="s"
+                      :rules="[isValidConnectionTimeout]"
+                    >
+                      <template #append-inner>
+                        <v-icon v-tooltip.bottom="'Reset to default'" color="white" @click="resetConnectionTimeout">
+                          mdi-restore
+                        </v-icon>
+                      </template>
+                    </v-text-field>
+                    <v-btn
+                      :size="interfaceStore.isOnSmallScreen ? 'small' : 'default'"
+                      :disabled="!connectionTimeoutFormValid"
+                      class="bg-transparent mt-1"
+                      variant="text"
+                      type="submit"
+                    >
+                      Apply
+                    </v-btn>
+                  </div>
+                </v-form>
               </div>
-            </v-form>
+              <div class="min-w-0">
+                <div class="mb-1 text-sm">Watchdog timeout</div>
+                <v-form
+                  ref="watchdogTimeoutForm"
+                  v-model="watchdogTimeoutFormValid"
+                  class="w-full"
+                  @submit.prevent="setWatchdogTimeout"
+                >
+                  <div class="flex items-start gap-2">
+                    <v-text-field
+                      v-model.number="newVehicleConnectionWatchdogTimeoutSeconds"
+                      variant="filled"
+                      type="number"
+                      density="compact"
+                      theme="dark"
+                      class="flex-1"
+                      suffix="s"
+                      :rules="[isValidWatchdogTimeout]"
+                    >
+                      <template #append-inner>
+                        <v-icon v-tooltip.bottom="'Reset to default'" color="white" @click="resetWatchdogTimeout">
+                          mdi-restore
+                        </v-icon>
+                      </template>
+                    </v-text-field>
+                    <v-btn
+                      :size="interfaceStore.isOnSmallScreen ? 'small' : 'default'"
+                      :disabled="!watchdogTimeoutFormValid"
+                      class="bg-transparent mt-1"
+                      variant="text"
+                      type="submit"
+                    >
+                      Apply
+                    </v-btn>
+                  </div>
+                </v-form>
+              </div>
+            </div>
           </template>
         </ExpansiblePanel>
       </div>
@@ -633,7 +679,9 @@ const addNewVehicleConnection = async (conn: Connection.URI): Promise<void> => {
   vehicleConnected.value = undefined
   setTimeout(() => (vehicleConnected.value ??= false), 5000)
   try {
-    ConnectionManager.addConnection(new Connection.URI(conn), Protocol.Type.MAVLink)
+    ConnectionManager.addConnection(new Connection.URI(conn), Protocol.Type.MAVLink, {
+      websocket: { getWatchdogTimeoutMs: () => mainVehicleStore.vehicleConnectionWatchdogTimeoutMs },
+    })
   } catch (error) {
     console.error(error)
     alert(`Could not update main connection. ${error}.`)
@@ -745,7 +793,7 @@ const isValidConnectionTimeout = (value: number | string): boolean | string => {
   const numericValue = typeof value === 'string' ? Number(value) : value
   if (!Number.isFinite(numericValue)) return 'Timeout must be a valid number.'
   if (numericValue < minVehicleConnectionTimeoutSeconds) {
-    return `Timeout must be at least ${minVehicleConnectionTimeoutSeconds} second.`
+    return `Minimum timeout is ${minVehicleConnectionTimeoutSeconds} s.`
   }
   return true
 }
@@ -760,6 +808,43 @@ const setConnectionTimeout = async (): Promise<void> => {
 const resetConnectionTimeout = (): void => {
   newVehicleConnectionTimeoutSeconds.value = defaultVehicleConnectionTimeoutSeconds
   mainVehicleStore.vehicleConnectionTimeoutMs = defaultVehicleConnectionTimeoutSeconds * 1000
+}
+
+/** Reconnection watchdog timeout */
+
+const defaultVehicleConnectionWatchdogTimeoutSeconds = 4
+const minVehicleConnectionWatchdogTimeoutSeconds = 1
+
+const watchdogTimeoutForm = ref()
+const watchdogTimeoutFormValid = ref(true)
+const vehicleConnectionWatchdogTimeoutSeconds = computed(
+  () => Math.round(mainVehicleStore.vehicleConnectionWatchdogTimeoutMs / 100) / 10
+)
+const newVehicleConnectionWatchdogTimeoutSeconds = ref<number>(vehicleConnectionWatchdogTimeoutSeconds.value)
+
+watch(vehicleConnectionWatchdogTimeoutSeconds, (value) => (newVehicleConnectionWatchdogTimeoutSeconds.value = value))
+
+const isValidWatchdogTimeout = (value: number | string): boolean | string => {
+  const numericValue = typeof value === 'string' ? Number(value) : value
+  if (!Number.isFinite(numericValue)) return 'Must be a valid number.'
+  if (numericValue < minVehicleConnectionWatchdogTimeoutSeconds) {
+    return `Minimum timeout is ${minVehicleConnectionWatchdogTimeoutSeconds} s.`
+  }
+  return true
+}
+
+const setWatchdogTimeout = async (): Promise<void> => {
+  const validation = await watchdogTimeoutForm.value.validate()
+  if (!validation.valid) return
+
+  mainVehicleStore.vehicleConnectionWatchdogTimeoutMs = Math.round(
+    newVehicleConnectionWatchdogTimeoutSeconds.value * 1000
+  )
+}
+
+const resetWatchdogTimeout = (): void => {
+  newVehicleConnectionWatchdogTimeoutSeconds.value = defaultVehicleConnectionWatchdogTimeoutSeconds
+  mainVehicleStore.vehicleConnectionWatchdogTimeoutMs = defaultVehicleConnectionWatchdogTimeoutSeconds * 1000
 }
 
 const isValidHostAddress = (value: string): boolean | string => {

--- a/src/views/ConfigurationGeneralView.vue
+++ b/src/views/ConfigurationGeneralView.vue
@@ -364,7 +364,7 @@
             </div>
           </template>
         </ExpansiblePanel>
-        <ExpansiblePanel no-bottom-divider :is-expanded="!interfaceStore.isOnPhoneScreen">
+        <ExpansiblePanel :is-expanded="!interfaceStore.isOnPhoneScreen">
           <template #title>Generic WebSocket connections</template>
           <template #info>
             <div class="w-full">
@@ -426,6 +426,59 @@
             </div>
           </template>
         </ExpansiblePanel>
+        <ExpansiblePanel no-bottom-divider :is-expanded="!interfaceStore.isOnPhoneScreen">
+          <template #title>Vehicle connection timeout</template>
+          <template #subtitle>Current value: {{ vehicleConnectionTimeoutSeconds }} s</template>
+          <template #info>
+            <p class="w-full">
+              Time without heartbeats before Cockpit considers the vehicle offline. Increase this value when using
+              high-latency or lossy links (e.g. cellular modems) where heartbeat packets may take longer than the
+              default 5 seconds to arrive. Unrelated to the autopilot's GCS (heartbeat) failsafe.
+            </p>
+          </template>
+          <template #content>
+            <v-form
+              ref="connectionTimeoutForm"
+              v-model="connectionTimeoutFormValid"
+              class="flex w-full mt-2 mb-2"
+              @submit.prevent="setConnectionTimeout"
+            >
+              <div
+                class="flex justify-start items-center w-[86%] mb-4"
+                :class="interfaceStore.isOnSmallScreen ? 'scale-80' : 'scale-100'"
+              >
+                <v-text-field
+                  v-model.number="newVehicleConnectionTimeoutSeconds"
+                  variant="filled"
+                  type="number"
+                  density="compact"
+                  theme="dark"
+                  hint="Heartbeat timeout in seconds (minimum 1)"
+                  hide-details="auto"
+                  class="w-[80%]"
+                  suffix="s"
+                  :rules="[isValidConnectionTimeout]"
+                >
+                  <template #append-inner>
+                    <v-icon v-tooltip.bottom="'Reset to default'" color="white" @click="resetConnectionTimeout">
+                      mdi-restore
+                    </v-icon>
+                  </template>
+                </v-text-field>
+                <v-btn
+                  :size="interfaceStore.isOnSmallScreen ? 'small' : 'default'"
+                  :disabled="!connectionTimeoutFormValid"
+                  class="bg-transparent"
+                  :class="interfaceStore.isOnSmallScreen ? 'ml-1' : 'ml-5'"
+                  variant="text"
+                  type="submit"
+                >
+                  Apply
+                </v-btn>
+              </div>
+            </v-form>
+          </template>
+        </ExpansiblePanel>
       </div>
     </template>
   </BaseConfigurationView>
@@ -434,7 +487,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 
 import { defaultGlobalAddress } from '@/assets/defaults'
 import ManageCockpitSettings from '@/components/configuration/CockpitSettingsManager.vue'
@@ -672,6 +725,41 @@ const resetWebRTCSignallingURI = (): void => {
     enabled: false,
     data: mainVehicleStore.defaultWebRTCSignallingURI.toString(),
   }
+}
+
+/** Vehicle connection timeout */
+
+const defaultVehicleConnectionTimeoutSeconds = 5
+const minVehicleConnectionTimeoutSeconds = 1
+
+const connectionTimeoutForm = ref()
+const connectionTimeoutFormValid = ref(true)
+const vehicleConnectionTimeoutSeconds = computed(
+  () => Math.round(mainVehicleStore.vehicleConnectionTimeoutMs / 100) / 10
+)
+const newVehicleConnectionTimeoutSeconds = ref<number>(vehicleConnectionTimeoutSeconds.value)
+
+watch(vehicleConnectionTimeoutSeconds, (value) => (newVehicleConnectionTimeoutSeconds.value = value))
+
+const isValidConnectionTimeout = (value: number | string): boolean | string => {
+  const numericValue = typeof value === 'string' ? Number(value) : value
+  if (!Number.isFinite(numericValue)) return 'Timeout must be a valid number.'
+  if (numericValue < minVehicleConnectionTimeoutSeconds) {
+    return `Timeout must be at least ${minVehicleConnectionTimeoutSeconds} second.`
+  }
+  return true
+}
+
+const setConnectionTimeout = async (): Promise<void> => {
+  const validation = await connectionTimeoutForm.value.validate()
+  if (!validation.valid) return
+
+  mainVehicleStore.vehicleConnectionTimeoutMs = Math.round(newVehicleConnectionTimeoutSeconds.value * 1000)
+}
+
+const resetConnectionTimeout = (): void => {
+  newVehicleConnectionTimeoutSeconds.value = defaultVehicleConnectionTimeoutSeconds
+  mainVehicleStore.vehicleConnectionTimeoutMs = defaultVehicleConnectionTimeoutSeconds * 1000
 }
 
 const isValidHostAddress = (value: string): boolean | string => {


### PR DESCRIPTION
This PR introduces several improvements in the vehicle connection mechanism, with the most important one being a watchdog that monitors for silent-disconnections (where the socket is still open but no messages are exchanged anymore).

I'm also introducing in this PR two variables to control that: one for controlling the heartbeat timeout (that was fixed in 5 seconds) and one for controlling the watchdog timeout. The default values are 5 and 4 seconds, respectively.

This branch was successfully tested by the same user that originally reported the disconnection problems when using the BlueBoat with a cellular modem.

Fix #2706