### PR TITLE
Fix external features modal auto-opening on an empty state

### DIFF
--- a/src/components/ExternalFeaturesDiscoveryModal.vue
+++ b/src/components/ExternalFeaturesDiscoveryModal.vue
@@ -778,7 +778,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 
 import GlassModal from '@/components/GlassModal.vue'
 import JoystickButtonIndicator from '@/components/JoystickButtonIndicator.vue'
@@ -1639,22 +1639,21 @@ const autoOpenIfPending = (): void => {
   }
 }
 
-onMounted(async () => {
+// Wait for settings sync before auto-opening; vehicle-online alone can show stale pending state.
+const onVehicleSyncComplete = async (): Promise<void> => {
   if (!props.autoCheckOnMount) return
   await fetchBlueOSFeatures()
   autoOpenIfPending()
+}
+
+onMounted(() => {
+  if (!props.autoCheckOnMount) return
+  window.addEventListener('vehicle-sync-complete', onVehicleSyncComplete)
 })
 
-// Retry fetching BlueOS features when the vehicle becomes reachable, since the
-// initial fetch on app boot may have failed if BlueOS was not yet up (issue #2650).
-watch(
-  () => mainVehicleStore.isVehicleOnline,
-  async (isOnline) => {
-    if (!isOnline) return
-    await fetchBlueOSFeatures()
-    if (props.autoCheckOnMount) autoOpenIfPending()
-  }
-)
+onBeforeUnmount(() => {
+  window.removeEventListener('vehicle-sync-complete', onVehicleSyncComplete)
+})
 
 watch(isVisible, (visible, oldVisible) => {
   if (!visible) return

--- a/src/libs/settings-management.ts
+++ b/src/libs/settings-management.ts
@@ -1077,6 +1077,27 @@ export class SettingsManager {
   public handleVehicleGettingOnline = async (vehicleAddress: string): Promise<void> => {
     console.log('[SettingsManager]', 'Handling vehicle getting online!')
 
+    let succeeded = false
+    try {
+      await this.runVehicleGettingOnlinePipeline(vehicleAddress)
+      succeeded = true
+    } catch (error) {
+      console.error('[SettingsManager]', 'Failed to fully handle vehicle getting online.', error)
+    } finally {
+      // Dispatch even on failure so listeners can proceed without a successful BlueOS round-trip.
+      dispatchEvent(
+        new CustomEvent('vehicle-sync-complete', {
+          detail: {
+            vehicleAddress,
+            vehicleId: this.currentVehicleId,
+            succeeded,
+          },
+        })
+      )
+    }
+  }
+
+  private runVehicleGettingOnlinePipeline = async (vehicleAddress: string): Promise<void> => {
     // Before anything else, back up old-style vehicle settings in the vehicle, if needed
     await this.backupOldStyleVehicleSettingsIfNeeded(vehicleAddress)
 

--- a/src/types/settings-management.ts
+++ b/src/types/settings-management.ts
@@ -119,6 +119,24 @@ export type VehicleOnlineEvent = CustomEvent<{
 }>
 
 /**
+ * VehicleSyncCompleteEvent is the type of the event for when vehicle sync completes.
+ */
+export type VehicleSyncCompleteEvent = CustomEvent<{
+  /**
+   * The address of the vehicle whose sync finished
+   */
+  vehicleAddress: string
+  /**
+   * The id of the vehicle whose sync finished, if it could be determined
+   */
+  vehicleId: string | undefined
+  /**
+   * Whether the sync pipeline finished without throwing
+   */
+  succeeded: boolean
+}>
+
+/**
  * UserChangedEvent is the type of the event for when a user changes.
  */
 export type UserChangedEvent = CustomEvent<{
@@ -141,6 +159,11 @@ declare global {
      */
     // eslint-disable-next-line jsdoc/require-jsdoc
     'vehicle-online': VehicleOnlineEvent
+    /**
+     * Event triggered when vehicle sync completes
+     */
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    'vehicle-sync-complete': VehicleSyncCompleteEvent
     /**
      * Event triggered when the user changes
      */


### PR DESCRIPTION
This was happening on a race condition with the settings sync.

Modified the modal to perform the checks after the sync finishes.

Fix #2731 