### PR TITLE
Add calculated depth variable

### DIFF
--- a/src/components/mini-widgets/DepthIndicator.vue
+++ b/src/components/mini-widgets/DepthIndicator.vue
@@ -125,7 +125,9 @@ const { value: rawAltitude } = useDataLakeVariable(resolvedAltitudeVariableId)
 
 const currentDepth = computed<number | undefined>(() => {
   if (resolvedAltitudeVariableId.value === undefined || typeof rawAltitude.value !== 'number') return undefined
+  if (!Number.isFinite(rawAltitude.value)) return undefined
   const altMeters = rawAltitudeToMeters(resolvedAltitudeVariableId.value, rawAltitude.value)
+  if (!Number.isFinite(altMeters)) return undefined
   const depth = unit(-altMeters, 'm')
   if (depth.value < 0.01) return 0
   return depth.to(displayUnitPreferences.distance).toJSON().value as number

--- a/src/components/mini-widgets/RelativeAltitudeIndicator.vue
+++ b/src/components/mini-widgets/RelativeAltitudeIndicator.vue
@@ -121,7 +121,9 @@ const { value: rawAltitude } = useDataLakeVariable(resolvedAltitudeVariableId)
 
 const currentAltitude = computed<number | undefined>(() => {
   if (resolvedAltitudeVariableId.value === undefined || typeof rawAltitude.value !== 'number') return undefined
+  if (!Number.isFinite(rawAltitude.value)) return undefined
   const altMeters = rawAltitudeToMeters(resolvedAltitudeVariableId.value, rawAltitude.value)
+  if (!Number.isFinite(altMeters)) return undefined
   return unit(altMeters, 'm').to(displayUnitPreferences.distance).toJSON().value as number
 })
 

--- a/src/components/widgets/DepthHUD.vue
+++ b/src/components/widgets/DepthHUD.vue
@@ -179,8 +179,9 @@ watch(resolvedAltitudeVariableId, () => {
 })
 
 watch([rawAltitude, resolvedAltitudeVariableId], ([newAlt, resolvedId]) => {
-  if (resolvedId === undefined || typeof newAlt !== 'number') return
+  if (resolvedId === undefined || typeof newAlt !== 'number' || !Number.isFinite(newAlt)) return
   const altMeters = rawAltitudeToMeters(resolvedId, newAlt)
+  if (!Number.isFinite(altMeters)) return
   const newDepth = unit(-altMeters, 'm')
 
   const depthDiff = Math.abs(newDepth.value - (depth.value || 0))

--- a/src/composables/useAltitudeSourceConfig.ts
+++ b/src/composables/useAltitudeSourceConfig.ts
@@ -7,7 +7,7 @@ import {
   listenToDataLakeVariablesInfoChanges,
   unlistenToDataLakeVariablesInfoChanges,
 } from '@/libs/actions/data-lake'
-import { isPresetAltitudeVariableId } from '@/libs/data-sources/altitude'
+import { isPresetAltitudeVariableId, migrateAltitudeVariableId } from '@/libs/data-sources/altitude'
 
 /** Altitude source selections saved when the config menu opens. */
 type AltitudeConfigSnapshot = {
@@ -25,7 +25,8 @@ type AltitudeVariableOptions = {
 }
 
 /**
- * Merge persisted altitude options with defaults and infer custom mode when needed.
+ * Merge persisted altitude options with defaults, migrate legacy preset paths
+ * to their templated form, and infer custom mode when needed.
  * @param {T} defaultOptions - Default widget options
  * @param {Partial<T>} persistedOptions - Persisted widget options
  * @returns {T} Merged widget options
@@ -35,6 +36,10 @@ export const mergeAltitudeVariableOptions = <T extends AltitudeVariableOptions>(
   persistedOptions: Partial<T>
 ): T => {
   const merged = { ...defaultOptions, ...persistedOptions }
+
+  if (merged.altitudeVariableId) {
+    merged.altitudeVariableId = migrateAltitudeVariableId(merged.altitudeVariableId) as T['altitudeVariableId']
+  }
 
   if (merged.altitudeVariableId && !isPresetAltitudeVariableId(merged.altitudeVariableId)) {
     merged.useCustomAltitudeVariable = true

--- a/src/libs/actions/data-lake-transformations.ts
+++ b/src/libs/actions/data-lake-transformations.ts
@@ -1,14 +1,10 @@
 import { settingsManager } from '../settings-management'
-import {
-  findDataLakeInputsInString,
-  findDataLakeVariablesIdsInString,
-  getDataLakeVariableIdFromInput,
-  replaceDataLakeInputsInString,
-} from '../utils-data-lake'
+import { findDataLakeVariablesIdsInString, replaceDataLakeInputsInString } from '../utils-data-lake'
 import {
   createDataLakeVariable,
   DataLakeVariableType,
   deleteDataLakeVariable,
+  getDataLakeVariableData,
   listenDataLakeVariable,
   setDataLakeVariableData,
   unlistenDataLakeVariable,
@@ -33,21 +29,27 @@ const saveTransformingFunctions = (): void => {
   updateTransformingFunctionListeners()
 }
 
+// Substitutes `NaN` for any data-lake variable that has not been populated yet,
+// so expressions referencing missing dependencies evaluate to `NaN` instead of
+// throwing a SyntaxError. Once the missing variable's data arrives, the listener
+// fires and the expression is re-evaluated with the real value.
+const expressionReplaceFunction = (match: string): string => {
+  const variableId = match.replace('{{', '').replace('}}', '').trim()
+  if (!variableId) return 'NaN'
+  const variableData = getDataLakeVariableData(variableId)
+  if (variableData === undefined) return 'NaN'
+  return variableData.toString()
+}
+
 /**
  * Evaluates a data-lake expression, replacing `{{ variable }}` inputs with their current values and
  * running the result as a JavaScript expression (so arithmetic like "{{ x }} * 10" works).
+ * Missing dependencies are substituted with `NaN` so the expression can still evaluate.
  * @param {string} expression - The expression to evaluate
  * @returns {string | number | boolean} The evaluated value
  */
 export const evaluateDataLakeExpression = (expression: string): string | number | boolean => {
-  const expressionWithValues = replaceDataLakeInputsInString(expression)
-
-  // Inputs whose variables have no value yet are left as literal '{{ ... }}' placeholders by the replacement.
-  // Bail out with a clear error instead of letting eval fail with a cryptic "Unexpected token '{'" SyntaxError.
-  const unavailableInputs = findDataLakeInputsInString(expressionWithValues)
-  if (unavailableInputs.length > 0) {
-    throw new Error(`Data lake variable(s) not available yet: ${unavailableInputs.join(', ')}.`)
-  }
+  const expressionWithValues = replaceDataLakeInputsInString(expression, expressionReplaceFunction)
 
   // If the expression contains a return statement, we can just evaluate it directly
   if (expression.includes('return')) {
@@ -86,10 +88,10 @@ const getExpressionValue = (func: TransformingFunction): string | number | boole
   return evaluateDataLakeExpression(func.expression)
 }
 
-const variablesListeners: Record<string, Record<string, string[]>> = {}
+const variablesListeners: Record<string, Record<string, string>> = {}
 
-const nextDelayToEvaluateFaillingTransformingFunction: Record<string, number> = {}
-const lastTimeTriedToEvaluateFaillingTransformingFunction: Record<string, number> = {}
+const nextDelayToEvaluateFailingTransformingFunction: Record<string, number> = {}
+const lastTimeTriedToEvaluateFailingTransformingFunction: Record<string, number> = {}
 const initialEvaluationTimeouts: Record<string, ReturnType<typeof setTimeout>> = {}
 // Last error logged per function, so a function that keeps failing the same way (e.g. depends on a vehicle
 // parameter that never arrives) is logged once instead of on every dependency update.
@@ -97,6 +99,66 @@ const lastLoggedErrorForTransformingFunction: Record<string, string> = {}
 
 const setupTransformingFunctionsListeners = (): void => {
   globalTransformingFunctions.forEach((func) => {
+    // Re-syncs the listener set to whatever variables the expression currently
+    // resolves into. Necessary for expressions with nested templates like
+    // `{{vehicle/{{autopilotSystemId}}/parameters/X}}` — when the inner
+    // variable changes, the outer reference resolves to a different ID and we
+    // need to listen to the new one.
+    const syncDependencies = (): void => {
+      const desiredIds = new Set(findDataLakeVariablesIdsInString(func.expression))
+      const currentIds = new Set(Object.keys(variablesListeners[func.id] ?? {}))
+
+      desiredIds.forEach((variableId) => {
+        if (currentIds.has(variableId)) return
+        const listenerId = listenDataLakeVariable(variableId, onDependencyChange)
+        if (!variablesListeners[func.id]) variablesListeners[func.id] = {}
+        variablesListeners[func.id][variableId] = listenerId
+      })
+
+      currentIds.forEach((variableId) => {
+        if (desiredIds.has(variableId)) return
+        const listenerId = variablesListeners[func.id]?.[variableId]
+        if (listenerId) unlistenDataLakeVariable(variableId, listenerId)
+        if (variablesListeners[func.id]) delete variablesListeners[func.id][variableId]
+      })
+    }
+
+    const evaluate = (): void => {
+      try {
+        // If the function is failing, we don't want to evaluate it too often
+        const currentDelay = nextDelayToEvaluateFailingTransformingFunction[func.id] || 10
+        const lastTimeTried = lastTimeTriedToEvaluateFailingTransformingFunction[func.id] || 0
+        if (currentDelay > 0 && lastTimeTried + currentDelay > Date.now()) return
+
+        setDataLakeVariableData(func.id, getExpressionValue(func))
+
+        delete nextDelayToEvaluateFailingTransformingFunction[func.id]
+        delete lastTimeTriedToEvaluateFailingTransformingFunction[func.id]
+        delete lastLoggedErrorForTransformingFunction[func.id]
+      } catch (error) {
+        lastTimeTriedToEvaluateFailingTransformingFunction[func.id] = Date.now()
+        const currentDelay = nextDelayToEvaluateFailingTransformingFunction[func.id] || 10
+        const nextDelay = Math.min(2 * currentDelay, 10000)
+        nextDelayToEvaluateFailingTransformingFunction[func.id] = nextDelay
+        // Avoid spamming the log when the same error repeats on every dependency update.
+        const errorText = `${error}`
+        if (lastLoggedErrorForTransformingFunction[func.id] !== errorText) {
+          lastLoggedErrorForTransformingFunction[func.id] = errorText
+          const msg = `Error evaluating expression for transforming function '${func.id}'. Next evaluation in ${nextDelay} ms. Error: ${errorText}`
+          console.error(msg)
+        }
+      }
+    }
+
+    const onDependencyChange = (): void => {
+      // If the variable changes, we don't need to perform the initial evaluation again
+      clearTimeout(initialEvaluationTimeouts[func.id])
+      evaluate()
+      // Re-sync after evaluation: a change to an inner template variable (e.g.
+      // `autopilotSystemId`) may have shifted the resolved dependency set.
+      syncDependencies()
+    }
+
     // This function is used to evaluate the transforming function when it's created.
     // It's called when the transforming function is created and then every 1000ms until it succeeds, with a max of 10 tries.
     const performInitialEvaluation = (timesTried = 0): void => {
@@ -111,49 +173,11 @@ const setupTransformingFunctionsListeners = (): void => {
           console.error(`Failed to set initial value for transforming function '${func.id}'. Won't try again.`)
         }
       }
+      syncDependencies()
     }
     initialEvaluationTimeouts[func.id] = setTimeout(performInitialEvaluation, 1000)
 
-    const dataLakeVariablesInExpression = getDataLakeVariableIdFromInput(func.expression)
-    if (dataLakeVariablesInExpression) {
-      const variableIds = findDataLakeVariablesIdsInString(func.expression)
-      variableIds.forEach((variableId) => {
-        const listenerId = listenDataLakeVariable(variableId, () => {
-          // If the variable changes, we don't need to perform the initial evaluation again
-          clearTimeout(initialEvaluationTimeouts[func.id])
-          try {
-            // If the function is failing, we don't want to evaluate it too often
-            const currentDelay = nextDelayToEvaluateFaillingTransformingFunction[func.id] || 10
-            const lastTimeTried = lastTimeTriedToEvaluateFaillingTransformingFunction[func.id] || 0
-            if (currentDelay > 0 && lastTimeTried + currentDelay > Date.now()) {
-              return
-            } else {
-              setDataLakeVariableData(func.id, getExpressionValue(func))
-              delete lastLoggedErrorForTransformingFunction[func.id]
-            }
-          } catch (error) {
-            lastTimeTriedToEvaluateFaillingTransformingFunction[func.id] = Date.now()
-            const currentDelay = nextDelayToEvaluateFaillingTransformingFunction[func.id] || 10
-            const nextDelay = Math.min(2 * currentDelay, 10000)
-            nextDelayToEvaluateFaillingTransformingFunction[func.id] = nextDelay
-            // Avoid spamming the log when the same error repeats on every dependency update.
-            const errorText = `${error}`
-            if (lastLoggedErrorForTransformingFunction[func.id] !== errorText) {
-              lastLoggedErrorForTransformingFunction[func.id] = errorText
-              const msg = `Error evaluating expression for transforming function '${func.id}'. Next evaluation in ${nextDelay} ms. Error: ${errorText}`
-              console.error(msg)
-            }
-          }
-        })
-        if (!variablesListeners[func.id]) {
-          variablesListeners[func.id] = { [variableId]: [listenerId] }
-        } else if (!variablesListeners[func.id][variableId]) {
-          variablesListeners[func.id][variableId] = [listenerId]
-        } else {
-          variablesListeners[func.id][variableId].push(listenerId)
-        }
-      })
-    }
+    syncDependencies()
   })
 }
 
@@ -165,16 +189,16 @@ const deleteAllTransformingFunctionsListeners = (): void => {
     clearTimeout(initialEvaluationTimeouts[funcId])
     delete initialEvaluationTimeouts[funcId]
   })
-  Object.keys(nextDelayToEvaluateFaillingTransformingFunction).forEach((funcId) => {
-    delete nextDelayToEvaluateFaillingTransformingFunction[funcId]
-    delete lastTimeTriedToEvaluateFaillingTransformingFunction[funcId]
+  Object.keys(nextDelayToEvaluateFailingTransformingFunction).forEach((funcId) => {
+    delete nextDelayToEvaluateFailingTransformingFunction[funcId]
+    delete lastTimeTriedToEvaluateFailingTransformingFunction[funcId]
   })
-  Object.keys(lastTimeTriedToEvaluateFaillingTransformingFunction).forEach((funcId) => {
-    delete lastTimeTriedToEvaluateFaillingTransformingFunction[funcId]
+  Object.keys(lastTimeTriedToEvaluateFailingTransformingFunction).forEach((funcId) => {
+    delete lastTimeTriedToEvaluateFailingTransformingFunction[funcId]
   })
   Object.entries(variablesListeners).forEach(([funcId, variableListeners]) => {
-    Object.entries(variableListeners).forEach(([variableId, listenerIds]) => {
-      listenerIds.forEach((listenerId) => unlistenDataLakeVariable(variableId, listenerId))
+    Object.entries(variableListeners).forEach(([variableId, listenerId]) => {
+      unlistenDataLakeVariable(variableId, listenerId)
     })
     delete variablesListeners[funcId]
   })

--- a/src/libs/data-sources/altitude.ts
+++ b/src/libs/data-sources/altitude.ts
@@ -2,10 +2,12 @@
 export type AltitudeSourceOption = {
   /** User-facing source label shown in widget config menus. */
   title: string
-  /** Templated data lake variable ID; resolved at runtime via the mustache system. */
+  /** Data lake variable ID the widget subscribes to (templated MAVLink path or compound-variable ID). */
   value: string
-  /** Converts the raw data lake altitude value to meters. */
-  toMeters: (rawAltitude: number) => number
+  /** Converts the raw data lake value to meters. */
+  toMeters: (rawValue: number) => number
+  /** Legacy MAVLink path suffixes to migrate to this option (e.g. `SCALED_PRESSURE2/press_abs`). */
+  legacyMatchSuffixes?: string[]
 }
 
 /** Altitude source options exposed to widget config menus. */
@@ -30,6 +32,18 @@ export const altitudeSourceOptions: AltitudeSourceOption[] = [
     value: '/mavlink/{{autopilotSystemId}}/1/GLOBAL_POSITION_INT/relative_alt',
     toMeters: (rawAltitude) => rawAltitude / 1000,
   },
+  {
+    title: 'baro2.pressure_alt',
+    value: 'baro2.pressure_alt',
+    toMeters: (rawAltitude) => rawAltitude,
+    legacyMatchSuffixes: ['SCALED_PRESSURE2/press_abs'],
+  },
+  {
+    title: 'baro3.pressure_alt',
+    value: 'baro3.pressure_alt',
+    toMeters: (rawAltitude) => rawAltitude,
+    legacyMatchSuffixes: ['SCALED_PRESSURE3/press_abs'],
+  },
 ]
 
 /** Default altitude source for depth widgets (ahrs2.alt). */
@@ -44,14 +58,20 @@ const ALTITUDE_PATH_PATTERN = /^\/mavlink\/(?:\d+|\{\{autopilotSystemId\}\})\/\d
 const extractAltitudeSuffix = (variableId: string): string | undefined => variableId.match(ALTITUDE_PATH_PATTERN)?.[1]
 
 const findOptionForVariableId = (variableId: string): AltitudeSourceOption | undefined => {
+  const exactMatch = altitudeSourceOptions.find((option) => option.value === variableId)
+  if (exactMatch) return exactMatch
+
   const suffix = extractAltitudeSuffix(variableId)
   if (!suffix) return undefined
-  return altitudeSourceOptions.find((option) => extractAltitudeSuffix(option.value) === suffix)
+  return altitudeSourceOptions.find((option) => {
+    if (extractAltitudeSuffix(option.value) === suffix) return true
+    return option.legacyMatchSuffixes?.includes(suffix) ?? false
+  })
 }
 
 /**
  * Whether the given variable ID matches a known altitude source preset
- * (templated form or a concrete /mavlink/N/N/SUFFIX path).
+ * (compound variable ID, templated form, or a concrete /mavlink/N/N/SUFFIX path).
  * @param {string} altitudeVariableId - Data lake variable ID or template
  * @returns {boolean} True if it matches a preset
  */
@@ -59,11 +79,25 @@ export const isPresetAltitudeVariableId = (altitudeVariableId: string): boolean 
   findOptionForVariableId(altitudeVariableId) !== undefined
 
 /**
- * Convert a raw altitude value from the selected altitude source to meters.
+ * Migrate a legacy persisted variable ID to the current preset value:
+ * concrete `/mavlink/N/N/...` paths are rewritten to their templated form,
+ * and retired raw paths (e.g. `SCALED_PRESSURE2/press_abs`) are pointed at
+ * the equivalent predefined compound variable. Anything that already matches
+ * a preset (or is a fully custom variable) is returned unchanged.
+ * @param {string} altitudeVariableId - Persisted data lake variable ID
+ * @returns {string} The current preset variable ID (or the input unchanged)
+ */
+export const migrateAltitudeVariableId = (altitudeVariableId: string): string => {
+  const option = findOptionForVariableId(altitudeVariableId)
+  return option ? option.value : altitudeVariableId
+}
+
+/**
+ * Convert a raw data-lake value from the selected altitude source to meters.
  * Accepts either the templated or the concrete data lake variable ID. Custom
  * (non-preset) variables are assumed to already be in meters and pass through unchanged.
  * @param {string} altitudeVariableId - Data lake variable ID for the altitude source
- * @param {number} rawAltitude - Raw altitude value from the data lake
+ * @param {number} rawAltitude - Raw value from the data lake
  * @returns {number} Altitude in meters
  */
 export const rawAltitudeToMeters = (altitudeVariableId: string, rawAltitude: number): number => {

--- a/src/libs/joystick/protocols/predefined-resources.ts
+++ b/src/libs/joystick/protocols/predefined-resources.ts
@@ -178,7 +178,63 @@ const setupJoystickAxesResources = (): void => {
   }
 }
 
+type PressureAltitudeCompoundVariable = {
+  /** Data-lake / transforming-function ID exposed to the rest of Cockpit. */
+  id: string
+  /** Human-readable name shown in the data-lake browser. */
+  name: string
+  /** Ground-pressure autopilot parameter that pairs with the chosen barometer. */
+  groundPressureParam: string
+  /** MAVLink message that streams the barometer's absolute pressure. */
+  pressureMessage: string
+}
+
+export const setupPressureAltitudeResources = (): void => {
+  const pressureAltitudeVariables: PressureAltitudeCompoundVariable[] = [
+    {
+      id: 'baro2.pressure_alt',
+      name: 'baro2.pressure_alt — Pressure-based altitude [m]',
+      groundPressureParam: 'BARO2_GND_PRESS',
+      pressureMessage: 'SCALED_PRESSURE2',
+    },
+    {
+      id: 'baro3.pressure_alt',
+      name: 'baro3.pressure_alt — Pressure-based altitude [m]',
+      groundPressureParam: 'BARO3_GND_PRESS',
+      pressureMessage: 'SCALED_PRESSURE3',
+    },
+  ]
+
+  pressureAltitudeVariables.forEach(({ id, name, groundPressureParam, pressureMessage }) => {
+    try {
+      if (getAllTransformingFunctions().find((f) => f.id === id)) return
+
+      // Nested `{{autopilotSystemId}}` references are resolved by the data-lake
+      // template engine, so the expression always tracks whichever autopilot is
+      // currently connected. Missing references substitute to `NaN`, which keeps
+      // the result `NaN` until every dependency has been received.
+      const expression = getUnindentedString(`
+        ({{vehicle/{{autopilotSystemId}}/parameters/${groundPressureParam}}} - {{/mavlink/{{autopilotSystemId}}/1/${pressureMessage}/press_abs}} * 100)
+        / 9800
+        / {{vehicle/{{autopilotSystemId}}/parameters/BARO_SPEC_GRAV}}
+        + {{vehicle/{{autopilotSystemId}}/parameters/BARO_ALT_OFFSET}}
+      `)
+      const description = getUnindentedString(`
+        Pressure-based altitude (meters) computed from ${pressureMessage}.press_abs together with
+        the ${groundPressureParam}, BARO_SPEC_GRAV and BARO_ALT_OFFSET autopilot parameters,
+        mirroring ArduSub's underwater depth formula. Returns NaN until all dependencies are
+        available.
+      `)
+
+      createTransformingFunction(id, name, 'number', expression, description)
+    } catch (error) {
+      console.error(`Error creating compound variable '${id}':`, error)
+    }
+  })
+}
+
 export const setupPredefinedLakeAndActionResources = (): void => {
   setupMavlinkCameraResources()
   setupJoystickAxesResources()
+  setupPressureAltitudeResources()
 }

--- a/src/libs/utils-data-lake.ts
+++ b/src/libs/utils-data-lake.ts
@@ -47,9 +47,15 @@ export const getDataLakeVariableIdFromInput = (input: string): string | null => 
   return match[0].replace('{{', '').replace('}}', '').trim()
 }
 
+/** Hard cap on substitution/discovery passes; protects against pathological inputs. */
+const MAX_DATA_LAKE_RESOLUTION_PASSES = 10
+
 /**
  * Replace all data lake inputs in a string with values from the data lake.
- * If a possible input is not found in the data lake, it will be left unchanged.
+ * Runs multiple substitution passes until the result is stable, so nested
+ * templates (e.g. `{{vehicle/{{autopilotSystemId}}/parameters/X}}`) resolve
+ * fully in a single call. Missing variables are left unchanged by the default
+ * replace function, so subsequent passes can't reintroduce new inputs.
  * @param {string} input The string to replace data lake inputs in
  * @param {Function} replaceFunction The function to use to replace the data lake inputs. If not provided, the default function will be used.
  * @returns {string} The string with data lake inputs replaced
@@ -67,17 +73,40 @@ export const replaceDataLakeInputsInString = (input: string, replaceFunction?: (
 
   const replaceFunctionToUse = replaceFunction || defaultReplaceFunction
 
-  return input.toString().replace(dataLakeInputRegex, (match) => replaceFunctionToUse(match))
+  let current = input.toString()
+  for (let pass = 0; pass < MAX_DATA_LAKE_RESOLUTION_PASSES; pass++) {
+    const next = current.replace(dataLakeInputRegex, (match) => replaceFunctionToUse(match))
+    if (next === current) break
+    current = next
+  }
+  return current
 }
 
 /**
- * Find all data lake variable ids in a string.
+ * Find all data lake variable ids referenced in a string, including those
+ * exposed only after intermediate templates resolve. The discovery runs the
+ * same multi-pass loop as `replaceDataLakeInputsInString` so callers that need
+ * to subscribe to dependencies see the IDs that the eventual substitution will
+ * touch (e.g. both `autopilotSystemId` and the path it expands into).
  * @param {string} input The string to search for data lake variable ids
  * @returns {string[]} An array of data lake variable ids
  */
 export const findDataLakeVariablesIdsInString = (input: string): string[] => {
-  const inputs = findDataLakeInputsInString(input)
-  return inputs.map((i) => getDataLakeVariableIdFromInput(i)).filter((id) => id !== null)
+  if (typeof input !== 'string') return []
+
+  const discoveredIds = new Set<string>()
+  let current = input.toString()
+  for (let pass = 0; pass < MAX_DATA_LAKE_RESOLUTION_PASSES; pass++) {
+    findDataLakeInputsInString(current)
+      .map((rawInput) => getDataLakeVariableIdFromInput(rawInput))
+      .filter((id): id is string => id !== null)
+      .forEach((id) => discoveredIds.add(id))
+
+    const next = replaceDataLakeInputsInString(current)
+    if (next === current) break
+    current = next
+  }
+  return Array.from(discoveredIds)
 }
 
 export const replaceDataLakeInputsInJsonString = (jsonString: string): string => {

--- a/src/libs/vehicle/mavlink/vehicle.ts
+++ b/src/libs/vehicle/mavlink/vehicle.ts
@@ -464,6 +464,7 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
         this._lastParameter = { name: param_name, value: trimmed_value }
         this._totalParametersCount = Number(param_count)
         this.onParameter.emit()
+        this.setParameterInDataLake(param_name, trimmed_value)
         break
       }
 
@@ -1488,6 +1489,27 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
       networkLatencyMs: { id: `${vehiclePath}/networkLatencyMs`, name: `Network Latency [ms] (${vehicleName})`, type: 'number' },
     }
     /* eslint-enable vue/max-len, prettier/prettier, max-len */
+  }
+
+  /**
+   * Mirror an autopilot parameter into the data lake under
+   * `vehicle/{systemId}/parameters/{paramName}` so widgets and transforming
+   * functions can read its latest value reactively.
+   * @param {string} paramName - Parameter name (e.g. 'BARO_SPEC_GRAV')
+   * @param {number} paramValue - Parameter value
+   */
+  private setParameterInDataLake(paramName: string, paramValue: number): void {
+    const dataLakeId = `vehicle/${this.currentSystemId}/parameters/${paramName}`
+    if (getDataLakeVariableInfo(dataLakeId) === undefined) {
+      createDataLakeVariable({
+        id: dataLakeId,
+        name: `Parameter ${paramName} (MAVLink / System: ${this.currentSystemId})`,
+        type: 'number',
+        // TODO: support writing selected parameters back to the vehicle.
+        allowUserToChangeValue: false,
+      })
+    }
+    setDataLakeVariableData(dataLakeId, paramValue)
   }
 
   /**


### PR DESCRIPTION
## Summary

Adds depth/altitude readings derived from `SCALED_PRESSURE2/3` as predefined data-lake variables, with the underlying machinery needed to make them work cleanly across vehicles. Widgets that currently read raw pressure (`DepthHUD`, `DepthIndicator`, `RelativeAltitudeIndicator`) can now subscribe directly to the resolved altitude in meters.

## What changed

- **Autopilot parameters in the data-lake.** Every `PARAM_VALUE` received from the autopilot is mirrored at `/vehicle/{systemId}/parameters/{paramName}`, making parameters reactive to widgets and transforming functions (addresses the readable half of #1848).
- **Predefined `baro2.pressure_alt` / `baro3.pressure_alt`.** Registered as transforming functions that compute altitude in meters from `SCALED_PRESSURE*.press_abs` and the autopilot's `BARO*/BARO_SPEC_GRAV/BARO_ALT_OFFSET` parameters using ArduSub's underwater depth formula, with the active vehicle resolved through the nested `{{autopilotSystemId}}` template.
- **Nested template resolution.** `replaceDataLakeInputsInString` / `findDataLakeVariablesIdsInString` now loop until stable (cap 10 passes), so a placeholder whose value itself contains `{{...}}` (e.g. `{{/vehicle/{{autopilotSystemId}}/parameters/BARO_SPEC_GRAV}}`) fully resolves. Non-nested inputs behave exactly as before.
- **Graceful transforming-function evaluation.** Missing dependencies now substitute `NaN` into the expression instead of leaving the literal `{{...}}` placeholder (which threw `SyntaxError` and burned the exponential-backoff budget). Listeners are re-discovered after every evaluation so expressions follow inner-template changes — e.g. when `autopilotSystemId` flips on connect, dependencies switch to the new `/vehicle/{N}/...` paths automatically.
- **Widget options wired through the new variables.** Depth/altitude widgets expose `baro2.pressure_alt` and `baro3.pressure_alt` as altitude sources whose `value` points directly at the compound-variable IDs (`toMeters` becomes the identity). A new `legacyMatchSuffixes` field migrates persisted settings that still reference the raw `SCALED_PRESSURE*/press_abs` paths.
- **`NaN` guards on altitude consumers.** `DepthHUD`, `DepthIndicator`, and `RelativeAltitudeIndicator` now treat non-finite altitude as missing, so the brief window where a compound variable is still resolving doesn't show "NaN m" or poison the depth-history canvas.

## Test plan

- [ ] Connect to an ArduSub vehicle and confirm `baro2.pressure_alt` / `baro3.pressure_alt` appear in the data lake and resolve to sensible values once parameters arrive.
- [ ] In `DepthHUD`, `DepthIndicator`, and `RelativeAltitudeIndicator` option menus, select the new altitude sources and confirm readings match the previous raw-pressure path.
- [ ] Existing widgets persisted on the old `SCALED_PRESSURE*/press_abs` source still load and switch to the new compound variable via `legacyMatchSuffixes`.
- [ ] During the first seconds after connect (before parameters land) widgets show `--` / blank instead of `NaN m`.
- [ ] Reconnecting to a vehicle with a different system ID, the compound variables re-bind to the new `/vehicle/{N}/...` paths without a refresh.

To be merged after #2725.
Closes #2736.