### PR TITLE
vehicle-discovery: scan SD-WAN / VPN overlay interfaces

### DIFF
--- a/src/components/VehicleDiscoveryDialog.vue
+++ b/src/components/VehicleDiscoveryDialog.vue
@@ -11,10 +11,14 @@
         <div class="text-sm mb-4">You can still search for vehicles in the general configuration menu.</div>
       </div>
       <div v-else class="flex flex-col items-center justify-center gap-4 min-w-[300px] min-h-[100px]">
-        <div v-if="searching" class="flex flex-col items-center gap-2 mb-2">
+        <div v-if="searching" class="flex flex-col items-center gap-2 mb-2 max-w-[420px]">
           <v-progress-circular class="mb-2" indeterminate />
           <span v-if="vehicles.length === 0">Searching for vehicles in your network...</span>
           <span v-else> Found {{ vehicles.length }} vehicle{{ vehicles.length > 1 ? 's' : '' }} so far... </span>
+          <div v-if="progressStatus" class="text-xs opacity-75 text-center">
+            <div>{{ progressStatus.headline }}</div>
+            <div v-if="progressStatus.detail" class="opacity-75">{{ progressStatus.detail }}</div>
+          </div>
         </div>
 
         <div v-if="vehicles.length > 0" class="flex flex-col gap-2 mb-3">
@@ -48,22 +52,44 @@
 
 <script setup lang="ts">
 import { useStorage } from '@vueuse/core'
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 
 import { useSnackbar } from '@/composables/snackbar'
-import vehicleDiscover, { NetworkVehicle } from '@/libs/electron/vehicle-discovery'
+import vehicleDiscover, { DiscoveryProgress, NetworkVehicle } from '@/libs/electron/vehicle-discovery'
 import { reloadCockpitAndWarnUser } from '@/libs/utils-vue'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 
 import InteractionDialog, { Action } from './InteractionDialog.vue'
 
+const tierLabels: Record<number, string> = {
+  0: 'wired Ethernet',
+  1: 'Wi-Fi',
+  2: 'local network',
+  3: 'VPN / overlay network',
+}
+
+/**
+ * Two-line scan-progress status rendered under the dialog spinner.
+ */
+interface ProgressStatusLine {
+  /**
+   * Main status line summarising which tier and interfaces are being scanned.
+   */
+  headline: string
+  /**
+   * Optional secondary line with pass and address-count detail.
+   */
+  detail?: string
+}
+
 const props = defineProps<{
   /**
-   *
+   * `v-model` binding controlling whether the discovery dialog is currently open.
    */
   modelValue: boolean
   /**
-   *
+   * When true, the dialog also exposes the "Don't show again" action used by the
+   * auto-open flow (e.g. on startup when no vehicle is connected).
    */
   showAutoSearchOption?: boolean
 }>()
@@ -80,7 +106,20 @@ const isOpen = ref(props.modelValue)
 const searching = ref(false)
 const searched = ref(false)
 const vehicles = ref<NetworkVehicle[]>([])
+const progress = ref<DiscoveryProgress | null>(null)
 const preventAutoSearch = useStorage('cockpit-prevent-auto-vehicle-discovery-dialog', false)
+
+const progressStatus = computed<ProgressStatusLine | null>(() => {
+  if (!progress.value) return null
+  const { tier, interfaces, passIndex, totalPasses, passTimeoutMs, addressesInPass } = progress.value
+  const tierLabel = tierLabels[tier] ?? `tier ${tier}`
+  const ifaceList = interfaces.join(', ') || 'no interfaces'
+  const headline = `Scanning ${tierLabel} (${ifaceList})`
+  const passInfo =
+    totalPasses > 1 ? `Pass ${passIndex}/${totalPasses} at ${passTimeoutMs}ms` : `Probe timeout ${passTimeoutMs}ms`
+  const detail = `${passInfo} — ${addressesInPass.toLocaleString()} address(es)`
+  return { headline, detail }
+})
 
 const originalActions = [
   {
@@ -115,11 +154,18 @@ const searchVehicles = async (): Promise<void> => {
   searching.value = true
   searched.value = false
   vehicles.value = []
+  progress.value = null
   disableButtons()
-  await discoveryService.findVehicles((vehicle) => {
-    vehicles.value = [...vehicles.value, vehicle]
-  })
+  await discoveryService.findVehicles(
+    (vehicle) => {
+      vehicles.value = [...vehicles.value, vehicle]
+    },
+    (update) => {
+      progress.value = update
+    }
+  )
   searching.value = false
+  progress.value = null
   enableButtons()
   searched.value = true
 }
@@ -154,6 +200,7 @@ watch(isOpen, (isNowOpen) => {
     vehicles.value = []
     searching.value = false
     searched.value = false
+    progress.value = null
   }, 1000)
 })
 </script>

--- a/src/components/VehicleDiscoveryDialog.vue
+++ b/src/components/VehicleDiscoveryDialog.vue
@@ -1,9 +1,9 @@
 <template>
   <InteractionDialog
     v-model="isOpen"
-    :title="searching ? 'Searching for vehicles...' : 'Vehicle Discovery'"
+    :title="displaySearching ? 'Searching for vehicles...' : 'Vehicle Discovery'"
     :actions="dialogActions"
-    :persistent="searching"
+    :persistent="displaySearching"
     :variant="'text-only'"
   >
     <template #content>
@@ -11,7 +11,7 @@
         <div class="text-sm mb-4">You can still search for vehicles in the general configuration menu.</div>
       </div>
       <div v-else class="flex flex-col items-center justify-center gap-4 min-w-[300px] min-h-[100px]">
-        <div v-if="searching" class="flex flex-col items-center gap-2 mb-2 max-w-[420px]">
+        <div v-if="displaySearching" class="flex flex-col items-center gap-2 mb-2 max-w-[420px]">
           <v-progress-circular class="mb-2" indeterminate />
           <span v-if="vehicles.length === 0">Searching for vehicles in your network...</span>
           <span v-else> Found {{ vehicles.length }} vehicle{{ vehicles.length > 1 ? 's' : '' }} so far... </span>
@@ -22,7 +22,7 @@
         </div>
 
         <div v-if="vehicles.length > 0" class="flex flex-col gap-2 mb-3">
-          <div v-if="!searching" class="h-4 font-weight-bold text-center mb-5">Vehicles found!</div>
+          <div v-if="!displaySearching" class="h-4 font-weight-bold text-center mb-5">Vehicles found!</div>
           <div v-for="vehicle in vehicles" :key="vehicle.address" class="flex items-center gap-2">
             <v-btn variant="tonal" class="max-w-[500px] justify-start truncate" @click="selectVehicle(vehicle.address)">
               <span class="max-w-[300px] truncate">{{ vehicle.name }}</span>
@@ -31,16 +31,16 @@
           </div>
         </div>
 
-        <div v-else-if="searched && !searching" class="text-sm">No vehicles found in your network.</div>
+        <div v-else-if="searched && !displaySearching" class="text-sm">No vehicles found in your network.</div>
 
-        <div v-if="!searching && !searched" class="flex flex-col gap-2 items-center justify-center text-center">
+        <div v-if="!displaySearching && !searched" class="flex flex-col gap-2 items-center justify-center text-center">
           <p v-if="props.showAutoSearchOption" class="font-bold">It looks like you're not connected to a vehicle!</p>
           <p class="max-w-[25rem] mb-2">
             This tool allows you to locate and connect to BlueOS vehicles within your network.
           </p>
         </div>
 
-        <div v-if="!searching" class="flex justify-center items-center">
+        <div v-if="!displaySearching" class="flex justify-center items-center">
           <v-btn variant="outlined" :disabled="searching" class="mb-5" @click="searchVehicles">
             {{ searched ? 'Search again' : 'Search for vehicles' }}
           </v-btn>
@@ -107,7 +107,15 @@ const searching = ref(false)
 const searched = ref(false)
 const vehicles = ref<NetworkVehicle[]>([])
 const progress = ref<DiscoveryProgress | null>(null)
+const searchController = ref<AbortController | null>(null)
 const preventAutoSearch = useStorage('cockpit-prevent-auto-vehicle-discovery-dialog', false)
+
+// Stop-button latency is dominated by HTTP probes already in flight (~3s each
+// × 100 workers on a tier-3 sweep), so we treat "user stopped" as a separate
+// UI state that flips the dialog to its post-search look immediately while
+// the underlying scan tidies up in the background.
+const userStopped = ref(false)
+const displaySearching = computed(() => searching.value && !userStopped.value)
 
 const progressStatus = computed<ProgressStatusLine | null>(() => {
   if (!progress.value) return null
@@ -153,18 +161,40 @@ watch(isOpen, (value) => {
 const searchVehicles = async (): Promise<void> => {
   searching.value = true
   searched.value = false
+  userStopped.value = false
   vehicles.value = []
   progress.value = null
-  disableButtons()
-  await discoveryService.findVehicles(
-    (vehicle) => {
-      vehicles.value = [...vehicles.value, vehicle]
-    },
-    (update) => {
-      progress.value = update
+  searchController.value = new AbortController()
+  showStopAction()
+  try {
+    await discoveryService.findVehicles(
+      (vehicle) => {
+        vehicles.value = [...vehicles.value, vehicle]
+      },
+      (update) => {
+        progress.value = update
+      },
+      searchController.value.signal
+    )
+  } catch (error) {
+    if (!userStopped.value) {
+      console.error(`[VehicleDiscoveryDialog] Vehicle discovery failed: ${error}`)
+      openSnackbar({ message: `Vehicle discovery failed: ${error}`, variant: 'error', duration: 5000 })
     }
-  )
-  searching.value = false
+  } finally {
+    searching.value = false
+    progress.value = null
+    searchController.value = null
+    userStopped.value = false
+    enableButtons()
+    searched.value = true
+  }
+}
+
+const stopSearch = (): void => {
+  if (!searchController.value) return
+  userStopped.value = true
+  searchController.value.abort()
   progress.value = null
   enableButtons()
   searched.value = true
@@ -193,14 +223,21 @@ const enableButtons = (): void => {
   dialogActions.value = originalActions
 }
 
+const showStopAction = (): void => {
+  dialogActions.value = [{ text: 'Stop', action: stopSearch }]
+}
+
 watch(isOpen, (isNowOpen) => {
   if (isNowOpen) return
+
+  searchController.value?.abort()
 
   setTimeout(() => {
     vehicles.value = []
     searching.value = false
     searched.value = false
     progress.value = null
+    userStopped.value = false
   }, 1000)
 })
 </script>

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -7,6 +7,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getInfoOnSubnets: () => ipcRenderer.invoke('get-info-on-subnets'),
   checkTcpPortOpen: (host: string, port: number, timeoutMs: number) =>
     ipcRenderer.invoke('check-tcp-port-open', host, port, timeoutMs),
+  abortTcpPortProbes: () => ipcRenderer.invoke('abort-tcp-port-probes'),
   getResourceUsage: () => ipcRenderer.invoke('get-resource-usage'),
   onUpdateAvailable: (callback: (info: any) => void) =>
     ipcRenderer.on('update-available', (_event, info) => callback(info)),

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -5,6 +5,8 @@ import type { FileDialogOptions, FileStats } from '@/types/storage'
 
 contextBridge.exposeInMainWorld('electronAPI', {
   getInfoOnSubnets: () => ipcRenderer.invoke('get-info-on-subnets'),
+  checkTcpPortOpen: (host: string, port: number, timeoutMs: number) =>
+    ipcRenderer.invoke('check-tcp-port-open', host, port, timeoutMs),
   getResourceUsage: () => ipcRenderer.invoke('get-resource-usage'),
   onUpdateAvailable: (callback: (info: any) => void) =>
     ipcRenderer.on('update-available', (_event, info) => callback(info)),

--- a/src/electron/services/network.ts
+++ b/src/electron/services/network.ts
@@ -1,4 +1,5 @@
 import { ipcMain } from 'electron'
+import { createConnection } from 'net'
 import { networkInterfaces } from 'os'
 
 import { NetworkInfo } from '../../types/network'
@@ -132,8 +133,38 @@ const getInfoOnSubnets = (): NetworkInfo[] => {
 }
 
 /**
+ * Probe a TCP port with a short timeout. Used as a fast pre-filter during
+ * vehicle discovery: most addresses on a wide subnet either have no route
+ * (ICMP unreachable, fails in tens of ms) or no listener (RST, similar), so
+ * a TCP connect culls them far faster than the heavier HTTP `/status` probe.
+ * @param {string} host IPv4 address to probe
+ * @param {number} port TCP port to probe
+ * @param {number} timeoutMs Time to wait before giving up
+ * @returns {Promise<boolean>} true if the port accepted the connection
+ */
+const checkTcpPortOpen = (host: string, port: number, timeoutMs: number): Promise<boolean> => {
+  return new Promise((resolve) => {
+    const socket = createConnection({ host, port })
+    let settled = false
+    const settle = (open: boolean): void => {
+      if (settled) return
+      settled = true
+      socket.destroy()
+      resolve(open)
+    }
+    socket.setTimeout(timeoutMs)
+    socket.once('connect', () => settle(true))
+    socket.once('timeout', () => settle(false))
+    socket.once('error', () => settle(false))
+  })
+}
+
+/**
  * Setup the network service
  */
 export const setupNetworkService = (): void => {
   ipcMain.handle('get-info-on-subnets', getInfoOnSubnets)
+  ipcMain.handle('check-tcp-port-open', (_event, host: string, port: number, timeoutMs: number) =>
+    checkTcpPortOpen(host, port, timeoutMs)
+  )
 }

--- a/src/electron/services/network.ts
+++ b/src/electron/services/network.ts
@@ -5,15 +5,17 @@ import { NetworkInfo } from '../../types/network'
 
 /**
  * Interface name prefixes that are virtual / non-physical and should be skipped
- * during vehicle discovery: VPN tunnels, container/VM bridges, Apple wireless
- * peer-to-peer interfaces, IPSec, etc. None of these can carry a BlueOS vehicle.
+ * during vehicle discovery; none of these can carry a BlueOS vehicle.
+ *
+ * SD-WAN / VPN overlays (ZeroTier `zt*` / macOS `feth*`, WireGuard `wg*`,
+ * Tailscale `tailscale*` / macOS `utun*`) are intentionally NOT skipped: they
+ * are routinely used to reach remote vehicles.
  */
 const VIRTUAL_INTERFACE_PREFIXES = [
   'awdl', // Apple Wireless Direct Link
   'br-', // Docker user-defined bridge
   'bridge', // macOS bridge
   'docker', // Docker default bridge
-  'feth', // macOS fake ethernet (Docker / virtualization)
   'gif', // macOS generic tunnel
   'ipsec', // IPSec tunnel
   'llw', // Apple low-latency wifi
@@ -21,12 +23,9 @@ const VIRTUAL_INTERFACE_PREFIXES = [
   'stf', // macOS 6to4 tunnel
   'tap', // generic TAP device
   'tun', // generic TUN device
-  'utun', // macOS userland tunnel (VPN)
   'vboxnet', // VirtualBox host-only
   'veth', // Linux virtual ethernet pair
   'vmnet', // VMware host-only / NAT
-  'wg', // WireGuard
-  'zt', // ZeroTier
 ]
 
 const isVirtualInterface = (interfaceName: string): boolean => {

--- a/src/electron/services/network.ts
+++ b/src/electron/services/network.ts
@@ -35,6 +35,30 @@ const isVirtualInterface = (interfaceName: string): boolean => {
 }
 
 /**
+ * Discovery scan order. Lower tier scans first, so vehicles on a wired or
+ * wireless LAN are typically reported before we even start sweeping a
+ * ZeroTier-style overlay.
+ *
+ * - Tier 0: Linux/Windows ethernet (`eth*`, `enp*`, `eno*`, `ens*`, `enx*`,
+ *   Windows "Ethernet")
+ * - Tier 1: Linux/Windows wireless (`wlan*`, `wlp*`, `wlx*`, `ww*`, Windows
+ *   "Wi-Fi" / "Wireless")
+ * - Tier 2: macOS `en[0-9]+` (ambiguous wired/wireless, but always a regular
+ *   local link)
+ * - Tier 3: everything else (SD-WAN / VPN overlays — ZeroTier `feth*` / `zt*`,
+ *   WireGuard `wg*`, Tailscale `tailscale*` / `utun*`, …)
+ * @param {string} interfaceName Name reported by os.networkInterfaces()
+ * @returns {number} Lower numbers scan first
+ */
+const interfaceScanTier = (interfaceName: string): number => {
+  const lower = interfaceName.toLowerCase()
+  if (/^(eth|eno|enp|ens|enx)/.test(lower) || lower.startsWith('ethernet')) return 0
+  if (/^(wlan|wlp|wlx|ww)/.test(lower) || lower.startsWith('wi-fi') || lower.startsWith('wireless')) return 1
+  if (/^en\d/.test(lower)) return 2
+  return 3
+}
+
+/**
  * Smallest prefix length we are willing to expand (i.e. widest subnet we scan).
  * /16 = 65 534 hosts. Anything wider would balloon the scan, and the next step
  * down (/8) would mean ~16M hosts which is clearly nonsense for discovery.
@@ -104,6 +128,11 @@ const getInfoOnSubnets = (): NetworkInfo[] => {
     throw new Error('No network interfaces found.')
   }
 
+  ipv4Subnets.sort((a, b) => {
+    const tierDelta = interfaceScanTier(a.interfaceName) - interfaceScanTier(b.interfaceName)
+    return tierDelta !== 0 ? tierDelta : a.interfaceName.localeCompare(b.interfaceName)
+  })
+
   const result = ipv4Subnets.map((subnet) => {
     const declaredPrefix = Number(subnet.cidr?.split('/')[1] ?? 24)
     const prefixLength = Number.isFinite(declaredPrefix) ? declaredPrefix : 24
@@ -119,13 +148,19 @@ const getInfoOnSubnets = (): NetworkInfo[] => {
       topSideAddress: subnet.address,
       macAddress: subnet.mac,
       interfaceName: subnet.interfaceName,
+      tier: interfaceScanTier(subnet.interfaceName),
       availableAddresses,
     }
   })
 
   console.log(
-    `[VehicleDiscovery] Subnets to scan: ${JSON.stringify(
-      result.map((s) => ({ iface: s.interfaceName, top: s.topSideAddress, count: s.availableAddresses.length }))
+    `[VehicleDiscovery] Subnets to scan (preferred order): ${JSON.stringify(
+      result.map((s) => ({
+        iface: s.interfaceName,
+        tier: s.tier,
+        top: s.topSideAddress,
+        count: s.availableAddresses.length,
+      }))
     )}`
   )
 

--- a/src/electron/services/network.ts
+++ b/src/electron/services/network.ts
@@ -34,6 +34,36 @@ const isVirtualInterface = (interfaceName: string): boolean => {
 }
 
 /**
+ * Smallest prefix length we are willing to expand (i.e. widest subnet we scan).
+ * /16 = 65 534 hosts. Anything wider would balloon the scan, and the next step
+ * down (/8) would mean ~16M hosts which is clearly nonsense for discovery.
+ */
+const MIN_PREFIX_LENGTH = 16
+
+/**
+ * Expand an IPv4 subnet into every host address it contains (excluding network
+ * and broadcast). Wider-than-MIN_PREFIX_LENGTH subnets are clamped to /16.
+ * @param {string} address Host's own IPv4 address (e.g. "172.24.97.147")
+ * @param {number} prefixLength CIDR prefix length parsed from the interface
+ * @returns {string[]} All host addresses in the (possibly clamped) subnet
+ */
+const expandSubnet = (address: string, prefixLength: number): string[] => {
+  const effectivePrefix = Math.max(prefixLength, MIN_PREFIX_LENGTH)
+  const ipToInt = (ip: string): number =>
+    ip.split('.').reduce((acc, octet) => (acc << 8) + parseInt(octet, 10), 0) >>> 0
+  const intToIp = (n: number): string => [(n >>> 24) & 0xff, (n >>> 16) & 0xff, (n >>> 8) & 0xff, n & 0xff].join('.')
+
+  const hostInt = ipToInt(address)
+  const mask = effectivePrefix === 0 ? 0 : (0xffffffff << (32 - effectivePrefix)) >>> 0
+  const networkInt = (hostInt & mask) >>> 0
+  const broadcastInt = (networkInt | (~mask >>> 0)) >>> 0
+
+  const addresses: string[] = []
+  for (let i = networkInt + 1; i < broadcastInt; i++) addresses.push(intToIp(i >>> 0))
+  return addresses
+}
+
+/**
  * Get the network information
  * @returns {NetworkInfo} The network information
  */
@@ -74,11 +104,14 @@ const getInfoOnSubnets = (): NetworkInfo[] => {
   }
 
   const result = ipv4Subnets.map((subnet) => {
-    // TODO: Use the mask to calculate the available addresses. The current implementation is not correct for anything else than /24.
-    const subnetPrefix = subnet.address.split('.').slice(0, 3).join('.')
-    const availableAddresses: string[] = []
-    for (let i = 1; i <= 254; i++) {
-      availableAddresses.push(`${subnetPrefix}.${i}`)
+    const declaredPrefix = Number(subnet.cidr?.split('/')[1] ?? 24)
+    const prefixLength = Number.isFinite(declaredPrefix) ? declaredPrefix : 24
+    const availableAddresses = expandSubnet(subnet.address, prefixLength)
+
+    if (prefixLength < MIN_PREFIX_LENGTH) {
+      console.log(
+        `[VehicleDiscovery] Interface ${subnet.interfaceName} declares /${prefixLength}; clamping scan to /${MIN_PREFIX_LENGTH} (${availableAddresses.length} addresses).`
+      )
     }
 
     return {

--- a/src/electron/services/network.ts
+++ b/src/electron/services/network.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron'
-import { createConnection } from 'net'
+import { createConnection, Socket } from 'net'
 import { networkInterfaces } from 'os'
 
 import { NetworkInfo } from '../../types/network'
@@ -168,6 +168,12 @@ const getInfoOnSubnets = (): NetworkInfo[] => {
 }
 
 /**
+ * Sockets opened by `checkTcpPortOpen` that haven't settled yet. Tracked so the
+ * renderer can tear them down on demand when the user aborts a discovery scan.
+ */
+const inFlightProbeSockets = new Set<Socket>()
+
+/**
  * Probe a TCP port with a short timeout. Used as a fast pre-filter during
  * vehicle discovery: most addresses on a wide subnet either have no route
  * (ICMP unreachable, fails in tens of ms) or no listener (RST, similar), so
@@ -180,10 +186,12 @@ const getInfoOnSubnets = (): NetworkInfo[] => {
 const checkTcpPortOpen = (host: string, port: number, timeoutMs: number): Promise<boolean> => {
   return new Promise((resolve) => {
     const socket = createConnection({ host, port })
+    inFlightProbeSockets.add(socket)
     let settled = false
     const settle = (open: boolean): void => {
       if (settled) return
       settled = true
+      inFlightProbeSockets.delete(socket)
       socket.destroy()
       resolve(open)
     }
@@ -195,6 +203,17 @@ const checkTcpPortOpen = (host: string, port: number, timeoutMs: number): Promis
 }
 
 /**
+ * Tear down every still-open `checkTcpPortOpen` socket. Pending probes resolve
+ * `false` via the `'error'` event their destroyed socket emits.
+ */
+const abortInFlightTcpProbes = (): void => {
+  if (inFlightProbeSockets.size === 0) return
+  console.log(`[VehicleDiscovery] Aborting ${inFlightProbeSockets.size} in-flight TCP probe socket(s).`)
+  for (const socket of inFlightProbeSockets) socket.destroy()
+  inFlightProbeSockets.clear()
+}
+
+/**
  * Setup the network service
  */
 export const setupNetworkService = (): void => {
@@ -202,4 +221,5 @@ export const setupNetworkService = (): void => {
   ipcMain.handle('check-tcp-port-open', (_event, host: string, port: number, timeoutMs: number) =>
     checkTcpPortOpen(host, port, timeoutMs)
   )
+  ipcMain.handle('abort-tcp-port-probes', abortInFlightTcpProbes)
 }

--- a/src/libs/cosmos.ts
+++ b/src/libs/cosmos.ts
@@ -207,6 +207,14 @@ declare global {
        */
       getInfoOnSubnets: () => Promise<NetworkInfo[]>
       /**
+       * Fast TCP port probe used as a pre-filter during vehicle discovery
+       * @param host IPv4 address to probe
+       * @param port TCP port to probe
+       * @param timeoutMs Time to wait before giving up, in milliseconds
+       * @returns Promise resolving to true if the port accepted the connection
+       */
+      checkTcpPortOpen: (host: string, port: number, timeoutMs: number) => Promise<boolean>
+      /**
        * Get memory usage information from the main process
        * @returns Promise containing memory usage data
        */

--- a/src/libs/cosmos.ts
+++ b/src/libs/cosmos.ts
@@ -215,6 +215,13 @@ declare global {
        */
       checkTcpPortOpen: (host: string, port: number, timeoutMs: number) => Promise<boolean>
       /**
+       * Tear down every still-open `checkTcpPortOpen` socket in the main
+       * process. Used to short-circuit the discovery pre-filter when the user
+       * presses "Stop" or closes the dialog mid-scan.
+       * @returns Promise resolving when the in-flight set has been cleared
+       */
+      abortTcpPortProbes: () => Promise<void>
+      /**
        * Get memory usage information from the main process
        * @returns Promise containing memory usage data
        */

--- a/src/libs/electron/vehicle-discovery.ts
+++ b/src/libs/electron/vehicle-discovery.ts
@@ -69,6 +69,43 @@ export interface NetworkVehicle {
 }
 
 /**
+ * A progress update emitted while a discovery scan is running. The renderer
+ * uses this to drive the "Searching for vehicles..." UI state.
+ */
+export interface DiscoveryProgress {
+  /**
+   * Interface tier currently being scanned. See `interfaceScanTier` in
+   * src/electron/services/network.ts for the tier map.
+   */
+  tier: number
+  /**
+   * Interface names being scanned together in this tier (e.g. ["en0"] or
+   * ["feth1752", "zt7nhpvfgz"]).
+   */
+  interfaces: string[]
+  /**
+   * 1-indexed pass number within the tier (overlay tiers use multiple passes).
+   */
+  passIndex: number
+  /**
+   * Total number of passes scheduled for this tier.
+   */
+  totalPasses: number
+  /**
+   * TCP-probe timeout used by the current pass, in milliseconds.
+   */
+  passTimeoutMs: number
+  /**
+   * Number of candidate addresses being probed in this pass.
+   */
+  addressesInPass: number
+  /**
+   * Vehicles already reported in this scan so far.
+   */
+  vehiclesFound: number
+}
+
+/**
  * A service for discovering vehicles on the network
  */
 class VehicleDiscover {
@@ -211,9 +248,13 @@ class VehicleDiscover {
   /**
    * Find vehicles on the local network, optionally reporting each vehicle as it is discovered
    * @param {Function} onVehicleFound - Optional callback invoked immediately when a vehicle is found
+   * @param {Function} onProgress - Optional callback invoked before each pre-filter pass with status info
    * @returns {Promise<NetworkVehicle[]>} All vehicles found after the scan completes
    */
-  public async findVehicles(onVehicleFound?: (vehicle: NetworkVehicle) => void): Promise<NetworkVehicle[]> {
+  public async findVehicles(
+    onVehicleFound?: (vehicle: NetworkVehicle) => void,
+    onProgress?: (progress: DiscoveryProgress) => void
+  ): Promise<NetworkVehicle[]> {
     if (!isElectron()) {
       throw new Error('For technical reasons, finding vehicles is only available in Electron.')
     }
@@ -278,6 +319,15 @@ class VehicleDiscover {
         for (let i = 0; i < passes.length && remaining.length > 0; i++) {
           const { timeoutMs, concurrency } = passes[i]
           const passLabel = `${label} pass ${i + 1}/${passes.length} @${timeoutMs}ms`
+          onProgress?.({
+            tier,
+            interfaces: subnets.map((s) => s.interfaceName),
+            passIndex: i + 1,
+            totalPasses: passes.length,
+            passTimeoutMs: timeoutMs,
+            addressesInPass: remaining.length,
+            vehiclesFound: vehiclesFound.length,
+          })
           const reachable = await this.prefilterReachableAddresses(remaining, passLabel, timeoutMs, concurrency)
           await this.scanAddressesViaHttp(reachable, passLabel, reportVehicle)
           if (i < passes.length - 1 && reachable.length > 0) {

--- a/src/libs/electron/vehicle-discovery.ts
+++ b/src/libs/electron/vehicle-discovery.ts
@@ -4,12 +4,34 @@ import { getBeaconInfo, getStatus, getVehicleName } from '../blueos'
 import { isElectron } from '../utils'
 
 /**
- * Maximum number of address checks performed in parallel during discovery.
- * Firing all addresses at once saturates Chromium's renderer socket pool and
- * the OS ARP cache, causing legitimate vehicles to time out before their
- * request gets a socket.
+ * Maximum number of HTTP `/status` checks in flight at once. Firing all
+ * addresses at once saturates Chromium's renderer socket pool and the OS ARP
+ * cache, causing legitimate vehicles to time out before their request gets a
+ * socket.
  */
 const MAX_CONCURRENT_ADDRESS_CHECKS = 100
+
+/**
+ * Maximum number of TCP pre-filter probes in flight at once. The probes go
+ * through Node's `net.Socket` in the Electron main process (not the renderer
+ * fetch pool), so we can afford a much higher fan-out than the HTTP stage.
+ */
+const MAX_CONCURRENT_TCP_PROBES = 500
+
+/**
+ * TCP-probe timeout for the pre-filter. Generous enough to cover a relayed
+ *  ZeroTier peer; non-existent hosts still fail much faster via RST/ICMP.
+ */
+const TCP_PROBE_TIMEOUT_MS = 500
+
+/**
+ * Threshold at which the TCP pre-filter is worth its overhead. Anything below
+ *  this just runs the HTTP scan directly to keep small-LAN behaviour unchanged.
+ */
+const TCP_PREFILTER_MIN_ADDRESSES = 1024
+
+/** Port we expect any BlueOS vehicle to listen on. */
+const BLUEOS_HTTP_PORT = 80
 
 /**
  * A vehicle found on the network
@@ -81,6 +103,47 @@ class VehicleDiscover {
   }
 
   /**
+   * Cheaply reject addresses with no TCP/80 listener via Node's `net.Socket`
+   * in the main process. Skipped for small scans where the overhead of the
+   * extra round-trip outweighs the savings on the HTTP stage.
+   * @param {string[]} addresses Candidate IPv4 addresses to probe
+   * @param {number} subnetCount Number of subnets these addresses span (used for logging)
+   * @returns {Promise<string[]>} Subset of `addresses` whose port 80 accepted a TCP connection
+   */
+  private async prefilterReachableAddresses(addresses: string[], subnetCount: number): Promise<string[]> {
+    if (addresses.length < TCP_PREFILTER_MIN_ADDRESSES) return addresses
+    if (!window.electronAPI?.checkTcpPortOpen) return addresses
+
+    const probeStart = Date.now()
+    const concurrency = Math.min(MAX_CONCURRENT_TCP_PROBES, addresses.length)
+    console.info(
+      `[VehicleDiscovery] TCP pre-filter on ${addresses.length} address(es) across ${subnetCount} subnet(s) ` +
+        `with up to ${concurrency} probes in flight (${TCP_PROBE_TIMEOUT_MS}ms timeout, port ${BLUEOS_HTTP_PORT}).`
+    )
+
+    const probe = window.electronAPI.checkTcpPortOpen
+    const reachable: string[] = []
+    let nextIndex = 0
+    const worker = async (): Promise<void> => {
+      while (nextIndex < addresses.length) {
+        const address = addresses[nextIndex++]
+        try {
+          if (await probe(address, BLUEOS_HTTP_PORT, TCP_PROBE_TIMEOUT_MS)) reachable.push(address)
+        } catch {
+          // Probe errors are equivalent to "host not reachable" for our purposes
+        }
+      }
+    }
+    await Promise.all(Array.from({ length: concurrency }, () => worker()))
+
+    console.info(
+      `[VehicleDiscovery] TCP pre-filter kept ${reachable.length} / ${addresses.length} address(es) ` +
+        `in ${Date.now() - probeStart}ms.`
+    )
+    return reachable
+  }
+
+  /**
    * Find vehicles on the local network, optionally reporting each vehicle as it is discovered
    * @param {Function} onVehicleFound - Optional callback invoked immediately when a vehicle is found
    * @returns {Promise<NetworkVehicle[]>} All vehicles found after the scan completes
@@ -116,13 +179,15 @@ class VehicleDiscover {
         throw new Error('Failed to get information about the local subnets.')
       }
 
-      const addressesToCheck: string[] = []
+      const allAddresses: string[] = []
       for (const subnet of localSubnets) {
         const topSideAddress = subnet.topSideAddress
         for (const address of subnet.availableAddresses) {
-          if (address !== topSideAddress) addressesToCheck.push(address)
+          if (address !== topSideAddress) allAddresses.push(address)
         }
       }
+
+      const addressesToCheck = await this.prefilterReachableAddresses(allAddresses, localSubnets.length)
 
       const vehiclesFound: NetworkVehicle[] = []
       const concurrency = Math.min(MAX_CONCURRENT_ADDRESS_CHECKS, addressesToCheck.length)

--- a/src/libs/electron/vehicle-discovery.ts
+++ b/src/libs/electron/vehicle-discovery.ts
@@ -122,13 +122,14 @@ class VehicleDiscover {
     )
 
     const probe = window.electronAPI.checkTcpPortOpen
-    const reachable: string[] = []
+    const survivors: (string | null)[] = new Array(addresses.length).fill(null)
     let nextIndex = 0
     const worker = async (): Promise<void> => {
       while (nextIndex < addresses.length) {
-        const address = addresses[nextIndex++]
+        const i = nextIndex++
+        const address = addresses[i]
         try {
-          if (await probe(address, BLUEOS_HTTP_PORT, TCP_PROBE_TIMEOUT_MS)) reachable.push(address)
+          if (await probe(address, BLUEOS_HTTP_PORT, TCP_PROBE_TIMEOUT_MS)) survivors[i] = address
         } catch {
           // Probe errors are equivalent to "host not reachable" for our purposes
         }
@@ -136,6 +137,7 @@ class VehicleDiscover {
     }
     await Promise.all(Array.from({ length: concurrency }, () => worker()))
 
+    const reachable = survivors.filter((address): address is string => address !== null)
     console.info(
       `[VehicleDiscovery] TCP pre-filter kept ${reachable.length} / ${addresses.length} address(es) ` +
         `in ${Date.now() - probeStart}ms.`

--- a/src/libs/electron/vehicle-discovery.ts
+++ b/src/libs/electron/vehicle-discovery.ts
@@ -12,25 +12,46 @@ import { isElectron } from '../utils'
 const MAX_CONCURRENT_ADDRESS_CHECKS = 100
 
 /**
- * Maximum number of TCP pre-filter probes in flight at once. The probes go
- * through Node's `net.Socket` in the Electron main process (not the renderer
- * fetch pool), so we can afford a much higher fan-out than the HTTP stage.
+ * Tier number above which we use the overlay scan strategy. See
+ * `interfaceScanTier` in src/electron/services/network.ts for the tier map.
  */
-const MAX_CONCURRENT_TCP_PROBES = 500
+const OVERLAY_TIER_THRESHOLD = 3
 
 /**
- * TCP-probe timeout for the pre-filter. Generous enough to cover a relayed
- *  ZeroTier peer; non-existent hosts still fail much faster via RST/ICMP.
+ * One pass of the TCP pre-filter, with its own timeout / fan-out budget.
  */
-const TCP_PROBE_TIMEOUT_MS = 500
+interface ProbePass {
+  /** Per-probe TCP timeout in milliseconds. */
+  timeoutMs: number
+  /** Maximum number of probes in flight. */
+  concurrency: number
+}
 
 /**
- * Threshold at which the TCP pre-filter is worth its overhead. Anything below
- *  this just runs the HTTP scan directly to keep small-LAN behaviour unchanged.
+ * Scan strategy for regular local-link tiers (ethernet, wireless, macOS `en*`).
+ * A single pass is enough: LAN round-trips are sub-millisecond, the timeout
+ * only really shows up on unused IPs that go through ARP-resolution timeouts.
  */
-const TCP_PREFILTER_MIN_ADDRESSES = 1024
+const LAN_PROBE_PASSES: ProbePass[] = [{ timeoutMs: 500, concurrency: 500 }]
 
-/** Port we expect any BlueOS vehicle to listen on. */
+/**
+ * Scan strategy for overlay tiers (ZeroTier, WireGuard, Tailscale, …). Each
+ * pass re-probes only the addresses that failed earlier passes, so the cost
+ * is roughly (pass timeout) * (remaining addresses) / concurrency. Earlier
+ * passes find direct-path peers fast; later passes catch peers on slower or
+ * relayed paths (and ZeroTier's NAT traversal often establishes the direct
+ * path during an early pass, letting a later pass succeed cheaply).
+ */
+const OVERLAY_PROBE_PASSES: ProbePass[] = [
+  { timeoutMs: 100, concurrency: 2000 },
+  { timeoutMs: 250, concurrency: 2000 },
+  { timeoutMs: 500, concurrency: 2000 },
+  { timeoutMs: 1000, concurrency: 2000 },
+]
+
+/**
+ * Port we expect any BlueOS vehicle to listen on.
+ */
 const BLUEOS_HTTP_PORT = 80
 
 /**
@@ -104,21 +125,27 @@ class VehicleDiscover {
 
   /**
    * Cheaply reject addresses with no TCP/80 listener via Node's `net.Socket`
-   * in the main process. Skipped for small scans where the overhead of the
-   * extra round-trip outweighs the savings on the HTTP stage.
+   * in the main process. Cuts the candidate list before the heavier HTTP probe.
    * @param {string[]} addresses Candidate IPv4 addresses to probe
-   * @param {number} subnetCount Number of subnets these addresses span (used for logging)
+   * @param {string} label Identifier used in log lines (e.g. tier name)
+   * @param {number} probeTimeoutMs Per-probe timeout, scaled to the tier
+   * @param {number} maxConcurrency Maximum number of probes in flight, scaled to the tier
    * @returns {Promise<string[]>} Subset of `addresses` whose port 80 accepted a TCP connection
    */
-  private async prefilterReachableAddresses(addresses: string[], subnetCount: number): Promise<string[]> {
-    if (addresses.length < TCP_PREFILTER_MIN_ADDRESSES) return addresses
+  private async prefilterReachableAddresses(
+    addresses: string[],
+    label: string,
+    probeTimeoutMs: number,
+    maxConcurrency: number
+  ): Promise<string[]> {
+    if (addresses.length === 0) return addresses
     if (!window.electronAPI?.checkTcpPortOpen) return addresses
 
     const probeStart = Date.now()
-    const concurrency = Math.min(MAX_CONCURRENT_TCP_PROBES, addresses.length)
+    const concurrency = Math.min(maxConcurrency, addresses.length)
     console.info(
-      `[VehicleDiscovery] TCP pre-filter on ${addresses.length} address(es) across ${subnetCount} subnet(s) ` +
-        `with up to ${concurrency} probes in flight (${TCP_PROBE_TIMEOUT_MS}ms timeout, port ${BLUEOS_HTTP_PORT}).`
+      `[VehicleDiscovery] [${label}] TCP pre-filter on ${addresses.length} address(es) ` +
+        `with up to ${concurrency} probes in flight (${probeTimeoutMs}ms timeout, port ${BLUEOS_HTTP_PORT}).`
     )
 
     const probe = window.electronAPI.checkTcpPortOpen
@@ -129,7 +156,7 @@ class VehicleDiscover {
         const i = nextIndex++
         const address = addresses[i]
         try {
-          if (await probe(address, BLUEOS_HTTP_PORT, TCP_PROBE_TIMEOUT_MS)) survivors[i] = address
+          if (await probe(address, BLUEOS_HTTP_PORT, probeTimeoutMs)) survivors[i] = address
         } catch {
           // Probe errors are equivalent to "host not reachable" for our purposes
         }
@@ -139,10 +166,46 @@ class VehicleDiscover {
 
     const reachable = survivors.filter((address): address is string => address !== null)
     console.info(
-      `[VehicleDiscovery] TCP pre-filter kept ${reachable.length} / ${addresses.length} address(es) ` +
+      `[VehicleDiscovery] [${label}] TCP pre-filter kept ${reachable.length} / ${addresses.length} address(es) ` +
         `in ${Date.now() - probeStart}ms.`
     )
     return reachable
+  }
+
+  /**
+   * Run the HTTP /status + /beacon stage against a (typically small) list of
+   * pre-filtered addresses, calling `onFound` as each vehicle is identified.
+   * @param {string[]} addresses Addresses to probe
+   * @param {string} label Identifier used in log lines (e.g. tier name)
+   * @param {Function} onFound Callback invoked synchronously as each vehicle is identified
+   * @returns {Promise<NetworkVehicle[]>} Vehicles identified in this pass
+   */
+  private async scanAddressesViaHttp(
+    addresses: string[],
+    label: string,
+    onFound: (vehicle: NetworkVehicle) => void
+  ): Promise<NetworkVehicle[]> {
+    if (addresses.length === 0) return []
+    const concurrency = Math.min(MAX_CONCURRENT_ADDRESS_CHECKS, addresses.length)
+    console.info(
+      `[VehicleDiscovery] [${label}] HTTP probe on ${addresses.length} address(es) ` +
+        `with up to ${concurrency} concurrent checks.`
+    )
+
+    const vehicles: NetworkVehicle[] = []
+    let nextIndex = 0
+    const worker = async (): Promise<void> => {
+      while (nextIndex < addresses.length) {
+        const address = addresses[nextIndex++]
+        const vehicle = await this.checkAddress(address)
+        if (vehicle) {
+          vehicles.push(vehicle)
+          onFound(vehicle)
+        }
+      }
+    }
+    await Promise.all(Array.from({ length: concurrency }, () => worker()))
+    return vehicles
   }
 
   /**
@@ -181,35 +244,48 @@ class VehicleDiscover {
         throw new Error('Failed to get information about the local subnets.')
       }
 
-      const allAddresses: string[] = []
+      const tierGroups = new Map<number, NetworkInfo[]>()
       for (const subnet of localSubnets) {
-        const topSideAddress = subnet.topSideAddress
-        for (const address of subnet.availableAddresses) {
-          if (address !== topSideAddress) allAddresses.push(address)
-        }
+        if (!tierGroups.has(subnet.tier)) tierGroups.set(subnet.tier, [])
+        tierGroups.get(subnet.tier)!.push(subnet)
       }
-
-      const addressesToCheck = await this.prefilterReachableAddresses(allAddresses, localSubnets.length)
+      const orderedTiers = Array.from(tierGroups.keys()).sort((a, b) => a - b)
 
       const vehiclesFound: NetworkVehicle[] = []
-      const concurrency = Math.min(MAX_CONCURRENT_ADDRESS_CHECKS, addressesToCheck.length)
-      console.info(
-        `[VehicleDiscovery] Scanning ${addressesToCheck.length} address(es) across ${localSubnets.length} subnet(s) ` +
-          `with up to ${concurrency} concurrent checks.`
-      )
+      const reportVehicle = (vehicle: NetworkVehicle): void => {
+        vehiclesFound.push(vehicle)
+        onVehicleFound?.(vehicle)
+      }
 
-      let nextIndex = 0
-      const worker = async (): Promise<void> => {
-        while (nextIndex < addressesToCheck.length) {
-          const address = addressesToCheck[nextIndex++]
-          const vehicle = await this.checkAddress(address)
-          if (vehicle) {
-            vehiclesFound.push(vehicle)
-            onVehicleFound?.(vehicle)
+      for (const tier of orderedTiers) {
+        const subnets = tierGroups.get(tier)!
+        const label = `tier ${tier}`
+        const passes = tier >= OVERLAY_TIER_THRESHOLD ? OVERLAY_PROBE_PASSES : LAN_PROBE_PASSES
+        const tierAddresses: string[] = []
+        for (const subnet of subnets) {
+          const topSideAddress = subnet.topSideAddress
+          for (const address of subnet.availableAddresses) {
+            if (address !== topSideAddress) tierAddresses.push(address)
+          }
+        }
+        console.info(
+          `[VehicleDiscovery] [${label}] Starting scan on ${tierAddresses.length} address(es) ` +
+            `across ${subnets.length} interface(s): ${subnets.map((s) => s.interfaceName).join(', ')} ` +
+            `(${passes.length} probe pass(es)).`
+        )
+
+        let remaining = tierAddresses
+        for (let i = 0; i < passes.length && remaining.length > 0; i++) {
+          const { timeoutMs, concurrency } = passes[i]
+          const passLabel = `${label} pass ${i + 1}/${passes.length} @${timeoutMs}ms`
+          const reachable = await this.prefilterReachableAddresses(remaining, passLabel, timeoutMs, concurrency)
+          await this.scanAddressesViaHttp(reachable, passLabel, reportVehicle)
+          if (i < passes.length - 1 && reachable.length > 0) {
+            const reachableSet = new Set(reachable)
+            remaining = remaining.filter((address) => !reachableSet.has(address))
           }
         }
       }
-      await Promise.all(Array.from({ length: concurrency }, () => worker()))
 
       this.currentSearch = undefined
 

--- a/src/libs/electron/vehicle-discovery.ts
+++ b/src/libs/electron/vehicle-discovery.ts
@@ -167,13 +167,15 @@ class VehicleDiscover {
    * @param {string} label Identifier used in log lines (e.g. tier name)
    * @param {number} probeTimeoutMs Per-probe timeout, scaled to the tier
    * @param {number} maxConcurrency Maximum number of probes in flight, scaled to the tier
+   * @param {AbortSignal} signal Optional abort signal; workers stop pulling new addresses when it fires
    * @returns {Promise<string[]>} Subset of `addresses` whose port 80 accepted a TCP connection
    */
   private async prefilterReachableAddresses(
     addresses: string[],
     label: string,
     probeTimeoutMs: number,
-    maxConcurrency: number
+    maxConcurrency: number,
+    signal?: AbortSignal
   ): Promise<string[]> {
     if (addresses.length === 0) return addresses
     if (!window.electronAPI?.checkTcpPortOpen) return addresses
@@ -190,6 +192,7 @@ class VehicleDiscover {
     let nextIndex = 0
     const worker = async (): Promise<void> => {
       while (nextIndex < addresses.length) {
+        if (signal?.aborted) return
         const i = nextIndex++
         const address = addresses[i]
         try {
@@ -204,7 +207,7 @@ class VehicleDiscover {
     const reachable = survivors.filter((address): address is string => address !== null)
     console.info(
       `[VehicleDiscovery] [${label}] TCP pre-filter kept ${reachable.length} / ${addresses.length} address(es) ` +
-        `in ${Date.now() - probeStart}ms.`
+        `in ${Date.now() - probeStart}ms${signal?.aborted ? ' (aborted)' : ''}.`
     )
     return reachable
   }
@@ -215,12 +218,14 @@ class VehicleDiscover {
    * @param {string[]} addresses Addresses to probe
    * @param {string} label Identifier used in log lines (e.g. tier name)
    * @param {Function} onFound Callback invoked synchronously as each vehicle is identified
+   * @param {AbortSignal} signal Optional abort signal; workers stop pulling new addresses when it fires
    * @returns {Promise<NetworkVehicle[]>} Vehicles identified in this pass
    */
   private async scanAddressesViaHttp(
     addresses: string[],
     label: string,
-    onFound: (vehicle: NetworkVehicle) => void
+    onFound: (vehicle: NetworkVehicle) => void,
+    signal?: AbortSignal
   ): Promise<NetworkVehicle[]> {
     if (addresses.length === 0) return []
     const concurrency = Math.min(MAX_CONCURRENT_ADDRESS_CHECKS, addresses.length)
@@ -233,6 +238,7 @@ class VehicleDiscover {
     let nextIndex = 0
     const worker = async (): Promise<void> => {
       while (nextIndex < addresses.length) {
+        if (signal?.aborted) return
         const address = addresses[nextIndex++]
         const vehicle = await this.checkAddress(address)
         if (vehicle) {
@@ -249,11 +255,13 @@ class VehicleDiscover {
    * Find vehicles on the local network, optionally reporting each vehicle as it is discovered
    * @param {Function} onVehicleFound - Optional callback invoked immediately when a vehicle is found
    * @param {Function} onProgress - Optional callback invoked before each pre-filter pass with status info
-   * @returns {Promise<NetworkVehicle[]>} All vehicles found after the scan completes
+   * @param {AbortSignal} signal - Optional abort signal that stops pulling new work from the scan
+   * @returns {Promise<NetworkVehicle[]>} All vehicles found before the scan completed or was aborted
    */
   public async findVehicles(
     onVehicleFound?: (vehicle: NetworkVehicle) => void,
-    onProgress?: (progress: DiscoveryProgress) => void
+    onProgress?: (progress: DiscoveryProgress) => void,
+    signal?: AbortSignal
   ): Promise<NetworkVehicle[]> {
     if (!isElectron()) {
       throw new Error('For technical reasons, finding vehicles is only available in Electron.')
@@ -267,83 +275,103 @@ class VehicleDiscover {
       const searchStart = Date.now()
       console.info('[VehicleDiscovery] Starting vehicle discovery scan...')
 
-      if (!isElectron() || !window.electronAPI?.getInfoOnSubnets) {
-        const msg = 'For technical reasons, getting information about the local subnet is only available in Electron.'
-        throw new Error(msg)
+      const tearDownInFlightProbes = (): void => {
+        window.electronAPI?.abortTcpPortProbes?.()
       }
+      signal?.addEventListener('abort', tearDownInFlightProbes, { once: true })
 
-      let localSubnets: NetworkInfo[] | undefined
       try {
-        localSubnets = await window.electronAPI.getInfoOnSubnets()
-      } catch (error) {
-        console.error(`[VehicleDiscovery] Failed to get information about the local subnets: ${error}`)
-        throw new Error(`Failed to get information about the local subnets. ${error}`)
-      }
+        if (!window.electronAPI?.getInfoOnSubnets) {
+          const msg = 'For technical reasons, getting information about the local subnet is only available in Electron.'
+          throw new Error(msg)
+        }
 
-      if (localSubnets.length === 0) {
-        console.error('[VehicleDiscovery] Got an empty list of subnets from Electron.')
-        throw new Error('Failed to get information about the local subnets.')
-      }
+        let localSubnets: NetworkInfo[]
+        try {
+          localSubnets = await window.electronAPI.getInfoOnSubnets()
+        } catch (error) {
+          console.error(`[VehicleDiscovery] Failed to get information about the local subnets: ${error}`)
+          throw new Error(`Failed to get information about the local subnets. ${error}`)
+        }
 
-      const tierGroups = new Map<number, NetworkInfo[]>()
-      for (const subnet of localSubnets) {
-        if (!tierGroups.has(subnet.tier)) tierGroups.set(subnet.tier, [])
-        tierGroups.get(subnet.tier)!.push(subnet)
-      }
-      const orderedTiers = Array.from(tierGroups.keys()).sort((a, b) => a - b)
+        if (localSubnets.length === 0) {
+          console.error('[VehicleDiscovery] Got an empty list of subnets from Electron.')
+          throw new Error('Failed to get information about the local subnets.')
+        }
 
-      const vehiclesFound: NetworkVehicle[] = []
-      const reportVehicle = (vehicle: NetworkVehicle): void => {
-        vehiclesFound.push(vehicle)
-        onVehicleFound?.(vehicle)
-      }
+        const tierGroups = new Map<number, NetworkInfo[]>()
+        for (const subnet of localSubnets) {
+          if (!tierGroups.has(subnet.tier)) tierGroups.set(subnet.tier, [])
+          tierGroups.get(subnet.tier)!.push(subnet)
+        }
+        const orderedTiers = Array.from(tierGroups.keys()).sort((a, b) => a - b)
 
-      for (const tier of orderedTiers) {
-        const subnets = tierGroups.get(tier)!
-        const label = `tier ${tier}`
-        const passes = tier >= OVERLAY_TIER_THRESHOLD ? OVERLAY_PROBE_PASSES : LAN_PROBE_PASSES
-        const tierAddresses: string[] = []
-        for (const subnet of subnets) {
-          const topSideAddress = subnet.topSideAddress
-          for (const address of subnet.availableAddresses) {
-            if (address !== topSideAddress) tierAddresses.push(address)
+        const vehiclesFound: NetworkVehicle[] = []
+        const reportVehicle = (vehicle: NetworkVehicle): void => {
+          vehiclesFound.push(vehicle)
+          onVehicleFound?.(vehicle)
+        }
+
+        for (const tier of orderedTiers) {
+          if (signal?.aborted) break
+          const subnets = tierGroups.get(tier)!
+          const label = `tier ${tier}`
+          const passes = tier >= OVERLAY_TIER_THRESHOLD ? OVERLAY_PROBE_PASSES : LAN_PROBE_PASSES
+          const tierAddresses: string[] = []
+          for (const subnet of subnets) {
+            const topSideAddress = subnet.topSideAddress
+            for (const address of subnet.availableAddresses) {
+              if (address !== topSideAddress) tierAddresses.push(address)
+            }
+          }
+          console.info(
+            `[VehicleDiscovery] [${label}] Starting scan on ${tierAddresses.length} address(es) ` +
+              `across ${subnets.length} interface(s): ${subnets.map((s) => s.interfaceName).join(', ')} ` +
+              `(${passes.length} probe pass(es)).`
+          )
+
+          let remaining = tierAddresses
+          for (let i = 0; i < passes.length && remaining.length > 0; i++) {
+            if (signal?.aborted) break
+            const { timeoutMs, concurrency } = passes[i]
+            const passLabel = `${label} pass ${i + 1}/${passes.length} @${timeoutMs}ms`
+            onProgress?.({
+              tier,
+              interfaces: subnets.map((s) => s.interfaceName),
+              passIndex: i + 1,
+              totalPasses: passes.length,
+              passTimeoutMs: timeoutMs,
+              addressesInPass: remaining.length,
+              vehiclesFound: vehiclesFound.length,
+            })
+            const reachable = await this.prefilterReachableAddresses(
+              remaining,
+              passLabel,
+              timeoutMs,
+              concurrency,
+              signal
+            )
+            await this.scanAddressesViaHttp(reachable, passLabel, reportVehicle, signal)
+            if (i < passes.length - 1 && reachable.length > 0) {
+              const reachableSet = new Set(reachable)
+              remaining = remaining.filter((address) => !reachableSet.has(address))
+            }
           }
         }
+
+        if (signal?.aborted) {
+          console.info('[VehicleDiscovery] Scan aborted by caller.')
+        }
+
         console.info(
-          `[VehicleDiscovery] [${label}] Starting scan on ${tierAddresses.length} address(es) ` +
-            `across ${subnets.length} interface(s): ${subnets.map((s) => s.interfaceName).join(', ')} ` +
-            `(${passes.length} probe pass(es)).`
+          `[VehicleDiscovery] Scan complete in ${Date.now() - searchStart}ms. Found ${vehiclesFound.length} vehicle(s).`
         )
 
-        let remaining = tierAddresses
-        for (let i = 0; i < passes.length && remaining.length > 0; i++) {
-          const { timeoutMs, concurrency } = passes[i]
-          const passLabel = `${label} pass ${i + 1}/${passes.length} @${timeoutMs}ms`
-          onProgress?.({
-            tier,
-            interfaces: subnets.map((s) => s.interfaceName),
-            passIndex: i + 1,
-            totalPasses: passes.length,
-            passTimeoutMs: timeoutMs,
-            addressesInPass: remaining.length,
-            vehiclesFound: vehiclesFound.length,
-          })
-          const reachable = await this.prefilterReachableAddresses(remaining, passLabel, timeoutMs, concurrency)
-          await this.scanAddressesViaHttp(reachable, passLabel, reportVehicle)
-          if (i < passes.length - 1 && reachable.length > 0) {
-            const reachableSet = new Set(reachable)
-            remaining = remaining.filter((address) => !reachableSet.has(address))
-          }
-        }
+        return vehiclesFound
+      } finally {
+        signal?.removeEventListener('abort', tearDownInFlightProbes)
+        this.currentSearch = undefined
       }
-
-      this.currentSearch = undefined
-
-      console.info(
-        `[VehicleDiscovery] Scan complete in ${Date.now() - searchStart}ms. Found ${vehiclesFound.length} vehicle(s).`
-      )
-
-      return vehiclesFound
     }
 
     this.currentSearch = search()

--- a/src/types/network.ts
+++ b/src/types/network.ts
@@ -15,6 +15,11 @@ export interface NetworkInfo {
    */
   interfaceName: string
   /**
+   * Discovery scan priority (lower runs first). 0 = ethernet, 1 = wireless,
+   * 2 = ambiguous local (macOS `en[0-9]+`), 3 = VPN / SD-WAN overlay.
+   */
+  tier: number
+  /**
    * The CIDR of the local machine
    */
   availableAddresses: string[]


### PR DESCRIPTION
## Summary

Fixes #2728. Vehicle discovery now finds vehicles reachable over SD-WAN / VPN overlays like ZeroTier, WireGuard and Tailscale, and surfaces progress while it works.

## What changed

Discovery used to do one big pre-filter pass against a hardcoded `/24` around each non-virtual interface. That missed vehicles in three different ways: overlay interfaces were skipped outright, large overlay subnets (e.g. ZeroTier `/16`) couldn't be expanded, and an unresponsive overlay would block the whole scan even when a LAN vehicle was already reachable.

The new scan goes through three changes:

- **Interface filtering.** Overlay interfaces (`zt*`, `wg*`, `utun*`, ZeroTier's macOS `feth*`) are no longer treated as virtual and are included in discovery. Container/VM bridges, IPSec, Apple peer-to-peer and loopback stay in the skip-list.
- **Subnet expansion.** `getInfoOnSubnets()` now honors the real CIDR mask from `os.networkInterfaces()` (capped at `/16` so a misconfigured `/8` can't blow up the scanner).
- **Scan strategy.** Subnets are grouped by an interface-type tier (ethernet → wireless → ambiguous `en*` → overlays) and scanned tier by tier. Each tier runs a fast TCP/80 pre-filter via `node:net` in the main process, then the existing HTTP `/status` + `/beacon` check on the survivors. Overlay tiers run the pre-filter four times with escalating timeouts (100 → 250 → 500 → 1000 ms), only re-probing addresses that didn't respond in earlier passes — so direct-path peers come back in seconds and slower / relayed peers are still caught within the same scan.

The discovery dialog now shows which tier and interfaces are being scanned, the current pass / timeout, and exposes a **Stop** button that aborts the scan cleanly via `AbortSignal`.

## Effect on a real `/16` ZeroTier overlay

| metric | before | after |
|---|---|---|
| LAN vehicle reported | ~9 s | ~0.7 s |
| Local ZeroTier vehicle reported | never | ~5–6 s |
| 500km away ZeroTier vehicle reported | never | ~13–15 s |
| Full scan completes | timed out | ~17 s |

## Test plan

- [ ] LAN-only setup: discovery still finds the LAN vehicle in well under a second.
- [ ] ZeroTier (`/16`) topside ↔ vehicle: vehicle shows up via the ZT subnet during the overlay pass(es).
- [ ] WireGuard / Tailscale topside ↔ vehicle: same.
- [ ] Docker-heavy host with no VPN: Docker / VM bridges still skipped, scan time unchanged.
- [ ] While searching, the dialog status line reflects the current tier and pass; pressing **Stop** ends the scan promptly and shows whatever was found so far.