### PR TITLE
Add communications range and antenna guidance for mission planning and flight mode

### DIFF
--- a/src/components/BaseStationConfigPanel.vue
+++ b/src/components/BaseStationConfigPanel.vue
@@ -27,6 +27,10 @@
         <template #content>
           <div class="flex flex-col pt-1 w-full gap-y-1">
             <div class="config-row">
+              <p class="config-label">Name</p>
+              <input v-model="config.name" type="text" class="config-input" />
+            </div>
+            <div class="config-row">
               <p class="config-label">Latitude</p>
               <input
                 :value="latText"
@@ -48,19 +52,6 @@
                 @input="(e) => onLatLngInput('lng', (e.target as HTMLInputElement).value)"
               />
             </div>
-            <div class="config-row pt-0 mt-0 -mb-1">
-              <p class="config-label">Track by GPS</p>
-              <v-checkbox
-                v-model="config.trackByGps"
-                hide-details
-                density="compact"
-                class="config-checkbox"
-                :disabled="!config.position"
-              />
-            </div>
-            <div v-if="config.trackByGps" class="text-[11px] text-white/70 px-1 -mt-1">
-              Position synced with browser geolocation.
-            </div>
           </div>
         </template>
       </ExpansiblePanel>
@@ -78,10 +69,20 @@
         <template #content>
           <div class="flex flex-col pt-1 w-full gap-y-1">
             <div class="config-row">
-              <p class="config-label">Topside</p>
+              <p class="config-label">Topside computer</p>
               <select v-model="config.topSideComputerType" class="config-input">
                 <option v-for="type in topSideTypes" :key="type" :value="type">{{ type }}</option>
               </select>
+            </div>
+            <div v-if="isPortableTopside" class="config-row config-checkbox-row">
+              <p class="config-label">Track position by GPS</p>
+              <v-checkbox
+                v-model="config.trackByGps"
+                hide-details
+                density="compact"
+                class="config-checkbox"
+                :disabled="!config.position"
+              />
             </div>
             <div class="config-row">
               <p class="config-label">Comms</p>
@@ -91,19 +92,151 @@
             </div>
             <div v-if="isMobileData" class="config-row">
               <p class="config-label">Coverage</p>
-              <select :value="config.mobileCoverage.provider" class="config-input" @change="onCoverageProviderChange">
-                <option v-for="p in mobileCoverageProviders" :key="p" :value="p">{{ p }}</option>
-              </select>
+              <div class="config-input-actions">
+                <div class="config-coverage-buttons">
+                  <button
+                    v-if="isOpenCellId || isOsmOverpass"
+                    type="button"
+                    class="config-target-btn"
+                    :class="{ 'config-target-btn-active': store.mobileCoverageTargetToolActive }"
+                    title="Click to pick a point on the map, or drag onto it"
+                    aria-label="Pick a point on the map to fetch coverage"
+                    draggable="true"
+                    @click="toggleMobileCoverageTargetTool"
+                    @dragstart="onMobileCoverageFetchDragStart"
+                  >
+                    <v-icon icon="mdi-crosshairs-gps" size="14" />
+                  </button>
+                  <v-menu location="bottom end" offset="4">
+                    <template #activator="{ props }">
+                      <button
+                        type="button"
+                        class="config-actions-menu-btn"
+                        title="Coverage actions"
+                        aria-label="Coverage actions"
+                        v-bind="props"
+                      >
+                        <v-icon icon="mdi-dots-vertical" size="16" />
+                      </button>
+                    </template>
+                    <v-list
+                      density="compact"
+                      class="config-actions-menu-list"
+                      :style="[interfaceStore.globalGlassMenuStyles, { background: '#0a2a3dee' }]"
+                    >
+                      <v-list-item v-if="isOpenCellId && isStandalone" @click="toggleOpenCellIdApiKeyField">
+                        <v-list-item-title>{{
+                          showOpenCellIdApiKeyField ? 'Hide API key' : 'Show API key'
+                        }}</v-list-item-title>
+                        <template #append>
+                          <v-icon icon="mdi-cog" size="14" class="-mt-[3px] -mr-[4px]" />
+                        </template>
+                      </v-list-item>
+                      <v-divider v-if="isOpenCellId && isStandalone" class="config-actions-divider" />
+                      <v-list-item
+                        :disabled="store.mobileCoverageLoading || !config.position"
+                        @click="reloadMobileCoverage"
+                      >
+                        <v-list-item-title>Reload coverage data</v-list-item-title>
+                        <template #append>
+                          <v-icon
+                            :icon="store.mobileCoverageLoading ? 'mdi-loading' : 'mdi-refresh'"
+                            size="15"
+                            :class="{ 'reload-spin': store.mobileCoverageLoading, '-mr-[3px]': isOpenCellId }"
+                          />
+                        </template>
+                      </v-list-item>
+                      <v-divider class="config-actions-divider" />
+                      <v-list-item :disabled="store.mobileCoverageLoading" @click="resetVisibleMobileCoverageData">
+                        <v-list-item-title>Reset visible data</v-list-item-title>
+                        <template #append>
+                          <v-icon icon="mdi-delete-sweep-outline" size="16" class="-mb-[2px] -mr-[6px]" />
+                        </template>
+                      </v-list-item>
+                    </v-list>
+                  </v-menu>
+                </div>
+                <div class="config-provider-select-wrap">
+                  <select
+                    :value="config.mobileCoverage.provider"
+                    class="config-input config-provider-select"
+                    @change="onCoverageProviderChange"
+                  >
+                    <option v-for="p in mobileCoverageProviders" :key="p" :value="p">{{ p }}</option>
+                  </select>
+                  <v-progress-linear
+                    v-if="store.mobileCoverageLoading"
+                    absolute
+                    indeterminate
+                    location="bottom"
+                    :height="2"
+                    color="white"
+                    bg-opacity="0"
+                    class="config-provider-loading"
+                  />
+                </div>
+              </div>
             </div>
-            <div v-if="isMobileData && isOpenCellId" class="config-row">
+            <div v-if="showOpenCellIdApiKeyField" class="config-row">
               <p class="config-label">API key</p>
-              <input v-model.trim="config.mobileCoverage.openCellIdApiKey" type="text" class="config-input" />
+              <div class="config-input-actions">
+                <input
+                  v-model.trim="config.mobileCoverage.openCellIdApiKey"
+                  type="text"
+                  class="config-input config-api-key-input"
+                />
+                <v-icon
+                  v-if="config.mobileCoverage.openCellIdApiKey.trim() && store.openCellIdApiKeyStatus === 'valid'"
+                  class="text-green-500"
+                  size="14"
+                >
+                  mdi-check-circle
+                </v-icon>
+                <v-icon
+                  v-else-if="
+                    config.mobileCoverage.openCellIdApiKey.trim() && store.openCellIdApiKeyStatus === 'invalid'
+                  "
+                  class="text-red-400"
+                  size="14"
+                >
+                  mdi-alert-circle
+                </v-icon>
+                <v-tooltip location="top" max-width="280">
+                  <template #activator="{ props }">
+                    <button
+                      type="button"
+                      class="config-info-btn"
+                      title="OpenCellID API information"
+                      aria-label="OpenCellID API information"
+                      v-bind="props"
+                    >
+                      <v-icon icon="mdi-information-outline" size="14" />
+                    </button>
+                  </template>
+                  <div class="config-open-cell-id-tip">
+                    API key mode uses the official OpenCellID API with your own request quota, so it is usually more
+                    stable and less aggressively rate-limited than the anonymous standalone service. Anonymous mode is
+                    easier to use but may return fewer results or cool down sooner. Get a key at
+                    `opencellid.org/register.php`, then copy it from your dashboard/API access page.
+                  </div>
+                </v-tooltip>
+              </div>
             </div>
             <div v-if="isMobileData && isOsmOverpass" class="config-row">
               <p class="config-label">Operator</p>
               <select v-model="config.mobileCoverage.osmOperator" class="config-input">
                 <option value="">All operators</option>
                 <option v-for="op in store.availableOsmOperators" :key="op" :value="op">{{ op }}</option>
+              </select>
+            </div>
+            <div
+              v-if="isMobileData && isOpenCellId && store.availableOpenCellIdOperators.length > 0"
+              class="config-row"
+            >
+              <p class="config-label">Operator</p>
+              <select v-model="config.mobileCoverage.openCellIdOperator" class="config-input">
+                <option value="">All operators</option>
+                <option v-for="op in store.availableOpenCellIdOperators" :key="op" :value="op">{{ op }}</option>
               </select>
             </div>
             <div v-if="isMobileData && isCustomCoverage" class="config-row">
@@ -334,7 +467,7 @@
       </ExpansiblePanel>
 
       <ExpansiblePanel
-        v-if="isRadioLink || isTethered"
+        v-if="isRadioLink || isTethered || isMobileData"
         mark-expanded
         compact
         elevation-effect
@@ -346,7 +479,7 @@
         <template #title><p class="ml-10">Display</p></template>
         <template #content>
           <div class="flex flex-col pt-1 w-full gap-y-1">
-            <div class="config-row">
+            <div v-if="isRadioLink || isTethered" class="config-row">
               <p class="config-label">Color</p>
               <v-menu :close-on-content-click="false" location="bottom end">
                 <template #activator="{ props: activatorProps }">
@@ -368,10 +501,31 @@
                 />
               </v-menu>
             </div>
-            <div class="config-row config-slider-row">
-              <p class="config-label">Opacity</p>
+            <div v-if="isMobileData && (isOpenCellId || isOsmOverpass)" class="config-row">
+              <p class="config-label">Signal view</p>
+              <select v-model="config.mobileCoverage.displayMode" class="config-input">
+                <option v-for="mode in mobileCoverageDisplayModes" :key="mode" :value="mode">{{ mode }}</option>
+              </select>
+            </div>
+            <div
+              v-if="isMobileData && (isOpenCellId || isOsmOverpass) && isCoverageRingsMode"
+              class="config-row config-checkbox-row"
+            >
+              <p class="config-label">Show ring labels</p>
+              <v-checkbox
+                v-model="config.mobileCoverage.showRingLabels"
+                hide-details
+                density="compact"
+                class="config-checkbox"
+              />
+            </div>
+            <div
+              v-if="isMobileData && (isOpenCellId || isOsmOverpass) && isHeatmapMode"
+              class="config-row config-slider-row"
+            >
+              <p class="config-label">Heatmap intensity</p>
               <v-slider
-                v-model="config.coverageOpacity"
+                v-model="config.mobileCoverage.heatmapIntensity"
                 :min="0"
                 :max="1"
                 :step="0.05"
@@ -383,7 +537,26 @@
                 track-color="rgba(255,255,255,0.2)"
                 class="config-slider"
               />
-              <p class="config-slider-value">{{ Math.round(config.coverageOpacity * 100) }}%</p>
+              <p class="config-slider-value">
+                {{ formatHeatmapIntensityLabel(config.mobileCoverage.heatmapIntensity) }}
+              </p>
+            </div>
+            <div class="config-row config-slider-row">
+              <p class="config-label">Opacity</p>
+              <v-slider
+                v-model="displayOpacityModel"
+                :min="0"
+                :max="1"
+                :step="0.05"
+                :thumb-size="12"
+                :track-size="2"
+                hide-details
+                density="compact"
+                color="white"
+                track-color="rgba(255,255,255,0.2)"
+                class="config-slider"
+              />
+              <p class="config-slider-value">{{ Math.round(displayOpacityModel * 100) }}%</p>
             </div>
           </div>
         </template>
@@ -459,14 +632,25 @@
   </div>
 </template>
 
+<script lang="ts">
+// Multiple Map widgets each mount their own config panel — keep the global Escape listener at
+// module scope and ref-count it so we never queue duplicate handlers.
+let targetToolEscapeListenerCount = 0
+const sharedTargetToolEscapeHandlers = new Set<(event: KeyboardEvent) => void>()
+const sharedTargetToolEscape = (event: KeyboardEvent): void => {
+  for (const handler of sharedTargetToolEscapeHandlers) handler(event)
+}
+</script>
+
 <script setup lang="ts">
 import * as turf from '@turf/turf'
 import { useWindowSize } from '@vueuse/core'
-import { computed, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
 
 import ExpansiblePanel from '@/components/ExpansiblePanel.vue'
 import { useBaseStation } from '@/composables/baseStation/useBaseStation'
 import { useInteractionDialog } from '@/composables/interactionDialog'
+import { isElectron } from '@/libs/utils'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useMissionStore } from '@/stores/mission'
@@ -475,6 +659,8 @@ import {
   AntennaType,
   BaseStationCommsType,
   BLUE_ROBOTICS_TX_POWER_MW,
+  MOBILE_COVERAGE_FETCH_DROP_MIME,
+  MobileCoverageDisplayMode,
   MobileCoverageProvider,
   RadioBaseStationKind,
   TopSideComputerType,
@@ -494,16 +680,34 @@ const topSideTypes = Object.values(TopSideComputerType)
 const commsTypes = Object.values(BaseStationCommsType)
 const radioKinds = Object.values(RadioBaseStationKind)
 const antennaTypes = Object.values(AntennaType)
+const mobileCoverageDisplayModes = Object.values(MobileCoverageDisplayMode)
 const mobileCoverageProviders = Object.values(MobileCoverageProvider)
 
 const isRadioLink = computed(() => config.value.commsType === BaseStationCommsType.RadioLink)
 const isTethered = computed(() => config.value.commsType === BaseStationCommsType.Tethered)
 const isMobileData = computed(() => config.value.commsType === BaseStationCommsType.MobileData)
+const isStandalone = isElectron()
+const isPortableTopside = computed(() => config.value.topSideComputerType === TopSideComputerType.Portable)
 const isOmni = computed(() => config.value.antenna.type === AntennaType.Omni)
 const isCustomRadio = computed(() => config.value.radioBaseStationKind === RadioBaseStationKind.Custom)
 const isOpenCellId = computed(() => config.value.mobileCoverage.provider === MobileCoverageProvider.OpenCellID)
 const isOsmOverpass = computed(() => config.value.mobileCoverage.provider === MobileCoverageProvider.OSMOverpass)
 const isCustomCoverage = computed(() => config.value.mobileCoverage.provider === MobileCoverageProvider.Custom)
+const isCoverageRingsMode = computed(
+  () => config.value.mobileCoverage.displayMode === MobileCoverageDisplayMode.CoverageRings
+)
+const isHeatmapMode = computed(() => config.value.mobileCoverage.displayMode === MobileCoverageDisplayMode.Heatmap)
+const openCellIdApiKeyFieldOpen = ref(isStandalone && !config.value.mobileCoverage.openCellIdApiKey.trim())
+const showOpenCellIdApiKeyField = computed(
+  () => isMobileData.value && isOpenCellId.value && (!isStandalone || openCellIdApiKeyFieldOpen.value)
+)
+const displayOpacityModel = computed({
+  get: () => (isMobileData.value ? config.value.mobileCoverage.overlayOpacity : config.value.coverageOpacity),
+  set: (value: number) => {
+    if (isMobileData.value) config.value.mobileCoverage.overlayOpacity = value
+    else config.value.coverageOpacity = value
+  },
+})
 
 const latText = ref('')
 const lngText = ref('')
@@ -517,6 +721,13 @@ const txPowerFocused = ref(false)
 const formatBearing = (bearing: number): string => bearing.toFixed(1)
 const formatGain = (gain: number): string => gain.toFixed(1)
 const formatTxPower = (mw: number): string => Math.round(mw).toString()
+
+const formatHeatmapIntensityLabel = (intensity: number): string => {
+  const percent = Math.round(intensity * 100)
+  if (percent <= 25) return 'Low'
+  if (percent >= 75) return 'High'
+  return 'Med'
+}
 
 watch(
   () => config.value.position,
@@ -637,7 +848,64 @@ const onCoverageProviderChange = (event: Event): void => {
   const next = (event.target as HTMLSelectElement).value as MobileCoverageProvider
   config.value.mobileCoverage.provider = next
   if (next === MobileCoverageProvider.Custom) openCustomCoverageDialog()
+  if (next !== MobileCoverageProvider.OpenCellID && isStandalone) openCellIdApiKeyFieldOpen.value = false
+  if (
+    next === MobileCoverageProvider.OpenCellID &&
+    isStandalone &&
+    !config.value.mobileCoverage.openCellIdApiKey.trim()
+  ) {
+    openCellIdApiKeyFieldOpen.value = true
+  }
 }
+
+const reloadMobileCoverage = (): void => {
+  store.requestMobileCoverageReload()
+}
+
+const resetVisibleMobileCoverageData = (): void => {
+  store.requestVisibleMobileCoverageDataReset()
+}
+
+const toggleOpenCellIdApiKeyField = (): void => {
+  openCellIdApiKeyFieldOpen.value = !openCellIdApiKeyFieldOpen.value
+}
+
+const onMobileCoverageFetchDragStart = (event: DragEvent): void => {
+  event.dataTransfer?.setData(MOBILE_COVERAGE_FETCH_DROP_MIME, 'mobile-coverage-fetch')
+  event.dataTransfer?.setData('text/plain', 'mobile-coverage-fetch')
+  if (event.dataTransfer) event.dataTransfer.effectAllowed = 'copy'
+  // Drag preview: capture only the icon glyph so the surrounding button chrome doesn't tag along.
+  const icon = (event.currentTarget as HTMLElement).querySelector('.v-icon') as HTMLElement | null
+  if (icon && event.dataTransfer) {
+    const rect = icon.getBoundingClientRect()
+    event.dataTransfer.setDragImage(icon, rect.width / 2, rect.height / 2)
+  }
+  // Picking up the tool by drag and clicking the map afterwards would be confusing.
+  store.mobileCoverageTargetToolActive = false
+}
+
+const toggleMobileCoverageTargetTool = (): void => {
+  store.mobileCoverageTargetToolActive = !store.mobileCoverageTargetToolActive
+}
+
+const onTargetToolEscape = (event: KeyboardEvent): void => {
+  if (event.key === 'Escape' && store.mobileCoverageTargetToolActive) {
+    store.mobileCoverageTargetToolActive = false
+  }
+}
+if (targetToolEscapeListenerCount === 0) {
+  window.addEventListener('keydown', sharedTargetToolEscape)
+}
+targetToolEscapeListenerCount++
+sharedTargetToolEscapeHandlers.add(onTargetToolEscape)
+onBeforeUnmount(() => {
+  sharedTargetToolEscapeHandlers.delete(onTargetToolEscape)
+  targetToolEscapeListenerCount = Math.max(0, targetToolEscapeListenerCount - 1)
+  if (targetToolEscapeListenerCount === 0) {
+    window.removeEventListener('keydown', sharedTargetToolEscape)
+  }
+  store.mobileCoverageTargetToolActive = false
+})
 
 const onAntennaTypeChange = (event: Event): void => {
   const value = (event.target as HTMLSelectElement).value as AntennaType
@@ -761,6 +1029,115 @@ const getMarginsFromBarsHeight = computed(() => {
   color: white;
   box-sizing: border-box;
   border: 1px solid transparent;
+}
+
+.config-input-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.config-provider-select-wrap {
+  position: relative;
+  width: 130px;
+  flex: 0 0 130px;
+}
+
+.config-provider-select {
+  width: 100%;
+}
+
+.config-provider-loading {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+  z-index: 1;
+  margin: 0;
+}
+
+.config-coverage-buttons {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.config-actions-menu-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  flex: 0 0 24px;
+  border: 1px solid transparent;
+  color: white;
+  background: transparent;
+}
+
+.config-info-btn,
+.config-target-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  flex: 0 0 24px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: white;
+}
+
+.config-target-btn-active {
+  color: #60a5fa;
+}
+
+.config-actions-menu-list {
+  min-width: 190px;
+  padding: 0;
+  border: 1px solid #ffffff22;
+  border-radius: 8px;
+}
+
+.config-actions-menu-list :deep(.v-list-item) {
+  min-height: 30px;
+  color: white;
+}
+
+.config-actions-menu-list :deep(.v-list-item-title) {
+  font-size: 12px;
+}
+
+.config-actions-menu-list :deep(.v-list-item__append) {
+  margin-left: 16px;
+}
+
+.config-actions-divider {
+  opacity: 0.22;
+}
+
+.config-api-key-input {
+  width: 100%;
+}
+
+.config-open-cell-id-tip {
+  font-size: 11px;
+  line-height: 1.35;
+  color: #ffffffde;
+  text-align: left;
+}
+
+.reload-spin {
+  animation: reload-spin 0.9s linear infinite;
+}
+
+@keyframes reload-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 /* Strip the native number-input spinner so number fields render at the same usable width as

--- a/src/components/BaseStationConfigPanel.vue
+++ b/src/components/BaseStationConfigPanel.vue
@@ -89,9 +89,55 @@
                 <option v-for="comms in commsTypes" :key="comms" :value="comms">{{ comms }}</option>
               </select>
             </div>
+            <div v-if="isMobileData" class="config-row">
+              <p class="config-label">Coverage</p>
+              <select :value="config.mobileCoverage.provider" class="config-input" @change="onCoverageProviderChange">
+                <option v-for="p in mobileCoverageProviders" :key="p" :value="p">{{ p }}</option>
+              </select>
+            </div>
+            <div v-if="isMobileData && isOpenCellId" class="config-row">
+              <p class="config-label">API key</p>
+              <input v-model.trim="config.mobileCoverage.openCellIdApiKey" type="text" class="config-input" />
+            </div>
+            <div v-if="isMobileData && isOsmOverpass" class="config-row">
+              <p class="config-label">Operator</p>
+              <select v-model="config.mobileCoverage.osmOperator" class="config-input">
+                <option value="">All operators</option>
+                <option v-for="op in store.availableOsmOperators" :key="op" :value="op">{{ op }}</option>
+              </select>
+            </div>
+            <div v-if="isMobileData && isCustomCoverage" class="config-row">
+              <p class="config-label">Tile URL</p>
+              <button type="button" class="config-input config-text-btn" @click="openCustomCoverageDialog">
+                {{ config.mobileCoverage.customTileUrl ? 'Edit URL' : 'Set URL' }}
+              </button>
+            </div>
           </div>
         </template>
       </ExpansiblePanel>
+
+      <v-dialog v-model="customCoverageDialogOpen" max-width="520">
+        <v-card class="rounded-lg" :style="interfaceStore.globalGlassMenuStyles">
+          <v-card-title class="text-h6 py-3 text-center">Custom coverage tile URL</v-card-title>
+          <v-card-text class="px-6">
+            <v-text-field
+              v-model="customTileUrlDraft"
+              label="Tile URL"
+              placeholder="https://tiles.example.com/{z}/{x}/{y}.png"
+              hint="Leaflet TileLayer URL with {z}, {x}, {y} placeholders. Add an API key to the URL itself if your provider requires one."
+              persistent-hint
+              variant="outlined"
+              density="compact"
+              autofocus
+            />
+          </v-card-text>
+          <v-card-actions class="px-6 pb-4">
+            <v-spacer />
+            <v-btn variant="text" @click="customCoverageDialogOpen = false">Cancel</v-btn>
+            <v-btn variant="elevated" color="primary" @click="saveCustomTileUrl">Save</v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-dialog>
 
       <ExpansiblePanel
         v-if="isRadioLink"
@@ -421,6 +467,7 @@ import { computed, ref, watch } from 'vue'
 import ExpansiblePanel from '@/components/ExpansiblePanel.vue'
 import { useBaseStation } from '@/composables/baseStation/useBaseStation'
 import { useInteractionDialog } from '@/composables/interactionDialog'
+import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useMissionStore } from '@/stores/mission'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
@@ -428,6 +475,7 @@ import {
   AntennaType,
   BaseStationCommsType,
   BLUE_ROBOTICS_TX_POWER_MW,
+  MobileCoverageProvider,
   RadioBaseStationKind,
   TopSideComputerType,
 } from '@/types/baseStation'
@@ -438,6 +486,7 @@ const store = useBaseStation()
 const widgetStore = useWidgetManagerStore()
 const vehicleStore = useMainVehicleStore()
 const missionStore = useMissionStore()
+const interfaceStore = useAppInterfaceStore()
 
 const config = computed(() => store.config)
 
@@ -445,11 +494,16 @@ const topSideTypes = Object.values(TopSideComputerType)
 const commsTypes = Object.values(BaseStationCommsType)
 const radioKinds = Object.values(RadioBaseStationKind)
 const antennaTypes = Object.values(AntennaType)
+const mobileCoverageProviders = Object.values(MobileCoverageProvider)
 
 const isRadioLink = computed(() => config.value.commsType === BaseStationCommsType.RadioLink)
 const isTethered = computed(() => config.value.commsType === BaseStationCommsType.Tethered)
+const isMobileData = computed(() => config.value.commsType === BaseStationCommsType.MobileData)
 const isOmni = computed(() => config.value.antenna.type === AntennaType.Omni)
 const isCustomRadio = computed(() => config.value.radioBaseStationKind === RadioBaseStationKind.Custom)
+const isOpenCellId = computed(() => config.value.mobileCoverage.provider === MobileCoverageProvider.OpenCellID)
+const isOsmOverpass = computed(() => config.value.mobileCoverage.provider === MobileCoverageProvider.OSMOverpass)
+const isCustomCoverage = computed(() => config.value.mobileCoverage.provider === MobileCoverageProvider.Custom)
 
 const latText = ref('')
 const lngText = ref('')
@@ -564,6 +618,26 @@ const onRadioKindChange = (event: Event): void => {
 }
 
 const estimatesInfoDialogOpen = ref(false)
+const customCoverageDialogOpen = ref(false)
+const customTileUrlDraft = ref('')
+
+const openCustomCoverageDialog = (): void => {
+  customTileUrlDraft.value = config.value.mobileCoverage.customTileUrl
+  customCoverageDialogOpen.value = true
+}
+
+const saveCustomTileUrl = (): void => {
+  config.value.mobileCoverage.customTileUrl = customTileUrlDraft.value.trim()
+  customCoverageDialogOpen.value = false
+}
+
+// Selecting Custom auto-pops the URL dialog (operator hasn't given us a tile URL yet),
+// matching the spec; the other providers just swap and let the overlay refresh.
+const onCoverageProviderChange = (event: Event): void => {
+  const next = (event.target as HTMLSelectElement).value as MobileCoverageProvider
+  config.value.mobileCoverage.provider = next
+  if (next === MobileCoverageProvider.Custom) openCustomCoverageDialog()
+}
 
 const onAntennaTypeChange = (event: Event): void => {
   const value = (event.target as HTMLSelectElement).value as AntennaType
@@ -750,6 +824,11 @@ const getMarginsFromBarsHeight = computed(() => {
   border-radius: 3px;
   cursor: pointer;
   padding: 0;
+}
+
+.config-text-btn {
+  text-align: center;
+  cursor: pointer;
 }
 
 /* Eyedropper hijacks the v-menu's outside-click and the OS picker UX is shaky on web; drop it. */

--- a/src/components/BaseStationConfigPanel.vue
+++ b/src/components/BaseStationConfigPanel.vue
@@ -1,0 +1,810 @@
+<template>
+  <div
+    v-if="store.configPanelOpen"
+    class="flex fixed w-[300px] right-0 top-0 border-l-[1px] border-[#FFFFFF44] text-white elevation-5 bg-[#051e2d] overflow-y-auto"
+    :style="getMarginsFromBarsHeight"
+  >
+    <div class="flex flex-col h-full text-center w-full [&>*]:shrink-0">
+      <v-btn
+        class="absolute top-0 left-0"
+        variant="text"
+        size="small"
+        icon="mdi-close"
+        style="z-index: 50000"
+        @click="closePanel"
+      />
+
+      <ExpansiblePanel
+        mark-expanded
+        compact
+        elevation-effect
+        no-bottom-divider
+        darken-content
+        invert-chevron
+        :is-expanded="true"
+      >
+        <template #title><p class="ml-10">Base station</p></template>
+        <template #content>
+          <div class="flex flex-col pt-1 w-full gap-y-1">
+            <div class="config-row">
+              <p class="config-label">Latitude</p>
+              <input
+                :value="latText"
+                type="number"
+                step="0.000001"
+                class="config-input"
+                :disabled="config.trackByGps"
+                @input="(e) => onLatLngInput('lat', (e.target as HTMLInputElement).value)"
+              />
+            </div>
+            <div class="config-row">
+              <p class="config-label">Longitude</p>
+              <input
+                :value="lngText"
+                type="number"
+                step="0.000001"
+                class="config-input"
+                :disabled="config.trackByGps"
+                @input="(e) => onLatLngInput('lng', (e.target as HTMLInputElement).value)"
+              />
+            </div>
+            <div class="config-row pt-0 mt-0 -mb-1">
+              <p class="config-label">Track by GPS</p>
+              <v-checkbox
+                v-model="config.trackByGps"
+                hide-details
+                density="compact"
+                class="config-checkbox"
+                :disabled="!config.position"
+              />
+            </div>
+            <div v-if="config.trackByGps" class="text-[11px] text-white/70 px-1 -mt-1">
+              Position synced with browser geolocation.
+            </div>
+          </div>
+        </template>
+      </ExpansiblePanel>
+
+      <ExpansiblePanel
+        mark-expanded
+        compact
+        elevation-effect
+        no-bottom-divider
+        darken-content
+        invert-chevron
+        :is-expanded="true"
+      >
+        <template #title><p class="ml-10">Setup</p></template>
+        <template #content>
+          <div class="flex flex-col pt-1 w-full gap-y-1">
+            <div class="config-row">
+              <p class="config-label">Topside</p>
+              <select v-model="config.topSideComputerType" class="config-input">
+                <option v-for="type in topSideTypes" :key="type" :value="type">{{ type }}</option>
+              </select>
+            </div>
+            <div class="config-row">
+              <p class="config-label">Comms</p>
+              <select v-model="config.commsType" class="config-input">
+                <option v-for="comms in commsTypes" :key="comms" :value="comms">{{ comms }}</option>
+              </select>
+            </div>
+          </div>
+        </template>
+      </ExpansiblePanel>
+
+      <ExpansiblePanel
+        v-if="isRadioLink"
+        mark-expanded
+        compact
+        elevation-effect
+        no-bottom-divider
+        darken-content
+        invert-chevron
+        :is-expanded="true"
+      >
+        <template #title><p class="ml-10">Radio</p></template>
+        <template #content>
+          <div class="flex flex-col pt-1 w-full gap-y-1">
+            <div class="config-row">
+              <p class="config-label">Radio model</p>
+              <select :value="config.radioBaseStationKind" class="config-input" @change="onRadioKindChange">
+                <option v-for="kind in radioKinds" :key="kind" :value="kind">{{ kind }}</option>
+              </select>
+            </div>
+            <div v-if="isCustomRadio" class="config-row">
+              <p class="config-label">TX power (mW)</p>
+              <input
+                :value="txPowerText"
+                type="number"
+                step="100"
+                min="1"
+                class="config-input"
+                @input="(e) => onTxPowerInput((e.target as HTMLInputElement).value)"
+                @focus="txPowerFocused = true"
+                @blur="onTxPowerBlur"
+              />
+            </div>
+            <div class="config-row">
+              <p class="config-label">Antenna</p>
+              <select :value="config.antenna.type" class="config-input" @change="onAntennaTypeChange">
+                <option v-for="type in antennaTypes" :key="type" :value="type">{{ type }}</option>
+              </select>
+            </div>
+            <div class="config-row">
+              <div class="config-label-with-info">
+                <p class="config-label">Antenna height (m)</p>
+                <v-tooltip location="top" max-width="300">
+                  <template #activator="{ props }">
+                    <button
+                      type="button"
+                      class="config-info-btn"
+                      title="Base station antenna height information"
+                      aria-label="Base station antenna height information"
+                      v-bind="props"
+                    >
+                      <v-icon icon="mdi-information-outline" size="14" />
+                    </button>
+                  </template>
+                  <div class="config-open-cell-id-tip">
+                    Higher antennas see farther over the horizon. For line-of-sight links, usable range grows roughly
+                    with the square root of height (for example, 4× the height ≈ 2× the range). The default 1 m matches
+                    the baseline used for the preset range values.
+                  </div>
+                </v-tooltip>
+              </div>
+              <input
+                v-model.number="config.baseStationAntennaHeightMeters"
+                type="number"
+                step="0.5"
+                min="0.5"
+                max="50"
+                class="config-input"
+              />
+            </div>
+            <div class="config-row">
+              <p class="config-label">Gain (dBi)</p>
+              <input
+                :value="gainText"
+                type="number"
+                step="0.1"
+                class="config-input"
+                @input="(e) => onGainInput((e.target as HTMLInputElement).value)"
+                @focus="gainFocused = true"
+                @blur="onGainBlur"
+              />
+            </div>
+            <div class="config-row">
+              <p class="config-label">Beamwidth (°)</p>
+              <input
+                v-model.number="config.antenna.beamwidth"
+                type="number"
+                step="1"
+                min="1"
+                max="360"
+                class="config-input"
+                :disabled="isOmni"
+              />
+            </div>
+            <div class="config-row">
+              <p class="config-label">Range (m)</p>
+              <input v-model.number="config.antenna.range" type="number" step="10" min="1" class="config-input" />
+            </div>
+            <div class="config-row config-checkbox-row">
+              <div class="config-label-with-info">
+                <p class="config-label">Vehicle has antenna mast</p>
+                <v-tooltip location="top" max-width="300">
+                  <template #activator="{ props }">
+                    <button
+                      type="button"
+                      class="config-info-btn"
+                      title="BlueBoat antenna mast information"
+                      aria-label="BlueBoat antenna mast information"
+                      v-bind="props"
+                    >
+                      <v-icon icon="mdi-information-outline" size="14" />
+                    </button>
+                  </template>
+                  <div class="config-open-cell-id-tip">
+                    The BlueBoat Antenna and Accessory Mast raises the vehicle antenna about 50 cm above the deck for
+                    clearer line of sight, which can increase communication range by up to 1.75× compared with the
+                    default deck mount.
+                  </div>
+                </v-tooltip>
+              </div>
+              <v-checkbox
+                v-model="config.vehicleHasBlueBoatAntennaMast"
+                hide-details
+                density="compact"
+                class="config-checkbox"
+              />
+            </div>
+            <div v-if="!isOmni" class="config-row">
+              <p class="config-label">Bearing (°)</p>
+              <input
+                :value="bearingText"
+                type="number"
+                step="1"
+                class="config-input"
+                @input="(e) => onBearingInput((e.target as HTMLInputElement).value)"
+                @focus="bearingFocused = true"
+                @blur="onBearingBlur"
+              />
+            </div>
+
+            <div v-if="!isOmni" class="flex w-full justify-between gap-x-1 mt-[5px]">
+              <v-btn
+                size="x-small"
+                variant="elevated"
+                class="bg-[#FFFFFF22] flex-1 disabled:!bg-[#FFFFFF22] disabled:!text-white/55 disabled:!opacity-50"
+                :disabled="!canSnapToVehicle"
+                @click="snapBearingToVehicle"
+              >
+                Aim at vehicle
+              </v-btn>
+              <v-btn
+                size="x-small"
+                variant="elevated"
+                class="bg-[#FFFFFF22] flex-1 disabled:!bg-[#FFFFFF22] disabled:!text-white/55 disabled:!opacity-50"
+                :disabled="!canSnapToMission"
+                @click="snapBearingToMission"
+              >
+                Aim at mission
+              </v-btn>
+            </div>
+
+            <v-btn
+              size="x-small"
+              variant="elevated"
+              class="bg-[#2b5779] my-2 w-3/4 mx-auto"
+              prepend-icon="mdi-restore"
+              @click="resetAntenna"
+            >
+              Reset antenna defaults
+            </v-btn>
+          </div>
+        </template>
+      </ExpansiblePanel>
+
+      <ExpansiblePanel
+        v-if="isTethered"
+        mark-expanded
+        compact
+        elevation-effect
+        no-bottom-divider
+        darken-content
+        invert-chevron
+        :is-expanded="true"
+      >
+        <template #title><p class="ml-10">Tether</p></template>
+        <template #content>
+          <div class="flex flex-col pt-1 w-full gap-y-1">
+            <div class="config-row">
+              <p class="config-label">Length (m)</p>
+              <input v-model.number="config.tetherLengthMeters" type="number" step="1" min="1" class="config-input" />
+            </div>
+          </div>
+        </template>
+      </ExpansiblePanel>
+
+      <ExpansiblePanel
+        v-if="isRadioLink || isTethered"
+        mark-expanded
+        compact
+        elevation-effect
+        no-bottom-divider
+        darken-content
+        invert-chevron
+        :is-expanded="true"
+      >
+        <template #title><p class="ml-10">Display</p></template>
+        <template #content>
+          <div class="flex flex-col pt-1 w-full gap-y-1">
+            <div class="config-row">
+              <p class="config-label">Color</p>
+              <v-menu :close-on-content-click="false" location="bottom end">
+                <template #activator="{ props: activatorProps }">
+                  <button
+                    v-bind="activatorProps"
+                    type="button"
+                    class="config-input config-color-swatch"
+                    :style="{ backgroundColor: config.coverageColor }"
+                    aria-label="Pick coverage color"
+                  />
+                </template>
+                <v-color-picker
+                  v-model="config.coverageColor"
+                  mode="hex"
+                  :modes="['hex']"
+                  theme="dark"
+                  width="220"
+                  class="base-station-color-picker"
+                />
+              </v-menu>
+            </div>
+            <div class="config-row config-slider-row">
+              <p class="config-label">Opacity</p>
+              <v-slider
+                v-model="config.coverageOpacity"
+                :min="0"
+                :max="1"
+                :step="0.05"
+                :thumb-size="12"
+                :track-size="2"
+                hide-details
+                density="compact"
+                color="white"
+                track-color="rgba(255,255,255,0.2)"
+                class="config-slider"
+              />
+              <p class="config-slider-value">{{ Math.round(config.coverageOpacity * 100) }}%</p>
+            </div>
+          </div>
+        </template>
+      </ExpansiblePanel>
+
+      <div class="base-station-panel-footer">
+        <v-btn
+          class="base-station-panel-remove-btn bg-[#FFFFFF22] text-white"
+          variant="elevated"
+          size="small"
+          prepend-icon="mdi-delete"
+          @click="removeBaseStation"
+        >
+          Remove base station
+        </v-btn>
+        <v-btn
+          class="base-station-panel-info-btn bg-[#FFFFFF22] text-white"
+          variant="elevated"
+          size="small"
+          rounded="sm"
+          icon="mdi-information-outline"
+          aria-label="About coverage estimates"
+          @click="estimatesInfoDialogOpen = true"
+        />
+      </div>
+
+      <v-dialog v-model="estimatesInfoDialogOpen" max-width="480">
+        <v-card class="rounded-lg" :style="interfaceStore.globalGlassMenuStyles">
+          <v-card-title class="text-h6 py-3 px-6">
+            <div class="relative flex items-center justify-center w-full min-h-[28px]">
+              <span class="text-center">About coverage estimates</span>
+              <v-btn
+                icon="mdi-close"
+                size="small"
+                variant="text"
+                color="white"
+                class="absolute right-0 -mr-4"
+                aria-label="Close about coverage estimates dialog"
+                @click="estimatesInfoDialogOpen = false"
+              />
+            </div>
+          </v-card-title>
+          <v-card-text class="text-body-2 base-station-estimates-dialog-text px-8">
+            <p>
+              The ranges and overlays shown here are estimates, not a guarantee of what you will see on the water or in
+              the field.
+            </p>
+            <p>
+              <strong>Radio and tether links</strong> are modeled from Blue Robotics product specifications — antenna
+              patterns, transmit power, and typical operating assumptions for our radios and related gear.
+            </p>
+            <p>
+              <strong>Mobile data coverage</strong> comes from open-source tower databases (OpenCellID and
+              OpenStreetMap). Records can be incomplete or out of date, and carriers change their networks over time.
+            </p>
+            <p class="mb-0">
+              Real-world signal also depends on terrain, weather, interference, and how your vehicle is set up. Use
+              these visuals to compare options, and verify connectivity on site when it really matters.
+            </p>
+          </v-card-text>
+          <div class="flex justify-center w-full px-6">
+            <v-divider class="opacity-10 border-[#fafafa] w-full" />
+          </div>
+          <v-card-actions class="px-6 pb-2 pt-2">
+            <v-spacer />
+            <v-btn variant="text" color="white" class="-mt-[1px]" @click="estimatesInfoDialogOpen = false"
+              >Got it</v-btn
+            >
+          </v-card-actions>
+        </v-card>
+      </v-dialog>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import * as turf from '@turf/turf'
+import { useWindowSize } from '@vueuse/core'
+import { computed, ref, watch } from 'vue'
+
+import ExpansiblePanel from '@/components/ExpansiblePanel.vue'
+import { useBaseStation } from '@/composables/baseStation/useBaseStation'
+import { useInteractionDialog } from '@/composables/interactionDialog'
+import { useMainVehicleStore } from '@/stores/mainVehicle'
+import { useMissionStore } from '@/stores/mission'
+import { useWidgetManagerStore } from '@/stores/widgetManager'
+import {
+  AntennaType,
+  BaseStationCommsType,
+  BLUE_ROBOTICS_TX_POWER_MW,
+  RadioBaseStationKind,
+  TopSideComputerType,
+} from '@/types/baseStation'
+import type { DialogActions } from '@/types/general'
+import type { Waypoint, WaypointCoordinates } from '@/types/mission'
+
+const store = useBaseStation()
+const widgetStore = useWidgetManagerStore()
+const vehicleStore = useMainVehicleStore()
+const missionStore = useMissionStore()
+
+const config = computed(() => store.config)
+
+const topSideTypes = Object.values(TopSideComputerType)
+const commsTypes = Object.values(BaseStationCommsType)
+const radioKinds = Object.values(RadioBaseStationKind)
+const antennaTypes = Object.values(AntennaType)
+
+const isRadioLink = computed(() => config.value.commsType === BaseStationCommsType.RadioLink)
+const isTethered = computed(() => config.value.commsType === BaseStationCommsType.Tethered)
+const isOmni = computed(() => config.value.antenna.type === AntennaType.Omni)
+const isCustomRadio = computed(() => config.value.radioBaseStationKind === RadioBaseStationKind.Custom)
+
+const latText = ref('')
+const lngText = ref('')
+const bearingText = ref('')
+const bearingFocused = ref(false)
+const gainText = ref('')
+const gainFocused = ref(false)
+const txPowerText = ref('')
+const txPowerFocused = ref(false)
+
+const formatBearing = (bearing: number): string => bearing.toFixed(1)
+const formatGain = (gain: number): string => gain.toFixed(1)
+const formatTxPower = (mw: number): string => Math.round(mw).toString()
+
+watch(
+  () => config.value.position,
+  (pos) => {
+    latText.value = pos ? pos[0].toString() : ''
+    lngText.value = pos ? pos[1].toString() : ''
+  },
+  { immediate: true }
+)
+
+// Skip the formatting round-trip while the user is editing — otherwise toFixed() rewrites the
+// input mid-keystroke (e.g. "1" -> "1.0") and the next digit lands in the decimal spot.
+watch(
+  () => config.value.antenna.bearing,
+  (b) => {
+    if (!bearingFocused.value) bearingText.value = formatBearing(b)
+  },
+  { immediate: true }
+)
+
+watch(
+  () => config.value.antenna.gain,
+  (g) => {
+    if (!gainFocused.value) gainText.value = formatGain(g)
+  },
+  { immediate: true }
+)
+
+watch(
+  () => config.value.txPowerMilliwatts,
+  (p) => {
+    if (!txPowerFocused.value) txPowerText.value = formatTxPower(p)
+  },
+  { immediate: true }
+)
+
+const onLatLngInput = (axis: 'lat' | 'lng', value: string): void => {
+  if (axis === 'lat') latText.value = value
+  else lngText.value = value
+  const lat = parseFloat(latText.value)
+  const lng = parseFloat(lngText.value)
+  if (Number.isFinite(lat) && Number.isFinite(lng)) store.setPosition([lat, lng])
+}
+
+const onBearingInput = (value: string): void => {
+  bearingText.value = value
+  const parsed = parseFloat(value)
+  if (Number.isFinite(parsed)) store.setBearing(parsed)
+}
+
+const onBearingBlur = (): void => {
+  bearingFocused.value = false
+  bearingText.value = formatBearing(config.value.antenna.bearing)
+}
+
+// Friis: a single-end gain delta scales LOS range by 10^(ΔG_dB/20).
+const onGainInput = (value: string): void => {
+  gainText.value = value
+  const parsed = parseFloat(value)
+  if (!Number.isFinite(parsed)) return
+  const oldGain = config.value.antenna.gain
+  if (parsed === oldGain) return
+  const ratio = Math.pow(10, (parsed - oldGain) / 20)
+  config.value.antenna.gain = parsed
+  config.value.antenna.range = Math.max(1, Math.round(config.value.antenna.range * ratio))
+}
+
+const onGainBlur = (): void => {
+  gainFocused.value = false
+  gainText.value = formatGain(config.value.antenna.gain)
+}
+
+// Same Friis scaling as gain (range ∝ √P_t ⇒ 10^(ΔP_dB/20)).
+const applyTxPower = (newPowerMw: number): void => {
+  const oldPower = config.value.txPowerMilliwatts
+  if (!Number.isFinite(newPowerMw) || newPowerMw <= 0 || newPowerMw === oldPower) return
+  const ratio = Math.sqrt(newPowerMw / oldPower)
+  config.value.txPowerMilliwatts = newPowerMw
+  config.value.antenna.range = Math.max(1, Math.round(config.value.antenna.range * ratio))
+}
+
+const onTxPowerInput = (value: string): void => {
+  txPowerText.value = value
+  const parsed = parseFloat(value)
+  if (Number.isFinite(parsed) && parsed > 0) applyTxPower(parsed)
+}
+
+const onTxPowerBlur = (): void => {
+  txPowerFocused.value = false
+  txPowerText.value = formatTxPower(config.value.txPowerMilliwatts)
+}
+
+// Switching back to the BR base station snaps power to its known 1 W radio and rescales range
+// accordingly, so the panel never claims BR-branded hardware while running off-spec power.
+const onRadioKindChange = (event: Event): void => {
+  const newKind = (event.target as HTMLSelectElement).value as RadioBaseStationKind
+  config.value.radioBaseStationKind = newKind
+  if (newKind === RadioBaseStationKind.BlueRobotics) applyTxPower(BLUE_ROBOTICS_TX_POWER_MW)
+}
+
+const estimatesInfoDialogOpen = ref(false)
+
+const onAntennaTypeChange = (event: Event): void => {
+  const value = (event.target as HTMLSelectElement).value as AntennaType
+  store.setAntennaType(value)
+}
+
+const closePanel = (): void => {
+  store.configPanelOpen = false
+}
+
+const { showDialog, closeDialog } = useInteractionDialog()
+
+const removeBaseStation = (): void => {
+  showDialog({
+    variant: 'text-only',
+    message: 'Remove the base station? This will clear its position and configuration.',
+    persistent: false,
+    maxWidth: '480px',
+    actions: [
+      { text: 'Cancel', color: 'white', action: closeDialog },
+      {
+        text: 'Remove',
+        color: 'white',
+        action: () => {
+          store.remove()
+          closeDialog()
+        },
+      },
+    ] as DialogActions[],
+  })
+}
+
+const resetAntenna = (): void => {
+  store.resetAntennaToDefaults()
+}
+
+const vehiclePosition = computed<WaypointCoordinates | null>(() => {
+  const lat = vehicleStore.coordinates?.latitude
+  const lng = vehicleStore.coordinates?.longitude
+  return lat && lng ? [lat, lng] : null
+})
+
+const missionCentroid = computed<WaypointCoordinates | null>(() => {
+  const planning = missionStore.currentPlanningWaypoints
+  const vehicleMissionWps = missionStore.vehicleMission
+  const wps = planning.length > 0 ? planning : vehicleMissionWps
+  if (!wps || wps.length === 0) return null
+  const [sumLat, sumLng] = wps.reduce<[number, number]>(
+    ([lat, lng], wp: Waypoint) => [lat + wp.coordinates[0], lng + wp.coordinates[1]],
+    [0, 0]
+  )
+  return [sumLat / wps.length, sumLng / wps.length]
+})
+
+const canSnapToVehicle = computed(() => Boolean(config.value.position && vehiclePosition.value))
+const canSnapToMission = computed(() => Boolean(config.value.position && missionCentroid.value))
+
+const bearingTo = (target: WaypointCoordinates): number => {
+  const center = config.value.position!
+  return turf.bearing(turf.point([center[1], center[0]]), turf.point([target[1], target[0]]))
+}
+
+const snapBearingToVehicle = (): void => {
+  if (!canSnapToVehicle.value) return
+  store.setBearing(bearingTo(vehiclePosition.value!))
+}
+
+const snapBearingToMission = (): void => {
+  if (!canSnapToMission.value) return
+  store.setBearing(bearingTo(missionCentroid.value!))
+}
+
+const { height: windowHeight } = useWindowSize()
+
+const getMarginsFromBarsHeight = computed(() => {
+  return {
+    marginTop: widgetStore.editingMode ? '0px' : widgetStore.currentTopBarHeightPixels + 'px',
+    marginBottom: widgetStore.editingMode ? '0px' : widgetStore.currentBottomBarHeightPixels + 'px',
+    height: widgetStore.editingMode
+      ? windowHeight.value + 'px'
+      : windowHeight.value -
+        widgetStore.currentTopBarHeightPixels -
+        widgetStore.currentBottomBarHeightPixels -
+        1 +
+        'px',
+    zIndex: 600,
+  }
+})
+</script>
+
+<style scoped>
+.config-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid #ffffff17;
+  padding: 2px 0 8px 0;
+  margin-top: 2px;
+  min-height: 36px;
+  box-sizing: border-box;
+}
+
+/* Drop the divider after the bottom-most row of each section so the section header below it
+   isn't visually attached to the previous control. */
+.config-row:last-child {
+  border-bottom: none;
+}
+
+.config-label {
+  text-align: start;
+  margin-left: 4px;
+  font-size: 13px;
+  width: 50%;
+}
+
+.config-input {
+  background-color: #ffffff11;
+  padding: 4px 8px;
+  width: 130px;
+  font-size: 13px;
+  color: white;
+  box-sizing: border-box;
+  border: 1px solid transparent;
+}
+
+/* Strip the native number-input spinner so number fields render at the same usable width as
+   the <select>s in the same column. */
+.config-input[type='number']::-webkit-inner-spin-button,
+.config-input[type='number']::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+.config-input[type='number'] {
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+
+/* Native <option> popups inherit OS chrome by default and render light-on-light over the
+   dark panel; force them onto the panel palette so the dropdowns stay readable. */
+.config-input option {
+  background-color: #0a2a3d;
+  color: white;
+}
+
+.config-input:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.config-checkbox {
+  margin-right: 6px;
+}
+
+.config-checkbox-row {
+  padding: 0 0 4px 0;
+  min-height: auto;
+}
+
+.config-label-with-info {
+  display: flex;
+  align-items: center;
+  flex: 1 1 auto;
+  justify-content: space-between;
+  min-width: 0;
+  margin-right: 8px;
+}
+
+.config-label-with-info .config-label {
+  width: auto;
+}
+
+.config-checkbox :deep(.v-selection-control) {
+  min-height: auto;
+}
+
+.config-checkbox :deep(.v-selection-control__wrapper) {
+  transform: scale(0.8);
+  transform-origin: center;
+}
+
+.config-color-swatch {
+  height: 24px;
+  border: 1px solid #ffffff33;
+  border-radius: 3px;
+  cursor: pointer;
+  padding: 0;
+}
+
+/* Eyedropper hijacks the v-menu's outside-click and the OS picker UX is shaky on web; drop it. */
+.base-station-color-picker :deep(.v-color-picker-preview__eye-dropper) {
+  display: none;
+}
+
+.config-slider-row {
+  gap: 6px;
+}
+
+.config-slider {
+  flex: 1;
+  margin: 0;
+}
+
+.config-slider-value {
+  font-size: 12px;
+  width: 36px;
+  text-align: right;
+  color: #ffffffcc;
+}
+
+.base-station-panel-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  box-sizing: border-box;
+  margin-top: auto;
+  margin-bottom: 8px;
+  padding: 0 8px;
+}
+
+.base-station-panel-info-btn {
+  flex: 0 0 auto;
+  width: 28px;
+  min-width: 28px;
+  height: 28px;
+  padding: 0;
+  border-radius: 4px !important;
+}
+
+.base-station-panel-remove-btn {
+  flex: 0 0 auto;
+}
+
+.base-station-estimates-dialog-text {
+  padding-left: 40px;
+  padding-right: 40px;
+  text-align: justify;
+  hyphens: auto;
+}
+
+.base-station-estimates-dialog-text p + p {
+  margin-top: 12px;
+}
+</style>

--- a/src/components/BaseStationConfigPanel.vue
+++ b/src/components/BaseStationConfigPanel.vue
@@ -479,6 +479,15 @@
         <template #title><p class="ml-10">Display</p></template>
         <template #content>
           <div class="flex flex-col pt-1 w-full gap-y-1">
+            <div v-if="isMissionPlanningContext" class="config-row config-checkbox-row">
+              <p class="config-label" style="width: auto; white-space: nowrap">Show signal on mission path</p>
+              <v-checkbox
+                v-model="missionStore.showMissionPathSignalStrength"
+                hide-details
+                density="compact"
+                class="config-checkbox"
+              />
+            </div>
             <div class="config-row config-checkbox-row">
               <p class="config-label">Show signal on map</p>
               <v-checkbox v-model="config.showSignalOnMap" hide-details density="compact" class="config-checkbox" />
@@ -671,6 +680,19 @@ import {
 } from '@/types/baseStation'
 import type { DialogActions } from '@/types/general'
 import type { Waypoint, WaypointCoordinates } from '@/types/mission'
+
+withDefaults(
+  defineProps<{
+    /**
+     * Whether the panel is mounted inside the mission planning view. Enables planning-only controls
+     * like the mission-path signal coloring toggle.
+     */
+    isMissionPlanningContext?: boolean
+  }>(),
+  {
+    isMissionPlanningContext: false,
+  }
+)
 
 const store = useBaseStation()
 const widgetStore = useWidgetManagerStore()

--- a/src/components/BaseStationConfigPanel.vue
+++ b/src/components/BaseStationConfigPanel.vue
@@ -479,6 +479,10 @@
         <template #title><p class="ml-10">Display</p></template>
         <template #content>
           <div class="flex flex-col pt-1 w-full gap-y-1">
+            <div class="config-row config-checkbox-row">
+              <p class="config-label">Show signal on map</p>
+              <v-checkbox v-model="config.showSignalOnMap" hide-details density="compact" class="config-checkbox" />
+            </div>
             <div v-if="isRadioLink || isTethered" class="config-row">
               <p class="config-label">Color</p>
               <v-menu :close-on-content-click="false" location="bottom end">

--- a/src/components/BaseStationContextPopup.vue
+++ b/src/components/BaseStationContextPopup.vue
@@ -1,0 +1,173 @@
+<template>
+  <Teleport to="body">
+    <div
+      v-if="store.contextPopupOpen && config.position"
+      class="base-station-context-popup fixed z-[99999] flex flex-col rounded-md text-white"
+      :style="[
+        interfaceStore.globalGlassMenuStyles,
+        { background: '#333333EE', border: '1px solid #FFFFFF44' },
+        { top: `${position.y}px`, left: `${position.x}px`, width: `${POPUP_WIDTH}px` },
+      ]"
+      @click.stop
+      @contextmenu.stop.prevent
+    >
+      <div class="flex justify-between items-center pt-1 pb-2 px-2">
+        <p class="text-[14px] truncate mr-2">Base station</p>
+        <div class="flex shrink-0 items-center gap-x-1">
+          <v-btn
+            v-tooltip="{ text: 'Remove base station', zIndex: TOOLTIP_Z_INDEX }"
+            icon="mdi-trash-can"
+            variant="text"
+            size="x-small"
+            color="white"
+            aria-label="Remove base station"
+            @click="onDelete"
+          />
+          <v-btn
+            v-tooltip="{ text: 'Configure base station', zIndex: TOOLTIP_Z_INDEX }"
+            icon="mdi-cog"
+            variant="text"
+            size="x-small"
+            color="white"
+            aria-label="Configure base station"
+            @click="onConfigure"
+          />
+        </div>
+      </div>
+
+      <v-divider />
+
+      <div
+        class="flex flex-col justify-center w-full items-center py-1 px-2 bg-[#EEEEEE] text-black rounded-bl-md rounded-br-md"
+      >
+        <div class="flex w-full items-center gap-x-2 text-[10px] py-[1px] mb-[2px]">
+          <v-icon
+            v-tooltip="{ text: 'Copy latitude to clipboard', zIndex: TOOLTIP_Z_INDEX }"
+            variant="text"
+            icon="mdi-content-copy"
+            size="x-small"
+            color="black"
+            class="text-[12px] cursor-pointer shrink-0"
+            @click="onCopyCoordinate(0)"
+          />
+          <p class="flex-1">Lat.:</p>
+          <p>{{ config.position[0].toFixed(7) }}</p>
+        </div>
+        <v-divider class="border-black w-full" />
+        <div class="flex w-full items-center gap-x-2 text-[10px] py-[1px]">
+          <v-icon
+            v-tooltip="{ text: 'Copy longitude to clipboard', zIndex: TOOLTIP_Z_INDEX }"
+            variant="text"
+            icon="mdi-content-copy"
+            size="x-small"
+            color="black"
+            class="text-[12px] cursor-pointer shrink-0"
+            @click="onCopyCoordinate(1)"
+          />
+          <p class="flex-1">Long.:</p>
+          <p>{{ config.position[1].toFixed(7) }}</p>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted } from 'vue'
+
+import { useBaseStation } from '@/composables/baseStation/useBaseStation'
+import { useInteractionDialog } from '@/composables/interactionDialog'
+import { openSnackbar } from '@/composables/snackbar'
+import { copyToClipboard } from '@/libs/utils'
+import { useAppInterfaceStore } from '@/stores/appInterface'
+import type { DialogActions } from '@/types/general'
+
+const POPUP_WIDTH = 221
+const POPUP_HEIGHT = 110
+const TOOLTIP_Z_INDEX = 100000
+
+// Popup state lives in the store, so the click/keydown listeners are registered once at the
+// module level, regardless of how many widgets mount this component.
+let activeInstanceCount = 0
+let documentClickHandler: ((event: MouseEvent) => void) | null = null
+let documentKeydownHandler: ((event: KeyboardEvent) => void) | null = null
+
+const store = useBaseStation()
+const interfaceStore = useAppInterfaceStore()
+const { showDialog, closeDialog } = useInteractionDialog()
+
+const config = computed(() => store.config)
+
+// Clamp the popup inside the viewport so it never opens off-screen near the map edges.
+const position = computed(() => {
+  const margin = 8
+  let x = store.contextPopupPosition.x
+  let y = store.contextPopupPosition.y
+  if (x + POPUP_WIDTH > window.innerWidth - margin) x = window.innerWidth - POPUP_WIDTH - margin
+  if (y + POPUP_HEIGHT > window.innerHeight - margin) y = window.innerHeight - POPUP_HEIGHT - margin
+  if (x < margin) x = margin
+  if (y < margin) y = margin
+  return { x, y }
+})
+
+const onDelete = (): void => {
+  store.closeContextPopup()
+  showDialog({
+    variant: 'text-only',
+    message: 'Remove the base station? This will clear its position and configuration.',
+    persistent: false,
+    maxWidth: '480px',
+    actions: [
+      { text: 'Cancel', color: 'white', action: closeDialog },
+      {
+        text: 'Remove',
+        color: 'white',
+        action: () => {
+          store.remove()
+          closeDialog()
+        },
+      },
+    ] as DialogActions[],
+  })
+}
+
+const onConfigure = (): void => {
+  store.configPanelOpen = true
+  store.closeContextPopup()
+}
+
+const onCopyCoordinate = async (index: 0 | 1): Promise<void> => {
+  if (!config.value.position) return
+  const label = index === 0 ? 'Latitude' : 'Longitude'
+  try {
+    await copyToClipboard(`${config.value.position[index]}`)
+    openSnackbar({ message: `${label} copied to clipboard.`, variant: 'success' })
+  } catch (error) {
+    openSnackbar({ message: `Failed to copy ${label.toLowerCase()}: ${(error as Error).message}`, variant: 'error' })
+  }
+}
+
+onMounted(() => {
+  if (activeInstanceCount === 0) {
+    documentClickHandler = () => {
+      if (store.contextPopupOpen) store.closeContextPopup()
+    }
+    documentKeydownHandler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && store.contextPopupOpen) store.closeContextPopup()
+    }
+    document.addEventListener('click', documentClickHandler)
+    window.addEventListener('keydown', documentKeydownHandler)
+  }
+  activeInstanceCount++
+})
+
+onBeforeUnmount(() => {
+  activeInstanceCount--
+  if (activeInstanceCount === 0) {
+    if (documentClickHandler) document.removeEventListener('click', documentClickHandler)
+    if (documentKeydownHandler) window.removeEventListener('keydown', documentKeydownHandler)
+    documentClickHandler = null
+    documentKeydownHandler = null
+  }
+})
+</script>

--- a/src/components/BaseStationContextPopup.vue
+++ b/src/components/BaseStationContextPopup.vue
@@ -15,6 +15,15 @@
         <p class="text-[14px] truncate mr-2">Base station</p>
         <div class="flex shrink-0 items-center gap-x-1">
           <v-btn
+            v-tooltip="{ text: signalVisibilityTooltip, zIndex: TOOLTIP_Z_INDEX }"
+            :icon="signalVisibilityIcon"
+            variant="text"
+            size="x-small"
+            color="white"
+            :aria-label="signalVisibilityTooltip"
+            @click="onToggleSignalVisibility"
+          />
+          <v-btn
             v-tooltip="{ text: 'Remove base station', zIndex: TOOLTIP_Z_INDEX }"
             icon="mdi-trash-can"
             variant="text"
@@ -97,6 +106,10 @@ const interfaceStore = useAppInterfaceStore()
 const { showDialog, closeDialog } = useInteractionDialog()
 
 const config = computed(() => store.config)
+const signalVisibilityIcon = computed(() => (config.value.showSignalOnMap ? 'mdi-eye' : 'mdi-eye-off'))
+const signalVisibilityTooltip = computed(() =>
+  config.value.showSignalOnMap ? 'Hide signal on map' : 'Show signal on map'
+)
 
 // Clamp the popup inside the viewport so it never opens off-screen near the map edges.
 const position = computed(() => {
@@ -134,6 +147,10 @@ const onDelete = (): void => {
 const onConfigure = (): void => {
   store.configPanelOpen = true
   store.closeContextPopup()
+}
+
+const onToggleSignalVisibility = (): void => {
+  store.toggleSignalVisibility()
 }
 
 const onCopyCoordinate = async (index: 0 | 1): Promise<void> => {

--- a/src/components/mission-planning/ContextMenu.vue
+++ b/src/components/mission-planning/ContextMenu.vue
@@ -175,6 +175,39 @@
           <span class="text-white text-sm ml-4">Set home waypoint</span>
         </v-list-item>
         <v-divider />
+        <v-list-item class="flex items-center gap-x-2 pb-2" @click="handlePlaceBaseStation">
+          <v-icon
+            variant="text"
+            icon="mdi-radio-tower"
+            rounded="full"
+            size="x-small"
+            color="white"
+            class="text-[16px]"
+          ></v-icon>
+          <span class="text-white text-sm ml-4">{{
+            baseStationStore.config.enabled ? 'Move base station here' : 'Set base station here'
+          }}</span>
+        </v-list-item>
+        <template v-if="baseStationStore.config.enabled">
+          <v-divider />
+          <v-list-item class="flex items-center gap-x-2 pb-2" @click="handleConfigureBaseStation">
+            <v-icon variant="text" icon="mdi-cog" rounded="full" size="x-small" color="white" class="text-[16px]" />
+            <span class="text-white text-sm ml-4">Configure base station</span>
+          </v-list-item>
+          <v-divider />
+          <v-list-item class="flex items-center gap-x-2 pb-2" @click="handleRemoveBaseStation">
+            <v-icon
+              variant="text"
+              icon="mdi-radio-tower"
+              rounded="full"
+              size="x-small"
+              color="white"
+              class="text-[16px]"
+            />
+            <span class="text-white text-sm ml-4">Remove base station</span>
+          </v-list-item>
+        </template>
+        <v-divider />
         <v-list-item class="flex items-center gap-x-2 pb-2" @click="handleClearVehiclePathHistory">
           <v-icon
             variant="text"
@@ -261,12 +294,14 @@
 import { computed, defineEmits, defineProps, nextTick, ref, watch } from 'vue'
 
 import ScanDirectionDial from '@/components/mission-planning/ScanDirectionDial.vue'
+import { useBaseStation } from '@/composables/baseStation/useBaseStation'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMissionStore } from '@/stores/mission'
 import { ContextMenuTypes, Survey, Waypoint } from '@/types/mission'
 
 const missionStore = useMissionStore()
 const interfaceStore = useAppInterfaceStore()
+const baseStationStore = useBaseStation()
 const menuEl = ref<HTMLElement | null>(null)
 
 /* eslint-disable jsdoc/require-jsdoc */
@@ -301,6 +336,9 @@ const emit = defineEmits<{
   (event: 'placePointOfInterest'): void
   (event: 'setHomePosition'): void
   (event: 'clearVehiclePathHistory'): void
+  (event: 'placeBaseStation'): void
+  (event: 'configureBaseStation'): void
+  (event: 'removeBaseStation'): void
 }>()
 
 const menuType = computed(() => props.menuType)
@@ -406,6 +444,21 @@ const handleSetHomePosition = (): void => {
 
 const handleClearVehiclePathHistory = (): void => {
   emit('clearVehiclePathHistory')
+  emit('close')
+}
+
+const handlePlaceBaseStation = (): void => {
+  emit('placeBaseStation')
+  emit('close')
+}
+
+const handleConfigureBaseStation = (): void => {
+  emit('configureBaseStation')
+  emit('close')
+}
+
+const handleRemoveBaseStation = (): void => {
+  emit('removeBaseStation')
   emit('close')
 }
 

--- a/src/components/mission-planning/ContextMenu.vue
+++ b/src/components/mission-planning/ContextMenu.vue
@@ -190,21 +190,28 @@
         </v-list-item>
         <template v-if="baseStationStore.config.enabled">
           <v-divider />
-          <v-list-item class="flex items-center gap-x-2 pb-2" @click="handleConfigureBaseStation">
-            <v-icon variant="text" icon="mdi-cog" rounded="full" size="x-small" color="white" class="text-[16px]" />
-            <span class="text-white text-sm ml-4">Configure base station</span>
+          <v-list-item class="flex items-center gap-x-2 pb-2" @click="handleRemoveBaseStation">
+            <v-icon variant="text" icon="mdi-delete" rounded="full" size="x-small" color="white" class="text-[16px]" />
+            <span class="text-white text-sm ml-4">Remove base station</span>
           </v-list-item>
           <v-divider />
-          <v-list-item class="flex items-center gap-x-2 pb-2" @click="handleRemoveBaseStation">
+          <v-list-item class="flex items-center gap-x-2 pb-2" @click="handleToggleBaseStationSignalVisibility">
             <v-icon
               variant="text"
-              icon="mdi-radio-tower"
+              :icon="baseStationStore.config.showSignalOnMap ? 'mdi-eye' : 'mdi-eye-off'"
               rounded="full"
               size="x-small"
               color="white"
               class="text-[16px]"
             />
-            <span class="text-white text-sm ml-4">Remove base station</span>
+            <span class="text-white text-sm ml-4">{{
+              baseStationStore.config.showSignalOnMap ? 'Hide signal on map' : 'Show signal on map'
+            }}</span>
+          </v-list-item>
+          <v-divider />
+          <v-list-item class="flex items-center gap-x-2 pb-2" @click="handleConfigureBaseStation">
+            <v-icon variant="text" icon="mdi-cog" rounded="full" size="x-small" color="white" class="text-[16px]" />
+            <span class="text-white text-sm ml-4">Configure base station</span>
           </v-list-item>
         </template>
         <v-divider />
@@ -339,6 +346,7 @@ const emit = defineEmits<{
   (event: 'placeBaseStation'): void
   (event: 'configureBaseStation'): void
   (event: 'removeBaseStation'): void
+  (event: 'toggleBaseStationSignalVisibility'): void
 }>()
 
 const menuType = computed(() => props.menuType)
@@ -454,6 +462,11 @@ const handlePlaceBaseStation = (): void => {
 
 const handleConfigureBaseStation = (): void => {
   emit('configureBaseStation')
+  emit('close')
+}
+
+const handleToggleBaseStationSignalVisibility = (): void => {
+  emit('toggleBaseStationSignalVisibility')
   emit('close')
 }
 

--- a/src/components/mission-planning/MissionEstimates.vue
+++ b/src/components/mission-planning/MissionEstimates.vue
@@ -40,6 +40,22 @@
       <div v-if="missionCoverage !== '—'" class="flex justify-between">
         <span>Mission area (≈)</span><span>{{ missionCoverage }}</span>
       </div>
+      <template v-if="isPathSignalAvailable">
+        <v-divider class="opacity-10 my-1" />
+        <div
+          v-tooltip:top="'Tint the mission path by expected radio or mobile-data coverage at each segment.'"
+          class="flex justify-between items-center -mb-1 pr-1"
+        >
+          <span>Show comms coverage on path</span>
+          <v-checkbox
+            v-model="missionStore.showMissionPathSignalStrength"
+            theme="dark"
+            density="compact"
+            hide-details
+            class="path-signal-checkbox"
+          />
+        </div>
+      </template>
     </div>
   </div>
   <v-dialog v-model="isSettingsOpen" persistent max-width="500px">
@@ -154,11 +170,13 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 
+import { useMissionPathSignal } from '@/composables/baseStation/useMissionPathSignal'
 import { openSnackbar } from '@/composables/snackbar'
 import { useMissionEstimates } from '@/composables/useMissionEstimates'
 import { MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
+import { useMissionStore } from '@/stores/mission'
 
 defineProps<{
   /**
@@ -171,6 +189,7 @@ const emit = defineEmits<{ (e: 'update:modelValue', v: boolean): void }>()
 
 const interfaceStore = useAppInterfaceStore()
 const vehicleStore = useMainVehicleStore()
+const missionStore = useMissionStore()
 
 const {
   totalMissionLength,
@@ -185,6 +204,8 @@ const {
 const isOptionsIconVisible = computed(() => vehicleStore.vehicleType === MavType.MAV_TYPE_SURFACE_BOAT)
 
 const maxDistance = computed(() => totalMaxDistance.value)
+const { isPathSignalAvailable } = useMissionPathSignal()
+
 const missionDuration = computed(() => totalMissionDuration.value)
 const missionEnergy = computed(() => totalMissionEnergy.value)
 const missionCoverage = computed(() => missionCoverageAreaSquareMeters.value)
@@ -212,3 +233,16 @@ const handleHideMissionEstimates = (): void => {
   })
 }
 </script>
+
+<style scoped>
+.path-signal-checkbox {
+  transform: scale(0.75);
+  transform-origin: right center;
+  flex: 0 0 auto;
+  margin-right: -8px;
+}
+
+.path-signal-checkbox :deep(.v-selection-control) {
+  min-height: 0;
+}
+</style>

--- a/src/components/poi/PoiMapArrows.vue
+++ b/src/components/poi/PoiMapArrows.vue
@@ -54,6 +54,24 @@
         </v-tooltip>
       </div>
     </template>
+    <template v-if="mapReady && showBaseStationArrow && baseStationEdgeArrow">
+      <div class="poi-edge-pin" :style="baseStationEdgeArrow.style">
+        <v-tooltip location="top" :text="baseStationEdgeArrow.tooltipText" content-class="poi-arrow-tooltip">
+          <template #activator="{ props: tooltipProps }">
+            <div v-bind="tooltipProps" class="poi-pin-container" @click.stop="handleBaseStationArrowClick">
+              <div
+                class="poi-pin-shape"
+                :style="{
+                  transform: `rotate(${baseStationEdgeArrow.angle - 135}deg)`,
+                  backgroundColor: baseStationEdgeArrow.color + '80',
+                }"
+              ></div>
+              <i class="mdi mdi-radio-tower poi-pin-icon"></i>
+            </div>
+          </template>
+        </v-tooltip>
+      </div>
+    </template>
   </div>
 </template>
 
@@ -91,6 +109,10 @@ interface Props {
    */
   showVehicleArrow: boolean
   /**
+   * Whether to show the base-station offscreen arrow
+   */
+  showBaseStationArrow: boolean
+  /**
    * Vehicle position coordinates
    */
   vehiclePosition: WaypointCoordinates | undefined
@@ -98,6 +120,14 @@ interface Props {
    * Home position coordinates
    */
   home: WaypointCoordinates | undefined
+  /**
+   * Base station position coordinates
+   */
+  baseStation: WaypointCoordinates | undefined
+  /**
+   * Base-station arrow tint, defaults to the panel/glass color when omitted.
+   */
+  baseStationColor?: string
   /**
    * Map center coordinates
    */
@@ -133,6 +163,7 @@ const map = computed(() => mapLayer.value ?? null)
 const poiEdgeArrows = ref<PoiEdgeArrow[]>([])
 const vehicleEdgeArrow = ref<TargetEdgeArrow | null>(null)
 const homeEdgeArrow = ref<TargetEdgeArrow | null>(null)
+const baseStationEdgeArrow = ref<TargetEdgeArrow | null>(null)
 
 const calculateMapEdgesIntersections = (
   centerPoint: L.Point,
@@ -503,16 +534,19 @@ const calculatePoiEdgeArrows = (): void => {
   poiEdgeArrows.value = arrows
 }
 
-const calculateVehicleAndHomeEdgeArrows = (): void => {
+const calculateTargetArrows = (): void => {
   vehicleEdgeArrow.value = calculateTargetEdgeArrow(props.vehiclePosition, 'Vehicle', '#1e498f')
   homeEdgeArrow.value = calculateTargetEdgeArrow(props.home, 'Home', '#1e498f')
+  baseStationEdgeArrow.value = props.showBaseStationArrow
+    ? calculateTargetEdgeArrow(props.baseStation, 'Base station', props.baseStationColor ?? '#2b5779')
+    : null
 }
 
 // Prevent poi arrows calculation from overloading the UI
 const debouncedUpdateArrows = useDebounceFn(calculatePoiEdgeArrows, 150)
 const throttledUpdateArrows = useThrottleFn(calculatePoiEdgeArrows, 15) // Max 60fps
-const debouncedUpdateVehicleAndHomeArrows = useDebounceFn(calculateVehicleAndHomeEdgeArrows, 150)
-const throttledUpdateVehicleAndHomeArrows = useThrottleFn(calculateVehicleAndHomeEdgeArrows, 15)
+const debouncedUpdateTargetArrows = useDebounceFn(calculateTargetArrows, 150)
+const throttledUpdateTargetArrows = useThrottleFn(calculateTargetArrows, 15)
 
 const centerMapOnPoi = (poiId: string): void => {
   if (!map.value) return
@@ -531,12 +565,16 @@ const handleHomeArrowClick = (): void => {
   props.targetFollower.goToTarget(WhoToFollow.HOME, true)
 }
 
+const handleBaseStationArrowClick = (): void => {
+  props.targetFollower.goToTarget(WhoToFollow.BASE_STATION, true)
+}
+
 watch(
   map,
   (mapInstance) => {
     if (mapInstance && props.mapReady) {
       debouncedUpdateArrows()
-      debouncedUpdateVehicleAndHomeArrows()
+      debouncedUpdateTargetArrows()
     }
   },
   { immediate: true }
@@ -548,7 +586,7 @@ watch(
   () => {
     if (props.mapReady && map.value && map.value instanceof L.Map) {
       debouncedUpdateArrows()
-      throttledUpdateVehicleAndHomeArrows()
+      throttledUpdateTargetArrows()
     }
   },
   { immediate: true }
@@ -559,17 +597,25 @@ watch(
   (ready) => {
     if (ready && map.value && map.value instanceof L.Map) {
       debouncedUpdateArrows()
-      debouncedUpdateVehicleAndHomeArrows()
+      debouncedUpdateTargetArrows()
     }
   }
 )
 
-// Watch for vehicle and home position changes
+// Watch for vehicle, home, and base-station position changes
 watch(
-  [() => props.vehiclePosition, () => props.home, () => props.mapCenter, () => props.zoom],
+  [
+    () => props.vehiclePosition,
+    () => props.home,
+    () => props.baseStation,
+    () => props.showBaseStationArrow,
+    () => props.baseStationColor,
+    () => props.mapCenter,
+    () => props.zoom,
+  ],
   () => {
     if (props.mapReady && map.value && map.value instanceof L.Map) {
-      throttledUpdateVehicleAndHomeArrows()
+      throttledUpdateTargetArrows()
     }
   },
   { immediate: true }
@@ -589,7 +635,7 @@ watch(
     if (mapInstance && ready && mapInstance instanceof L.Map) {
       moveHandler = (): void => {
         throttledUpdateArrows()
-        throttledUpdateVehicleAndHomeArrows()
+        throttledUpdateTargetArrows()
       }
       mapInstance.on('move', moveHandler)
     }

--- a/src/components/widgets/CompassHUD.vue
+++ b/src/components/widgets/CompassHUD.vue
@@ -146,6 +146,7 @@ import { colord } from 'colord'
 import gsap from 'gsap'
 import { computed, onBeforeMount, onBeforeUnmount, onMounted, reactive, ref, toRefs, watch } from 'vue'
 
+import { useBaseStation } from '@/composables/baseStation/useBaseStation'
 import { calculateHaversineDistance } from '@/libs/mission/general-estimates'
 import { datalogger, DatalogVariable } from '@/libs/sensors-logging'
 import { degrees, radians, resetCanvas } from '@/libs/utils'
@@ -165,6 +166,7 @@ import type { Widget } from '@/types/widgets'
 const widgetStore = useWidgetManagerStore()
 const interfaceStore = useAppInterfaceStore()
 const missionStore = useMissionStore()
+const baseStationStore = useBaseStation()
 
 datalogger.registerUsage(DatalogVariable.heading)
 const store = useMainVehicleStore()
@@ -288,21 +290,18 @@ const calculateBearing = (vehicleLat: number, vehicleLng: number, poiLat: number
   return bearing
 }
 
+const formatHudDistanceText = (distance: number, isReached: boolean): string =>
+  isReached ? 'Reached' : distance >= 2000 ? `${(distance / 1000).toFixed(1)}km` : `${Math.round(distance)}m`
+
 // Get POI data with bearing and distance relative to vehicle
 const poiData = computed(() => {
   if (!store.coordinates.latitude || !store.coordinates.longitude) return []
 
-  return missionStore.pointsOfInterest.map((poi) => {
-    const distance = calculateHaversineDistance(
-      [store.coordinates.latitude!, store.coordinates.longitude!],
-      poi.coordinates
-    )
-    const bearing = calculateBearing(
-      store.coordinates.latitude!,
-      store.coordinates.longitude!,
-      poi.coordinates[0],
-      poi.coordinates[1]
-    )
+  const vehicleLat = store.coordinates.latitude!
+  const vehicleLng = store.coordinates.longitude!
+  const hudTargets = missionStore.pointsOfInterest.map((poi) => {
+    const distance = calculateHaversineDistance([vehicleLat, vehicleLng], poi.coordinates)
+    const bearing = calculateBearing(vehicleLat, vehicleLng, poi.coordinates[0], poi.coordinates[1])
 
     return {
       poi,
@@ -310,6 +309,31 @@ const poiData = computed(() => {
       bearing,
     }
   })
+
+  if (baseStationStore.config.enabled && baseStationStore.config.position) {
+    const distance = calculateHaversineDistance([vehicleLat, vehicleLng], baseStationStore.config.position)
+    const bearing = calculateBearing(
+      vehicleLat,
+      vehicleLng,
+      baseStationStore.config.position[0],
+      baseStationStore.config.position[1]
+    )
+    hudTargets.push({
+      poi: {
+        id: 'base-station',
+        name: baseStationStore.config.name.trim() || 'Base station',
+        description: '',
+        coordinates: baseStationStore.config.position,
+        icon: 'mdi-radio-tower',
+        color: baseStationStore.config.coverageColor,
+        timestamp: 0,
+      },
+      distance,
+      bearing,
+    })
+  }
+
+  return hudTargets
 })
 
 const homeCoordinates = computed(() => missionStore.homeMarkerPosition)
@@ -539,7 +563,8 @@ const updatePoiMarkers = (): void => {
     }
 
     const x = halfWidth + ((2 * halfWidth) / Math.PI) * Math.sin(radians(relativeBearing))
-    const isReachedNow = distance <= 1
+    const supportsReachedBlink = poi.id !== 'base-station'
+    const isReachedNow = supportsReachedBlink && distance <= 1
     // How long the POI will stay marked as reached (blinking animation)
     if (isReachedNow) {
       reachedMarkers.value.set(poi.id, {
@@ -550,13 +575,10 @@ const updatePoiMarkers = (): void => {
     }
 
     const reachedData = reachedMarkers.value.get(poi.id)
-    const isReached = isReachedNow || (reachedData !== undefined && now < reachedData.expiresAt)
+    const isReached =
+      supportsReachedBlink && (isReachedNow || (reachedData !== undefined && now < reachedData.expiresAt))
     // How far from a POI to mark as reached (2 meters)
-    const distanceText = isReached
-      ? 'Reached'
-      : distance >= 2000
-      ? `${(distance / 1000).toFixed(1)}km`
-      : `${Math.round(distance)}m`
+    const distanceText = formatHudDistanceText(distance, isReached)
 
     const mode = widget.value.options.poi?.showDistances
     const isHighlighted = highlightedMarkers.value.has(poi.id)

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -231,6 +231,7 @@
   </p>
 
   <PoiManager ref="poiManagerMapWidgetRef" />
+  <BaseStationConfigPanel />
   <BaseStationContextPopup />
   <MissionChecklist
     :model-value="isMissionChecklistOpen"
@@ -292,6 +293,7 @@ import copterMarkerImage from '@/assets/arducopter-top-view.avif'
 import blueboatMarkerImage from '@/assets/blueboat-marker.avif'
 import brov2MarkerImage from '@/assets/brov2-marker.avif'
 import genericVehicleMarkerImage from '@/assets/generic-vehicle-marker.avif'
+import BaseStationConfigPanel from '@/components/BaseStationConfigPanel.vue'
 import BaseStationContextPopup from '@/components/BaseStationContextPopup.vue'
 import GlobalOriginDialog from '@/components/GlobalOriginDialog.vue'
 import MissionChecklist from '@/components/MissionChecklist.vue'
@@ -2421,5 +2423,20 @@ watch(
   padding: 1px 4px;
   border-radius: 2px;
   white-space: nowrap;
+}
+
+.base-station-bearing-handle {
+  background: none;
+  border: none;
+  cursor: grab;
+}
+
+.base-station-bearing-handle-dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background-color: #fff;
+  border: 2px solid #008bff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
 }
 </style>

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -134,8 +134,11 @@
         :show-poi-arrows="widget.options.showPoiArrows"
         :show-home-arrow="widget.options.showHomeArrow"
         :show-vehicle-arrow="widget.options.showVehicleArrow"
+        :show-base-station-arrow="widget.options.showBaseStationArrow"
         :vehicle-position="vehiclePosition"
         :home="home"
+        :base-station="baseStationStore.config.enabled ? baseStationStore.config.position ?? undefined : undefined"
+        :base-station-color="baseStationStore.config.coverageColor"
         :map-center="mapCenter"
         :zoom="zoom"
         :widget="widget"
@@ -203,6 +206,15 @@
                   class="my-1"
                   label="Vehicle arrow"
                   :color="widget.options.showVehicleArrow ? 'white' : undefined"
+                  hide-details
+                />
+              </v-col>
+              <v-col cols="4">
+                <v-switch
+                  v-model="widget.options.showBaseStationArrow"
+                  class="my-1"
+                  label="Base station arrow"
+                  :color="widget.options.showBaseStationArrow ? 'white' : undefined"
                   hide-details
                 />
               </v-col>
@@ -564,6 +576,9 @@ onBeforeMount(() => {
   }
   if (widget.value.options.showVehicleArrow === undefined) {
     widget.value.options.showVehicleArrow = true
+  }
+  if (widget.value.options.showBaseStationArrow === undefined) {
+    widget.value.options.showBaseStationArrow = true
   }
   targetFollower.enableAutoUpdate()
 })
@@ -1190,6 +1205,9 @@ const targetFollower = new TargetFollower(
 )
 targetFollower.setTrackableTarget(WhoToFollow.VEHICLE, () => vehiclePosition.value)
 targetFollower.setTrackableTarget(WhoToFollow.HOME, () => home.value)
+targetFollower.setTrackableTarget(WhoToFollow.BASE_STATION, () =>
+  baseStationStore.config.enabled ? baseStationStore.config.position ?? undefined : undefined
+)
 
 useBaseStationOverlay(map, mapReady)
 

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -1474,19 +1474,18 @@ const globalOriginLatitude = ref(0)
 const globalOriginLongitude = ref(0)
 const globalOriginMarker = shallowRef<L.Marker>()
 
-// Tag used to identify the base-station "place" entry so the watcher can rebind it
-// on store changes without relying on label/icon string matching.
-type BaseStationMenuTags = {
-  /* eslint-disable jsdoc/require-jsdoc */
-  _isBaseStationPlace?: boolean
-  /* eslint-enable jsdoc/require-jsdoc */
-}
+/**
+ * Discriminator used to find base-station-owned context-menu entries when rebuilding them,
+ * without relying on label/icon string matching.
+ */
+// eslint-disable-next-line jsdoc/require-jsdoc -- Single-field discriminator; doc above the type covers it.
+type BaseStationMenuTag = { baseStationTag?: 'place' | 'context' }
 
 const baseStationMenuItem = computed(() => ({
   item: baseStationStore.config.enabled ? 'Move base station here' : 'Set base station here',
   action: () => onMenuOptionSelect('place-base-station'),
   icon: 'mdi-radio-tower',
-  _isBaseStationPlace: true,
+  baseStationTag: 'place' as const,
 }))
 
 const menuItems = reactive([
@@ -1521,7 +1520,7 @@ const menuItems = reactive([
 
 // The base-station entry's label depends on whether one already exists; rebind on store changes.
 watch(baseStationMenuItem, (newItem) => {
-  const idx = menuItems.findIndex((i) => (i as BaseStationMenuTags)._isBaseStationPlace === true)
+  const idx = menuItems.findIndex((i) => (i as BaseStationMenuTag).baseStationTag === 'place')
   if (idx >= 0) menuItems[idx] = newItem
 })
 
@@ -1529,16 +1528,22 @@ const baseStationContextItems = computed(() =>
   baseStationStore.config.enabled
     ? [
         {
+          item: 'Remove base station',
+          action: () => onMenuOptionSelect('remove-base-station'),
+          icon: 'mdi-delete',
+          baseStationTag: 'context' as const,
+        },
+        {
+          item: baseStationStore.config.showSignalOnMap ? 'Hide signal on map' : 'Show signal on map',
+          action: () => onMenuOptionSelect('toggle-base-station-signal-visibility'),
+          icon: baseStationStore.config.showSignalOnMap ? 'mdi-eye' : 'mdi-eye-off',
+          baseStationTag: 'context' as const,
+        },
+        {
           item: 'Configure base station',
           action: () => onMenuOptionSelect('configure-base-station'),
           icon: 'mdi-cog',
-          _isBaseStationContext: true,
-        },
-        {
-          item: 'Remove base station',
-          action: () => onMenuOptionSelect('remove-base-station'),
-          icon: 'mdi-radio-tower',
-          _isBaseStationContext: true,
+          baseStationTag: 'context' as const,
         },
       ]
     : []
@@ -1548,7 +1553,7 @@ watch(
   baseStationContextItems,
   (newItems) => {
     for (let i = menuItems.length - 1; i >= 0; i--) {
-      if ((menuItems[i] as { _isBaseStationContext?: boolean })._isBaseStationContext) {
+      if ((menuItems[i] as BaseStationMenuTag).baseStationTag === 'context') {
         menuItems.splice(i, 1)
       }
     }
@@ -1758,6 +1763,10 @@ const onMenuOptionSelect = async (option: string): Promise<void> => {
 
     case 'remove-base-station':
       baseStationStore.remove()
+      break
+
+    case 'toggle-base-station-signal-visibility':
+      baseStationStore.toggleSignalVisibility()
       break
 
     default:

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -6,7 +6,7 @@
     :class="widgetStore.editingMode ? 'pointer-events-none' : 'pointer-events-auto'"
     :style="glassMenuCssVars"
   >
-    <div :id="mapId" ref="map" class="map">
+    <div :id="mapId" class="map">
       <v-menu v-model="downloadMenuOpen" :close-on-content-click="false" location="top end">
         <template #activator="{ props: menuProps }">
           <v-tooltip location="top" text="Download tiles for offline use">
@@ -231,6 +231,7 @@
   </p>
 
   <PoiManager ref="poiManagerMapWidgetRef" />
+  <BaseStationContextPopup />
   <MissionChecklist
     :model-value="isMissionChecklistOpen"
     @confirmed="executeMissionOnVehicle"
@@ -291,10 +292,13 @@ import copterMarkerImage from '@/assets/arducopter-top-view.avif'
 import blueboatMarkerImage from '@/assets/blueboat-marker.avif'
 import brov2MarkerImage from '@/assets/brov2-marker.avif'
 import genericVehicleMarkerImage from '@/assets/generic-vehicle-marker.avif'
+import BaseStationContextPopup from '@/components/BaseStationContextPopup.vue'
 import GlobalOriginDialog from '@/components/GlobalOriginDialog.vue'
 import MissionChecklist from '@/components/MissionChecklist.vue'
 import PoiManager from '@/components/poi/PoiManager.vue'
 import PoiMapArrows from '@/components/poi/PoiMapArrows.vue'
+import { useBaseStation } from '@/composables/baseStation/useBaseStation'
+import { useBaseStationOverlay } from '@/composables/baseStation/useBaseStationOverlay'
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { provideMapContext } from '@/composables/map/useMapContext'
 import { openSnackbar } from '@/composables/snackbar'
@@ -341,6 +345,7 @@ const {
 const vehicleStore = useMainVehicleStore()
 const missionStore = useMissionStore()
 const widgetStore = useWidgetManagerStore()
+const baseStationStore = useBaseStation()
 const router = useRouter()
 
 const mapContext = provideMapContext()
@@ -1184,6 +1189,8 @@ const targetFollower = new TargetFollower(
 targetFollower.setTrackableTarget(WhoToFollow.VEHICLE, () => vehiclePosition.value)
 targetFollower.setTrackableTarget(WhoToFollow.HOME, () => home.value)
 
+useBaseStationOverlay(map, mapReady)
+
 // Calculate live vehicle position
 const vehiclePosition = computed(() =>
   vehicleStore.coordinates.latitude
@@ -1465,6 +1472,21 @@ const globalOriginLatitude = ref(0)
 const globalOriginLongitude = ref(0)
 const globalOriginMarker = shallowRef<L.Marker>()
 
+// Tag used to identify the base-station "place" entry so the watcher can rebind it
+// on store changes without relying on label/icon string matching.
+type BaseStationMenuTags = {
+  /* eslint-disable jsdoc/require-jsdoc */
+  _isBaseStationPlace?: boolean
+  /* eslint-enable jsdoc/require-jsdoc */
+}
+
+const baseStationMenuItem = computed(() => ({
+  item: baseStationStore.config.enabled ? 'Move base station here' : 'Set base station here',
+  action: () => onMenuOptionSelect('place-base-station'),
+  icon: 'mdi-radio-tower',
+  _isBaseStationPlace: true,
+}))
+
 const menuItems = reactive([
   {
     item: 'Set home waypoint',
@@ -1481,6 +1503,7 @@ const menuItems = reactive([
     action: () => onMenuOptionSelect('place-poi'),
     icon: 'mdi-map-marker-plus',
   },
+  baseStationMenuItem.value,
   { item: 'GoTo', action: () => onMenuOptionSelect('goto'), icon: 'mdi-crosshairs-gps' },
   {
     item: 'Set default map position',
@@ -1493,6 +1516,44 @@ const menuItems = reactive([
     icon: 'mdi-gesture',
   },
 ])
+
+// The base-station entry's label depends on whether one already exists; rebind on store changes.
+watch(baseStationMenuItem, (newItem) => {
+  const idx = menuItems.findIndex((i) => (i as BaseStationMenuTags)._isBaseStationPlace === true)
+  if (idx >= 0) menuItems[idx] = newItem
+})
+
+const baseStationContextItems = computed(() =>
+  baseStationStore.config.enabled
+    ? [
+        {
+          item: 'Configure base station',
+          action: () => onMenuOptionSelect('configure-base-station'),
+          icon: 'mdi-cog',
+          _isBaseStationContext: true,
+        },
+        {
+          item: 'Remove base station',
+          action: () => onMenuOptionSelect('remove-base-station'),
+          icon: 'mdi-radio-tower',
+          _isBaseStationContext: true,
+        },
+      ]
+    : []
+)
+
+watch(
+  baseStationContextItems,
+  (newItems) => {
+    for (let i = menuItems.length - 1; i >= 0; i--) {
+      if ((menuItems[i] as { _isBaseStationContext?: boolean })._isBaseStationContext) {
+        menuItems.splice(i, 1)
+      }
+    }
+    newItems.forEach((i) => menuItems.push(i))
+  },
+  { immediate: true }
+)
 
 const updateSkipToWpMenu = (): void => {
   const want = contextMenuSelectedWpIndex.value !== null
@@ -1680,6 +1741,21 @@ const onMenuOptionSelect = async (option: string): Promise<void> => {
     case 'clear-vehicle-path-history':
       missionStore.clearVehicleHistory()
       openSnackbar({ message: 'Vehicle path history cleared', variant: 'success' })
+      break
+
+    case 'place-base-station':
+      if (clickedLocation.value) {
+        baseStationStore.setPosition(clickedLocation.value)
+        baseStationStore.configPanelOpen = true
+      }
+      break
+
+    case 'configure-base-station':
+      baseStationStore.configPanelOpen = true
+      break
+
+    case 'remove-base-station':
+      baseStationStore.remove()
       break
 
     default:
@@ -2306,5 +2382,44 @@ watch(
   to {
     opacity: 1;
   }
+}
+
+/* Base-station marker styles must be global because Leaflet's `divIcon` renders the markup
+   outside this component's scoped boundary. */
+.base-station-marker-icon {
+  background: none;
+  border: none;
+}
+
+.base-station-marker-container {
+  position: relative;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: grab;
+}
+
+.base-station-marker-background {
+  position: absolute;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background-color: #005fad;
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  z-index: 1;
+}
+
+.base-station-marker-label {
+  position: absolute;
+  bottom: -12px;
+  background-color: rgba(0, 0, 0, 0.7);
+  color: white;
+  font-size: 10px;
+  padding: 1px 4px;
+  border-radius: 2px;
+  white-space: nowrap;
 }
 </style>

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -2408,7 +2408,6 @@ watch(
   width: 24px;
   height: 24px;
   border-radius: 50%;
-  background-color: #005fad;
   border: 1px solid rgba(255, 255, 255, 0.7);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
   z-index: 1;

--- a/src/composables/baseStation/useBaseStation.ts
+++ b/src/composables/baseStation/useBaseStation.ts
@@ -23,7 +23,15 @@ function initialize() {
     ...DEFAULT_BASE_STATION_CONFIG,
     ...config.value,
     antenna: { ...DEFAULT_BASE_STATION_CONFIG.antenna, ...(config.value.antenna ?? {}) },
+    mobileCoverage: {
+      ...DEFAULT_BASE_STATION_CONFIG.mobileCoverage,
+      ...(config.value.mobileCoverage ?? {}),
+    },
   }
+
+  // Operators discovered in the most recent Overpass response. Populates the panel selector
+  // dynamically since the OSM `operator` tag varies wildly between regions.
+  const availableOsmOperators = ref<string[]>([])
 
   const configPanelOpen = ref(false)
 
@@ -114,6 +122,7 @@ function initialize() {
     configPanelOpen,
     contextPopupOpen,
     contextPopupPosition,
+    availableOsmOperators,
     showCoverage,
     setPosition,
     setBearing,

--- a/src/composables/baseStation/useBaseStation.ts
+++ b/src/composables/baseStation/useBaseStation.ts
@@ -87,6 +87,7 @@ function initialize() {
   const showCoverage = computed(
     () =>
       config.value.enabled &&
+      config.value.showSignalOnMap &&
       config.value.position !== null &&
       (config.value.commsType === BaseStationCommsType.RadioLink ||
         config.value.commsType === BaseStationCommsType.Tethered)
@@ -121,6 +122,10 @@ function initialize() {
 
   const setBearing = (bearing: number): void => {
     config.value.antenna.bearing = normalizeBearing(bearing)
+  }
+
+  const toggleSignalVisibility = (): void => {
+    config.value.showSignalOnMap = !config.value.showSignalOnMap
   }
 
   let geoWatchId: number | null = null
@@ -187,6 +192,7 @@ function initialize() {
     showCoverage,
     setPosition,
     setBearing,
+    toggleSignalVisibility,
     setAntennaType,
     resetAntennaToDefaults,
     openContextPopup,

--- a/src/composables/baseStation/useBaseStation.ts
+++ b/src/composables/baseStation/useBaseStation.ts
@@ -1,17 +1,36 @@
-import { reactive, ref } from 'vue'
+import { computed, reactive, ref, watch } from 'vue'
 
 import { useBlueOsStorage } from '@/composables/settingsSyncer'
-import { type BaseStationConfig, DEFAULT_BASE_STATION_CONFIG } from '@/types/baseStation'
+import { openSnackbar } from '@/composables/snackbar'
+import { useAppInterfaceStore } from '@/stores/appInterface'
+import {
+  type BaseStationConfig,
+  ANTENNA_FACTORY_DEFAULTS,
+  AntennaType,
+  BaseStationCommsType,
+  DEFAULT_BASE_STATION_CONFIG,
+} from '@/types/baseStation'
 import type { WaypointCoordinates } from '@/types/mission'
+
+const normalizeBearing = (bearing: number): number => ((bearing % 360) + 360) % 360
 
 // eslint-disable-next-line jsdoc/require-jsdoc, @typescript-eslint/explicit-function-return-type -- type inferred for the reactive() output to keep per-state-field typing local to this file
 function initialize() {
   const config = useBlueOsStorage<BaseStationConfig>('cockpit-base-station-config', DEFAULT_BASE_STATION_CONFIG)
 
   // Merge defaults so newly-added fields are populated for existing users.
-  config.value = { ...DEFAULT_BASE_STATION_CONFIG, ...config.value }
+  config.value = {
+    ...DEFAULT_BASE_STATION_CONFIG,
+    ...config.value,
+    antenna: { ...DEFAULT_BASE_STATION_CONFIG.antenna, ...(config.value.antenna ?? {}) },
+  }
 
   const configPanelOpen = ref(false)
+
+  const interfaceStore = useAppInterfaceStore()
+  watch(configPanelOpen, (isOpen) => {
+    interfaceStore.configPanelVisible = isOpen
+  })
 
   const contextPopupOpen = ref(false)
   const contextPopupPosition = ref({ x: 0, y: 0 })
@@ -25,6 +44,14 @@ function initialize() {
     contextPopupOpen.value = false
   }
 
+  const showCoverage = computed(
+    () =>
+      config.value.enabled &&
+      config.value.position !== null &&
+      (config.value.commsType === BaseStationCommsType.RadioLink ||
+        config.value.commsType === BaseStationCommsType.Tethered)
+  )
+
   const setPosition = (position: WaypointCoordinates): void => {
     config.value.position = [Number(position[0].toFixed(8)), Number(position[1].toFixed(8))]
     config.value.enabled = true
@@ -36,14 +63,64 @@ function initialize() {
     contextPopupOpen.value = false
   }
 
+  const resetAntennaToDefaults = (): void => {
+    const factory = ANTENNA_FACTORY_DEFAULTS[config.value.antenna.type]
+    config.value.antenna = { ...factory, bearing: config.value.antenna.bearing }
+  }
+
+  const setAntennaType = (type: AntennaType): void => {
+    const factory = ANTENNA_FACTORY_DEFAULTS[type]
+    config.value.antenna = { ...factory, bearing: config.value.antenna.bearing }
+  }
+
+  const setBearing = (bearing: number): void => {
+    config.value.antenna.bearing = normalizeBearing(bearing)
+  }
+
+  let geoWatchId: number | null = null
+  const stopGeoWatch = (): void => {
+    if (geoWatchId !== null && navigator?.geolocation) {
+      navigator.geolocation.clearWatch(geoWatchId)
+      geoWatchId = null
+    }
+  }
+  const startGeoWatch = (): void => {
+    if (geoWatchId !== null || !navigator?.geolocation) return
+    geoWatchId = navigator.geolocation.watchPosition(
+      (position) => setPosition([position.coords.latitude, position.coords.longitude]),
+      (error) => {
+        openSnackbar({
+          variant: 'error',
+          message: `Base station GPS tracking failed: ${error.message}. Disabling.`,
+          duration: 4000,
+        })
+        config.value.trackByGps = false
+      },
+      { enableHighAccuracy: true, timeout: 10000, maximumAge: 1000 }
+    )
+  }
+
+  watch(
+    () => [config.value.trackByGps, config.value.enabled] as const,
+    ([tracking, enabled]) => {
+      if (tracking && enabled) startGeoWatch()
+      else stopGeoWatch()
+    },
+    { immediate: true }
+  )
+
   return reactive({
     config,
     configPanelOpen,
     contextPopupOpen,
     contextPopupPosition,
+    showCoverage,
+    setPosition,
+    setBearing,
+    setAntennaType,
+    resetAntennaToDefaults,
     openContextPopup,
     closeContextPopup,
-    setPosition,
     remove,
   })
 }

--- a/src/composables/baseStation/useBaseStation.ts
+++ b/src/composables/baseStation/useBaseStation.ts
@@ -1,0 +1,63 @@
+import { reactive, ref } from 'vue'
+
+import { useBlueOsStorage } from '@/composables/settingsSyncer'
+import { type BaseStationConfig, DEFAULT_BASE_STATION_CONFIG } from '@/types/baseStation'
+import type { WaypointCoordinates } from '@/types/mission'
+
+// eslint-disable-next-line jsdoc/require-jsdoc, @typescript-eslint/explicit-function-return-type -- type inferred for the reactive() output to keep per-state-field typing local to this file
+function initialize() {
+  const config = useBlueOsStorage<BaseStationConfig>('cockpit-base-station-config', DEFAULT_BASE_STATION_CONFIG)
+
+  // Merge defaults so newly-added fields are populated for existing users.
+  config.value = { ...DEFAULT_BASE_STATION_CONFIG, ...config.value }
+
+  const configPanelOpen = ref(false)
+
+  const contextPopupOpen = ref(false)
+  const contextPopupPosition = ref({ x: 0, y: 0 })
+
+  const openContextPopup = (x: number, y: number): void => {
+    contextPopupPosition.value = { x, y }
+    contextPopupOpen.value = true
+  }
+
+  const closeContextPopup = (): void => {
+    contextPopupOpen.value = false
+  }
+
+  const setPosition = (position: WaypointCoordinates): void => {
+    config.value.position = [Number(position[0].toFixed(8)), Number(position[1].toFixed(8))]
+    config.value.enabled = true
+  }
+
+  const remove = (): void => {
+    config.value = { ...DEFAULT_BASE_STATION_CONFIG }
+    configPanelOpen.value = false
+    contextPopupOpen.value = false
+  }
+
+  return reactive({
+    config,
+    configPanelOpen,
+    contextPopupOpen,
+    contextPopupPosition,
+    openContextPopup,
+    closeContextPopup,
+    setPosition,
+    remove,
+  })
+}
+
+let api: ReturnType<typeof initialize> | null = null
+
+/**
+ * Singleton-style composable holding the base-station configuration, transient UI state
+ * (config panel / context popup / coverage controls), and the actions that mutate them.
+ * State is shared across all callers; the first call lazily initializes it so dependent
+ * stores (Pinia, BlueOS settings) are guaranteed to be ready.
+ * @returns {ReturnType<typeof initialize>} Reactive base-station state and actions.
+ */
+export const useBaseStation = (): ReturnType<typeof initialize> => {
+  if (!api) api = initialize()
+  return api
+}

--- a/src/composables/baseStation/useBaseStation.ts
+++ b/src/composables/baseStation/useBaseStation.ts
@@ -5,10 +5,13 @@ import { openSnackbar } from '@/composables/snackbar'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import {
   type BaseStationConfig,
+  type MobileCoverageCache,
   ANTENNA_FACTORY_DEFAULTS,
   AntennaType,
   BaseStationCommsType,
   DEFAULT_BASE_STATION_CONFIG,
+  DEFAULT_MOBILE_COVERAGE_CACHE,
+  TopSideComputerType,
 } from '@/types/baseStation'
 import type { WaypointCoordinates } from '@/types/mission'
 
@@ -17,6 +20,10 @@ const normalizeBearing = (bearing: number): number => ((bearing % 360) + 360) % 
 // eslint-disable-next-line jsdoc/require-jsdoc, @typescript-eslint/explicit-function-return-type -- type inferred for the reactive() output to keep per-state-field typing local to this file
 function initialize() {
   const config = useBlueOsStorage<BaseStationConfig>('cockpit-base-station-config', DEFAULT_BASE_STATION_CONFIG)
+  const mobileCoverageCache = useBlueOsStorage<MobileCoverageCache>(
+    'cockpit-base-station-mobile-coverage-cache',
+    DEFAULT_MOBILE_COVERAGE_CACHE
+  )
 
   // Merge defaults so newly-added fields are populated for existing users.
   config.value = {
@@ -28,10 +35,27 @@ function initialize() {
       ...(config.value.mobileCoverage ?? {}),
     },
   }
+  mobileCoverageCache.value = {
+    ...DEFAULT_MOBILE_COVERAGE_CACHE,
+    ...mobileCoverageCache.value,
+    openCellId: mobileCoverageCache.value.openCellId ?? [],
+    osmOverpass: mobileCoverageCache.value.osmOverpass ?? [],
+  }
+  // Migration shim for the legacy 'Mobile'/'Relocatable' enum values. Safe to drop once we are
+  // confident no installs still carry the old persistence (target: a couple of releases past v1.x).
+  if (config.value.topSideComputerType === 'Mobile' || config.value.topSideComputerType === 'Relocatable') {
+    config.value.topSideComputerType = TopSideComputerType.Portable
+  }
 
   // Operators discovered in the most recent Overpass response. Populates the panel selector
   // dynamically since the OSM `operator` tag varies wildly between regions.
   const availableOsmOperators = ref<string[]>([])
+  const availableOpenCellIdOperators = ref<string[]>([])
+  const mobileCoverageLoading = ref(false)
+  const mobileCoverageReloadToken = ref(0)
+  const mobileCoverageVisibleDataResetToken = ref(0)
+  const mobileCoverageTargetToolActive = ref(false)
+  const openCellIdApiKeyStatus = ref<'unknown' | 'valid' | 'invalid'>('unknown')
 
   const configPanelOpen = ref(false)
 
@@ -52,6 +76,14 @@ function initialize() {
     contextPopupOpen.value = false
   }
 
+  const requestMobileCoverageReload = (): void => {
+    mobileCoverageReloadToken.value += 1
+  }
+
+  const requestVisibleMobileCoverageDataReset = (): void => {
+    mobileCoverageVisibleDataResetToken.value += 1
+  }
+
   const showCoverage = computed(
     () =>
       config.value.enabled &&
@@ -66,7 +98,13 @@ function initialize() {
   }
 
   const remove = (): void => {
-    config.value = { ...DEFAULT_BASE_STATION_CONFIG }
+    // Keep the OpenCellID API key around as a user-level credential — having to retype it
+    // every time the base station is removed/recreated would be annoying and error-prone.
+    const preservedApiKey = config.value.mobileCoverage.openCellIdApiKey
+    config.value = {
+      ...DEFAULT_BASE_STATION_CONFIG,
+      mobileCoverage: { ...DEFAULT_BASE_STATION_CONFIG.mobileCoverage, openCellIdApiKey: preservedApiKey },
+    }
     configPanelOpen.value = false
     contextPopupOpen.value = false
   }
@@ -117,12 +155,35 @@ function initialize() {
     { immediate: true }
   )
 
+  watch(
+    () => config.value.topSideComputerType,
+    (topSideType) => {
+      if (topSideType !== TopSideComputerType.Portable) config.value.trackByGps = false
+    },
+    { immediate: true }
+  )
+
+  // Provider/key changes invalidate any previously-determined validity; the next fetch resets it.
+  watch(
+    () => [config.value.mobileCoverage.provider, config.value.mobileCoverage.openCellIdApiKey] as const,
+    () => {
+      openCellIdApiKeyStatus.value = 'unknown'
+    }
+  )
+
   return reactive({
     config,
+    mobileCoverageCache,
     configPanelOpen,
     contextPopupOpen,
     contextPopupPosition,
     availableOsmOperators,
+    availableOpenCellIdOperators,
+    mobileCoverageLoading,
+    mobileCoverageReloadToken,
+    mobileCoverageVisibleDataResetToken,
+    mobileCoverageTargetToolActive,
+    openCellIdApiKeyStatus,
     showCoverage,
     setPosition,
     setBearing,
@@ -130,6 +191,8 @@ function initialize() {
     resetAntennaToDefaults,
     openContextPopup,
     closeContextPopup,
+    requestMobileCoverageReload,
+    requestVisibleMobileCoverageDataReset,
     remove,
   })
 }

--- a/src/composables/baseStation/useBaseStationOverlay.ts
+++ b/src/composables/baseStation/useBaseStationOverlay.ts
@@ -4,48 +4,21 @@ import { type Ref, type ShallowRef, onBeforeUnmount, shallowRef, watch } from 'v
 
 import { openSnackbar } from '@/composables/snackbar'
 import { useBaseStation } from '@/composables/baseStation/useBaseStation'
+import { isElectron } from '@/libs/utils'
 import {
   type BaseStationConfig,
+  type CachedMobileCoverageEntry,
+  type CachedOpenCellIdSite,
+  type CachedOverpassTower,
+  type CoverageBbox,
   AntennaType,
   BaseStationCommsType,
   effectiveAntennaRangeMeters,
+  MOBILE_COVERAGE_FETCH_DROP_MIME,
+  MobileCoverageDisplayMode,
   MobileCoverageProvider,
 } from '@/types/baseStation'
 import type { WaypointCoordinates } from '@/types/mission'
-
-/* eslint-disable jsdoc/require-jsdoc -- `leaflet.heat` ships no typings; this is a minimal augmentation. */
-declare module 'leaflet' {
-  type HeatLatLngTuple = [number, number, number]
-  interface HeatMapOptions {
-    minOpacity?: number
-    maxZoom?: number
-    max?: number
-    radius?: number
-    blur?: number
-    gradient?: Record<number, string>
-  }
-  interface HeatLayer extends Layer {
-    setOptions(options: HeatMapOptions): HeatLayer
-    addLatLng(latlng: LatLng | HeatLatLngTuple): HeatLayer
-    setLatLngs(latlngs: Array<LatLng | HeatLatLngTuple>): HeatLayer
-  }
-  function heatLayer(latlngs: Array<LatLng | HeatLatLngTuple>, options?: HeatMapOptions): HeatLayer
-}
-/* eslint-enable jsdoc/require-jsdoc */
-
-// `leaflet.heat` is a UMD-style plugin: its IIFE assigns `L.HeatLayer = …` against whatever
-// `L` it finds on the scope chain — i.e. `window.L`. With ESM imports leaflet doesn't auto-
-// publish to the global, so the plugin's IIFE silently no-ops and `L.heatLayer` ends up
-// undefined. Expose `L` on `window` first, then load the plugin lazily on first use.
-let heatLayerLoader: Promise<void> | null = null
-const ensureHeatLayer = (): Promise<void> => {
-  if (heatLayerLoader) return heatLayerLoader
-  heatLayerLoader = (async () => {
-    Object.assign(window, { L })
-    await import('leaflet.heat')
-  })()
-  return heatLayerLoader
-}
 
 const SECTOR_ARC_STEPS = 64
 
@@ -106,15 +79,21 @@ const bearingFromCenter = (center: WaypointCoordinates, point: WaypointCoordinat
 
 // OSM Overpass has no per-call area cap, so we use a single ~11 km half-side bbox.
 const OVERPASS_BBOX_DEG = 0.1
-// OpenCellID's getInArea caps at 4 km² per call (`code: 3` otherwise), so we tile a 3×3 grid
-// of small boxes around the base station — ~5 km × 5 km of total coverage in 9 parallel calls.
-const OPENCELLID_TILE_HALF_DEG = 0.0075
-const OPENCELLID_TILES_PER_SIDE = 3
-// `range` is reported in meters; this anchor (~5 km) maps a typical urban tower reach to
-// full intensity in the heatmap.
-const OPENCELLID_RANGE_NORMALIZER_M = 5000
+const OPENCELLID_COVERAGE_HALF_SIDE_KM = 25
+// Keyed browser endpoint caps at ~4 km²; standalone's no-key ajax endpoint rejects around 25 km²,
+// so we use smaller tiles on Lite and larger ones on standalone.
+const OPENCELLID_KEYED_TILE_HALF_SIDE_KM = 0.95
+const OPENCELLID_KEYED_FOREGROUND_TILE_COUNT = 9
+const OPENCELLID_LITE_TILE_HALF_SIDE_KM = 1
+const OPENCELLID_STANDALONE_TILE_HALF_SIDE_KM = 2
+const OPENCELLID_STANDALONE_FOREGROUND_TILE_COUNT = 1
+// Keep the persisted bbox cache small; users rarely need more than the most recent few areas.
+const MOBILE_COVERAGE_CACHE_MAX_ENTRIES = 8
+type OpenCellIdSite = CachedOpenCellIdSite
+type OverpassTower = CachedOverpassTower
 
-type CoverageBbox = { south: number; west: number; north: number; east: number }
+const isOpenCellIdInvalidApiKeyError = (message: string): boolean =>
+  /invalid.*key|api key.*invalid|missing.*key|key required|unauthorized|forbidden/i.test(message)
 
 const overpassBboxAround = (lat: number, lng: number): CoverageBbox => ({
   south: lat - OVERPASS_BBOX_DEG,
@@ -123,8 +102,125 @@ const overpassBboxAround = (lat: number, lng: number): CoverageBbox => ({
   east: lng + OVERPASS_BBOX_DEG,
 })
 
+const kmToLatDegrees = (km: number): number => km / 111.32
+
+const kmToLngDegrees = (km: number, lat: number): number => {
+  const cosLat = Math.max(0.2, Math.cos((lat * Math.PI) / 180))
+  return km / (111.32 * cosLat)
+}
+
+const openCellIdCoverageBboxAround = (lat: number, lng: number): CoverageBbox => ({
+  south: lat - kmToLatDegrees(OPENCELLID_COVERAGE_HALF_SIDE_KM),
+  west: lng - kmToLngDegrees(OPENCELLID_COVERAGE_HALF_SIDE_KM, lat),
+  north: lat + kmToLatDegrees(OPENCELLID_COVERAGE_HALF_SIDE_KM),
+  east: lng + kmToLngDegrees(OPENCELLID_COVERAGE_HALF_SIDE_KM, lat),
+})
+
+const bboxContains = (bbox: CoverageBbox, position: WaypointCoordinates): boolean => {
+  const [lat, lng] = position
+  return lat >= bbox.south && lat <= bbox.north && lng >= bbox.west && lng <= bbox.east
+}
+
+const bboxIntersects = (left: CoverageBbox, right: CoverageBbox): boolean =>
+  left.west <= right.east && left.east >= right.west && left.south <= right.north && left.north >= right.south
+
+const bboxEquals = (left: CoverageBbox, right: CoverageBbox): boolean =>
+  left.south === right.south && left.west === right.west && left.north === right.north && left.east === right.east
+
+const leafletBoundsToCoverageBbox = (bounds: L.LatLngBounds): CoverageBbox => ({
+  south: bounds.getSouth(),
+  west: bounds.getWest(),
+  north: bounds.getNorth(),
+  east: bounds.getEast(),
+})
+
+const trimCacheEntries = <T>(entries: CachedMobileCoverageEntry<T>[]): CachedMobileCoverageEntry<T>[] => {
+  return entries.sort((a, b) => b.fetchedAtMs - a.fetchedAtMs).slice(0, MOBILE_COVERAGE_CACHE_MAX_ENTRIES)
+}
+
+const tiledCoverageBboxes = (area: CoverageBbox, centerLat: number, tileHalfSideKm: number): CoverageBbox[] => {
+  const tileLatSize = kmToLatDegrees(tileHalfSideKm * 2)
+  const tileLngSize = kmToLngDegrees(tileHalfSideKm * 2, centerLat)
+  const latCount = Math.ceil((area.north - area.south) / tileLatSize)
+  const lngCount = Math.ceil((area.east - area.west) / tileLngSize)
+  const tiles: CoverageBbox[] = []
+
+  for (let latIndex = 0; latIndex < latCount; latIndex++) {
+    const south = area.south + latIndex * tileLatSize
+    const north = Math.min(area.north, south + tileLatSize)
+    for (let lngIndex = 0; lngIndex < lngCount; lngIndex++) {
+      const west = area.west + lngIndex * tileLngSize
+      const east = Math.min(area.east, west + tileLngSize)
+      tiles.push({ south, west, north, east })
+    }
+  }
+
+  return tiles
+}
+
+const bboxCenter = (bbox: CoverageBbox): WaypointCoordinates => [
+  (bbox.south + bbox.north) / 2,
+  (bbox.west + bbox.east) / 2,
+]
+
+const sortCoverageBboxesByDistance = (center: WaypointCoordinates, bboxes: CoverageBbox[]): CoverageBbox[] =>
+  [...bboxes].sort((left, right) => {
+    const [leftLat, leftLng] = bboxCenter(left)
+    const [rightLat, rightLng] = bboxCenter(right)
+    const leftDistance = turf.distance(turf.point([center[1], center[0]]), turf.point([leftLng, leftLat]))
+    const rightDistance = turf.distance(turf.point([center[1], center[0]]), turf.point([rightLng, rightLat]))
+    return leftDistance - rightDistance
+  })
+
+const unionCoverageBboxes = (bboxes: CoverageBbox[]): CoverageBbox => ({
+  south: Math.min(...bboxes.map((bbox) => bbox.south)),
+  west: Math.min(...bboxes.map((bbox) => bbox.west)),
+  north: Math.max(...bboxes.map((bbox) => bbox.north)),
+  east: Math.max(...bboxes.map((bbox) => bbox.east)),
+})
+
+const mapWithConcurrency = async <T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<R>
+): Promise<PromiseSettledResult<R>[]> => {
+  const settled: PromiseSettledResult<R>[] = new Array(items.length)
+  let nextIndex = 0
+
+  const worker = async (): Promise<void> => {
+    while (nextIndex < items.length) {
+      const currentIndex = nextIndex++
+      try {
+        settled[currentIndex] = {
+          status: 'fulfilled',
+          value: await mapper(items[currentIndex]),
+        }
+      } catch (error) {
+        settled[currentIndex] = {
+          status: 'rejected',
+          reason: error,
+        }
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => worker()))
+  return settled
+}
+
 type OpenCellIdResponse = {
-  cells?: Array<{ lat: number; lon: number; range?: number }>
+  cells?: Array<{
+    lat: number
+    lon: number
+    range?: number
+    radio?: string
+    mcc?: number
+    mnc?: number
+    lac?: number
+    cellid?: number
+    samples?: number
+    averageSignalStrength?: number
+  }>
   error?: string
   code?: number
 }
@@ -133,68 +229,258 @@ const fetchOpenCellIdTile = async (
   bbox: CoverageBbox,
   apiKey: string,
   signal: AbortSignal
-): Promise<L.HeatLatLngTuple[]> => {
+): Promise<OpenCellIdSite[]> => {
   const url =
     `https://opencellid.org/cell/getInArea?key=${encodeURIComponent(apiKey)}` +
     `&BBOX=${bbox.south},${bbox.west},${bbox.north},${bbox.east}` +
-    `&format=json&radio=LTE,NR&limit=1000`
+    `&format=json&limit=50`
   const res = await fetch(url, { signal })
   if (!res.ok) throw new Error(`OpenCellID HTTP ${res.status}`)
   const data = (await res.json()) as OpenCellIdResponse
   // `code: 1` ("No cells found") is HTTP 200 + an `error` field; treat as empty, not failure.
   if (data.error && data.code !== 1) throw new Error(`OpenCellID: ${data.error}`)
-  return (data.cells ?? []).map<L.HeatLatLngTuple>((c) => [
-    c.lat,
-    c.lon,
-    Math.min(1, (c.range ?? 1000) / OPENCELLID_RANGE_NORMALIZER_M),
-  ])
+  return (data.cells ?? []).map<OpenCellIdSite>((c) => ({
+    lat: c.lat,
+    lon: c.lon,
+    rangeMeters: c.range ?? 1000,
+    radio: c.radio,
+    mcc: c.mcc,
+    mnc: c.mnc,
+    lac: c.lac,
+    cellId: c.cellid,
+    samples: c.samples,
+    averageSignalStrength: c.averageSignalStrength,
+  }))
 }
 
-const fetchOpenCellIdPoints = async (
+const fetchOpenCellIdTileInElectron = async (bbox: CoverageBbox, apiKey: string): Promise<OpenCellIdSite[]> => {
+  const cells = await window.electronAPI?.fetchNearbyOpenCellIdCells({
+    west: bbox.west,
+    south: bbox.south,
+    east: bbox.east,
+    north: bbox.north,
+    apiKey: apiKey || undefined,
+  })
+  if (!cells) throw new Error('OpenCellID standalone bridge unavailable')
+  return cells.map<OpenCellIdSite>((c) => ({
+    lat: c.lat,
+    lon: c.lon,
+    rangeMeters: c.range ?? 1000,
+    radio: c.radio,
+    mcc: c.mcc,
+    mnc: c.mnc,
+    lac: c.lac,
+    cellId: c.cellId,
+    samples: c.samples,
+    averageSignalStrength: c.averageSignalStrength,
+  }))
+}
+
+const fetchOpenCellIdSites = async (
   center: WaypointCoordinates,
   apiKey: string,
   signal: AbortSignal
-): Promise<L.HeatLatLngTuple[]> => {
+): Promise<{ sites: OpenCellIdSite[]; fetchedBbox: CoverageBbox }> => {
   const [lat, lng] = center
-  const tileEdge = OPENCELLID_TILE_HALF_DEG * 2
-  const offsetBase = (OPENCELLID_TILES_PER_SIDE - 1) / 2
-  const tiles: CoverageBbox[] = []
-  for (let i = 0; i < OPENCELLID_TILES_PER_SIDE; i++) {
-    for (let j = 0; j < OPENCELLID_TILES_PER_SIDE; j++) {
-      const cLat = lat + (i - offsetBase) * tileEdge
-      const cLng = lng + (j - offsetBase) * tileEdge
-      tiles.push({
-        south: cLat - OPENCELLID_TILE_HALF_DEG,
-        west: cLng - OPENCELLID_TILE_HALF_DEG,
-        north: cLat + OPENCELLID_TILE_HALF_DEG,
-        east: cLng + OPENCELLID_TILE_HALF_DEG,
-      })
-    }
-  }
-  const settled = await Promise.allSettled(tiles.map((b) => fetchOpenCellIdTile(b, apiKey, signal)))
-  const fulfilled = settled.filter((r): r is PromiseFulfilledResult<L.HeatLatLngTuple[]> => r.status === 'fulfilled')
+  const coverageArea = openCellIdCoverageBboxAround(lat, lng)
+  const usesApiKey = apiKey.trim().length > 0
+  const tileHalfSideKm = usesApiKey
+    ? OPENCELLID_KEYED_TILE_HALF_SIDE_KM
+    : isElectron()
+    ? OPENCELLID_STANDALONE_TILE_HALF_SIDE_KM
+    : OPENCELLID_LITE_TILE_HALF_SIDE_KM
+  const tiles = tiledCoverageBboxes(coverageArea, lat, tileHalfSideKm)
+  const selectedTiles = usesApiKey
+    ? sortCoverageBboxesByDistance(center, tiles).slice(0, OPENCELLID_KEYED_FOREGROUND_TILE_COUNT)
+    : isElectron()
+    ? sortCoverageBboxesByDistance(center, tiles).slice(0, OPENCELLID_STANDALONE_FOREGROUND_TILE_COUNT)
+    : tiles
+  const tileFetcher = isElectron()
+    ? (bbox: CoverageBbox) => fetchOpenCellIdTileInElectron(bbox, apiKey)
+    : (bbox: CoverageBbox) => fetchOpenCellIdTile(bbox, apiKey, signal)
+  const settled = await mapWithConcurrency(selectedTiles, usesApiKey ? 4 : isElectron() ? 2 : 4, tileFetcher)
+  const fulfilled = settled.filter((r): r is PromiseFulfilledResult<OpenCellIdSite[]> => r.status === 'fulfilled')
   // If every tile failed, surface the first error so the operator gets a real diagnostic
   // (invalid key, network down, …) instead of a silent empty heatmap.
   if (fulfilled.length === 0) {
     const firstReject = settled.find((r): r is PromiseRejectedResult => r.status === 'rejected')
     if (firstReject) throw firstReject.reason
   }
-  return fulfilled.flatMap((r) => r.value)
+  const uniqueSites = new Map<string, OpenCellIdSite>()
+  for (const site of fulfilled.flatMap((r) => r.value)) {
+    const key = `${site.lat.toFixed(6)}:${site.lon.toFixed(6)}:${Math.round(site.rangeMeters)}`
+    if (!uniqueSites.has(key)) uniqueSites.set(key, site)
+  }
+  return {
+    sites: [...uniqueSites.values()],
+    fetchedBbox: unionCoverageBboxes(selectedTiles),
+  }
 }
 
 type OverpassResponse = {
-  elements?: Array<{ lat?: number; lon?: number; tags?: Record<string, string> }>
+  elements?: Array<{ id?: number; lat?: number; lon?: number; tags?: Record<string, string> }>
 }
 
-type OverpassTower = { lat: number; lon: number; operator: string | null }
+type OsmCoverageLabelSpec = {
+  id: string
+  center: WaypointCoordinates
+  rangeMeters: number
+  bearing: number | null
+  beamwidth: number
+  labelParts: string[]
+  color: string
+}
+
+const OSM_DEFAULT_RANGE_METERS = 1800
+const OSM_DEFAULT_DIRECTIONAL_BEAMWIDTH = 90
+const OSM_COVERAGE_FILL_OPACITY = 0.12
+const OSM_COVERAGE_STROKE_OPACITY = 0.75
+const OPENCELLID_RING_FILL_OPACITY = 0.08
+const OSM_LABEL_FONT_SIZE_PX = 10
+const OSM_LABEL_CHAR_WIDTH_PX = 5.7
+const OSM_LABEL_RIM_INSET = 0.92
+const OSM_TOP_ARC_START_DEG = 300
+const OSM_TOP_ARC_END_DEG = 60
+const OSM_OPERATOR_COLORS = ['#38BDF8', '#22C55E', '#A855F7', '#F59E0B', '#EF4444', '#14B8A6']
+
+const splitTagList = (value?: string): string[] =>
+  value
+    ?.split(/[;,]/)
+    .map((item) => item.trim())
+    .filter(Boolean) ?? []
+
+const parseTagNumber = (tags: Record<string, string>, ...keys: string[]): number | null => {
+  for (const key of keys) {
+    const value = tags[key]
+    if (!value) continue
+    const parsed = parseFloat(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return null
+}
+
+const pickTagValue = (tags: Record<string, string>, ...keys: string[]): string | null => {
+  for (const key of keys) {
+    const value = tags[key]?.trim()
+    if (value) return value
+  }
+  return null
+}
+
+const formatHeightLabel = (height: string): string => (/^[\d.]+$/.test(height) ? `${height}m` : height)
+
+const normalizeAngle = (angle: number): number => ((angle % 360) + 360) % 360
+
+const overpassTechnologies = (tags: Record<string, string>): string[] => {
+  const technologies = splitTagList(tags['technology:mobile_phone']).map((tech) => tech.toLowerCase())
+  const legacyCommunication = splitTagList(tags['communication:mobile_phone'])
+    .map((tech) => tech.toLowerCase())
+    .filter((tech) => tech !== 'yes')
+  return [...new Set([...technologies, ...legacyCommunication])]
+}
+
+const overpassTechnologyGenerations = (tags: Record<string, string>): string[] => {
+  const technologies = overpassTechnologies(tags)
+  const generations = technologies.flatMap((tech) => {
+    if (tech.includes('nr') || tech.includes('5g')) return ['5G']
+    if (tech.includes('lte')) return ['4G']
+    if (tech.includes('umts') || tech.includes('wcdma') || tech.includes('hspa') || tech.includes('hsupa'))
+      return ['3G']
+    if (tech.includes('gsm') || tech.includes('edge') || tech.includes('gprs')) return ['2G']
+    return []
+  })
+  return [...new Set(generations)]
+}
+
+const overpassTechnologyLabel = (tags: Record<string, string>): string | null => {
+  const generations = overpassTechnologyGenerations(tags)
+  if (generations.length > 0) return generations.join('/')
+  const technologies = overpassTechnologies(tags)
+  if (technologies.length === 0) return null
+  return technologies.map((tech) => tech.toUpperCase()).join('/')
+}
+
+const overpassRangeMeters = (tags: Record<string, string>): number => {
+  const technologies = overpassTechnologies(tags)
+  if (technologies.length === 0) return OSM_DEFAULT_RANGE_METERS
+  return Math.max(
+    ...technologies.map((tech) => {
+      if (tech.includes('nr') || tech.includes('5g')) return 1200
+      if (tech.includes('lte')) return 1800
+      if (tech.includes('umts')) return 2200
+      if (tech.includes('gsm')) return 2800
+      return OSM_DEFAULT_RANGE_METERS
+    })
+  )
+}
+
+const overpassBearing = (tags: Record<string, string>): number | null => {
+  const parsed = parseTagNumber(tags, 'communications_transponder:bearing', 'antenna:direction', 'direction', 'bearing')
+  return parsed === null ? null : normalizeAngle(parsed)
+}
+
+const overpassBeamwidth = (tags: Record<string, string>, bearing: number | null): number => {
+  const parsed = parseTagNumber(tags, 'beamwidth', 'antenna:beamwidth')
+  if (parsed !== null && parsed > 0 && parsed <= 360) return parsed
+  return bearing === null ? 360 : OSM_DEFAULT_DIRECTIONAL_BEAMWIDTH
+}
+
+const overpassLabelParts = (tower: OverpassTower): string[] => {
+  const parts = [tower.operator ?? 'Unknown operator']
+  const technologyLabel = overpassTechnologyLabel(tower.tags)
+  const manMade = pickTagValue(tower.tags, 'man_made')
+  const height = pickTagValue(tower.tags, 'height')
+
+  if (technologyLabel) parts.push(technologyLabel)
+  if (manMade) parts.push(manMade)
+  if (height) parts.push(formatHeightLabel(height))
+  return parts
+}
+
+const fitLabelToArc = (parts: string[], maxWidthPx: number): string => {
+  for (let count = parts.length; count > 0; count--) {
+    const candidate = parts.slice(0, count).join(' - ')
+    if (candidate.length * OSM_LABEL_CHAR_WIDTH_PX <= maxWidthPx) return candidate
+  }
+  const fallback = parts[0]
+  const maxChars = Math.max(8, Math.floor(maxWidthPx / OSM_LABEL_CHAR_WIDTH_PX) - 1)
+  return fallback.length > maxChars ? `${fallback.slice(0, maxChars)}…` : fallback
+}
+
+const openCellIdOperatorLabel = (site: OpenCellIdSite): string | null => {
+  if (site.mcc === undefined || site.mnc === undefined) return null
+  return `MCC ${site.mcc} / MNC ${site.mnc}`
+}
+
+const openCellIdLabelParts = (site: OpenCellIdSite): string[] => {
+  const parts: string[] = []
+  const operator = openCellIdOperatorLabel(site)
+  if (operator) parts.push(operator)
+  if (site.radio) parts.push(site.radio.toUpperCase())
+  parts.push(`${Math.round(site.rangeMeters)}m`)
+  if (site.cellId !== undefined) parts.push(`CID ${site.cellId}`)
+  return parts
+}
+
+const filterOpenCellIdSites = (sites: OpenCellIdSite[], selectedOperator: string): OpenCellIdSite[] => {
+  if (!selectedOperator) return sites
+  return sites.filter((site) => openCellIdOperatorLabel(site) === selectedOperator)
+}
+
+const operatorColor = (operator: string | null): string => {
+  if (!operator) return OSM_OPERATOR_COLORS[0]
+  const hash = [...operator].reduce((acc, char) => acc + char.charCodeAt(0), 0)
+  return OSM_OPERATOR_COLORS[hash % OSM_OPERATOR_COLORS.length]
+}
 
 const fetchOverpassTowers = async (bbox: CoverageBbox, signal: AbortSignal): Promise<OverpassTower[]> => {
   const region = `(${bbox.south},${bbox.west},${bbox.north},${bbox.east})`
   const query =
     `[out:json][timeout:25];` +
-    `(node["man_made"="communications_tower"]${region};` +
-    `node["tower:type"="communication"]${region};);` +
-    // `out body` (= `out;`) is required to keep node lat/lon. `out tags;` drops coords.
+    // Limit the overlay to mobile-phone infrastructure so the map reflects cellular coverage
+    // rather than every generic communications site in the area.
+    `(node["communication:mobile_phone"]${region};` +
+    `node["technology:mobile_phone"]${region};);` +
     `out body;`
   const res = await fetch('https://overpass-api.de/api/interpreter', {
     method: 'POST',
@@ -204,40 +490,191 @@ const fetchOverpassTowers = async (bbox: CoverageBbox, signal: AbortSignal): Pro
   })
   if (!res.ok) throw new Error(`Overpass HTTP ${res.status}`)
   const data = (await res.json()) as OverpassResponse
+  const seenIds = new Set<number>()
   return (data.elements ?? [])
     .filter(
-      (e): e is { lat: number; lon: number; tags?: Record<string, string> } =>
-        typeof e.lat === 'number' && typeof e.lon === 'number'
+      (e): e is { id: number; lat: number; lon: number; tags?: Record<string, string> } =>
+        typeof e.id === 'number' && typeof e.lat === 'number' && typeof e.lon === 'number'
     )
-    .map<OverpassTower>((e) => ({ lat: e.lat, lon: e.lon, operator: e.tags?.operator?.trim() || null }))
+    .filter((e) => {
+      if (seenIds.has(e.id)) return false
+      seenIds.add(e.id)
+      return true
+    })
+    .map<OverpassTower>((e) => ({
+      id: e.id,
+      lat: e.lat,
+      lon: e.lon,
+      operator: e.tags?.operator?.trim() || null,
+      tags: e.tags ?? {},
+    }))
 }
 
-// Real cellular sites have ~1-3 km of usable urban coverage; pick a middle value and let the
-// heatmap pixel radius track this in real meters as the operator zooms in/out.
-const HEAT_COVERAGE_METERS = 1500
-const HEAT_RADIUS_MIN_PX = 30
-const HEAT_RADIUS_MAX_PX = 140
-// Equator meters-per-pixel at zoom 0. Halves with each zoom level; multiplied by cos(lat) to
-// account for the Mercator projection narrowing toward the poles.
-const METERS_PER_PIXEL_AT_Z0 = 156543.03392
-
-type HeatRadius = { radius: number; blur: number }
-type BaseStationOverlayApi = { openConfigPanel: () => void }
 /* eslint-enable jsdoc/require-jsdoc */
 
-const heatRadiusForMap = (mapInstance: L.Map): HeatRadius => {
-  const center = mapInstance.getCenter()
-  const metersPerPixel = (METERS_PER_PIXEL_AT_Z0 * Math.cos((center.lat * Math.PI) / 180)) / 2 ** mapInstance.getZoom()
-  const ideal = HEAT_COVERAGE_METERS / metersPerPixel
-  const radius = Math.max(HEAT_RADIUS_MIN_PX, Math.min(HEAT_RADIUS_MAX_PX, ideal))
-  return { radius, blur: radius * 0.6 }
+// Slider 0% → blob radius is 5% of the cell range, slider 100% → full range. Linear blend
+// between the two so the slider has visible effect at every zoom level.
+const OPENCELLID_HEATMAP_MIN_RADIUS_FRACTION = 0.05
+// Per-cell peak alpha contributed at the gradient center. Two cells overlapping at full alpha
+// reach 1.0 thanks to the `lighter` compositing — this is what surfaces the warm hotspot tail
+// of the gradient when several towers cover the same patch.
+const OPENCELLID_HEATMAP_PEAK_ALPHA = 0.55
+// Cool-to-warm gradient stops mapped from per-pixel density (0..1). A single cell tops out
+// around mid-gradient (cyan/green); two cells overlapping bleed into yellow; three or more
+// reach the red hotspot range.
+const OPENCELLID_HEATMAP_GRADIENT_STOPS: ReadonlyArray<readonly [number, string]> = [
+  [0.0, 'rgba(0, 0, 255, 0)'],
+  [0.05, 'rgba(0, 80, 255, 0.4)'],
+  [0.2, 'rgba(0, 140, 255, 0.65)'],
+  [0.4, 'rgba(0, 230, 220, 0.8)'],
+  [0.6, 'rgba(60, 220, 80, 0.85)'],
+  [0.8, 'rgba(255, 220, 0, 0.9)'],
+  [1.0, 'rgba(255, 40, 0, 0.95)'],
+]
+const EARTH_CIRCUMFERENCE_M = 40075016.686
+const TILE_SIZE_PX = 256
+
+/* eslint-disable jsdoc/require-jsdoc -- helper return shapes; their property names are self-describing. */
+type BaseStationOverlayApi = { openConfigPanel: () => void }
+type HeatmapSite = { lat: number; lon: number; rangeMeters: number }
+type CellIdHeatLayerOptions = { sites: HeatmapSite[]; radiusFraction: number; opacity: number }
+type CellIdHeatLayerInstance = L.Layer
+/* eslint-enable jsdoc/require-jsdoc */
+
+let cachedHeatGradientLut: Uint8ClampedArray | null = null
+const heatmapGradientLut = (): Uint8ClampedArray => {
+  if (cachedHeatGradientLut) return cachedHeatGradientLut
+  const lutCanvas = document.createElement('canvas')
+  lutCanvas.width = 1
+  lutCanvas.height = 256
+  const ctx = lutCanvas.getContext('2d')
+  if (!ctx) throw new Error('Heatmap LUT: 2D canvas context unavailable')
+  const grad = ctx.createLinearGradient(0, 0, 0, 256)
+  OPENCELLID_HEATMAP_GRADIENT_STOPS.forEach(([stop, color]) => grad.addColorStop(stop, color))
+  ctx.fillStyle = grad
+  ctx.fillRect(0, 0, 1, 256)
+  cachedHeatGradientLut = ctx.getImageData(0, 0, 1, 256).data
+  return cachedHeatGradientLut
 }
 
-const baseStationMarkerHtml = (label: string): string => `
+const metersPerPixelAt = (mapInstance: L.Map, lat: number): number => {
+  const pixelsAcrossEquator = TILE_SIZE_PX * 2 ** mapInstance.getZoom()
+  return (EARTH_CIRCUMFERENCE_M * Math.cos((lat * Math.PI) / 180)) / pixelsAcrossEquator
+}
+
+// Custom Leaflet layer that renders the OpenCellID heatmap on a single canvas, with cumulative
+// alpha → cool-to-warm color mapping. Built to replace the (uninstalled) `leaflet.heat` plugin
+// so we can keep per-cell radius, eliminate canvas-edge clipping, and apply layer opacity once
+// without it bleeding into the color ramp.
+const CellIdHeatLayer = L.Layer.extend({
+  /* eslint-disable jsdoc/require-jsdoc -- Leaflet layer prototype methods, not exported API. */
+  initialize(this: CellIdHeatLayerInternal, options: CellIdHeatLayerOptions) {
+    this._heatOptions = { ...options }
+  },
+  onAdd(this: CellIdHeatLayerInternal, mapInstance: L.Map) {
+    this._map = mapInstance
+    const canvas = L.DomUtil.create('canvas', 'leaflet-cellid-heat-layer leaflet-zoom-hide')
+    canvas.style.position = 'absolute'
+    canvas.style.pointerEvents = 'none'
+    canvas.style.opacity = String(this._heatOptions.opacity)
+    this._canvas = canvas
+    mapInstance.getPanes().overlayPane.appendChild(canvas)
+    mapInstance.on('moveend resize viewreset zoomend', this._reset, this)
+    this._reset()
+    return this
+  },
+  onRemove(this: CellIdHeatLayerInternal, mapInstance: L.Map) {
+    mapInstance.getPanes().overlayPane.removeChild(this._canvas!)
+    mapInstance.off('moveend resize viewreset zoomend', this._reset, this)
+    this._canvas = undefined
+    this._map = undefined
+    return this
+  },
+  _reset(this: CellIdHeatLayerInternal) {
+    if (!this._map || !this._canvas) return
+    const topLeft = this._map.containerPointToLayerPoint([0, 0])
+    L.DomUtil.setPosition(this._canvas, topLeft)
+    const size = this._map.getSize()
+    if (this._canvas.width !== size.x) this._canvas.width = size.x
+    if (this._canvas.height !== size.y) this._canvas.height = size.y
+    this._redraw()
+  },
+  _redraw(this: CellIdHeatLayerInternal) {
+    if (!this._map || !this._canvas) return
+    const ctx = this._canvas.getContext('2d')
+    if (!ctx) return
+    const size = this._map.getSize()
+    ctx.clearRect(0, 0, size.x, size.y)
+    if (this._heatOptions.sites.length === 0) return
+    // Stage 1: accumulate per-cell radial gradients on the alpha channel. Using `lighter`
+    // makes overlapping cells brighten cumulatively → density per pixel.
+    ctx.globalCompositeOperation = 'lighter'
+    const mpp = metersPerPixelAt(this._map, this._map.getCenter().lat)
+    this._heatOptions.sites.forEach((site) => {
+      const center = this._map!.latLngToContainerPoint([site.lat, site.lon])
+      const radiusPx = Math.max(2, (site.rangeMeters * this._heatOptions.radiusFraction) / mpp)
+      if (
+        center.x + radiusPx < 0 ||
+        center.x - radiusPx > size.x ||
+        center.y + radiusPx < 0 ||
+        center.y - radiusPx > size.y
+      ) {
+        return
+      }
+      const radial = ctx.createRadialGradient(center.x, center.y, 0, center.x, center.y, radiusPx)
+      radial.addColorStop(0, `rgba(255,255,255,${OPENCELLID_HEATMAP_PEAK_ALPHA})`)
+      radial.addColorStop(1, 'rgba(255,255,255,0)')
+      ctx.fillStyle = radial
+      ctx.fillRect(center.x - radiusPx, center.y - radiusPx, 2 * radiusPx, 2 * radiusPx)
+    })
+    // Stage 2: remap each pixel's alpha through the cool→warm gradient LUT so density turns
+    // into color. The LUT also dictates the final pixel alpha so the natural radial fade is
+    // preserved while hotspots get punchier.
+    const lut = heatmapGradientLut()
+    const img = ctx.getImageData(0, 0, size.x, size.y)
+    const data = img.data
+    for (let i = 0; i < data.length; i += 4) {
+      const a = data[i + 3]
+      if (a === 0) continue
+      const lutIdx = a * 4
+      data[i] = lut[lutIdx]
+      data[i + 1] = lut[lutIdx + 1]
+      data[i + 2] = lut[lutIdx + 2]
+      data[i + 3] = lut[lutIdx + 3]
+    }
+    ctx.putImageData(img, 0, 0)
+  },
+  /* eslint-enable jsdoc/require-jsdoc */
+})
+
+/* eslint-disable jsdoc/require-jsdoc -- internal layer fields, kept private to this module. */
+type CellIdHeatLayerInternal = L.Layer & {
+  _map?: L.Map
+  _canvas?: HTMLCanvasElement
+  _heatOptions: CellIdHeatLayerOptions
+  _reset: () => void
+  _redraw: () => void
+}
+/* eslint-enable jsdoc/require-jsdoc */
+
+const createCellIdHeatLayer = (options: CellIdHeatLayerOptions): CellIdHeatLayerInstance => {
+  const Ctor = CellIdHeatLayer as unknown as new (opts: CellIdHeatLayerOptions) => CellIdHeatLayerInstance
+  return new Ctor(options)
+}
+
+const escapeMarkerLabel = (label: string): string =>
+  label
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
+
+const baseStationMarkerHtml = (label: string, color: string): string => `
   <div class="base-station-marker-container">
-    <div class="base-station-marker-background"></div>
+    <div class="base-station-marker-background" style="background-color: ${color.slice(0, 7)}cc"></div>
     <i class="v-icon notranslate mdi mdi-radio-tower" style="color: white; position: relative; z-index: 2; font-size: 16px;"></i>
-    <div class="base-station-marker-label">${label}</div>
+    ${label ? `<div class="base-station-marker-label">${escapeMarkerLabel(label)}</div>` : ''}
   </div>
 `
 
@@ -262,23 +699,292 @@ export const useBaseStationOverlay = (
   const bearingLine = shallowRef<L.Polyline | undefined>()
   const aimingArc = shallowRef<L.Polyline | undefined>()
   const mobileCoverageLayer = shallowRef<L.Layer | undefined>()
+  const cachedOpenCellIdSites = shallowRef<OpenCellIdSite[] | null>(null)
+  const cachedOverpassTowers = shallowRef<OverpassTower[] | null>(null)
 
   let mobileCoverageController: AbortController | null = null
+  let mobileCoverageTargetToolController: AbortController | null = null
   let mobileCoverageDebounce: ReturnType<typeof setTimeout> | null = null
-  let heatZoomCleanup: (() => void) | null = null
+  let detachMapDropHandlers: (() => void) | null = null
+  let detachTargetToolHandlers: (() => void) | null = null
+  let osmLabelOverlayEl: HTMLDivElement | null = null
+  let osmLabelSvgEl: SVGSVGElement | null = null
+  let osmLabelCleanup: (() => void) | null = null
+  let lastMarkerLabel: string | null = null
+  let lastMarkerColor: string | null = null
 
   const openConfigPanel = (): void => {
     store.configPanelOpen = true
+  }
+
+  const attachMapDropHandlers = (): void => {
+    if (!map.value) return
+    detachMapDropHandlers?.()
+    const container = map.value.getContainer()
+    const onDragOver = (event: DragEvent): void => {
+      if (!event.dataTransfer?.types.includes(MOBILE_COVERAGE_FETCH_DROP_MIME)) return
+      event.preventDefault()
+      event.dataTransfer.dropEffect = 'copy'
+    }
+    const onDrop = (event: DragEvent): void => {
+      if (!event.dataTransfer?.types.includes(MOBILE_COVERAGE_FETCH_DROP_MIME) || !map.value) return
+      event.preventDefault()
+      const rect = container.getBoundingClientRect()
+      const point = L.point(event.clientX - rect.left, event.clientY - rect.top)
+      const latLng = map.value.containerPointToLatLng(point)
+      void fetchAndAppendMobileCoverage([latLng.lat, latLng.lng])
+    }
+    container.addEventListener('dragover', onDragOver)
+    container.addEventListener('drop', onDrop)
+    detachMapDropHandlers = () => {
+      container.removeEventListener('dragover', onDragOver)
+      container.removeEventListener('drop', onDrop)
+      detachMapDropHandlers = null
+    }
+  }
+
+  // SVG-as-cursor: mdi-crosshairs-gps glyph on a transparent canvas so the cursor visually
+  // matches the toolbar icon while the operator is picking a point.
+  const TARGET_CURSOR_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="white" stroke="black" stroke-width="0.5" d="M12,8A4,4 0 0,0 8,12A4,4 0 0,0 12,16A4,4 0 0,0 16,12A4,4 0 0,0 12,8M3.05,13H1V11H3.05C3.5,6.83 6.83,3.5 11,3.05V1H13V3.05C17.17,3.5 20.5,6.83 20.95,11H23V13H20.95C20.5,17.17 17.17,20.5 13,20.95V23H11V20.95C6.83,20.5 3.5,17.17 3.05,13M12,5A7,7 0 0,0 5,12A7,7 0 0,0 12,19A7,7 0 0,0 19,12A7,7 0 0,0 12,5Z"/></svg>`
+  const TARGET_CURSOR_URL = `url('data:image/svg+xml;utf8,${encodeURIComponent(TARGET_CURSOR_SVG)}') 12 12, crosshair`
+
+  const attachTargetToolHandlers = (): void => {
+    if (!map.value) return
+    detachTargetToolHandlers?.()
+    const container = map.value.getContainer()
+    const previousCursor = container.style.cursor
+    container.style.cursor = TARGET_CURSOR_URL
+    const onMapClick = (event: L.LeafletMouseEvent): void => {
+      store.mobileCoverageTargetToolActive = false
+      void fetchAndAppendMobileCoverage([event.latlng.lat, event.latlng.lng])
+    }
+    map.value.on('click', onMapClick)
+    detachTargetToolHandlers = () => {
+      container.style.cursor = previousCursor
+      map.value?.off('click', onMapClick)
+      detachTargetToolHandlers = null
+    }
   }
 
   const removeLayer = (layer: L.Layer | undefined): void => {
     if (layer && map.value) map.value.removeLayer(layer)
   }
 
-  const buildMarkerIcon = (): L.DivIcon =>
+  const clearLoadedMobileCoverageData = (): void => {
+    cachedOpenCellIdSites.value = null
+    cachedOverpassTowers.value = null
+    store.availableOsmOperators = []
+    store.availableOpenCellIdOperators = []
+    store.config.mobileCoverage.openCellIdOperator = ''
+  }
+
+  const openCellIdEntryForPosition = (
+    position: WaypointCoordinates
+  ): CachedMobileCoverageEntry<OpenCellIdSite> | undefined =>
+    store.mobileCoverageCache.openCellId.find((entry) => bboxContains(entry.bbox, position))
+
+  const overpassEntryForPosition = (
+    position: WaypointCoordinates
+  ): CachedMobileCoverageEntry<OverpassTower> | undefined =>
+    store.mobileCoverageCache.osmOverpass.find((entry) => bboxContains(entry.bbox, position))
+
+  const loadOpenCellIdSitesFromStorage = (position: WaypointCoordinates): boolean => {
+    // Drop empty entries that cover this position — leftover from rate-limited fetches that
+    // returned 0 sites (was previously the H1 bug where empty caches blocked re-fetching).
+    const positionalEntry = openCellIdEntryForPosition(position)
+    if (positionalEntry && positionalEntry.data.length === 0) {
+      store.mobileCoverageCache.openCellId = store.mobileCoverageCache.openCellId.filter(
+        (cachedEntry) => !bboxEquals(cachedEntry.bbox, positionalEntry.bbox)
+      )
+    }
+    // Union *every* cached entry so drag-target appends — whose bboxes don't necessarily
+    // contain the base station — still light up after a restart.
+    const merged = store.mobileCoverageCache.openCellId.reduce<OpenCellIdSite[] | null>(
+      (acc, entry) => mergeOpenCellIdSites(acc, entry.data),
+      null
+    )
+    cachedOpenCellIdSites.value = merged && merged.length > 0 ? merged : null
+    const operators = merged
+      ? [
+          ...new Set(merged.map((site) => openCellIdOperatorLabel(site)).filter((label): label is string => !!label)),
+        ].sort()
+      : []
+    store.availableOpenCellIdOperators = operators
+    if (
+      store.config.mobileCoverage.openCellIdOperator &&
+      !operators.includes(store.config.mobileCoverage.openCellIdOperator)
+    ) {
+      store.config.mobileCoverage.openCellIdOperator = ''
+    }
+    // Return the positional check so `fetchMobileCoverageData` only skips the fetch when the
+    // base station itself is already covered, regardless of how much side data we have.
+    return openCellIdEntryForPosition(position) !== undefined
+  }
+
+  const loadOverpassTowersFromStorage = (position: WaypointCoordinates): boolean => {
+    const merged = store.mobileCoverageCache.osmOverpass.reduce<OverpassTower[] | null>(
+      (acc, entry) => mergeOverpassTowers(acc, entry.data),
+      null
+    )
+    cachedOverpassTowers.value = merged && merged.length > 0 ? merged : null
+    store.availableOsmOperators = merged
+      ? [...new Set(merged.map((tower) => tower.operator).filter((operator): operator is string => !!operator))].sort()
+      : []
+    return overpassEntryForPosition(position) !== undefined
+  }
+
+  const resetVisibleMobileCoverageData = async (): Promise<void> => {
+    if (!map.value) return
+    mobileCoverageController?.abort()
+    mobileCoverageController = null
+    if (mobileCoverageDebounce) {
+      clearTimeout(mobileCoverageDebounce)
+      mobileCoverageDebounce = null
+    }
+    const visibleArea = leafletBoundsToCoverageBbox(map.value.getBounds())
+    const openCellIdBefore = store.mobileCoverageCache.openCellId.length
+    const overpassBefore = store.mobileCoverageCache.osmOverpass.length
+    store.mobileCoverageCache.openCellId = store.mobileCoverageCache.openCellId.filter(
+      (entry) => !bboxIntersects(entry.bbox, visibleArea)
+    )
+    store.mobileCoverageCache.osmOverpass = store.mobileCoverageCache.osmOverpass.filter(
+      (entry) => !bboxIntersects(entry.bbox, visibleArea)
+    )
+    const removedEntries =
+      openCellIdBefore -
+      store.mobileCoverageCache.openCellId.length +
+      (overpassBefore - store.mobileCoverageCache.osmOverpass.length)
+    clearLoadedMobileCoverageData()
+    if (store.config.position) {
+      if (store.config.mobileCoverage.provider === MobileCoverageProvider.OpenCellID) {
+        loadOpenCellIdSitesFromStorage(store.config.position)
+      } else if (store.config.mobileCoverage.provider === MobileCoverageProvider.OSMOverpass) {
+        loadOverpassTowersFromStorage(store.config.position)
+      }
+    }
+    teardownMobileCoverageData()
+    await renderMobileCoverage(store.config)
+    openSnackbar({
+      variant: 'info',
+      message:
+        removedEntries > 0
+          ? `Reset ${removedEntries} cached mobile coverage area${removedEntries === 1 ? '' : 's'} in view.`
+          : 'No cached mobile coverage data was stored for the current view.',
+      duration: 3000,
+    })
+  }
+
+  const storeOpenCellIdSites = (bbox: CoverageBbox, sites: OpenCellIdSite[]): void => {
+    cachedOpenCellIdSites.value = sites
+    const operators = [
+      ...new Set(sites.map((site) => openCellIdOperatorLabel(site)).filter((label): label is string => !!label)),
+    ].sort()
+    store.availableOpenCellIdOperators = operators
+    if (
+      store.config.mobileCoverage.openCellIdOperator &&
+      !operators.includes(store.config.mobileCoverage.openCellIdOperator)
+    ) {
+      store.config.mobileCoverage.openCellIdOperator = ''
+    }
+    if (sites.length === 0) {
+      store.mobileCoverageCache.openCellId = store.mobileCoverageCache.openCellId.filter(
+        (entry) => !bboxEquals(entry.bbox, bbox)
+      )
+      return
+    }
+    store.mobileCoverageCache.openCellId = trimCacheEntries([
+      {
+        bbox,
+        fetchedAtMs: Date.now(),
+        data: sites,
+      },
+      ...store.mobileCoverageCache.openCellId.filter((entry) => !bboxEquals(entry.bbox, bbox)),
+    ])
+  }
+
+  const storeOverpassTowers = (bbox: CoverageBbox, towers: OverpassTower[]): void => {
+    cachedOverpassTowers.value = towers
+    store.availableOsmOperators = [
+      ...new Set(towers.map((tower) => tower.operator).filter((operator): operator is string => !!operator)),
+    ].sort()
+    store.mobileCoverageCache.osmOverpass = trimCacheEntries([
+      {
+        bbox,
+        fetchedAtMs: Date.now(),
+        data: towers,
+      },
+      ...store.mobileCoverageCache.osmOverpass.filter((entry) => !bboxEquals(entry.bbox, bbox)),
+    ])
+  }
+
+  const mergeOpenCellIdSites = (existing: OpenCellIdSite[] | null, incoming: OpenCellIdSite[]): OpenCellIdSite[] => {
+    const merged = new Map<string, OpenCellIdSite>()
+    ;[...(existing ?? []), ...incoming].forEach((site) => {
+      const key = `${site.lat.toFixed(6)}:${site.lon.toFixed(6)}:${Math.round(site.rangeMeters)}`
+      merged.set(key, site)
+    })
+    return [...merged.values()]
+  }
+
+  const mergeOverpassTowers = (existing: OverpassTower[] | null, incoming: OverpassTower[]): OverpassTower[] => {
+    const merged = new Map<number, OverpassTower>()
+    ;[...(existing ?? []), ...incoming].forEach((tower) => {
+      merged.set(tower.id, tower)
+    })
+    return [...merged.values()]
+  }
+
+  const appendOpenCellIdSites = (bbox: CoverageBbox, sites: OpenCellIdSite[]): void => {
+    const entry = store.mobileCoverageCache.openCellId.find((cachedEntry) => bboxEquals(cachedEntry.bbox, bbox))
+    const mergedEntrySites = mergeOpenCellIdSites(entry?.data ?? null, sites)
+    const mergedLoadedSites = mergeOpenCellIdSites(cachedOpenCellIdSites.value, sites)
+    cachedOpenCellIdSites.value = mergedLoadedSites
+    const operators = [
+      ...new Set(
+        mergedLoadedSites.map((site) => openCellIdOperatorLabel(site)).filter((label): label is string => !!label)
+      ),
+    ].sort()
+    store.availableOpenCellIdOperators = operators
+    if (
+      store.config.mobileCoverage.openCellIdOperator &&
+      !operators.includes(store.config.mobileCoverage.openCellIdOperator)
+    ) {
+      store.config.mobileCoverage.openCellIdOperator = ''
+    }
+    store.mobileCoverageCache.openCellId = trimCacheEntries([
+      {
+        bbox,
+        fetchedAtMs: Date.now(),
+        data: mergedEntrySites,
+      },
+      ...store.mobileCoverageCache.openCellId.filter((cachedEntry) => !bboxEquals(cachedEntry.bbox, bbox)),
+    ])
+  }
+
+  const appendOverpassTowers = (bbox: CoverageBbox, towers: OverpassTower[]): void => {
+    const entry = store.mobileCoverageCache.osmOverpass.find((cachedEntry) => bboxEquals(cachedEntry.bbox, bbox))
+    const mergedEntryTowers = mergeOverpassTowers(entry?.data ?? null, towers)
+    const mergedLoadedTowers = mergeOverpassTowers(cachedOverpassTowers.value, towers)
+    cachedOverpassTowers.value = mergedLoadedTowers
+    store.availableOsmOperators = [
+      ...new Set(
+        mergedLoadedTowers.map((tower) => tower.operator).filter((operator): operator is string => !!operator)
+      ),
+    ].sort()
+    store.mobileCoverageCache.osmOverpass = trimCacheEntries([
+      {
+        bbox,
+        fetchedAtMs: Date.now(),
+        data: mergedEntryTowers,
+      },
+      ...store.mobileCoverageCache.osmOverpass.filter((cachedEntry) => !bboxEquals(cachedEntry.bbox, bbox)),
+    ])
+  }
+
+  const buildMarkerIcon = (label: string, color: string): L.DivIcon =>
     L.divIcon({
       className: 'base-station-marker-icon',
-      html: baseStationMarkerHtml('Base'),
+      html: baseStationMarkerHtml(label, color),
       iconSize: [24, 24],
       iconAnchor: [12, 12],
     })
@@ -293,18 +999,27 @@ export const useBaseStationOverlay = (
 
   const ensureMarker = (config: BaseStationConfig): void => {
     if (!map.value || !config.position) return
+    const markerLabel = config.name.trim()
     if (marker.value) {
       marker.value.setLatLng(config.position)
-      applyMarkerColor(config.coverageColor)
+      // setIcon during a drag rebuilds the DOM element Leaflet is tracking and stops the drag
+      // after the first few pixels, so only rebuild when the icon definition actually changed.
+      if (markerLabel !== lastMarkerLabel || config.coverageColor !== lastMarkerColor) {
+        marker.value.setIcon(buildMarkerIcon(markerLabel, config.coverageColor))
+        lastMarkerLabel = markerLabel
+        lastMarkerColor = config.coverageColor
+      }
       return
     }
     const m = L.marker(config.position, {
-      icon: buildMarkerIcon(),
+      icon: buildMarkerIcon(markerLabel, config.coverageColor),
       draggable: true,
       zIndexOffset: 600,
       // The marker owns its own right-click popup; don't propagate to the map context menu.
       bubblingMouseEvents: false,
     })
+    lastMarkerLabel = markerLabel
+    lastMarkerColor = config.coverageColor
     m.on('drag', (event: L.LeafletEvent) => {
       const target = event.target as L.Marker
       const { lat, lng } = target.getLatLng()
@@ -318,17 +1033,152 @@ export const useBaseStationOverlay = (
     })
     m.addTo(map.value)
     marker.value = m
-    applyMarkerColor(config.coverageColor)
   }
 
-  // Marker stays fully visible regardless of the opacity slider — only the coverage and
-  // bearing/arc dotted lines fade with `coverageOpacity`. The trailing `cc` keeps the
-  // marker's original 80% fill so the icon underneath stays legible against the map.
-  const applyMarkerColor = (color: string): void => {
-    const el = marker.value?.getElement()
-    if (!el) return
-    const bg = el.querySelector('.base-station-marker-background') as HTMLElement | null
-    if (bg) bg.style.backgroundColor = `${color.slice(0, 7)}cc`
+  const ensureOsmLabelOverlay = (): void => {
+    if (!map.value || osmLabelOverlayEl) return
+    const container = map.value.getContainer()
+    osmLabelOverlayEl = document.createElement('div')
+    osmLabelOverlayEl.style.position = 'absolute'
+    osmLabelOverlayEl.style.top = '0'
+    osmLabelOverlayEl.style.left = '0'
+    osmLabelOverlayEl.style.width = '100%'
+    osmLabelOverlayEl.style.height = '100%'
+    osmLabelOverlayEl.style.pointerEvents = 'none'
+    osmLabelOverlayEl.style.zIndex = '620'
+
+    osmLabelSvgEl = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    osmLabelSvgEl.setAttribute('width', '100%')
+    osmLabelSvgEl.setAttribute('height', '100%')
+    osmLabelSvgEl.style.position = 'absolute'
+    osmLabelSvgEl.style.top = '0'
+    osmLabelSvgEl.style.left = '0'
+
+    osmLabelOverlayEl.appendChild(osmLabelSvgEl)
+    container.appendChild(osmLabelOverlayEl)
+  }
+
+  const teardownOsmLabelOverlay = (): void => {
+    if (osmLabelCleanup) {
+      osmLabelCleanup()
+      osmLabelCleanup = null
+    }
+    if (osmLabelOverlayEl) {
+      osmLabelOverlayEl.remove()
+      osmLabelOverlayEl = null
+    }
+    osmLabelSvgEl = null
+  }
+
+  const pointOnArc = (center: L.Point, radiusPx: number, angleDeg: number): L.Point => {
+    const radians = ((angleDeg - 90) * Math.PI) / 180
+    return L.point(center.x + radiusPx * Math.cos(radians), center.y + radiusPx * Math.sin(radians))
+  }
+
+  const svgArcPath = (center: L.Point, radiusPx: number, startDeg: number, endDeg: number): string => {
+    let normalizedEnd = endDeg
+    while (normalizedEnd <= startDeg) normalizedEnd += 360
+    const start = pointOnArc(center, radiusPx, startDeg)
+    const end = pointOnArc(center, radiusPx, normalizedEnd)
+    const largeArc = normalizedEnd - startDeg > 180 ? 1 : 0
+    return `M ${start.x.toFixed(1)} ${start.y.toFixed(1)} A ${radiusPx.toFixed(1)} ${radiusPx.toFixed(
+      1
+    )} 0 ${largeArc} 1 ${end.x.toFixed(1)} ${end.y.toFixed(1)}`
+  }
+
+  const renderOsmCoverageLabels = (labels: OsmCoverageLabelSpec[]): void => {
+    if (!map.value || labels.length === 0) {
+      teardownOsmLabelOverlay()
+      return
+    }
+    ensureOsmLabelOverlay()
+    if (!osmLabelSvgEl) return
+    osmLabelSvgEl.replaceChildren()
+
+    labels.forEach((labelSpec) => {
+      const center = labelSpec.center
+      const centerPoint = map.value!.latLngToContainerPoint(center)
+      const radiusPoint = map.value!.latLngToContainerPoint(bearingHandlePosition(center, labelSpec.rangeMeters, 90))
+      const radiusPx = centerPoint.distanceTo(radiusPoint) * OSM_LABEL_RIM_INSET
+      if (radiusPx < 24) return
+
+      const pathStart =
+        labelSpec.bearing === null
+          ? OSM_TOP_ARC_START_DEG
+          : labelSpec.bearing - labelSpec.beamwidth / 2 + Math.min(8, labelSpec.beamwidth * 0.15)
+      const pathEnd =
+        labelSpec.bearing === null
+          ? OSM_TOP_ARC_END_DEG
+          : labelSpec.bearing + labelSpec.beamwidth / 2 - Math.min(8, labelSpec.beamwidth * 0.15)
+      const angleSpan =
+        labelSpec.bearing === null ? 120 : Math.max(24, labelSpec.beamwidth - Math.min(16, labelSpec.beamwidth * 0.3))
+      const maxWidthPx = radiusPx * ((angleSpan * Math.PI) / 180)
+      const text = fitLabelToArc(labelSpec.labelParts, maxWidthPx)
+
+      const path = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+      path.setAttribute('id', labelSpec.id)
+      path.setAttribute('d', svgArcPath(centerPoint, radiusPx, pathStart, pathEnd))
+      path.setAttribute('fill', 'none')
+      path.setAttribute('stroke', 'none')
+
+      const textEl = document.createElementNS('http://www.w3.org/2000/svg', 'text')
+      textEl.setAttribute('font-size', `${OSM_LABEL_FONT_SIZE_PX}`)
+      textEl.setAttribute('font-family', 'sans-serif')
+      textEl.setAttribute('fill', labelSpec.color)
+      textEl.setAttribute('fill-opacity', `${store.config.mobileCoverage.overlayOpacity}`)
+      textEl.setAttribute('stroke', 'rgba(0, 0, 0, 0.55)')
+      textEl.setAttribute('stroke-width', '2')
+      textEl.setAttribute('stroke-opacity', `${Math.max(0.35, store.config.mobileCoverage.overlayOpacity)}`)
+      textEl.setAttribute('paint-order', 'stroke')
+      textEl.setAttribute('letter-spacing', '0.2')
+
+      const textPath = document.createElementNS('http://www.w3.org/2000/svg', 'textPath')
+      textPath.setAttributeNS('http://www.w3.org/1999/xlink', 'href', `#${labelSpec.id}`)
+      textPath.setAttribute('href', `#${labelSpec.id}`)
+      textPath.setAttribute('startOffset', '50%')
+      textPath.setAttribute('text-anchor', 'middle')
+      textPath.textContent = text
+
+      textEl.appendChild(textPath)
+      osmLabelSvgEl.appendChild(path)
+      osmLabelSvgEl.appendChild(textEl)
+    })
+  }
+
+  const renderOpenCellIdCoverageRings = (sites: OpenCellIdSite[], config: BaseStationConfig): void => {
+    if (!map.value) return
+    const filteredSites = filterOpenCellIdSites(sites, config.mobileCoverage.openCellIdOperator)
+    if (filteredSites.length === 0) return
+    const group = L.layerGroup()
+    const labels: OsmCoverageLabelSpec[] = []
+    filteredSites.forEach((site, index) => {
+      L.circle([site.lat, site.lon], {
+        radius: site.rangeMeters,
+        color: config.coverageColor,
+        weight: 1,
+        dashArray: '5 5',
+        opacity: config.mobileCoverage.overlayOpacity,
+        fillColor: config.coverageColor,
+        fillOpacity: OPENCELLID_RING_FILL_OPACITY * config.mobileCoverage.overlayOpacity,
+        interactive: false,
+      }).addTo(group)
+      labels.push({
+        id: `open-cell-id-label-${index}`,
+        center: [site.lat, site.lon],
+        rangeMeters: site.rangeMeters,
+        bearing: null,
+        beamwidth: 360,
+        labelParts: openCellIdLabelParts(site),
+        color: config.coverageColor,
+      })
+    })
+    group.addTo(map.value)
+    mobileCoverageLayer.value = group
+    if (!config.mobileCoverage.showRingLabels) return
+    renderOsmCoverageLabels(labels)
+    const rerenderLabels = (): void => renderOsmCoverageLabels(labels)
+    map.value.on('move zoom resize', rerenderLabels)
+    osmLabelCleanup = () => map.value?.off('move zoom resize', rerenderLabels)
   }
 
   const updateCoverage = (config: BaseStationConfig): void => {
@@ -457,83 +1307,342 @@ export const useBaseStationOverlay = (
     bearingHandle.value = handle
   }
 
-  const teardownMobileCoverage = (): void => {
+  const teardownRenderedMobileCoverage = (): void => {
     if (mobileCoverageController) {
       mobileCoverageController.abort()
       mobileCoverageController = null
     }
-    if (heatZoomCleanup) {
-      heatZoomCleanup()
-      heatZoomCleanup = null
+    if (mobileCoverageTargetToolController) {
+      mobileCoverageTargetToolController.abort()
+      mobileCoverageTargetToolController = null
     }
+    if (mobileCoverageDebounce) {
+      clearTimeout(mobileCoverageDebounce)
+      mobileCoverageDebounce = null
+    }
+    teardownOsmLabelOverlay()
     removeLayer(mobileCoverageLayer.value)
     mobileCoverageLayer.value = undefined
   }
 
-  const updateMobileCoverage = async (config: BaseStationConfig): Promise<void> => {
-    teardownMobileCoverage()
+  const teardownMobileCoverageData = (): void => {
+    teardownRenderedMobileCoverage()
+    clearLoadedMobileCoverageData()
+  }
+
+  const mobileHeatmapRadiusFraction = (config: BaseStationConfig, intensityBoost = 1): number =>
+    OPENCELLID_HEATMAP_MIN_RADIUS_FRACTION +
+    Math.max(0, Math.min(1, config.mobileCoverage.heatmapIntensity * intensityBoost)) *
+      (1 - OPENCELLID_HEATMAP_MIN_RADIUS_FRACTION)
+
+  const renderOpenCellIdHeatmap = (sites: OpenCellIdSite[], config: BaseStationConfig): void => {
+    if (!map.value) return
+    const filteredSites = filterOpenCellIdSites(sites, config.mobileCoverage.openCellIdOperator)
+    if (filteredSites.length === 0) return
+
+    const heat = createCellIdHeatLayer({
+      sites: filteredSites,
+      radiusFraction: mobileHeatmapRadiusFraction(config),
+      opacity: config.mobileCoverage.overlayOpacity,
+    })
+    heat.addTo(map.value)
+    mobileCoverageLayer.value = heat
+  }
+
+  const renderOsmHeatmap = (towers: OverpassTower[], config: BaseStationConfig): void => {
+    if (!map.value || towers.length === 0) return
+    const selectedOperator = config.mobileCoverage.osmOperator
+    const heatSites = (selectedOperator ? towers.filter((tower) => tower.operator === selectedOperator) : towers).map(
+      (tower) => ({
+        lat: tower.lat,
+        lon: tower.lon,
+        rangeMeters: overpassRangeMeters(tower.tags),
+      })
+    )
+    if (heatSites.length === 0) return
+    const heat = createCellIdHeatLayer({
+      sites: heatSites,
+      radiusFraction: mobileHeatmapRadiusFraction(config, 1.5),
+      opacity: config.mobileCoverage.overlayOpacity,
+    })
+    heat.addTo(map.value)
+    mobileCoverageLayer.value = heat
+  }
+
+  const renderOsmCoverage = (towers: OverpassTower[], config: BaseStationConfig): void => {
+    if (!map.value || towers.length === 0) return
+    const selectedOperator = config.mobileCoverage.osmOperator
+    const filtered = selectedOperator ? towers.filter((t) => t.operator === selectedOperator) : towers
+    if (filtered.length === 0) return
+
+    const group = L.layerGroup()
+    const labels: OsmCoverageLabelSpec[] = []
+
+    filtered.forEach((tower) => {
+      const center = [tower.lat, tower.lon] as WaypointCoordinates
+      const bearing = overpassBearing(tower.tags)
+      const beamwidth = overpassBeamwidth(tower.tags, bearing)
+      const rangeMeters = overpassRangeMeters(tower.tags)
+      const color = operatorColor(tower.operator)
+
+      if (bearing === null || beamwidth >= 360) {
+        L.circle(center, {
+          radius: rangeMeters,
+          color,
+          weight: 1,
+          dashArray: '5 5',
+          opacity: OSM_COVERAGE_STROKE_OPACITY * config.mobileCoverage.overlayOpacity,
+          fillColor: color,
+          fillOpacity: OSM_COVERAGE_FILL_OPACITY * config.mobileCoverage.overlayOpacity,
+          interactive: false,
+        }).addTo(group)
+      } else {
+        L.polygon(sectorPolygonLatLngs(center, rangeMeters, bearing, beamwidth), {
+          color,
+          weight: 1,
+          dashArray: '5 5',
+          opacity: OSM_COVERAGE_STROKE_OPACITY * config.mobileCoverage.overlayOpacity,
+          fillColor: color,
+          fillOpacity: OSM_COVERAGE_FILL_OPACITY * config.mobileCoverage.overlayOpacity,
+          interactive: false,
+        }).addTo(group)
+      }
+
+      labels.push({
+        id: `osm-coverage-label-${tower.id}`,
+        center,
+        rangeMeters,
+        bearing,
+        beamwidth,
+        labelParts: overpassLabelParts(tower),
+        color,
+      })
+    })
+
+    group.addTo(map.value)
+    mobileCoverageLayer.value = group
+    if (!config.mobileCoverage.showRingLabels) return
+    renderOsmCoverageLabels(labels)
+
+    const rerenderLabels = (): void => renderOsmCoverageLabels(labels)
+    map.value.on('move zoom resize', rerenderLabels)
+    osmLabelCleanup = () => map.value?.off('move zoom resize', rerenderLabels)
+  }
+
+  const renderMobileCoverage = async (config: BaseStationConfig): Promise<void> => {
+    teardownRenderedMobileCoverage()
 
     if (!map.value || !config.enabled || !config.position) return
     if (config.commsType !== BaseStationCommsType.MobileData) return
 
     const provider = config.mobileCoverage.provider
-
     if (provider === MobileCoverageProvider.Custom) {
       const url = config.mobileCoverage.customTileUrl.trim()
       if (!url) return
-      mobileCoverageLayer.value = L.tileLayer(url, { opacity: 0.55 }).addTo(map.value)
+      mobileCoverageLayer.value = L.tileLayer(url, { opacity: config.mobileCoverage.overlayOpacity }).addTo(map.value)
+      return
+    }
+
+    if (provider === MobileCoverageProvider.OpenCellID) {
+      const sites =
+        cachedOpenCellIdSites.value ??
+        (loadOpenCellIdSitesFromStorage(config.position) ? cachedOpenCellIdSites.value : null)
+      if (!sites || sites.length === 0) return
+      if (config.mobileCoverage.displayMode === MobileCoverageDisplayMode.CoverageRings) {
+        renderOpenCellIdCoverageRings(sites, config)
+        return
+      }
+      renderOpenCellIdHeatmap(sites, config)
+      return
+    }
+
+    const towers =
+      cachedOverpassTowers.value ?? (loadOverpassTowersFromStorage(config.position) ? cachedOverpassTowers.value : null)
+    if (!towers || towers.length === 0) return
+    if (config.mobileCoverage.displayMode === MobileCoverageDisplayMode.Heatmap) {
+      renderOsmHeatmap(towers, config)
+      return
+    }
+    renderOsmCoverage(towers, config)
+  }
+
+  const fetchAndAppendMobileCoverage = async (position: WaypointCoordinates): Promise<void> => {
+    const provider = store.config.mobileCoverage.provider
+    if (provider === MobileCoverageProvider.Custom) {
+      openSnackbar({
+        variant: 'info',
+        message: 'Custom overlays cannot be fetched from the map target tool.',
+        duration: 3500,
+      })
+      return
+    }
+
+    if (mobileCoverageTargetToolController) mobileCoverageTargetToolController.abort()
+    const controller = new AbortController()
+    mobileCoverageTargetToolController = controller
+    store.mobileCoverageLoading = true
+    try {
+      if (provider === MobileCoverageProvider.OpenCellID) {
+        const apiKey = store.config.mobileCoverage.openCellIdApiKey.trim()
+        const { sites, fetchedBbox } = await fetchOpenCellIdSites(position, apiKey, controller.signal)
+        if (controller.signal.aborted) return
+        appendOpenCellIdSites(fetchedBbox, sites)
+        store.openCellIdApiKeyStatus = apiKey ? 'valid' : 'unknown'
+        if (sites.length === 0) {
+          openSnackbar({
+            variant: 'info',
+            message: `${provider} returned no cellular data around the dropped target.`,
+            duration: 4000,
+          })
+        } else {
+          openSnackbar({
+            variant: 'success',
+            message: `Added ${sites.length} OpenCellID sites around the dropped target.`,
+            duration: 3000,
+          })
+        }
+      } else {
+        const bbox = overpassBboxAround(position[0], position[1])
+        const towers = await fetchOverpassTowers(bbox, controller.signal)
+        if (controller.signal.aborted) return
+        appendOverpassTowers(bbox, towers)
+        if (towers.length === 0) {
+          openSnackbar({
+            variant: 'info',
+            message: `${provider} returned no cellular data around the dropped target.`,
+            duration: 4000,
+          })
+        } else {
+          openSnackbar({
+            variant: 'success',
+            message: `Added ${towers.length} OSM towers around the dropped target.`,
+            duration: 3000,
+          })
+        }
+      }
+      await renderMobileCoverage(store.config)
+    } catch (err) {
+      if ((err as DOMException)?.name === 'AbortError') return
+      const errorMessage = (err as Error).message
+      if (provider === MobileCoverageProvider.OpenCellID && store.config.mobileCoverage.openCellIdApiKey.trim()) {
+        if (isOpenCellIdInvalidApiKeyError(errorMessage)) {
+          store.openCellIdApiKeyStatus = 'invalid'
+          openSnackbar({
+            variant: 'error',
+            message: 'OpenCellID API key is invalid. Check the key and try again.',
+            duration: 4000,
+          })
+          return
+        }
+        store.openCellIdApiKeyStatus = 'unknown'
+      }
+      openSnackbar({
+        variant: 'error',
+        message: `Mobile coverage fetch failed: ${errorMessage}`,
+        duration: 4000,
+      })
+    } finally {
+      if (mobileCoverageTargetToolController === controller) mobileCoverageTargetToolController = null
+      store.mobileCoverageLoading = false
+    }
+  }
+
+  const fetchMobileCoverageData = async (config: BaseStationConfig, forceReload = false): Promise<void> => {
+    if (!map.value || !config.enabled || !config.position) return
+    if (config.commsType !== BaseStationCommsType.MobileData) return
+
+    const provider = config.mobileCoverage.provider
+    if (provider === MobileCoverageProvider.Custom) {
+      await renderMobileCoverage(config)
       return
     }
 
     const controller = new AbortController()
     mobileCoverageController = controller
+    store.mobileCoverageLoading = true
     try {
-      let points: L.HeatLatLngTuple[]
       if (provider === MobileCoverageProvider.OpenCellID) {
         const apiKey = config.mobileCoverage.openCellIdApiKey.trim()
-        if (!apiKey) return
-        points = await fetchOpenCellIdPoints(config.position, apiKey, controller.signal)
-      } else {
-        const towers = await fetchOverpassTowers(
-          overpassBboxAround(config.position[0], config.position[1]),
-          controller.signal
-        )
+        if (!apiKey) {
+          store.openCellIdApiKeyStatus = 'unknown'
+          if (!isElectron()) {
+            openSnackbar({
+              variant: 'info',
+              message:
+                'OpenCellID requires an API key in the web build. Add one in the base-station config to load coverage.',
+              duration: 5000,
+            })
+            return
+          }
+        }
+        if (!forceReload && loadOpenCellIdSitesFromStorage(config.position)) {
+          await renderMobileCoverage(config)
+          return
+        }
+        const { sites, fetchedBbox } = await fetchOpenCellIdSites(config.position, apiKey, controller.signal)
         if (controller.signal.aborted) return
-        // Surface the operator vocabulary actually present in the bbox so the panel can render
-        // a meaningful selector (the OSM `operator` tag is region-specific).
-        store.availableOsmOperators = [...new Set(towers.map((t) => t.operator).filter((o): o is string => !!o))].sort()
-        const selectedOperator = config.mobileCoverage.osmOperator
-        const filtered = selectedOperator ? towers.filter((t) => t.operator === selectedOperator) : towers
-        points = filtered.map<L.HeatLatLngTuple>((t) => [t.lat, t.lon, 1])
+        storeOpenCellIdSites(fetchedBbox, sites)
+        if (apiKey) store.openCellIdApiKeyStatus = 'valid'
+        if (sites.length === 0) {
+          openSnackbar({
+            variant: 'info',
+            message: `${provider} returned no cellular data around the base station.`,
+            duration: 4000,
+          })
+          return
+        }
+      } else {
+        const coverageBbox = overpassBboxAround(config.position[0], config.position[1])
+        if (!forceReload && loadOverpassTowersFromStorage(config.position)) {
+          await renderMobileCoverage(config)
+          return
+        }
+        const towers = await fetchOverpassTowers(coverageBbox, controller.signal)
+        if (controller.signal.aborted) return
+        storeOverpassTowers(coverageBbox, towers)
+        if (towers.length === 0) {
+          openSnackbar({
+            variant: 'info',
+            message: `${provider} returned no cellular data around the base station.`,
+            duration: 4000,
+          })
+          return
+        }
       }
-      if (controller.signal.aborted || !map.value) return
-      if (points.length === 0) {
-        openSnackbar({
-          variant: 'info',
-          message: `${provider} returned no cellular data around the base station.`,
-          duration: 4000,
-        })
-        return
-      }
-      await ensureHeatLayer()
-      if (controller.signal.aborted || !map.value) return
-      const heat = L.heatLayer(points, { ...heatRadiusForMap(map.value), minOpacity: 0.25 }).addTo(map.value)
-      mobileCoverageLayer.value = heat
-      // Re-tune pixel radius on zoom so the visual stays anchored to ~1.5 km of real coverage.
-      const onZoom = (): void => {
-        if (map.value) heat.setOptions(heatRadiusForMap(map.value))
-      }
-      map.value.on('zoomend', onZoom)
-      heatZoomCleanup = () => map.value?.off('zoomend', onZoom)
+
+      await renderMobileCoverage(config)
     } catch (err) {
       if ((err as DOMException)?.name === 'AbortError') return
+      const errorMessage = (err as Error).message
+      if (provider === MobileCoverageProvider.OpenCellID && config.mobileCoverage.openCellIdApiKey.trim()) {
+        if (isOpenCellIdInvalidApiKeyError(errorMessage)) {
+          store.openCellIdApiKeyStatus = 'invalid'
+          openSnackbar({
+            variant: 'error',
+            message: 'OpenCellID API key is invalid. Check the key and try again.',
+            duration: 4000,
+          })
+          return
+        }
+        store.openCellIdApiKeyStatus = 'unknown'
+      }
+      if (
+        provider === MobileCoverageProvider.OpenCellID &&
+        config.position &&
+        loadOpenCellIdSitesFromStorage(config.position) &&
+        cachedOpenCellIdSites.value?.length
+      ) {
+        await renderMobileCoverage(config)
+        return
+      }
       openSnackbar({
         variant: 'error',
-        message: `Mobile coverage fetch failed: ${(err as Error).message}`,
+        message: `Mobile coverage fetch failed: ${errorMessage}`,
         duration: 4000,
       })
     } finally {
       if (mobileCoverageController === controller) mobileCoverageController = null
+      store.mobileCoverageLoading = false
     }
   }
 
@@ -548,13 +1657,15 @@ export const useBaseStationOverlay = (
       removeLayer(bearingHandle.value)
       removeLayer(bearingLine.value)
       removeLayer(aimingArc.value)
-      teardownMobileCoverage()
+      teardownMobileCoverageData()
       marker.value = undefined
       coverageLayer.value = undefined
       tetherLayer.value = undefined
       bearingHandle.value = undefined
       bearingLine.value = undefined
       aimingArc.value = undefined
+      lastMarkerLabel = null
+      lastMarkerColor = null
       return
     }
 
@@ -565,6 +1676,14 @@ export const useBaseStationOverlay = (
   }
 
   watch([map, mapReady], refreshAll, { immediate: true })
+  watch(
+    [map, mapReady],
+    () => {
+      if (!map.value || !mapReady.value) return
+      attachMapDropHandlers()
+    },
+    { immediate: true }
+  )
   watch(() => store.config, refreshAll, { deep: true })
 
   // Debounced so live edits to API key / tile URL don't hammer the public APIs on every keystroke.
@@ -575,22 +1694,64 @@ export const useBaseStationOverlay = (
       store.config.mobileCoverage.provider,
       store.config.mobileCoverage.openCellIdApiKey,
       store.config.mobileCoverage.customTileUrl,
-      store.config.mobileCoverage.osmOperator,
       store.config.position,
     ],
     () => {
-      if (mobileCoverageDebounce) clearTimeout(mobileCoverageDebounce)
-      mobileCoverageDebounce = setTimeout(() => updateMobileCoverage(store.config), 500)
+      teardownMobileCoverageData()
+      mobileCoverageDebounce = setTimeout(() => void fetchMobileCoverageData(store.config), 500)
+    },
+    { immediate: true }
+  )
+
+  watch(
+    () => store.mobileCoverageReloadToken,
+    () => {
+      teardownMobileCoverageData()
+      mobileCoverageDebounce = setTimeout(() => void fetchMobileCoverageData(store.config, true), 100)
+    }
+  )
+
+  watch(
+    () => store.mobileCoverageVisibleDataResetToken,
+    () => {
+      void resetVisibleMobileCoverageData()
+    }
+  )
+
+  // Visual-only re-render. Provider/commsType/customTileUrl/position are already covered by
+  // the fetch watcher above — pulling them in here would cause a render against the empty
+  // cache before the fetch completes.
+  watch(
+    () => [
+      mapReady.value,
+      store.config.mobileCoverage.displayMode,
+      store.config.mobileCoverage.overlayOpacity,
+      store.config.mobileCoverage.osmOperator,
+      store.config.mobileCoverage.openCellIdOperator,
+      store.config.mobileCoverage.showRingLabels,
+      store.config.mobileCoverage.heatmapIntensity,
+      store.config.coverageColor,
+    ],
+    () => {
+      void renderMobileCoverage(store.config)
+    },
+    { immediate: true }
+  )
+
+  watch(
+    () => [mapReady.value, store.mobileCoverageTargetToolActive] as const,
+    ([ready, active]) => {
+      if (!ready || !map.value) return
+      if (active) attachTargetToolHandlers()
+      else detachTargetToolHandlers?.()
     },
     { immediate: true }
   )
 
   onBeforeUnmount(() => {
-    if (mobileCoverageDebounce) {
-      clearTimeout(mobileCoverageDebounce)
-      mobileCoverageDebounce = null
-    }
-    teardownMobileCoverage()
+    detachMapDropHandlers?.()
+    detachTargetToolHandlers?.()
+    teardownMobileCoverageData()
     removeLayer(marker.value)
     removeLayer(coverageLayer.value)
     removeLayer(tetherLayer.value)

--- a/src/composables/baseStation/useBaseStationOverlay.ts
+++ b/src/composables/baseStation/useBaseStationOverlay.ts
@@ -1,0 +1,100 @@
+import L from 'leaflet'
+import { type Ref, type ShallowRef, onBeforeUnmount, shallowRef, watch } from 'vue'
+
+import { useBaseStation } from '@/composables/baseStation/useBaseStation'
+import type { BaseStationConfig } from '@/types/baseStation'
+
+/* eslint-disable jsdoc/require-jsdoc -- internal helper return shape, name is self-describing. */
+type BaseStationOverlayApi = { openConfigPanel: () => void }
+/* eslint-enable jsdoc/require-jsdoc */
+
+const baseStationMarkerHtml = (label: string): string => `
+  <div class="base-station-marker-container">
+    <div class="base-station-marker-background"></div>
+    <i class="v-icon notranslate mdi mdi-radio-tower" style="color: white; position: relative; z-index: 2; font-size: 16px;"></i>
+    <div class="base-station-marker-label">${label}</div>
+  </div>
+`
+
+/**
+ * Renders the base-station marker on a Leaflet map and keeps it in sync with the
+ * {@link useBaseStation} state. Mounting and unmounting are handled automatically.
+ * @param {ShallowRef<L.Map | undefined>} map Reactive reference to the Leaflet map instance.
+ * @param {Ref<boolean>} mapReady Reactive flag that becomes true once the map is initialized.
+ * @returns {BaseStationOverlayApi} Helpers to drive the overlay from the host view.
+ */
+export const useBaseStationOverlay = (
+  map: ShallowRef<L.Map | undefined>,
+  mapReady: Ref<boolean>
+): BaseStationOverlayApi => {
+  const store = useBaseStation()
+
+  const marker = shallowRef<L.Marker | undefined>()
+
+  const openConfigPanel = (): void => {
+    store.configPanelOpen = true
+  }
+
+  const removeLayer = (layer: L.Layer | undefined): void => {
+    if (layer && map.value) map.value.removeLayer(layer)
+  }
+
+  const buildMarkerIcon = (): L.DivIcon =>
+    L.divIcon({
+      className: 'base-station-marker-icon',
+      html: baseStationMarkerHtml('Base'),
+      iconSize: [24, 24],
+      iconAnchor: [12, 12],
+    })
+
+  const ensureMarker = (config: BaseStationConfig): void => {
+    if (!map.value || !config.position) return
+    if (marker.value) {
+      marker.value.setLatLng(config.position)
+      return
+    }
+    const m = L.marker(config.position, {
+      icon: buildMarkerIcon(),
+      draggable: true,
+      zIndexOffset: 600,
+      // The marker owns its own right-click popup; don't propagate to the map context menu.
+      bubblingMouseEvents: false,
+    })
+    m.on('drag', (event: L.LeafletEvent) => {
+      const target = event.target as L.Marker
+      const { lat, lng } = target.getLatLng()
+      store.setPosition([lat, lng])
+    })
+    m.on('contextmenu', (event: L.LeafletMouseEvent) => {
+      L.DomEvent.stopPropagation(event)
+      event.originalEvent.stopPropagation()
+      event.originalEvent.preventDefault()
+      store.openContextPopup(event.originalEvent.clientX, event.originalEvent.clientY)
+    })
+    m.addTo(map.value)
+    marker.value = m
+  }
+
+  const refreshAll = (): void => {
+    if (!map.value || !mapReady.value) return
+    const config = store.config
+
+    if (!config.enabled || !config.position) {
+      removeLayer(marker.value)
+      marker.value = undefined
+      return
+    }
+
+    ensureMarker(config)
+  }
+
+  watch([map, mapReady], refreshAll, { immediate: true })
+  watch(() => store.config, refreshAll, { deep: true })
+
+  onBeforeUnmount(() => {
+    removeLayer(marker.value)
+    marker.value = undefined
+  })
+
+  return { openConfigPanel }
+}

--- a/src/composables/baseStation/useBaseStationOverlay.ts
+++ b/src/composables/baseStation/useBaseStationOverlay.ts
@@ -1,8 +1,70 @@
+import * as turf from '@turf/turf'
 import L from 'leaflet'
 import { type Ref, type ShallowRef, onBeforeUnmount, shallowRef, watch } from 'vue'
 
 import { useBaseStation } from '@/composables/baseStation/useBaseStation'
-import type { BaseStationConfig } from '@/types/baseStation'
+import {
+  type BaseStationConfig,
+  AntennaType,
+  BaseStationCommsType,
+  effectiveAntennaRangeMeters,
+} from '@/types/baseStation'
+import type { WaypointCoordinates } from '@/types/mission'
+
+const SECTOR_ARC_STEPS = 64
+
+// Concentric coverage rings with decreasing radius. Stacking them at the same per-layer opacity
+// produces a smooth radial fade that mimics the pattern published in BR's directional antenna
+// guide while keeping the brightest band where the signal is strongest.
+const COVERAGE_GRADIENT_STEPS = 12
+const COVERAGE_STEP_OPACITY = 0.045
+
+const sectorPolygonLatLngs = (
+  center: WaypointCoordinates,
+  rangeMeters: number,
+  bearingDeg: number,
+  beamwidthDeg: number
+): L.LatLngExpression[] => {
+  const halfBeam = beamwidthDeg / 2
+  const startBearing = bearingDeg - halfBeam
+  const endBearing = bearingDeg + halfBeam
+  const rangeKm = rangeMeters / 1000
+  const turfCenter = turf.point([center[1], center[0]])
+
+  const arc = turf.lineArc(turfCenter, rangeKm, startBearing, endBearing, { steps: SECTOR_ARC_STEPS })
+  const arcPoints = arc.geometry.coordinates.map(([lng, lat]) => [lat, lng] as L.LatLngExpression)
+  return [center as L.LatLngExpression, ...arcPoints, center as L.LatLngExpression]
+}
+
+const bearingHandlePosition = (
+  center: WaypointCoordinates,
+  rangeMeters: number,
+  bearingDeg: number
+): WaypointCoordinates => {
+  const dest = turf.destination(turf.point([center[1], center[0]]), rangeMeters / 1000, bearingDeg, {
+    units: 'kilometers',
+  })
+  const [lng, lat] = dest.geometry.coordinates
+  return [lat, lng]
+}
+
+// 180° front-facing arc at the antenna's max range, used to preview where the signal will land
+// as the operator rotates the antenna.
+const aimingArcLatLngs = (
+  center: WaypointCoordinates,
+  rangeMeters: number,
+  bearingDeg: number
+): L.LatLngExpression[] => {
+  const turfCenter = turf.point([center[1], center[0]])
+  const arc = turf.lineArc(turfCenter, rangeMeters / 1000, bearingDeg - 90, bearingDeg + 90, {
+    steps: SECTOR_ARC_STEPS,
+  })
+  return arc.geometry.coordinates.map(([lng, lat]) => [lat, lng] as L.LatLngExpression)
+}
+
+const bearingFromCenter = (center: WaypointCoordinates, point: WaypointCoordinates): number => {
+  return turf.bearing(turf.point([center[1], center[0]]), turf.point([point[1], point[0]]))
+}
 
 /* eslint-disable jsdoc/require-jsdoc -- internal helper return shape, name is self-describing. */
 type BaseStationOverlayApi = { openConfigPanel: () => void }
@@ -17,8 +79,9 @@ const baseStationMarkerHtml = (label: string): string => `
 `
 
 /**
- * Renders the base-station marker on a Leaflet map and keeps it in sync with the
- * {@link useBaseStation} state. Mounting and unmounting are handled automatically.
+ * Renders the base-station marker, antenna coverage and tether circle on a Leaflet map and
+ * keeps them in sync with the {@link useBaseStation} state. Mounting and unmounting are
+ * handled automatically.
  * @param {ShallowRef<L.Map | undefined>} map Reactive reference to the Leaflet map instance.
  * @param {Ref<boolean>} mapReady Reactive flag that becomes true once the map is initialized.
  * @returns {BaseStationOverlayApi} Helpers to drive the overlay from the host view.
@@ -30,6 +93,11 @@ export const useBaseStationOverlay = (
   const store = useBaseStation()
 
   const marker = shallowRef<L.Marker | undefined>()
+  const coverageLayer = shallowRef<L.LayerGroup | undefined>()
+  const tetherLayer = shallowRef<L.Circle | undefined>()
+  const bearingHandle = shallowRef<L.Marker | undefined>()
+  const bearingLine = shallowRef<L.Polyline | undefined>()
+  const aimingArc = shallowRef<L.Polyline | undefined>()
 
   const openConfigPanel = (): void => {
     store.configPanelOpen = true
@@ -47,10 +115,19 @@ export const useBaseStationOverlay = (
       iconAnchor: [12, 12],
     })
 
+  const buildBearingHandleIcon = (): L.DivIcon =>
+    L.divIcon({
+      className: 'base-station-bearing-handle',
+      html: '<div class="base-station-bearing-handle-dot"></div>',
+      iconSize: [18, 18],
+      iconAnchor: [9, 9],
+    })
+
   const ensureMarker = (config: BaseStationConfig): void => {
     if (!map.value || !config.position) return
     if (marker.value) {
       marker.value.setLatLng(config.position)
+      applyMarkerColor(config.coverageColor)
       return
     }
     const m = L.marker(config.position, {
@@ -73,6 +150,143 @@ export const useBaseStationOverlay = (
     })
     m.addTo(map.value)
     marker.value = m
+    applyMarkerColor(config.coverageColor)
+  }
+
+  // Marker stays fully visible regardless of the opacity slider — only the coverage and
+  // bearing/arc dotted lines fade with `coverageOpacity`. The trailing `cc` keeps the
+  // marker's original 80% fill so the icon underneath stays legible against the map.
+  const applyMarkerColor = (color: string): void => {
+    const el = marker.value?.getElement()
+    if (!el) return
+    const bg = el.querySelector('.base-station-marker-background') as HTMLElement | null
+    if (bg) bg.style.backgroundColor = `${color.slice(0, 7)}cc`
+  }
+
+  const updateCoverage = (config: BaseStationConfig): void => {
+    removeLayer(coverageLayer.value)
+    coverageLayer.value = undefined
+
+    if (!map.value || !store.showCoverage || !config.position) return
+    if (config.commsType !== BaseStationCommsType.RadioLink) return
+
+    const stepStyle = {
+      color: config.coverageColor,
+      weight: 0,
+      fillColor: config.coverageColor,
+      fillOpacity: COVERAGE_STEP_OPACITY * config.coverageOpacity,
+      interactive: false,
+    }
+
+    const isOmni = config.antenna.type === AntennaType.Omni
+    const rangeMeters = effectiveAntennaRangeMeters(config)
+    const group = L.layerGroup()
+
+    for (let step = 1; step <= COVERAGE_GRADIENT_STEPS; step++) {
+      const radius = (rangeMeters * step) / COVERAGE_GRADIENT_STEPS
+      if (isOmni) {
+        L.circle(config.position, { ...stepStyle, radius }).addTo(group)
+        continue
+      }
+      const latlngs = sectorPolygonLatLngs(config.position, radius, config.antenna.bearing, config.antenna.beamwidth)
+      L.polygon(latlngs, stepStyle).addTo(group)
+    }
+
+    group.addTo(map.value)
+    coverageLayer.value = group
+  }
+
+  const updateTether = (config: BaseStationConfig): void => {
+    removeLayer(tetherLayer.value)
+    tetherLayer.value = undefined
+
+    if (!map.value || !store.showCoverage || !config.position) return
+    if (config.commsType !== BaseStationCommsType.Tethered) return
+
+    tetherLayer.value = L.circle(config.position, {
+      radius: config.tetherLengthMeters,
+      color: config.coverageColor,
+      weight: 1,
+      opacity: config.coverageOpacity,
+      fillColor: config.coverageColor,
+      fillOpacity: 0.1 * config.coverageOpacity,
+      dashArray: '4 4',
+      interactive: false,
+    }).addTo(map.value)
+  }
+
+  const updateBearingHandle = (config: BaseStationConfig): void => {
+    const shouldShow =
+      map.value !== undefined &&
+      config.position !== null &&
+      config.commsType === BaseStationCommsType.RadioLink &&
+      config.antenna.type !== AntennaType.Omni
+
+    if (!shouldShow) {
+      removeLayer(bearingHandle.value)
+      removeLayer(bearingLine.value)
+      removeLayer(aimingArc.value)
+      bearingHandle.value = undefined
+      bearingLine.value = undefined
+      aimingArc.value = undefined
+      return
+    }
+
+    const rangeMeters = effectiveAntennaRangeMeters(config)
+    const handleLatLng = bearingHandlePosition(config.position!, rangeMeters, config.antenna.bearing)
+    const lineLatLngs = [config.position!, handleLatLng] as L.LatLngExpression[]
+    const arcLatLngs = aimingArcLatLngs(config.position!, rangeMeters, config.antenna.bearing)
+    const lineOpacity = 0.3 * config.coverageOpacity
+    const arcOpacity = 0.25 * config.coverageOpacity
+
+    if (bearingLine.value) {
+      bearingLine.value.setLatLngs(lineLatLngs)
+      bearingLine.value.setStyle({ color: config.coverageColor, opacity: lineOpacity })
+    } else {
+      bearingLine.value = L.polyline(lineLatLngs, {
+        color: config.coverageColor,
+        weight: 1,
+        dashArray: '6 4',
+        opacity: lineOpacity,
+        interactive: false,
+      }).addTo(map.value!)
+    }
+
+    if (aimingArc.value) {
+      aimingArc.value.setLatLngs(arcLatLngs)
+      aimingArc.value.setStyle({ color: config.coverageColor, opacity: arcOpacity })
+    } else {
+      aimingArc.value = L.polyline(arcLatLngs, {
+        color: config.coverageColor,
+        weight: 1,
+        dashArray: '6 4',
+        opacity: arcOpacity,
+        interactive: false,
+      }).addTo(map.value!)
+    }
+
+    // Update in place; recreating during drag would destroy the handle Leaflet is tracking
+    // and stop the rotation after a single drag step.
+    if (bearingHandle.value) {
+      bearingHandle.value.setLatLng(handleLatLng)
+      return
+    }
+
+    const handle = L.marker(handleLatLng, {
+      icon: buildBearingHandleIcon(),
+      draggable: true,
+      zIndexOffset: 700,
+      bubblingMouseEvents: true,
+    })
+    handle.on('drag', (event: L.LeafletEvent) => {
+      const center = store.config.position
+      if (!center) return
+      const target = event.target as L.Marker
+      const { lat, lng } = target.getLatLng()
+      store.setBearing(bearingFromCenter(center, [lat, lng]))
+    })
+    handle.addTo(map.value!)
+    bearingHandle.value = handle
   }
 
   const refreshAll = (): void => {
@@ -81,11 +295,24 @@ export const useBaseStationOverlay = (
 
     if (!config.enabled || !config.position) {
       removeLayer(marker.value)
+      removeLayer(coverageLayer.value)
+      removeLayer(tetherLayer.value)
+      removeLayer(bearingHandle.value)
+      removeLayer(bearingLine.value)
+      removeLayer(aimingArc.value)
       marker.value = undefined
+      coverageLayer.value = undefined
+      tetherLayer.value = undefined
+      bearingHandle.value = undefined
+      bearingLine.value = undefined
+      aimingArc.value = undefined
       return
     }
 
     ensureMarker(config)
+    updateCoverage(config)
+    updateTether(config)
+    updateBearingHandle(config)
   }
 
   watch([map, mapReady], refreshAll, { immediate: true })
@@ -93,7 +320,17 @@ export const useBaseStationOverlay = (
 
   onBeforeUnmount(() => {
     removeLayer(marker.value)
+    removeLayer(coverageLayer.value)
+    removeLayer(tetherLayer.value)
+    removeLayer(bearingHandle.value)
+    removeLayer(bearingLine.value)
+    removeLayer(aimingArc.value)
     marker.value = undefined
+    coverageLayer.value = undefined
+    tetherLayer.value = undefined
+    bearingHandle.value = undefined
+    bearingLine.value = undefined
+    aimingArc.value = undefined
   })
 
   return { openConfigPanel }

--- a/src/composables/baseStation/useBaseStationOverlay.ts
+++ b/src/composables/baseStation/useBaseStationOverlay.ts
@@ -1,15 +1,49 @@
-import * as turf from '@turf/turf'
 import L from 'leaflet'
 import { type Ref, type ShallowRef, onBeforeUnmount, shallowRef, watch } from 'vue'
 
-import { openSnackbar } from '@/composables/snackbar'
 import { useBaseStation } from '@/composables/baseStation/useBaseStation'
+import { openSnackbar } from '@/composables/snackbar'
+import { createCellIdHeatLayer, mobileHeatmapRadiusFraction } from '@/libs/baseStation/cellIdHeatLayer'
+import {
+  bboxContains,
+  bboxEquals,
+  bboxIntersects,
+  leafletBoundsToCoverageBbox,
+  overpassBboxAround,
+  trimCacheEntries,
+} from '@/libs/baseStation/coverageBbox'
+import {
+  aimingArcLatLngs,
+  bearingFromCenter,
+  bearingHandlePosition,
+  sectorPolygonLatLngs,
+} from '@/libs/baseStation/geometry'
+import {
+  filterOpenCellIdSites,
+  mergeOpenCellIdSites,
+  mergeOverpassTowers,
+  openCellIdOperatorLabel,
+  overpassRangeMeters,
+} from '@/libs/baseStation/mobileCoverage'
+import {
+  type OpenCellIdSite,
+  fetchOpenCellIdSites,
+  isOpenCellIdInvalidApiKeyError,
+} from '@/libs/baseStation/openCellId'
+import {
+  type OverpassTower,
+  fetchOverpassTowers,
+  fitLabelToArc,
+  openCellIdLabelParts,
+  operatorColor,
+  overpassBeamwidth,
+  overpassBearing,
+  overpassLabelParts,
+} from '@/libs/baseStation/overpass'
 import { isElectron } from '@/libs/utils'
 import {
   type BaseStationConfig,
   type CachedMobileCoverageEntry,
-  type CachedOpenCellIdSite,
-  type CachedOverpassTower,
   type CoverageBbox,
   AntennaType,
   BaseStationCommsType,
@@ -20,307 +54,13 @@ import {
 } from '@/types/baseStation'
 import type { WaypointCoordinates } from '@/types/mission'
 
-const SECTOR_ARC_STEPS = 64
-
 // Concentric coverage rings with decreasing radius. Stacking them at the same per-layer opacity
 // produces a smooth radial fade that mimics the pattern published in BR's directional antenna
 // guide while keeping the brightest band where the signal is strongest.
 const COVERAGE_GRADIENT_STEPS = 12
 const COVERAGE_STEP_OPACITY = 0.045
 
-const sectorPolygonLatLngs = (
-  center: WaypointCoordinates,
-  rangeMeters: number,
-  bearingDeg: number,
-  beamwidthDeg: number
-): L.LatLngExpression[] => {
-  const halfBeam = beamwidthDeg / 2
-  const startBearing = bearingDeg - halfBeam
-  const endBearing = bearingDeg + halfBeam
-  const rangeKm = rangeMeters / 1000
-  const turfCenter = turf.point([center[1], center[0]])
-
-  const arc = turf.lineArc(turfCenter, rangeKm, startBearing, endBearing, { steps: SECTOR_ARC_STEPS })
-  const arcPoints = arc.geometry.coordinates.map(([lng, lat]) => [lat, lng] as L.LatLngExpression)
-  return [center as L.LatLngExpression, ...arcPoints, center as L.LatLngExpression]
-}
-
-const bearingHandlePosition = (
-  center: WaypointCoordinates,
-  rangeMeters: number,
-  bearingDeg: number
-): WaypointCoordinates => {
-  const dest = turf.destination(turf.point([center[1], center[0]]), rangeMeters / 1000, bearingDeg, {
-    units: 'kilometers',
-  })
-  const [lng, lat] = dest.geometry.coordinates
-  return [lat, lng]
-}
-
-// 180° front-facing arc at the antenna's max range, used to preview where the signal will land
-// as the operator rotates the antenna.
-const aimingArcLatLngs = (
-  center: WaypointCoordinates,
-  rangeMeters: number,
-  bearingDeg: number
-): L.LatLngExpression[] => {
-  const turfCenter = turf.point([center[1], center[0]])
-  const arc = turf.lineArc(turfCenter, rangeMeters / 1000, bearingDeg - 90, bearingDeg + 90, {
-    steps: SECTOR_ARC_STEPS,
-  })
-  return arc.geometry.coordinates.map(([lng, lat]) => [lat, lng] as L.LatLngExpression)
-}
-
-const bearingFromCenter = (center: WaypointCoordinates, point: WaypointCoordinates): number => {
-  return turf.bearing(turf.point([center[1], center[0]]), turf.point([point[1], point[0]]))
-}
-
-/* eslint-disable jsdoc/require-jsdoc -- Inline transport DTOs; field meanings follow upstream docs. */
-
-// OSM Overpass has no per-call area cap, so we use a single ~11 km half-side bbox.
-const OVERPASS_BBOX_DEG = 0.1
-const OPENCELLID_COVERAGE_HALF_SIDE_KM = 25
-// Keyed browser endpoint caps at ~4 km²; standalone's no-key ajax endpoint rejects around 25 km²,
-// so we use smaller tiles on Lite and larger ones on standalone.
-const OPENCELLID_KEYED_TILE_HALF_SIDE_KM = 0.95
-const OPENCELLID_KEYED_FOREGROUND_TILE_COUNT = 9
-const OPENCELLID_LITE_TILE_HALF_SIDE_KM = 1
-const OPENCELLID_STANDALONE_TILE_HALF_SIDE_KM = 2
-const OPENCELLID_STANDALONE_FOREGROUND_TILE_COUNT = 1
-// Keep the persisted bbox cache small; users rarely need more than the most recent few areas.
-const MOBILE_COVERAGE_CACHE_MAX_ENTRIES = 8
-type OpenCellIdSite = CachedOpenCellIdSite
-type OverpassTower = CachedOverpassTower
-
-const isOpenCellIdInvalidApiKeyError = (message: string): boolean =>
-  /invalid.*key|api key.*invalid|missing.*key|key required|unauthorized|forbidden/i.test(message)
-
-const overpassBboxAround = (lat: number, lng: number): CoverageBbox => ({
-  south: lat - OVERPASS_BBOX_DEG,
-  west: lng - OVERPASS_BBOX_DEG,
-  north: lat + OVERPASS_BBOX_DEG,
-  east: lng + OVERPASS_BBOX_DEG,
-})
-
-const kmToLatDegrees = (km: number): number => km / 111.32
-
-const kmToLngDegrees = (km: number, lat: number): number => {
-  const cosLat = Math.max(0.2, Math.cos((lat * Math.PI) / 180))
-  return km / (111.32 * cosLat)
-}
-
-const openCellIdCoverageBboxAround = (lat: number, lng: number): CoverageBbox => ({
-  south: lat - kmToLatDegrees(OPENCELLID_COVERAGE_HALF_SIDE_KM),
-  west: lng - kmToLngDegrees(OPENCELLID_COVERAGE_HALF_SIDE_KM, lat),
-  north: lat + kmToLatDegrees(OPENCELLID_COVERAGE_HALF_SIDE_KM),
-  east: lng + kmToLngDegrees(OPENCELLID_COVERAGE_HALF_SIDE_KM, lat),
-})
-
-const bboxContains = (bbox: CoverageBbox, position: WaypointCoordinates): boolean => {
-  const [lat, lng] = position
-  return lat >= bbox.south && lat <= bbox.north && lng >= bbox.west && lng <= bbox.east
-}
-
-const bboxIntersects = (left: CoverageBbox, right: CoverageBbox): boolean =>
-  left.west <= right.east && left.east >= right.west && left.south <= right.north && left.north >= right.south
-
-const bboxEquals = (left: CoverageBbox, right: CoverageBbox): boolean =>
-  left.south === right.south && left.west === right.west && left.north === right.north && left.east === right.east
-
-const leafletBoundsToCoverageBbox = (bounds: L.LatLngBounds): CoverageBbox => ({
-  south: bounds.getSouth(),
-  west: bounds.getWest(),
-  north: bounds.getNorth(),
-  east: bounds.getEast(),
-})
-
-const trimCacheEntries = <T>(entries: CachedMobileCoverageEntry<T>[]): CachedMobileCoverageEntry<T>[] => {
-  return entries.sort((a, b) => b.fetchedAtMs - a.fetchedAtMs).slice(0, MOBILE_COVERAGE_CACHE_MAX_ENTRIES)
-}
-
-const tiledCoverageBboxes = (area: CoverageBbox, centerLat: number, tileHalfSideKm: number): CoverageBbox[] => {
-  const tileLatSize = kmToLatDegrees(tileHalfSideKm * 2)
-  const tileLngSize = kmToLngDegrees(tileHalfSideKm * 2, centerLat)
-  const latCount = Math.ceil((area.north - area.south) / tileLatSize)
-  const lngCount = Math.ceil((area.east - area.west) / tileLngSize)
-  const tiles: CoverageBbox[] = []
-
-  for (let latIndex = 0; latIndex < latCount; latIndex++) {
-    const south = area.south + latIndex * tileLatSize
-    const north = Math.min(area.north, south + tileLatSize)
-    for (let lngIndex = 0; lngIndex < lngCount; lngIndex++) {
-      const west = area.west + lngIndex * tileLngSize
-      const east = Math.min(area.east, west + tileLngSize)
-      tiles.push({ south, west, north, east })
-    }
-  }
-
-  return tiles
-}
-
-const bboxCenter = (bbox: CoverageBbox): WaypointCoordinates => [
-  (bbox.south + bbox.north) / 2,
-  (bbox.west + bbox.east) / 2,
-]
-
-const sortCoverageBboxesByDistance = (center: WaypointCoordinates, bboxes: CoverageBbox[]): CoverageBbox[] =>
-  [...bboxes].sort((left, right) => {
-    const [leftLat, leftLng] = bboxCenter(left)
-    const [rightLat, rightLng] = bboxCenter(right)
-    const leftDistance = turf.distance(turf.point([center[1], center[0]]), turf.point([leftLng, leftLat]))
-    const rightDistance = turf.distance(turf.point([center[1], center[0]]), turf.point([rightLng, rightLat]))
-    return leftDistance - rightDistance
-  })
-
-const unionCoverageBboxes = (bboxes: CoverageBbox[]): CoverageBbox => ({
-  south: Math.min(...bboxes.map((bbox) => bbox.south)),
-  west: Math.min(...bboxes.map((bbox) => bbox.west)),
-  north: Math.max(...bboxes.map((bbox) => bbox.north)),
-  east: Math.max(...bboxes.map((bbox) => bbox.east)),
-})
-
-const mapWithConcurrency = async <T, R>(
-  items: T[],
-  concurrency: number,
-  mapper: (item: T) => Promise<R>
-): Promise<PromiseSettledResult<R>[]> => {
-  const settled: PromiseSettledResult<R>[] = new Array(items.length)
-  let nextIndex = 0
-
-  const worker = async (): Promise<void> => {
-    while (nextIndex < items.length) {
-      const currentIndex = nextIndex++
-      try {
-        settled[currentIndex] = {
-          status: 'fulfilled',
-          value: await mapper(items[currentIndex]),
-        }
-      } catch (error) {
-        settled[currentIndex] = {
-          status: 'rejected',
-          reason: error,
-        }
-      }
-    }
-  }
-
-  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => worker()))
-  return settled
-}
-
-type OpenCellIdResponse = {
-  cells?: Array<{
-    lat: number
-    lon: number
-    range?: number
-    radio?: string
-    mcc?: number
-    mnc?: number
-    lac?: number
-    cellid?: number
-    samples?: number
-    averageSignalStrength?: number
-  }>
-  error?: string
-  code?: number
-}
-
-const fetchOpenCellIdTile = async (
-  bbox: CoverageBbox,
-  apiKey: string,
-  signal: AbortSignal
-): Promise<OpenCellIdSite[]> => {
-  const url =
-    `https://opencellid.org/cell/getInArea?key=${encodeURIComponent(apiKey)}` +
-    `&BBOX=${bbox.south},${bbox.west},${bbox.north},${bbox.east}` +
-    `&format=json&limit=50`
-  const res = await fetch(url, { signal })
-  if (!res.ok) throw new Error(`OpenCellID HTTP ${res.status}`)
-  const data = (await res.json()) as OpenCellIdResponse
-  // `code: 1` ("No cells found") is HTTP 200 + an `error` field; treat as empty, not failure.
-  if (data.error && data.code !== 1) throw new Error(`OpenCellID: ${data.error}`)
-  return (data.cells ?? []).map<OpenCellIdSite>((c) => ({
-    lat: c.lat,
-    lon: c.lon,
-    rangeMeters: c.range ?? 1000,
-    radio: c.radio,
-    mcc: c.mcc,
-    mnc: c.mnc,
-    lac: c.lac,
-    cellId: c.cellid,
-    samples: c.samples,
-    averageSignalStrength: c.averageSignalStrength,
-  }))
-}
-
-const fetchOpenCellIdTileInElectron = async (bbox: CoverageBbox, apiKey: string): Promise<OpenCellIdSite[]> => {
-  const cells = await window.electronAPI?.fetchNearbyOpenCellIdCells({
-    west: bbox.west,
-    south: bbox.south,
-    east: bbox.east,
-    north: bbox.north,
-    apiKey: apiKey || undefined,
-  })
-  if (!cells) throw new Error('OpenCellID standalone bridge unavailable')
-  return cells.map<OpenCellIdSite>((c) => ({
-    lat: c.lat,
-    lon: c.lon,
-    rangeMeters: c.range ?? 1000,
-    radio: c.radio,
-    mcc: c.mcc,
-    mnc: c.mnc,
-    lac: c.lac,
-    cellId: c.cellId,
-    samples: c.samples,
-    averageSignalStrength: c.averageSignalStrength,
-  }))
-}
-
-const fetchOpenCellIdSites = async (
-  center: WaypointCoordinates,
-  apiKey: string,
-  signal: AbortSignal
-): Promise<{ sites: OpenCellIdSite[]; fetchedBbox: CoverageBbox }> => {
-  const [lat, lng] = center
-  const coverageArea = openCellIdCoverageBboxAround(lat, lng)
-  const usesApiKey = apiKey.trim().length > 0
-  const tileHalfSideKm = usesApiKey
-    ? OPENCELLID_KEYED_TILE_HALF_SIDE_KM
-    : isElectron()
-    ? OPENCELLID_STANDALONE_TILE_HALF_SIDE_KM
-    : OPENCELLID_LITE_TILE_HALF_SIDE_KM
-  const tiles = tiledCoverageBboxes(coverageArea, lat, tileHalfSideKm)
-  const selectedTiles = usesApiKey
-    ? sortCoverageBboxesByDistance(center, tiles).slice(0, OPENCELLID_KEYED_FOREGROUND_TILE_COUNT)
-    : isElectron()
-    ? sortCoverageBboxesByDistance(center, tiles).slice(0, OPENCELLID_STANDALONE_FOREGROUND_TILE_COUNT)
-    : tiles
-  const tileFetcher = isElectron()
-    ? (bbox: CoverageBbox) => fetchOpenCellIdTileInElectron(bbox, apiKey)
-    : (bbox: CoverageBbox) => fetchOpenCellIdTile(bbox, apiKey, signal)
-  const settled = await mapWithConcurrency(selectedTiles, usesApiKey ? 4 : isElectron() ? 2 : 4, tileFetcher)
-  const fulfilled = settled.filter((r): r is PromiseFulfilledResult<OpenCellIdSite[]> => r.status === 'fulfilled')
-  // If every tile failed, surface the first error so the operator gets a real diagnostic
-  // (invalid key, network down, …) instead of a silent empty heatmap.
-  if (fulfilled.length === 0) {
-    const firstReject = settled.find((r): r is PromiseRejectedResult => r.status === 'rejected')
-    if (firstReject) throw firstReject.reason
-  }
-  const uniqueSites = new Map<string, OpenCellIdSite>()
-  for (const site of fulfilled.flatMap((r) => r.value)) {
-    const key = `${site.lat.toFixed(6)}:${site.lon.toFixed(6)}:${Math.round(site.rangeMeters)}`
-    if (!uniqueSites.has(key)) uniqueSites.set(key, site)
-  }
-  return {
-    sites: [...uniqueSites.values()],
-    fetchedBbox: unionCoverageBboxes(selectedTiles),
-  }
-}
-
-type OverpassResponse = {
-  elements?: Array<{ id?: number; lat?: number; lon?: number; tags?: Record<string, string> }>
-}
-
+/* eslint-disable jsdoc/require-jsdoc -- Inline label spec; field names are self-describing. */
 type OsmCoverageLabelSpec = {
   id: string
   center: WaypointCoordinates
@@ -330,337 +70,19 @@ type OsmCoverageLabelSpec = {
   labelParts: string[]
   color: string
 }
+/* eslint-enable jsdoc/require-jsdoc */
 
-const OSM_DEFAULT_RANGE_METERS = 1800
-const OSM_DEFAULT_DIRECTIONAL_BEAMWIDTH = 90
 const OSM_COVERAGE_FILL_OPACITY = 0.12
 const OSM_COVERAGE_STROKE_OPACITY = 0.75
 const OPENCELLID_RING_FILL_OPACITY = 0.08
 const OSM_LABEL_FONT_SIZE_PX = 10
-const OSM_LABEL_CHAR_WIDTH_PX = 5.7
 const OSM_LABEL_RIM_INSET = 0.92
 const OSM_TOP_ARC_START_DEG = 300
 const OSM_TOP_ARC_END_DEG = 60
-const OSM_OPERATOR_COLORS = ['#38BDF8', '#22C55E', '#A855F7', '#F59E0B', '#EF4444', '#14B8A6']
 
-const splitTagList = (value?: string): string[] =>
-  value
-    ?.split(/[;,]/)
-    .map((item) => item.trim())
-    .filter(Boolean) ?? []
-
-const parseTagNumber = (tags: Record<string, string>, ...keys: string[]): number | null => {
-  for (const key of keys) {
-    const value = tags[key]
-    if (!value) continue
-    const parsed = parseFloat(value)
-    if (Number.isFinite(parsed)) return parsed
-  }
-  return null
-}
-
-const pickTagValue = (tags: Record<string, string>, ...keys: string[]): string | null => {
-  for (const key of keys) {
-    const value = tags[key]?.trim()
-    if (value) return value
-  }
-  return null
-}
-
-const formatHeightLabel = (height: string): string => (/^[\d.]+$/.test(height) ? `${height}m` : height)
-
-const normalizeAngle = (angle: number): number => ((angle % 360) + 360) % 360
-
-const overpassTechnologies = (tags: Record<string, string>): string[] => {
-  const technologies = splitTagList(tags['technology:mobile_phone']).map((tech) => tech.toLowerCase())
-  const legacyCommunication = splitTagList(tags['communication:mobile_phone'])
-    .map((tech) => tech.toLowerCase())
-    .filter((tech) => tech !== 'yes')
-  return [...new Set([...technologies, ...legacyCommunication])]
-}
-
-const overpassTechnologyGenerations = (tags: Record<string, string>): string[] => {
-  const technologies = overpassTechnologies(tags)
-  const generations = technologies.flatMap((tech) => {
-    if (tech.includes('nr') || tech.includes('5g')) return ['5G']
-    if (tech.includes('lte')) return ['4G']
-    if (tech.includes('umts') || tech.includes('wcdma') || tech.includes('hspa') || tech.includes('hsupa'))
-      return ['3G']
-    if (tech.includes('gsm') || tech.includes('edge') || tech.includes('gprs')) return ['2G']
-    return []
-  })
-  return [...new Set(generations)]
-}
-
-const overpassTechnologyLabel = (tags: Record<string, string>): string | null => {
-  const generations = overpassTechnologyGenerations(tags)
-  if (generations.length > 0) return generations.join('/')
-  const technologies = overpassTechnologies(tags)
-  if (technologies.length === 0) return null
-  return technologies.map((tech) => tech.toUpperCase()).join('/')
-}
-
-const overpassRangeMeters = (tags: Record<string, string>): number => {
-  const technologies = overpassTechnologies(tags)
-  if (technologies.length === 0) return OSM_DEFAULT_RANGE_METERS
-  return Math.max(
-    ...technologies.map((tech) => {
-      if (tech.includes('nr') || tech.includes('5g')) return 1200
-      if (tech.includes('lte')) return 1800
-      if (tech.includes('umts')) return 2200
-      if (tech.includes('gsm')) return 2800
-      return OSM_DEFAULT_RANGE_METERS
-    })
-  )
-}
-
-const overpassBearing = (tags: Record<string, string>): number | null => {
-  const parsed = parseTagNumber(tags, 'communications_transponder:bearing', 'antenna:direction', 'direction', 'bearing')
-  return parsed === null ? null : normalizeAngle(parsed)
-}
-
-const overpassBeamwidth = (tags: Record<string, string>, bearing: number | null): number => {
-  const parsed = parseTagNumber(tags, 'beamwidth', 'antenna:beamwidth')
-  if (parsed !== null && parsed > 0 && parsed <= 360) return parsed
-  return bearing === null ? 360 : OSM_DEFAULT_DIRECTIONAL_BEAMWIDTH
-}
-
-const overpassLabelParts = (tower: OverpassTower): string[] => {
-  const parts = [tower.operator ?? 'Unknown operator']
-  const technologyLabel = overpassTechnologyLabel(tower.tags)
-  const manMade = pickTagValue(tower.tags, 'man_made')
-  const height = pickTagValue(tower.tags, 'height')
-
-  if (technologyLabel) parts.push(technologyLabel)
-  if (manMade) parts.push(manMade)
-  if (height) parts.push(formatHeightLabel(height))
-  return parts
-}
-
-const fitLabelToArc = (parts: string[], maxWidthPx: number): string => {
-  for (let count = parts.length; count > 0; count--) {
-    const candidate = parts.slice(0, count).join(' - ')
-    if (candidate.length * OSM_LABEL_CHAR_WIDTH_PX <= maxWidthPx) return candidate
-  }
-  const fallback = parts[0]
-  const maxChars = Math.max(8, Math.floor(maxWidthPx / OSM_LABEL_CHAR_WIDTH_PX) - 1)
-  return fallback.length > maxChars ? `${fallback.slice(0, maxChars)}…` : fallback
-}
-
-const openCellIdOperatorLabel = (site: OpenCellIdSite): string | null => {
-  if (site.mcc === undefined || site.mnc === undefined) return null
-  return `MCC ${site.mcc} / MNC ${site.mnc}`
-}
-
-const openCellIdLabelParts = (site: OpenCellIdSite): string[] => {
-  const parts: string[] = []
-  const operator = openCellIdOperatorLabel(site)
-  if (operator) parts.push(operator)
-  if (site.radio) parts.push(site.radio.toUpperCase())
-  parts.push(`${Math.round(site.rangeMeters)}m`)
-  if (site.cellId !== undefined) parts.push(`CID ${site.cellId}`)
-  return parts
-}
-
-const filterOpenCellIdSites = (sites: OpenCellIdSite[], selectedOperator: string): OpenCellIdSite[] => {
-  if (!selectedOperator) return sites
-  return sites.filter((site) => openCellIdOperatorLabel(site) === selectedOperator)
-}
-
-const operatorColor = (operator: string | null): string => {
-  if (!operator) return OSM_OPERATOR_COLORS[0]
-  const hash = [...operator].reduce((acc, char) => acc + char.charCodeAt(0), 0)
-  return OSM_OPERATOR_COLORS[hash % OSM_OPERATOR_COLORS.length]
-}
-
-const fetchOverpassTowers = async (bbox: CoverageBbox, signal: AbortSignal): Promise<OverpassTower[]> => {
-  const region = `(${bbox.south},${bbox.west},${bbox.north},${bbox.east})`
-  const query =
-    `[out:json][timeout:25];` +
-    // Limit the overlay to mobile-phone infrastructure so the map reflects cellular coverage
-    // rather than every generic communications site in the area.
-    `(node["communication:mobile_phone"]${region};` +
-    `node["technology:mobile_phone"]${region};);` +
-    `out body;`
-  const res = await fetch('https://overpass-api.de/api/interpreter', {
-    method: 'POST',
-    headers: { 'Content-Type': 'text/plain' },
-    body: query,
-    signal,
-  })
-  if (!res.ok) throw new Error(`Overpass HTTP ${res.status}`)
-  const data = (await res.json()) as OverpassResponse
-  const seenIds = new Set<number>()
-  return (data.elements ?? [])
-    .filter(
-      (e): e is { id: number; lat: number; lon: number; tags?: Record<string, string> } =>
-        typeof e.id === 'number' && typeof e.lat === 'number' && typeof e.lon === 'number'
-    )
-    .filter((e) => {
-      if (seenIds.has(e.id)) return false
-      seenIds.add(e.id)
-      return true
-    })
-    .map<OverpassTower>((e) => ({
-      id: e.id,
-      lat: e.lat,
-      lon: e.lon,
-      operator: e.tags?.operator?.trim() || null,
-      tags: e.tags ?? {},
-    }))
-}
-
-/* eslint-enable jsdoc/require-jsdoc */
-
-// Slider 0% → blob radius is 5% of the cell range, slider 100% → full range. Linear blend
-// between the two so the slider has visible effect at every zoom level.
-const OPENCELLID_HEATMAP_MIN_RADIUS_FRACTION = 0.05
-// Per-cell peak alpha contributed at the gradient center. Two cells overlapping at full alpha
-// reach 1.0 thanks to the `lighter` compositing — this is what surfaces the warm hotspot tail
-// of the gradient when several towers cover the same patch.
-const OPENCELLID_HEATMAP_PEAK_ALPHA = 0.55
-// Cool-to-warm gradient stops mapped from per-pixel density (0..1). A single cell tops out
-// around mid-gradient (cyan/green); two cells overlapping bleed into yellow; three or more
-// reach the red hotspot range.
-const OPENCELLID_HEATMAP_GRADIENT_STOPS: ReadonlyArray<readonly [number, string]> = [
-  [0.0, 'rgba(0, 0, 255, 0)'],
-  [0.05, 'rgba(0, 80, 255, 0.4)'],
-  [0.2, 'rgba(0, 140, 255, 0.65)'],
-  [0.4, 'rgba(0, 230, 220, 0.8)'],
-  [0.6, 'rgba(60, 220, 80, 0.85)'],
-  [0.8, 'rgba(255, 220, 0, 0.9)'],
-  [1.0, 'rgba(255, 40, 0, 0.95)'],
-]
-const EARTH_CIRCUMFERENCE_M = 40075016.686
-const TILE_SIZE_PX = 256
-
-/* eslint-disable jsdoc/require-jsdoc -- helper return shapes; their property names are self-describing. */
+/* eslint-disable jsdoc/require-jsdoc -- Composable return shape; field names are self-describing. */
 type BaseStationOverlayApi = { openConfigPanel: () => void }
-type HeatmapSite = { lat: number; lon: number; rangeMeters: number }
-type CellIdHeatLayerOptions = { sites: HeatmapSite[]; radiusFraction: number; opacity: number }
-type CellIdHeatLayerInstance = L.Layer
 /* eslint-enable jsdoc/require-jsdoc */
-
-let cachedHeatGradientLut: Uint8ClampedArray | null = null
-const heatmapGradientLut = (): Uint8ClampedArray => {
-  if (cachedHeatGradientLut) return cachedHeatGradientLut
-  const lutCanvas = document.createElement('canvas')
-  lutCanvas.width = 1
-  lutCanvas.height = 256
-  const ctx = lutCanvas.getContext('2d')
-  if (!ctx) throw new Error('Heatmap LUT: 2D canvas context unavailable')
-  const grad = ctx.createLinearGradient(0, 0, 0, 256)
-  OPENCELLID_HEATMAP_GRADIENT_STOPS.forEach(([stop, color]) => grad.addColorStop(stop, color))
-  ctx.fillStyle = grad
-  ctx.fillRect(0, 0, 1, 256)
-  cachedHeatGradientLut = ctx.getImageData(0, 0, 1, 256).data
-  return cachedHeatGradientLut
-}
-
-const metersPerPixelAt = (mapInstance: L.Map, lat: number): number => {
-  const pixelsAcrossEquator = TILE_SIZE_PX * 2 ** mapInstance.getZoom()
-  return (EARTH_CIRCUMFERENCE_M * Math.cos((lat * Math.PI) / 180)) / pixelsAcrossEquator
-}
-
-// Custom Leaflet layer that renders the OpenCellID heatmap on a single canvas, with cumulative
-// alpha → cool-to-warm color mapping. Built to replace the (uninstalled) `leaflet.heat` plugin
-// so we can keep per-cell radius, eliminate canvas-edge clipping, and apply layer opacity once
-// without it bleeding into the color ramp.
-const CellIdHeatLayer = L.Layer.extend({
-  /* eslint-disable jsdoc/require-jsdoc -- Leaflet layer prototype methods, not exported API. */
-  initialize(this: CellIdHeatLayerInternal, options: CellIdHeatLayerOptions) {
-    this._heatOptions = { ...options }
-  },
-  onAdd(this: CellIdHeatLayerInternal, mapInstance: L.Map) {
-    this._map = mapInstance
-    const canvas = L.DomUtil.create('canvas', 'leaflet-cellid-heat-layer leaflet-zoom-hide')
-    canvas.style.position = 'absolute'
-    canvas.style.pointerEvents = 'none'
-    canvas.style.opacity = String(this._heatOptions.opacity)
-    this._canvas = canvas
-    mapInstance.getPanes().overlayPane.appendChild(canvas)
-    mapInstance.on('moveend resize viewreset zoomend', this._reset, this)
-    this._reset()
-    return this
-  },
-  onRemove(this: CellIdHeatLayerInternal, mapInstance: L.Map) {
-    mapInstance.getPanes().overlayPane.removeChild(this._canvas!)
-    mapInstance.off('moveend resize viewreset zoomend', this._reset, this)
-    this._canvas = undefined
-    this._map = undefined
-    return this
-  },
-  _reset(this: CellIdHeatLayerInternal) {
-    if (!this._map || !this._canvas) return
-    const topLeft = this._map.containerPointToLayerPoint([0, 0])
-    L.DomUtil.setPosition(this._canvas, topLeft)
-    const size = this._map.getSize()
-    if (this._canvas.width !== size.x) this._canvas.width = size.x
-    if (this._canvas.height !== size.y) this._canvas.height = size.y
-    this._redraw()
-  },
-  _redraw(this: CellIdHeatLayerInternal) {
-    if (!this._map || !this._canvas) return
-    const ctx = this._canvas.getContext('2d')
-    if (!ctx) return
-    const size = this._map.getSize()
-    ctx.clearRect(0, 0, size.x, size.y)
-    if (this._heatOptions.sites.length === 0) return
-    // Stage 1: accumulate per-cell radial gradients on the alpha channel. Using `lighter`
-    // makes overlapping cells brighten cumulatively → density per pixel.
-    ctx.globalCompositeOperation = 'lighter'
-    const mpp = metersPerPixelAt(this._map, this._map.getCenter().lat)
-    this._heatOptions.sites.forEach((site) => {
-      const center = this._map!.latLngToContainerPoint([site.lat, site.lon])
-      const radiusPx = Math.max(2, (site.rangeMeters * this._heatOptions.radiusFraction) / mpp)
-      if (
-        center.x + radiusPx < 0 ||
-        center.x - radiusPx > size.x ||
-        center.y + radiusPx < 0 ||
-        center.y - radiusPx > size.y
-      ) {
-        return
-      }
-      const radial = ctx.createRadialGradient(center.x, center.y, 0, center.x, center.y, radiusPx)
-      radial.addColorStop(0, `rgba(255,255,255,${OPENCELLID_HEATMAP_PEAK_ALPHA})`)
-      radial.addColorStop(1, 'rgba(255,255,255,0)')
-      ctx.fillStyle = radial
-      ctx.fillRect(center.x - radiusPx, center.y - radiusPx, 2 * radiusPx, 2 * radiusPx)
-    })
-    // Stage 2: remap each pixel's alpha through the cool→warm gradient LUT so density turns
-    // into color. The LUT also dictates the final pixel alpha so the natural radial fade is
-    // preserved while hotspots get punchier.
-    const lut = heatmapGradientLut()
-    const img = ctx.getImageData(0, 0, size.x, size.y)
-    const data = img.data
-    for (let i = 0; i < data.length; i += 4) {
-      const a = data[i + 3]
-      if (a === 0) continue
-      const lutIdx = a * 4
-      data[i] = lut[lutIdx]
-      data[i + 1] = lut[lutIdx + 1]
-      data[i + 2] = lut[lutIdx + 2]
-      data[i + 3] = lut[lutIdx + 3]
-    }
-    ctx.putImageData(img, 0, 0)
-  },
-  /* eslint-enable jsdoc/require-jsdoc */
-})
-
-/* eslint-disable jsdoc/require-jsdoc -- internal layer fields, kept private to this module. */
-type CellIdHeatLayerInternal = L.Layer & {
-  _map?: L.Map
-  _canvas?: HTMLCanvasElement
-  _heatOptions: CellIdHeatLayerOptions
-  _reset: () => void
-  _redraw: () => void
-}
-/* eslint-enable jsdoc/require-jsdoc */
-
-const createCellIdHeatLayer = (options: CellIdHeatLayerOptions): CellIdHeatLayerInstance => {
-  const Ctor = CellIdHeatLayer as unknown as new (opts: CellIdHeatLayerOptions) => CellIdHeatLayerInstance
-  return new Ctor(options)
-}
 
 const escapeMarkerLabel = (label: string): string =>
   label
@@ -915,23 +337,6 @@ export const useBaseStationOverlay = (
       },
       ...store.mobileCoverageCache.osmOverpass.filter((entry) => !bboxEquals(entry.bbox, bbox)),
     ])
-  }
-
-  const mergeOpenCellIdSites = (existing: OpenCellIdSite[] | null, incoming: OpenCellIdSite[]): OpenCellIdSite[] => {
-    const merged = new Map<string, OpenCellIdSite>()
-    ;[...(existing ?? []), ...incoming].forEach((site) => {
-      const key = `${site.lat.toFixed(6)}:${site.lon.toFixed(6)}:${Math.round(site.rangeMeters)}`
-      merged.set(key, site)
-    })
-    return [...merged.values()]
-  }
-
-  const mergeOverpassTowers = (existing: OverpassTower[] | null, incoming: OverpassTower[]): OverpassTower[] => {
-    const merged = new Map<number, OverpassTower>()
-    ;[...(existing ?? []), ...incoming].forEach((tower) => {
-      merged.set(tower.id, tower)
-    })
-    return [...merged.values()]
   }
 
   const appendOpenCellIdSites = (bbox: CoverageBbox, sites: OpenCellIdSite[]): void => {
@@ -1330,11 +735,6 @@ export const useBaseStationOverlay = (
     teardownRenderedMobileCoverage()
     clearLoadedMobileCoverageData()
   }
-
-  const mobileHeatmapRadiusFraction = (config: BaseStationConfig, intensityBoost = 1): number =>
-    OPENCELLID_HEATMAP_MIN_RADIUS_FRACTION +
-    Math.max(0, Math.min(1, config.mobileCoverage.heatmapIntensity * intensityBoost)) *
-      (1 - OPENCELLID_HEATMAP_MIN_RADIUS_FRACTION)
 
   const renderOpenCellIdHeatmap = (sites: OpenCellIdSite[], config: BaseStationConfig): void => {
     if (!map.value) return

--- a/src/composables/baseStation/useBaseStationOverlay.ts
+++ b/src/composables/baseStation/useBaseStationOverlay.ts
@@ -1237,6 +1237,7 @@ export const useBaseStationOverlay = (
     const shouldShow =
       map.value !== undefined &&
       config.position !== null &&
+      config.showSignalOnMap &&
       config.commsType === BaseStationCommsType.RadioLink &&
       config.antenna.type !== AntennaType.Omni
 
@@ -1433,6 +1434,7 @@ export const useBaseStationOverlay = (
     teardownRenderedMobileCoverage()
 
     if (!map.value || !config.enabled || !config.position) return
+    if (!config.showSignalOnMap) return
     if (config.commsType !== BaseStationCommsType.MobileData) return
 
     const provider = config.mobileCoverage.provider
@@ -1684,7 +1686,30 @@ export const useBaseStationOverlay = (
     },
     { immediate: true }
   )
-  watch(() => store.config, refreshAll, { deep: true })
+  // Geometry-relevant fields only; mobile-coverage overlay has its own watcher above and
+  // is intentionally excluded so live edits to API keys / opacity / labels don't rebuild
+  // every Leaflet layer in the overlay.
+  watch(
+    () => [
+      store.config.enabled,
+      store.config.position?.[0],
+      store.config.position?.[1],
+      store.config.name,
+      store.config.coverageColor,
+      store.config.coverageOpacity,
+      store.config.commsType,
+      store.config.tetherLengthMeters,
+      store.config.showSignalOnMap,
+      store.config.antenna.type,
+      store.config.antenna.bearing,
+      store.config.antenna.beamwidth,
+      store.config.antenna.range,
+      store.config.baseStationAntennaHeightMeters,
+      store.config.vehicleHasBlueBoatAntennaMast,
+      store.showCoverage,
+    ],
+    refreshAll
+  )
 
   // Debounced so live edits to API key / tile URL don't hammer the public APIs on every keystroke.
   watch(
@@ -1731,6 +1756,7 @@ export const useBaseStationOverlay = (
       store.config.mobileCoverage.showRingLabels,
       store.config.mobileCoverage.heatmapIntensity,
       store.config.coverageColor,
+      store.config.showSignalOnMap,
     ],
     () => {
       void renderMobileCoverage(store.config)

--- a/src/composables/baseStation/useBaseStationOverlay.ts
+++ b/src/composables/baseStation/useBaseStationOverlay.ts
@@ -2,14 +2,50 @@ import * as turf from '@turf/turf'
 import L from 'leaflet'
 import { type Ref, type ShallowRef, onBeforeUnmount, shallowRef, watch } from 'vue'
 
+import { openSnackbar } from '@/composables/snackbar'
 import { useBaseStation } from '@/composables/baseStation/useBaseStation'
 import {
   type BaseStationConfig,
   AntennaType,
   BaseStationCommsType,
   effectiveAntennaRangeMeters,
+  MobileCoverageProvider,
 } from '@/types/baseStation'
 import type { WaypointCoordinates } from '@/types/mission'
+
+/* eslint-disable jsdoc/require-jsdoc -- `leaflet.heat` ships no typings; this is a minimal augmentation. */
+declare module 'leaflet' {
+  type HeatLatLngTuple = [number, number, number]
+  interface HeatMapOptions {
+    minOpacity?: number
+    maxZoom?: number
+    max?: number
+    radius?: number
+    blur?: number
+    gradient?: Record<number, string>
+  }
+  interface HeatLayer extends Layer {
+    setOptions(options: HeatMapOptions): HeatLayer
+    addLatLng(latlng: LatLng | HeatLatLngTuple): HeatLayer
+    setLatLngs(latlngs: Array<LatLng | HeatLatLngTuple>): HeatLayer
+  }
+  function heatLayer(latlngs: Array<LatLng | HeatLatLngTuple>, options?: HeatMapOptions): HeatLayer
+}
+/* eslint-enable jsdoc/require-jsdoc */
+
+// `leaflet.heat` is a UMD-style plugin: its IIFE assigns `L.HeatLayer = …` against whatever
+// `L` it finds on the scope chain — i.e. `window.L`. With ESM imports leaflet doesn't auto-
+// publish to the global, so the plugin's IIFE silently no-ops and `L.heatLayer` ends up
+// undefined. Expose `L` on `window` first, then load the plugin lazily on first use.
+let heatLayerLoader: Promise<void> | null = null
+const ensureHeatLayer = (): Promise<void> => {
+  if (heatLayerLoader) return heatLayerLoader
+  heatLayerLoader = (async () => {
+    Object.assign(window, { L })
+    await import('leaflet.heat')
+  })()
+  return heatLayerLoader
+}
 
 const SECTOR_ARC_STEPS = 64
 
@@ -66,9 +102,136 @@ const bearingFromCenter = (center: WaypointCoordinates, point: WaypointCoordinat
   return turf.bearing(turf.point([center[1], center[0]]), turf.point([point[1], point[0]]))
 }
 
-/* eslint-disable jsdoc/require-jsdoc -- internal helper return shape, name is self-describing. */
+/* eslint-disable jsdoc/require-jsdoc -- Inline transport DTOs; field meanings follow upstream docs. */
+
+// OSM Overpass has no per-call area cap, so we use a single ~11 km half-side bbox.
+const OVERPASS_BBOX_DEG = 0.1
+// OpenCellID's getInArea caps at 4 km² per call (`code: 3` otherwise), so we tile a 3×3 grid
+// of small boxes around the base station — ~5 km × 5 km of total coverage in 9 parallel calls.
+const OPENCELLID_TILE_HALF_DEG = 0.0075
+const OPENCELLID_TILES_PER_SIDE = 3
+// `range` is reported in meters; this anchor (~5 km) maps a typical urban tower reach to
+// full intensity in the heatmap.
+const OPENCELLID_RANGE_NORMALIZER_M = 5000
+
+type CoverageBbox = { south: number; west: number; north: number; east: number }
+
+const overpassBboxAround = (lat: number, lng: number): CoverageBbox => ({
+  south: lat - OVERPASS_BBOX_DEG,
+  west: lng - OVERPASS_BBOX_DEG,
+  north: lat + OVERPASS_BBOX_DEG,
+  east: lng + OVERPASS_BBOX_DEG,
+})
+
+type OpenCellIdResponse = {
+  cells?: Array<{ lat: number; lon: number; range?: number }>
+  error?: string
+  code?: number
+}
+
+const fetchOpenCellIdTile = async (
+  bbox: CoverageBbox,
+  apiKey: string,
+  signal: AbortSignal
+): Promise<L.HeatLatLngTuple[]> => {
+  const url =
+    `https://opencellid.org/cell/getInArea?key=${encodeURIComponent(apiKey)}` +
+    `&BBOX=${bbox.south},${bbox.west},${bbox.north},${bbox.east}` +
+    `&format=json&radio=LTE,NR&limit=1000`
+  const res = await fetch(url, { signal })
+  if (!res.ok) throw new Error(`OpenCellID HTTP ${res.status}`)
+  const data = (await res.json()) as OpenCellIdResponse
+  // `code: 1` ("No cells found") is HTTP 200 + an `error` field; treat as empty, not failure.
+  if (data.error && data.code !== 1) throw new Error(`OpenCellID: ${data.error}`)
+  return (data.cells ?? []).map<L.HeatLatLngTuple>((c) => [
+    c.lat,
+    c.lon,
+    Math.min(1, (c.range ?? 1000) / OPENCELLID_RANGE_NORMALIZER_M),
+  ])
+}
+
+const fetchOpenCellIdPoints = async (
+  center: WaypointCoordinates,
+  apiKey: string,
+  signal: AbortSignal
+): Promise<L.HeatLatLngTuple[]> => {
+  const [lat, lng] = center
+  const tileEdge = OPENCELLID_TILE_HALF_DEG * 2
+  const offsetBase = (OPENCELLID_TILES_PER_SIDE - 1) / 2
+  const tiles: CoverageBbox[] = []
+  for (let i = 0; i < OPENCELLID_TILES_PER_SIDE; i++) {
+    for (let j = 0; j < OPENCELLID_TILES_PER_SIDE; j++) {
+      const cLat = lat + (i - offsetBase) * tileEdge
+      const cLng = lng + (j - offsetBase) * tileEdge
+      tiles.push({
+        south: cLat - OPENCELLID_TILE_HALF_DEG,
+        west: cLng - OPENCELLID_TILE_HALF_DEG,
+        north: cLat + OPENCELLID_TILE_HALF_DEG,
+        east: cLng + OPENCELLID_TILE_HALF_DEG,
+      })
+    }
+  }
+  const settled = await Promise.allSettled(tiles.map((b) => fetchOpenCellIdTile(b, apiKey, signal)))
+  const fulfilled = settled.filter((r): r is PromiseFulfilledResult<L.HeatLatLngTuple[]> => r.status === 'fulfilled')
+  // If every tile failed, surface the first error so the operator gets a real diagnostic
+  // (invalid key, network down, …) instead of a silent empty heatmap.
+  if (fulfilled.length === 0) {
+    const firstReject = settled.find((r): r is PromiseRejectedResult => r.status === 'rejected')
+    if (firstReject) throw firstReject.reason
+  }
+  return fulfilled.flatMap((r) => r.value)
+}
+
+type OverpassResponse = {
+  elements?: Array<{ lat?: number; lon?: number; tags?: Record<string, string> }>
+}
+
+type OverpassTower = { lat: number; lon: number; operator: string | null }
+
+const fetchOverpassTowers = async (bbox: CoverageBbox, signal: AbortSignal): Promise<OverpassTower[]> => {
+  const region = `(${bbox.south},${bbox.west},${bbox.north},${bbox.east})`
+  const query =
+    `[out:json][timeout:25];` +
+    `(node["man_made"="communications_tower"]${region};` +
+    `node["tower:type"="communication"]${region};);` +
+    // `out body` (= `out;`) is required to keep node lat/lon. `out tags;` drops coords.
+    `out body;`
+  const res = await fetch('https://overpass-api.de/api/interpreter', {
+    method: 'POST',
+    headers: { 'Content-Type': 'text/plain' },
+    body: query,
+    signal,
+  })
+  if (!res.ok) throw new Error(`Overpass HTTP ${res.status}`)
+  const data = (await res.json()) as OverpassResponse
+  return (data.elements ?? [])
+    .filter(
+      (e): e is { lat: number; lon: number; tags?: Record<string, string> } =>
+        typeof e.lat === 'number' && typeof e.lon === 'number'
+    )
+    .map<OverpassTower>((e) => ({ lat: e.lat, lon: e.lon, operator: e.tags?.operator?.trim() || null }))
+}
+
+// Real cellular sites have ~1-3 km of usable urban coverage; pick a middle value and let the
+// heatmap pixel radius track this in real meters as the operator zooms in/out.
+const HEAT_COVERAGE_METERS = 1500
+const HEAT_RADIUS_MIN_PX = 30
+const HEAT_RADIUS_MAX_PX = 140
+// Equator meters-per-pixel at zoom 0. Halves with each zoom level; multiplied by cos(lat) to
+// account for the Mercator projection narrowing toward the poles.
+const METERS_PER_PIXEL_AT_Z0 = 156543.03392
+
+type HeatRadius = { radius: number; blur: number }
 type BaseStationOverlayApi = { openConfigPanel: () => void }
 /* eslint-enable jsdoc/require-jsdoc */
+
+const heatRadiusForMap = (mapInstance: L.Map): HeatRadius => {
+  const center = mapInstance.getCenter()
+  const metersPerPixel = (METERS_PER_PIXEL_AT_Z0 * Math.cos((center.lat * Math.PI) / 180)) / 2 ** mapInstance.getZoom()
+  const ideal = HEAT_COVERAGE_METERS / metersPerPixel
+  const radius = Math.max(HEAT_RADIUS_MIN_PX, Math.min(HEAT_RADIUS_MAX_PX, ideal))
+  return { radius, blur: radius * 0.6 }
+}
 
 const baseStationMarkerHtml = (label: string): string => `
   <div class="base-station-marker-container">
@@ -98,6 +261,11 @@ export const useBaseStationOverlay = (
   const bearingHandle = shallowRef<L.Marker | undefined>()
   const bearingLine = shallowRef<L.Polyline | undefined>()
   const aimingArc = shallowRef<L.Polyline | undefined>()
+  const mobileCoverageLayer = shallowRef<L.Layer | undefined>()
+
+  let mobileCoverageController: AbortController | null = null
+  let mobileCoverageDebounce: ReturnType<typeof setTimeout> | null = null
+  let heatZoomCleanup: (() => void) | null = null
 
   const openConfigPanel = (): void => {
     store.configPanelOpen = true
@@ -289,6 +457,86 @@ export const useBaseStationOverlay = (
     bearingHandle.value = handle
   }
 
+  const teardownMobileCoverage = (): void => {
+    if (mobileCoverageController) {
+      mobileCoverageController.abort()
+      mobileCoverageController = null
+    }
+    if (heatZoomCleanup) {
+      heatZoomCleanup()
+      heatZoomCleanup = null
+    }
+    removeLayer(mobileCoverageLayer.value)
+    mobileCoverageLayer.value = undefined
+  }
+
+  const updateMobileCoverage = async (config: BaseStationConfig): Promise<void> => {
+    teardownMobileCoverage()
+
+    if (!map.value || !config.enabled || !config.position) return
+    if (config.commsType !== BaseStationCommsType.MobileData) return
+
+    const provider = config.mobileCoverage.provider
+
+    if (provider === MobileCoverageProvider.Custom) {
+      const url = config.mobileCoverage.customTileUrl.trim()
+      if (!url) return
+      mobileCoverageLayer.value = L.tileLayer(url, { opacity: 0.55 }).addTo(map.value)
+      return
+    }
+
+    const controller = new AbortController()
+    mobileCoverageController = controller
+    try {
+      let points: L.HeatLatLngTuple[]
+      if (provider === MobileCoverageProvider.OpenCellID) {
+        const apiKey = config.mobileCoverage.openCellIdApiKey.trim()
+        if (!apiKey) return
+        points = await fetchOpenCellIdPoints(config.position, apiKey, controller.signal)
+      } else {
+        const towers = await fetchOverpassTowers(
+          overpassBboxAround(config.position[0], config.position[1]),
+          controller.signal
+        )
+        if (controller.signal.aborted) return
+        // Surface the operator vocabulary actually present in the bbox so the panel can render
+        // a meaningful selector (the OSM `operator` tag is region-specific).
+        store.availableOsmOperators = [...new Set(towers.map((t) => t.operator).filter((o): o is string => !!o))].sort()
+        const selectedOperator = config.mobileCoverage.osmOperator
+        const filtered = selectedOperator ? towers.filter((t) => t.operator === selectedOperator) : towers
+        points = filtered.map<L.HeatLatLngTuple>((t) => [t.lat, t.lon, 1])
+      }
+      if (controller.signal.aborted || !map.value) return
+      if (points.length === 0) {
+        openSnackbar({
+          variant: 'info',
+          message: `${provider} returned no cellular data around the base station.`,
+          duration: 4000,
+        })
+        return
+      }
+      await ensureHeatLayer()
+      if (controller.signal.aborted || !map.value) return
+      const heat = L.heatLayer(points, { ...heatRadiusForMap(map.value), minOpacity: 0.25 }).addTo(map.value)
+      mobileCoverageLayer.value = heat
+      // Re-tune pixel radius on zoom so the visual stays anchored to ~1.5 km of real coverage.
+      const onZoom = (): void => {
+        if (map.value) heat.setOptions(heatRadiusForMap(map.value))
+      }
+      map.value.on('zoomend', onZoom)
+      heatZoomCleanup = () => map.value?.off('zoomend', onZoom)
+    } catch (err) {
+      if ((err as DOMException)?.name === 'AbortError') return
+      openSnackbar({
+        variant: 'error',
+        message: `Mobile coverage fetch failed: ${(err as Error).message}`,
+        duration: 4000,
+      })
+    } finally {
+      if (mobileCoverageController === controller) mobileCoverageController = null
+    }
+  }
+
   const refreshAll = (): void => {
     if (!map.value || !mapReady.value) return
     const config = store.config
@@ -300,6 +548,7 @@ export const useBaseStationOverlay = (
       removeLayer(bearingHandle.value)
       removeLayer(bearingLine.value)
       removeLayer(aimingArc.value)
+      teardownMobileCoverage()
       marker.value = undefined
       coverageLayer.value = undefined
       tetherLayer.value = undefined
@@ -318,7 +567,30 @@ export const useBaseStationOverlay = (
   watch([map, mapReady], refreshAll, { immediate: true })
   watch(() => store.config, refreshAll, { deep: true })
 
+  // Debounced so live edits to API key / tile URL don't hammer the public APIs on every keystroke.
+  watch(
+    () => [
+      mapReady.value,
+      store.config.commsType,
+      store.config.mobileCoverage.provider,
+      store.config.mobileCoverage.openCellIdApiKey,
+      store.config.mobileCoverage.customTileUrl,
+      store.config.mobileCoverage.osmOperator,
+      store.config.position,
+    ],
+    () => {
+      if (mobileCoverageDebounce) clearTimeout(mobileCoverageDebounce)
+      mobileCoverageDebounce = setTimeout(() => updateMobileCoverage(store.config), 500)
+    },
+    { immediate: true }
+  )
+
   onBeforeUnmount(() => {
+    if (mobileCoverageDebounce) {
+      clearTimeout(mobileCoverageDebounce)
+      mobileCoverageDebounce = null
+    }
+    teardownMobileCoverage()
     removeLayer(marker.value)
     removeLayer(coverageLayer.value)
     removeLayer(tetherLayer.value)

--- a/src/composables/baseStation/useMissionPathSignal.ts
+++ b/src/composables/baseStation/useMissionPathSignal.ts
@@ -1,0 +1,36 @@
+import { type ComputedRef, computed } from 'vue'
+
+import { useBaseStation } from '@/composables/baseStation/useBaseStation'
+import { type MobileCoverageCircle, getMobileCoverageCircles } from '@/libs/baseStation/mobileCoverage'
+import { BaseStationCommsType } from '@/types/baseStation'
+
+// Reactive helpers driving the mission-path signal coloring.
+export const useMissionPathSignal = (): {
+  /**
+   * Whether a configured comms link can color the path
+   */
+  isPathSignalAvailable: ComputedRef<boolean>
+  /**
+   * Active mobile coverage circles
+   */
+  mobileCoverageCircles: ComputedRef<MobileCoverageCircle[]>
+} => {
+  const baseStationStore = useBaseStation()
+
+  const mobileCoverageCircles = computed(() =>
+    getMobileCoverageCircles(baseStationStore.config, baseStationStore.mobileCoverageCache)
+  )
+
+  const isPathSignalAvailable = computed(() => {
+    if (!baseStationStore.config.enabled) return false
+    if (baseStationStore.config.commsType === BaseStationCommsType.RadioLink) {
+      return baseStationStore.config.position !== null
+    }
+    if (baseStationStore.config.commsType === BaseStationCommsType.MobileData) {
+      return mobileCoverageCircles.value.length > 0
+    }
+    return false
+  })
+
+  return { isPathSignalAvailable, mobileCoverageCircles }
+}

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -9,6 +9,7 @@ import { setupHardwareTelemetryService } from './services/hardware-telemetry'
 import { setupJoystickMonitoring } from './services/joystick'
 import { linkService } from './services/link'
 import { setupNetworkService } from './services/network'
+import { setupOpenCellIdService } from './services/openCellId'
 import { setupOsmRefererService } from './services/osm-referer'
 import { setupResourceMonitoringService } from './services/resource-monitoring'
 import { setupFilesystemStorage } from './services/storage'
@@ -97,6 +98,7 @@ protocol.registerSchemesAsPrivileged([
 
 setupFilesystemStorage()
 setupNetworkService()
+setupOpenCellIdService()
 setupResourceMonitoringService()
 setupSystemInfoService()
 setupHardwareTelemetryService()

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -1,5 +1,6 @@
 import { contextBridge, ipcRenderer } from 'electron'
 
+import type { OpenCellIdBboxRequest } from '@/types/baseStation'
 import type { ElectronSDLJoystickControllerStateEventData } from '@/types/joystick'
 import type { FileDialogOptions, FileStats } from '@/types/storage'
 
@@ -8,6 +9,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   checkTcpPortOpen: (host: string, port: number, timeoutMs: number) =>
     ipcRenderer.invoke('check-tcp-port-open', host, port, timeoutMs),
   abortTcpPortProbes: () => ipcRenderer.invoke('abort-tcp-port-probes'),
+  fetchNearbyOpenCellIdCells: (bbox: OpenCellIdBboxRequest) =>
+    ipcRenderer.invoke('fetch-nearby-open-cell-id-cells', bbox),
   getResourceUsage: () => ipcRenderer.invoke('get-resource-usage'),
   onUpdateAvailable: (callback: (info: any) => void) =>
     ipcRenderer.on('update-available', (_event, info) => callback(info)),

--- a/src/electron/services/openCellId.ts
+++ b/src/electron/services/openCellId.ts
@@ -1,0 +1,202 @@
+import { createHash } from 'crypto'
+import { ipcMain } from 'electron'
+
+import type { NearbyOpenCellIdCell, OpenCellIdBboxRequest } from '../../types/baseStation'
+
+/* eslint-disable jsdoc/require-jsdoc -- Internal OpenCellID DTOs; field meanings follow upstream API docs. */
+type OpenCellIdOfficialResponse = {
+  cells?: OpenCellIdOfficialCell[]
+  error?: string
+  code?: number
+}
+
+type OpenCellIdOfficialCell = {
+  lat: number
+  lon: number
+  range?: number
+  radio?: string
+  mcc?: number
+  mnc?: number
+  lac?: number
+  cellid?: number
+  samples?: number
+  averageSignalStrength?: number
+}
+
+type CachedOpenCellIdBboxEntry = {
+  cachedAtMs: number
+  cells: NearbyOpenCellIdCell[]
+}
+/* eslint-enable jsdoc/require-jsdoc */
+
+const OPEN_CELL_ID_MIN_REQUEST_INTERVAL_MS = 350
+const OPEN_CELL_ID_CACHE_TTL_MS = 10 * 60 * 1000
+const OPEN_CELL_ID_REQUEST_TIMEOUT_MS = 15 * 1000
+const OPEN_CELL_ID_RATE_LIMIT_COOLDOWN_MS = 2 * 60 * 1000
+const OPEN_CELL_ID_TOO_MANY_REQUESTS_BACKOFF_MS = [2000, 5000, 10000]
+const OPEN_CELL_ID_BBOX_CACHE_MAX_ENTRIES = 200
+const openCellIdBboxCache = new Map<string, CachedOpenCellIdBboxEntry>()
+const openCellIdInflight = new Map<string, Promise<NearbyOpenCellIdCell[]>>()
+let openCellIdQueue: Promise<void> = Promise.resolve()
+let lastOpenCellIdRequestMs = 0
+let openCellIdRateLimitUntilMs = 0
+
+const trimOpenCellIdCache = (): void => {
+  while (openCellIdBboxCache.size > OPEN_CELL_ID_BBOX_CACHE_MAX_ENTRIES) {
+    const oldestKey = openCellIdBboxCache.keys().next().value
+    if (oldestKey === undefined) break
+    openCellIdBboxCache.delete(oldestKey)
+  }
+}
+
+const validateBbox = (bbox: OpenCellIdBboxRequest): void => {
+  for (const value of [bbox.west, bbox.south, bbox.east, bbox.north]) {
+    if (!Number.isFinite(value)) throw new Error('OpenCellID: bbox must contain finite numbers.')
+  }
+  if (bbox.south < -90 || bbox.south > 90 || bbox.north < -90 || bbox.north > 90) {
+    throw new Error('OpenCellID: latitude out of [-90, 90] range.')
+  }
+  if (bbox.west < -180 || bbox.west > 180 || bbox.east < -180 || bbox.east > 180) {
+    throw new Error('OpenCellID: longitude out of [-180, 180] range.')
+  }
+  if (bbox.south >= bbox.north) throw new Error('OpenCellID: bbox south must be < north.')
+  if (bbox.west >= bbox.east) throw new Error('OpenCellID: bbox west must be < east.')
+}
+
+const fetchWithTimeout = async (url: string, timeoutMs: number): Promise<Response> => {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    return await fetch(url, { signal: controller.signal })
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+const sleep = async (delayMs: number): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, delayMs))
+}
+
+// Switching API keys must invalidate cached responses fetched with the previous key, so the
+// cache key folds in a short fingerprint of the trimmed key (or `none` when missing).
+const openCellIdApiKeyFingerprint = (apiKey: string | undefined): string => {
+  const trimmed = apiKey?.trim() ?? ''
+  if (!trimmed) return 'none'
+  return createHash('sha256').update(trimmed).digest('hex').slice(0, 12)
+}
+
+const openCellIdBboxKey = (bbox: OpenCellIdBboxRequest): string =>
+  `${openCellIdApiKeyFingerprint(bbox.apiKey)}:` +
+  [bbox.west, bbox.south, bbox.east, bbox.north].map((value) => value.toFixed(6)).join(':')
+
+const isTooManyRequestsError = (error: unknown): boolean => {
+  if (!(error instanceof Error)) return false
+  return /\b429\b/.test(error.message) || /too many requests/i.test(error.message)
+}
+
+const fetchOpenCellIdCellsWithApiKey = async (
+  bbox: OpenCellIdBboxRequest,
+  apiKey: string
+): Promise<NearbyOpenCellIdCell[]> => {
+  const url = new URL('https://opencellid.org/cell/getInArea')
+  url.searchParams.set('key', apiKey)
+  url.searchParams.set('BBOX', `${bbox.south},${bbox.west},${bbox.north},${bbox.east}`)
+  url.searchParams.set('format', 'json')
+  url.searchParams.set('limit', '50')
+
+  const response = await fetchWithTimeout(url.toString(), OPEN_CELL_ID_REQUEST_TIMEOUT_MS)
+  if (!response.ok) throw new Error(`OpenCellID HTTP ${response.status}`)
+
+  const data = (await response.json()) as OpenCellIdOfficialResponse
+  if (data.error && data.code !== 1) throw new Error(`OpenCellID: ${data.error}`)
+  return (data.cells ?? []).map((cell) => ({
+    lat: cell.lat,
+    lon: cell.lon,
+    range: cell.range,
+    radio: cell.radio,
+    mcc: cell.mcc,
+    mnc: cell.mnc,
+    lac: cell.lac,
+    cellId: cell.cellid,
+    samples: cell.samples,
+    averageSignalStrength: cell.averageSignalStrength,
+  }))
+}
+
+const fetchOpenCellIdCellsQueued = async (bbox: OpenCellIdBboxRequest): Promise<NearbyOpenCellIdCell[]> => {
+  validateBbox(bbox)
+  const apiKey = bbox.apiKey?.trim()
+  if (!apiKey) throw new Error('OpenCellID: missing API key.')
+
+  const key = openCellIdBboxKey(bbox)
+  const cached = openCellIdBboxCache.get(key)
+  if (cached && Date.now() - cached.cachedAtMs < OPEN_CELL_ID_CACHE_TTL_MS) {
+    // Refresh LRU order so hot entries survive the size-based eviction below.
+    openCellIdBboxCache.delete(key)
+    openCellIdBboxCache.set(key, cached)
+    return cached.cells
+  }
+
+  const inflight = openCellIdInflight.get(key)
+  if (inflight) return inflight
+  if (Date.now() < openCellIdRateLimitUntilMs) {
+    throw new Error('OpenCellID: Too many requests. Cooling down before the next retry.')
+  }
+
+  const request = new Promise<NearbyOpenCellIdCell[]>((resolve, reject) => {
+    openCellIdQueue = openCellIdQueue
+      .catch(() => undefined)
+      .then(async () => {
+        try {
+          const waitMs = Math.max(0, OPEN_CELL_ID_MIN_REQUEST_INTERVAL_MS - (Date.now() - lastOpenCellIdRequestMs))
+          if (waitMs > 0) await sleep(waitMs)
+
+          let lastError: unknown = undefined
+          for (let attempt = 0; attempt <= OPEN_CELL_ID_TOO_MANY_REQUESTS_BACKOFF_MS.length; attempt++) {
+            try {
+              const cells = await fetchOpenCellIdCellsWithApiKey(bbox, apiKey)
+              lastOpenCellIdRequestMs = Date.now()
+              openCellIdBboxCache.set(key, { cachedAtMs: Date.now(), cells })
+              trimOpenCellIdCache()
+              resolve(cells)
+              return
+            } catch (error) {
+              lastError = error
+              if (!isTooManyRequestsError(error) || attempt === OPEN_CELL_ID_TOO_MANY_REQUESTS_BACKOFF_MS.length) {
+                if (isTooManyRequestsError(error)) {
+                  openCellIdRateLimitUntilMs = Date.now() + OPEN_CELL_ID_RATE_LIMIT_COOLDOWN_MS
+                }
+                reject(error)
+                return
+              }
+              await sleep(OPEN_CELL_ID_TOO_MANY_REQUESTS_BACKOFF_MS[attempt])
+            }
+          }
+          reject(lastError)
+        } catch (error) {
+          reject(error)
+        }
+      })
+  }).finally(() => {
+    openCellIdInflight.delete(key)
+  })
+
+  openCellIdInflight.set(key, request)
+  return request
+}
+
+const fetchNearbyOpenCellIdCells = async (
+  _event: Electron.IpcMainInvokeEvent,
+  bbox: OpenCellIdBboxRequest
+): Promise<NearbyOpenCellIdCell[]> => {
+  return await fetchOpenCellIdCellsQueued(bbox)
+}
+
+/**
+ * Setup the OpenCellID bridge service. Exposes a renderer-callable IPC handler
+ * that proxies bbox queries to opencellid.org with caching, rate-limiting and
+ * 429 backoff so the renderer never sees the raw upstream API.
+ */
+export const setupOpenCellIdService = (): void => {
+  ipcMain.handle('fetch-nearby-open-cell-id-cells', fetchNearbyOpenCellIdCells)
+}

--- a/src/libs/baseStation/cellIdHeatLayer.ts
+++ b/src/libs/baseStation/cellIdHeatLayer.ts
@@ -1,0 +1,168 @@
+import L from 'leaflet'
+
+import type { BaseStationConfig } from '@/types/baseStation'
+
+// Slider 0% → blob radius is 5% of the cell range, slider 100% → full range. Linear blend
+// between the two so the slider has visible effect at every zoom level.
+const OPENCELLID_HEATMAP_MIN_RADIUS_FRACTION = 0.05
+// Per-cell peak alpha contributed at the gradient center. Two cells overlapping at full alpha
+// reach 1.0 thanks to the `lighter` compositing — this is what surfaces the warm hotspot tail
+// of the gradient when several towers cover the same patch.
+const OPENCELLID_HEATMAP_PEAK_ALPHA = 0.55
+// Cool-to-warm gradient stops mapped from per-pixel density (0..1). A single cell tops out
+// around mid-gradient (cyan/green); two cells overlapping bleed into yellow; three or more
+// reach the red hotspot range.
+const OPENCELLID_HEATMAP_GRADIENT_STOPS: ReadonlyArray<readonly [number, string]> = [
+  [0.0, 'rgba(0, 0, 255, 0)'],
+  [0.05, 'rgba(0, 80, 255, 0.4)'],
+  [0.2, 'rgba(0, 140, 255, 0.65)'],
+  [0.4, 'rgba(0, 230, 220, 0.8)'],
+  [0.6, 'rgba(60, 220, 80, 0.85)'],
+  [0.8, 'rgba(255, 220, 0, 0.9)'],
+  [1.0, 'rgba(255, 40, 0, 0.95)'],
+]
+const EARTH_CIRCUMFERENCE_M = 40075016.686
+const TILE_SIZE_PX = 256
+
+/* eslint-disable jsdoc/require-jsdoc -- helper return shapes; their property names are self-describing. */
+export type HeatmapSite = { lat: number; lon: number; rangeMeters: number }
+export type CellIdHeatLayerOptions = { sites: HeatmapSite[]; radiusFraction: number; opacity: number }
+export type CellIdHeatLayerInstance = L.Layer
+/* eslint-enable jsdoc/require-jsdoc */
+
+let cachedHeatGradientLut: Uint8ClampedArray | null = null
+const heatmapGradientLut = (): Uint8ClampedArray => {
+  if (cachedHeatGradientLut) return cachedHeatGradientLut
+  const lutCanvas = document.createElement('canvas')
+  lutCanvas.width = 1
+  lutCanvas.height = 256
+  const ctx = lutCanvas.getContext('2d')
+  if (!ctx) throw new Error('Heatmap LUT: 2D canvas context unavailable')
+  const grad = ctx.createLinearGradient(0, 0, 0, 256)
+  OPENCELLID_HEATMAP_GRADIENT_STOPS.forEach(([stop, color]) => grad.addColorStop(stop, color))
+  ctx.fillStyle = grad
+  ctx.fillRect(0, 0, 1, 256)
+  cachedHeatGradientLut = ctx.getImageData(0, 0, 1, 256).data
+  return cachedHeatGradientLut
+}
+
+const metersPerPixelAt = (mapInstance: L.Map, lat: number): number => {
+  const pixelsAcrossEquator = TILE_SIZE_PX * 2 ** mapInstance.getZoom()
+  return (EARTH_CIRCUMFERENCE_M * Math.cos((lat * Math.PI) / 180)) / pixelsAcrossEquator
+}
+
+/* eslint-disable jsdoc/require-jsdoc -- internal layer fields, kept private to this module. */
+type CellIdHeatLayerInternal = L.Layer & {
+  _map?: L.Map
+  _canvas?: HTMLCanvasElement
+  _heatOptions: CellIdHeatLayerOptions
+  _reset: () => void
+  _redraw: () => void
+}
+/* eslint-enable jsdoc/require-jsdoc */
+
+// Custom Leaflet layer that renders the OpenCellID heatmap on a single canvas, with cumulative
+// alpha → cool-to-warm color mapping. Built to replace the (uninstalled) `leaflet.heat` plugin
+// so we can keep per-cell radius, eliminate canvas-edge clipping, and apply layer opacity once
+// without it bleeding into the color ramp.
+const CellIdHeatLayer = L.Layer.extend({
+  /* eslint-disable jsdoc/require-jsdoc -- Leaflet layer prototype methods, not exported API. */
+  initialize(this: CellIdHeatLayerInternal, options: CellIdHeatLayerOptions) {
+    this._heatOptions = { ...options }
+  },
+  onAdd(this: CellIdHeatLayerInternal, mapInstance: L.Map) {
+    this._map = mapInstance
+    const canvas = L.DomUtil.create('canvas', 'leaflet-cellid-heat-layer leaflet-zoom-hide')
+    canvas.style.position = 'absolute'
+    canvas.style.pointerEvents = 'none'
+    canvas.style.opacity = String(this._heatOptions.opacity)
+    this._canvas = canvas
+    mapInstance.getPanes().overlayPane.appendChild(canvas)
+    mapInstance.on('moveend resize viewreset zoomend', this._reset, this)
+    this._reset()
+    return this
+  },
+  onRemove(this: CellIdHeatLayerInternal, mapInstance: L.Map) {
+    mapInstance.getPanes().overlayPane.removeChild(this._canvas!)
+    mapInstance.off('moveend resize viewreset zoomend', this._reset, this)
+    this._canvas = undefined
+    this._map = undefined
+    return this
+  },
+  _reset(this: CellIdHeatLayerInternal) {
+    if (!this._map || !this._canvas) return
+    const topLeft = this._map.containerPointToLayerPoint([0, 0])
+    L.DomUtil.setPosition(this._canvas, topLeft)
+    const size = this._map.getSize()
+    if (this._canvas.width !== size.x) this._canvas.width = size.x
+    if (this._canvas.height !== size.y) this._canvas.height = size.y
+    this._redraw()
+  },
+  _redraw(this: CellIdHeatLayerInternal) {
+    if (!this._map || !this._canvas) return
+    const ctx = this._canvas.getContext('2d')
+    if (!ctx) return
+    const size = this._map.getSize()
+    ctx.clearRect(0, 0, size.x, size.y)
+    if (this._heatOptions.sites.length === 0) return
+    // Stage 1: accumulate per-cell radial gradients on the alpha channel. Using `lighter`
+    // makes overlapping cells brighten cumulatively → density per pixel.
+    ctx.globalCompositeOperation = 'lighter'
+    const mpp = metersPerPixelAt(this._map, this._map.getCenter().lat)
+    this._heatOptions.sites.forEach((site) => {
+      const center = this._map!.latLngToContainerPoint([site.lat, site.lon])
+      const radiusPx = Math.max(2, (site.rangeMeters * this._heatOptions.radiusFraction) / mpp)
+      if (
+        center.x + radiusPx < 0 ||
+        center.x - radiusPx > size.x ||
+        center.y + radiusPx < 0 ||
+        center.y - radiusPx > size.y
+      ) {
+        return
+      }
+      const radial = ctx.createRadialGradient(center.x, center.y, 0, center.x, center.y, radiusPx)
+      radial.addColorStop(0, `rgba(255,255,255,${OPENCELLID_HEATMAP_PEAK_ALPHA})`)
+      radial.addColorStop(1, 'rgba(255,255,255,0)')
+      ctx.fillStyle = radial
+      ctx.fillRect(center.x - radiusPx, center.y - radiusPx, 2 * radiusPx, 2 * radiusPx)
+    })
+    // Stage 2: remap each pixel's alpha through the cool→warm gradient LUT so density turns
+    // into color. The LUT also dictates the final pixel alpha so the natural radial fade is
+    // preserved while hotspots get punchier.
+    const lut = heatmapGradientLut()
+    const img = ctx.getImageData(0, 0, size.x, size.y)
+    const data = img.data
+    for (let i = 0; i < data.length; i += 4) {
+      const a = data[i + 3]
+      if (a === 0) continue
+      const lutIdx = a * 4
+      data[i] = lut[lutIdx]
+      data[i + 1] = lut[lutIdx + 1]
+      data[i + 2] = lut[lutIdx + 2]
+      data[i + 3] = lut[lutIdx + 3]
+    }
+    ctx.putImageData(img, 0, 0)
+  },
+  /* eslint-enable jsdoc/require-jsdoc */
+})
+
+/**
+ * Instantiate a {@link CellIdHeatLayer}.
+ * @param {CellIdHeatLayerOptions} options Layer options.
+ * @returns {CellIdHeatLayerInstance} Leaflet layer instance.
+ */
+export const createCellIdHeatLayer = (options: CellIdHeatLayerOptions): CellIdHeatLayerInstance => {
+  const Ctor = CellIdHeatLayer as unknown as new (opts: CellIdHeatLayerOptions) => CellIdHeatLayerInstance
+  return new Ctor(options)
+}
+
+/**
+ * Resolve the heatmap radius fraction for the active config + intensity boost.
+ * @param {BaseStationConfig} config Base station configuration.
+ * @param {number} intensityBoost Multiplier applied to `heatmapIntensity` before blending.
+ * @returns {number} Radius fraction in [{@link OPENCELLID_HEATMAP_MIN_RADIUS_FRACTION}, 1].
+ */
+export const mobileHeatmapRadiusFraction = (config: BaseStationConfig, intensityBoost = 1): number =>
+  OPENCELLID_HEATMAP_MIN_RADIUS_FRACTION +
+  Math.max(0, Math.min(1, config.mobileCoverage.heatmapIntensity * intensityBoost)) *
+    (1 - OPENCELLID_HEATMAP_MIN_RADIUS_FRACTION)

--- a/src/libs/baseStation/coverageBbox.ts
+++ b/src/libs/baseStation/coverageBbox.ts
@@ -1,0 +1,122 @@
+import * as turf from '@turf/turf'
+import type L from 'leaflet'
+
+import type { CachedMobileCoverageEntry, CoverageBbox } from '@/types/baseStation'
+import type { WaypointCoordinates } from '@/types/mission'
+
+/** OSM Overpass has no per-call area cap, so a single ~11 km half-side bbox is enough. */
+export const OVERPASS_BBOX_DEG = 0.1
+
+/** Half-side of the OpenCellID coverage bounding box around the base station. */
+export const OPENCELLID_COVERAGE_HALF_SIDE_KM = 25
+
+/** Keep the persisted bbox cache small; users rarely need more than the most recent few areas. */
+export const MOBILE_COVERAGE_CACHE_MAX_ENTRIES = 8
+
+export const kmToLatDegrees = (km: number): number => km / 111.32
+
+export const kmToLngDegrees = (km: number, lat: number): number => {
+  const cosLat = Math.max(0.2, Math.cos((lat * Math.PI) / 180))
+  return km / (111.32 * cosLat)
+}
+
+/**
+ * Square-ish Overpass bbox centered on the given coordinate.
+ * @param {number} lat Center latitude.
+ * @param {number} lng Center longitude.
+ * @returns {CoverageBbox} Bounding box.
+ */
+export const overpassBboxAround = (lat: number, lng: number): CoverageBbox => ({
+  south: lat - OVERPASS_BBOX_DEG,
+  west: lng - OVERPASS_BBOX_DEG,
+  north: lat + OVERPASS_BBOX_DEG,
+  east: lng + OVERPASS_BBOX_DEG,
+})
+
+/**
+ * OpenCellID coverage bbox sized via {@link OPENCELLID_COVERAGE_HALF_SIDE_KM}.
+ * @param {number} lat Center latitude.
+ * @param {number} lng Center longitude.
+ * @returns {CoverageBbox} Bounding box.
+ */
+export const openCellIdCoverageBboxAround = (lat: number, lng: number): CoverageBbox => ({
+  south: lat - kmToLatDegrees(OPENCELLID_COVERAGE_HALF_SIDE_KM),
+  west: lng - kmToLngDegrees(OPENCELLID_COVERAGE_HALF_SIDE_KM, lat),
+  north: lat + kmToLatDegrees(OPENCELLID_COVERAGE_HALF_SIDE_KM),
+  east: lng + kmToLngDegrees(OPENCELLID_COVERAGE_HALF_SIDE_KM, lat),
+})
+
+export const bboxContains = (bbox: CoverageBbox, position: WaypointCoordinates): boolean => {
+  const [lat, lng] = position
+  return lat >= bbox.south && lat <= bbox.north && lng >= bbox.west && lng <= bbox.east
+}
+
+export const bboxIntersects = (left: CoverageBbox, right: CoverageBbox): boolean =>
+  left.west <= right.east && left.east >= right.west && left.south <= right.north && left.north >= right.south
+
+export const bboxEquals = (left: CoverageBbox, right: CoverageBbox): boolean =>
+  left.south === right.south && left.west === right.west && left.north === right.north && left.east === right.east
+
+export const leafletBoundsToCoverageBbox = (bounds: L.LatLngBounds): CoverageBbox => ({
+  south: bounds.getSouth(),
+  west: bounds.getWest(),
+  north: bounds.getNorth(),
+  east: bounds.getEast(),
+})
+
+/**
+ * Sort by `fetchedAtMs` (newest first) and clip to {@link MOBILE_COVERAGE_CACHE_MAX_ENTRIES}.
+ * @param {CachedMobileCoverageEntry<T>[]} entries Cache entries to trim.
+ * @returns {CachedMobileCoverageEntry<T>[]} Newest entries up to the cache cap.
+ */
+export const trimCacheEntries = <T>(entries: CachedMobileCoverageEntry<T>[]): CachedMobileCoverageEntry<T>[] => {
+  return entries.sort((a, b) => b.fetchedAtMs - a.fetchedAtMs).slice(0, MOBILE_COVERAGE_CACHE_MAX_ENTRIES)
+}
+
+/**
+ * Slice an area into uniform tiles of size `tileHalfSideKm * 2`.
+ * @param {CoverageBbox} area Outer area.
+ * @param {number} centerLat Reference latitude (controls longitude scaling).
+ * @param {number} tileHalfSideKm Tile half-side, in kilometers.
+ * @returns {CoverageBbox[]} Tile bboxes covering the area.
+ */
+export const tiledCoverageBboxes = (area: CoverageBbox, centerLat: number, tileHalfSideKm: number): CoverageBbox[] => {
+  const tileLatSize = kmToLatDegrees(tileHalfSideKm * 2)
+  const tileLngSize = kmToLngDegrees(tileHalfSideKm * 2, centerLat)
+  const latCount = Math.ceil((area.north - area.south) / tileLatSize)
+  const lngCount = Math.ceil((area.east - area.west) / tileLngSize)
+  const tiles: CoverageBbox[] = []
+
+  for (let latIndex = 0; latIndex < latCount; latIndex++) {
+    const south = area.south + latIndex * tileLatSize
+    const north = Math.min(area.north, south + tileLatSize)
+    for (let lngIndex = 0; lngIndex < lngCount; lngIndex++) {
+      const west = area.west + lngIndex * tileLngSize
+      const east = Math.min(area.east, west + tileLngSize)
+      tiles.push({ south, west, north, east })
+    }
+  }
+
+  return tiles
+}
+
+export const bboxCenter = (bbox: CoverageBbox): WaypointCoordinates => [
+  (bbox.south + bbox.north) / 2,
+  (bbox.west + bbox.east) / 2,
+]
+
+export const sortCoverageBboxesByDistance = (center: WaypointCoordinates, bboxes: CoverageBbox[]): CoverageBbox[] =>
+  [...bboxes].sort((left, right) => {
+    const [leftLat, leftLng] = bboxCenter(left)
+    const [rightLat, rightLng] = bboxCenter(right)
+    const leftDistance = turf.distance(turf.point([center[1], center[0]]), turf.point([leftLng, leftLat]))
+    const rightDistance = turf.distance(turf.point([center[1], center[0]]), turf.point([rightLng, rightLat]))
+    return leftDistance - rightDistance
+  })
+
+export const unionCoverageBboxes = (bboxes: CoverageBbox[]): CoverageBbox => ({
+  south: Math.min(...bboxes.map((bbox) => bbox.south)),
+  west: Math.min(...bboxes.map((bbox) => bbox.west)),
+  north: Math.max(...bboxes.map((bbox) => bbox.north)),
+  east: Math.max(...bboxes.map((bbox) => bbox.east)),
+})

--- a/src/libs/baseStation/geometry.ts
+++ b/src/libs/baseStation/geometry.ts
@@ -1,0 +1,81 @@
+import * as turf from '@turf/turf'
+import type L from 'leaflet'
+
+import type { WaypointCoordinates } from '@/types/mission'
+
+const SECTOR_ARC_STEPS = 64
+
+/**
+ * Build the LatLng polygon describing a directional antenna's coverage sector.
+ * @param {WaypointCoordinates} center Antenna position.
+ * @param {number} rangeMeters Effective antenna range.
+ * @param {number} bearingDeg Antenna bearing (degrees).
+ * @param {number} beamwidthDeg Antenna beamwidth (degrees).
+ * @returns {L.LatLngExpression[]} Polygon vertices, including the apex at both ends.
+ */
+export const sectorPolygonLatLngs = (
+  center: WaypointCoordinates,
+  rangeMeters: number,
+  bearingDeg: number,
+  beamwidthDeg: number
+): L.LatLngExpression[] => {
+  const halfBeam = beamwidthDeg / 2
+  const startBearing = bearingDeg - halfBeam
+  const endBearing = bearingDeg + halfBeam
+  const rangeKm = rangeMeters / 1000
+  const turfCenter = turf.point([center[1], center[0]])
+
+  const arc = turf.lineArc(turfCenter, rangeKm, startBearing, endBearing, { steps: SECTOR_ARC_STEPS })
+  const arcPoints = arc.geometry.coordinates.map(([lng, lat]) => [lat, lng] as L.LatLngExpression)
+  return [center as L.LatLngExpression, ...arcPoints, center as L.LatLngExpression]
+}
+
+/**
+ * Project a point at the antenna's max range along its current bearing — used as the
+ * draggable handle position on the map.
+ * @param {WaypointCoordinates} center Antenna position.
+ * @param {number} rangeMeters Effective antenna range.
+ * @param {number} bearingDeg Antenna bearing (degrees).
+ * @returns {WaypointCoordinates} Handle position.
+ */
+export const bearingHandlePosition = (
+  center: WaypointCoordinates,
+  rangeMeters: number,
+  bearingDeg: number
+): WaypointCoordinates => {
+  const dest = turf.destination(turf.point([center[1], center[0]]), rangeMeters / 1000, bearingDeg, {
+    units: 'kilometers',
+  })
+  const [lng, lat] = dest.geometry.coordinates
+  return [lat, lng]
+}
+
+/**
+ * 180° front-facing arc at the antenna's max range, used to preview where the signal will land
+ * as the operator rotates the antenna.
+ * @param {WaypointCoordinates} center Antenna position.
+ * @param {number} rangeMeters Effective antenna range.
+ * @param {number} bearingDeg Antenna bearing (degrees).
+ * @returns {L.LatLngExpression[]} Polyline points along the aiming arc.
+ */
+export const aimingArcLatLngs = (
+  center: WaypointCoordinates,
+  rangeMeters: number,
+  bearingDeg: number
+): L.LatLngExpression[] => {
+  const turfCenter = turf.point([center[1], center[0]])
+  const arc = turf.lineArc(turfCenter, rangeMeters / 1000, bearingDeg - 90, bearingDeg + 90, {
+    steps: SECTOR_ARC_STEPS,
+  })
+  return arc.geometry.coordinates.map(([lng, lat]) => [lat, lng] as L.LatLngExpression)
+}
+
+/**
+ * Compass bearing from `center` to `point`, in degrees.
+ * @param {WaypointCoordinates} center Reference point.
+ * @param {WaypointCoordinates} point Target point.
+ * @returns {number} Bearing in degrees (-180..180).
+ */
+export const bearingFromCenter = (center: WaypointCoordinates, point: WaypointCoordinates): number => {
+  return turf.bearing(turf.point([center[1], center[0]]), turf.point([point[1], point[0]]))
+}

--- a/src/libs/baseStation/missionPathSignal.ts
+++ b/src/libs/baseStation/missionPathSignal.ts
@@ -1,0 +1,156 @@
+import * as turf from '@turf/turf'
+
+import { calculateHaversineDistance } from '@/libs/mission/general-estimates'
+import { type BaseStationConfig, BaseStationCommsType, effectiveAntennaRangeMeters } from '@/types/baseStation'
+import type { WaypointCoordinates } from '@/types/mission'
+
+import type { MobileCoverageCircle } from './mobileCoverage'
+
+/**
+ * Risk levels used to color the mission path according to expected comms quality.
+ */
+export enum MissionCoverageRisk {
+  Good = 'good',
+  Marginal = 'marginal',
+  LikelyLost = 'likely_lost',
+  Unknown = 'unknown',
+}
+
+export type MissionCoverageSegment = {
+  /**
+   * Segment start coordinates.
+   */
+  start: WaypointCoordinates
+  /**
+   * Segment end coordinates.
+   */
+  end: WaypointCoordinates
+  /**
+   * Risk classification for the segment.
+   */
+  risk: MissionCoverageRisk
+}
+
+/** Sampling step (meters) used to subdivide the mission path for color shading. */
+export const DEFAULT_MISSION_COVERAGE_DISPLAY_SAMPLE_INTERVAL_METERS = 8
+
+/** In-range distances above this fraction of effective range are treated as marginal. */
+const GOOD_RANGE_FRACTION = 0.75
+
+/** Distance past the nearest mobile coverage ring border that still counts as marginal. */
+const MOBILE_MARGINAL_OUTSIDE_METERS = 300
+
+export const MISSION_COVERAGE_RISK_COLORS: Record<MissionCoverageRisk, string> = {
+  [MissionCoverageRisk.Good]: '#22c55e',
+  [MissionCoverageRisk.Marginal]: '#f59e0b',
+  [MissionCoverageRisk.LikelyLost]: '#ef4444',
+  [MissionCoverageRisk.Unknown]: '#94a3b8',
+}
+
+const buildSamplesAlongCoordinates = (
+  path: WaypointCoordinates[],
+  sampleIntervalMeters: number
+): WaypointCoordinates[] => {
+  if (path.length < 2) return []
+
+  const line = turf.lineString(path.map((coordinates) => [coordinates[1], coordinates[0]]))
+  const totalLengthMeters = turf.length(line, { units: 'kilometers' }) * 1000
+  if (totalLengthMeters <= 0) return []
+
+  const alongDistances: number[] = []
+  if (totalLengthMeters <= sampleIntervalMeters) {
+    alongDistances.push(0, totalLengthMeters)
+  } else {
+    for (let d = 0; d < totalLengthMeters; d += sampleIntervalMeters) {
+      alongDistances.push(d)
+    }
+    if (alongDistances[alongDistances.length - 1] !== totalLengthMeters) {
+      alongDistances.push(totalLengthMeters)
+    }
+  }
+
+  return alongDistances.map((distanceAlongMissionMeters) => {
+    const pt = turf.along(line, distanceAlongMissionMeters / 1000, { units: 'kilometers' })
+    const [lng, lat] = pt.geometry.coordinates
+    return [lat, lng] as WaypointCoordinates
+  })
+}
+
+const distanceToNearestRingBorderMeters = (point: WaypointCoordinates, circles: MobileCoverageCircle[]): number => {
+  let best = Number.POSITIVE_INFINITY
+  for (const circle of circles) {
+    const distanceToCenter = calculateHaversineDistance(circle.center, point)
+    const borderDistance = distanceToCenter - circle.rangeMeters
+    if (borderDistance < best) best = borderDistance
+  }
+  return best
+}
+
+/**
+ * Classify comms risk at a geographic point. Radio-link missions use the antenna range arc;
+ * mobile-data missions use the nearest cellular coverage ring border.
+ * @param {BaseStationConfig} config Base-station configuration.
+ * @param {WaypointCoordinates} point Point to evaluate.
+ * @param {MobileCoverageCircle[]} mobileCoverageCircles Active mobile coverage circles (only used for MobileData).
+ * @returns {MissionCoverageRisk} Risk classification at the point.
+ */
+export const classifyCoverageAtPoint = (
+  config: BaseStationConfig,
+  point: WaypointCoordinates,
+  mobileCoverageCircles: MobileCoverageCircle[] = []
+): MissionCoverageRisk => {
+  if (!config.enabled) return MissionCoverageRisk.Unknown
+
+  if (config.commsType === BaseStationCommsType.RadioLink) {
+    if (!config.position) return MissionCoverageRisk.Unknown
+
+    const distanceFromBaseMeters = calculateHaversineDistance(config.position, point)
+    const rangeMeters = effectiveAntennaRangeMeters(config)
+
+    if (distanceFromBaseMeters > rangeMeters) return MissionCoverageRisk.LikelyLost
+    if (distanceFromBaseMeters > rangeMeters * GOOD_RANGE_FRACTION) return MissionCoverageRisk.Marginal
+    return MissionCoverageRisk.Good
+  }
+
+  if (config.commsType === BaseStationCommsType.MobileData) {
+    if (mobileCoverageCircles.length === 0) return MissionCoverageRisk.Unknown
+    const borderDistance = distanceToNearestRingBorderMeters(point, mobileCoverageCircles)
+    if (borderDistance <= 0) return MissionCoverageRisk.Good
+    if (borderDistance <= MOBILE_MARGINAL_OUTSIDE_METERS) return MissionCoverageRisk.Marginal
+    return MissionCoverageRisk.LikelyLost
+  }
+
+  return MissionCoverageRisk.Unknown
+}
+
+/**
+ * Build map display segments by sampling along the path so color follows range changes.
+ * @param {BaseStationConfig} config Base-station configuration.
+ * @param {WaypointCoordinates[]} path Path vertices in mission order.
+ * @param {MobileCoverageCircle[]} mobileCoverageCircles Active mobile coverage circles (only used for MobileData).
+ * @param {number} sampleIntervalMeters Distance between samples along the path.
+ * @returns {MissionCoverageSegment[]} Colored segments matching the path geometry.
+ */
+export const buildMissionPathDisplaySegments = (
+  config: BaseStationConfig,
+  path: WaypointCoordinates[],
+  mobileCoverageCircles: MobileCoverageCircle[] = [],
+  sampleIntervalMeters = DEFAULT_MISSION_COVERAGE_DISPLAY_SAMPLE_INTERVAL_METERS
+): MissionCoverageSegment[] => {
+  const samples = buildSamplesAlongCoordinates(path, sampleIntervalMeters)
+  if (samples.length < 2) return []
+
+  const segments: MissionCoverageSegment[] = []
+  for (let i = 0; i < samples.length - 1; i++) {
+    const start = samples[i]
+    const end = samples[i + 1]
+    const mid: WaypointCoordinates = [(start[0] + end[0]) / 2, (start[1] + end[1]) / 2]
+    segments.push({
+      start,
+      end,
+      risk: classifyCoverageAtPoint(config, mid, mobileCoverageCircles),
+    })
+  }
+
+  return segments
+}

--- a/src/libs/baseStation/mobileCoverage.ts
+++ b/src/libs/baseStation/mobileCoverage.ts
@@ -1,0 +1,159 @@
+import {
+  type BaseStationConfig,
+  type CachedOpenCellIdSite,
+  type CachedOverpassTower,
+  type MobileCoverageCache,
+  MobileCoverageProvider,
+} from '@/types/baseStation'
+import type { WaypointCoordinates } from '@/types/mission'
+
+export type MobileCoverageCircle = {
+  /** Circle center in [lat, lng]. */
+  center: WaypointCoordinates
+  /** Effective coverage radius in meters. */
+  rangeMeters: number
+}
+
+export const OSM_DEFAULT_RANGE_METERS = 1800
+
+const splitTagList = (value?: string): string[] =>
+  value
+    ?.split(/[;,]/)
+    .map((item) => item.trim())
+    .filter(Boolean) ?? []
+
+/**
+ * Normalized list of radio technologies declared on an OSM Overpass mobile-phone tower.
+ * Combines the modern `technology:mobile_phone` and legacy `communication:mobile_phone` tags.
+ * @param {Record<string, string>} tags Overpass tags for the tower.
+ * @returns {string[]} Lowercase, deduped list of radio technologies (empty when none declared).
+ */
+export const overpassTechnologies = (tags: Record<string, string>): string[] => {
+  const technologies = splitTagList(tags['technology:mobile_phone']).map((tech) => tech.toLowerCase())
+  const legacyCommunication = splitTagList(tags['communication:mobile_phone'])
+    .map((tech) => tech.toLowerCase())
+    .filter((tech) => tech !== 'yes')
+  return [...new Set([...technologies, ...legacyCommunication])]
+}
+
+/**
+ * Approximate coverage radius for an OSM Overpass mobile-phone tower based on its declared
+ * radio technologies. Falls back to {@link OSM_DEFAULT_RANGE_METERS} when nothing is declared.
+ * @param {Record<string, string>} tags Overpass tags for the tower.
+ * @returns {number} Range in meters.
+ */
+export const overpassRangeMeters = (tags: Record<string, string>): number => {
+  const technologies = overpassTechnologies(tags)
+  if (technologies.length === 0) return OSM_DEFAULT_RANGE_METERS
+  return Math.max(
+    ...technologies.map((tech) => {
+      if (tech.includes('nr') || tech.includes('5g')) return 1200
+      if (tech.includes('lte')) return 1800
+      if (tech.includes('umts')) return 2200
+      if (tech.includes('gsm')) return 2800
+      return OSM_DEFAULT_RANGE_METERS
+    })
+  )
+}
+
+/**
+ * Build the operator label used to filter OpenCellID sites by network. Returns null when the
+ * site doesn't carry mobile country / network codes.
+ * @param {CachedOpenCellIdSite} site OpenCellID site.
+ * @returns {string | null} Operator label or null.
+ */
+export const openCellIdOperatorLabel = (site: CachedOpenCellIdSite): string | null => {
+  if (site.mcc === undefined || site.mnc === undefined) return null
+  return `MCC ${site.mcc} / MNC ${site.mnc}`
+}
+
+/**
+ * Filter OpenCellID sites by the user-selected operator label. Empty operator keeps everything.
+ * @param {CachedOpenCellIdSite[]} sites OpenCellID sites.
+ * @param {string} selectedOperator Operator label (empty string = no filter).
+ * @returns {CachedOpenCellIdSite[]} Filtered sites.
+ */
+export const filterOpenCellIdSites = (
+  sites: CachedOpenCellIdSite[],
+  selectedOperator: string
+): CachedOpenCellIdSite[] => {
+  if (!selectedOperator) return sites
+  return sites.filter((site) => openCellIdOperatorLabel(site) === selectedOperator)
+}
+
+const filterOverpassTowers = (towers: CachedOverpassTower[], selectedOperator: string): CachedOverpassTower[] => {
+  if (!selectedOperator) return towers
+  return towers.filter((tower) => tower.operator === selectedOperator)
+}
+
+const dedupeOpenCellIdSites = (sites: CachedOpenCellIdSite[]): CachedOpenCellIdSite[] => {
+  const map = new Map<string, CachedOpenCellIdSite>()
+  for (const site of sites) {
+    const key = `${site.lat.toFixed(6)}|${site.lon.toFixed(6)}|${site.cellId ?? ''}`
+    if (!map.has(key)) map.set(key, site)
+  }
+  return [...map.values()]
+}
+
+const dedupeOverpassTowers = (towers: CachedOverpassTower[]): CachedOverpassTower[] => {
+  const map = new Map<number, CachedOverpassTower>()
+  for (const tower of towers) {
+    if (!map.has(tower.id)) map.set(tower.id, tower)
+  }
+  return [...map.values()]
+}
+
+/**
+ * Merge two OpenCellID site lists, deduplicating by (lat, lon, cell id).
+ * @param {CachedOpenCellIdSite[] | null} existing Sites already known.
+ * @param {CachedOpenCellIdSite[]} incoming New sites to fold in.
+ * @returns {CachedOpenCellIdSite[]} Merged, deduplicated sites.
+ */
+export const mergeOpenCellIdSites = (
+  existing: CachedOpenCellIdSite[] | null,
+  incoming: CachedOpenCellIdSite[]
+): CachedOpenCellIdSite[] => dedupeOpenCellIdSites([...(existing ?? []), ...incoming])
+
+/**
+ * Merge two Overpass tower lists, deduplicating by OSM id.
+ * @param {CachedOverpassTower[] | null} existing Towers already known.
+ * @param {CachedOverpassTower[]} incoming New towers to fold in.
+ * @returns {CachedOverpassTower[]} Merged, deduplicated towers.
+ */
+export const mergeOverpassTowers = (
+  existing: CachedOverpassTower[] | null,
+  incoming: CachedOverpassTower[]
+): CachedOverpassTower[] => dedupeOverpassTowers([...(existing ?? []), ...incoming])
+
+/**
+ * Collect the active mobile coverage circles for the current base station configuration. Returns
+ * an empty array when the comms type isn't MobileData or when no cached data is available for
+ * the active provider.
+ * @param {BaseStationConfig} config Base station configuration.
+ * @param {MobileCoverageCache} cache Persisted mobile coverage cache.
+ * @returns {MobileCoverageCircle[]} Filtered coverage circles.
+ */
+export const getMobileCoverageCircles = (
+  config: BaseStationConfig,
+  cache: MobileCoverageCache
+): MobileCoverageCircle[] => {
+  const { provider, openCellIdOperator, osmOperator } = config.mobileCoverage
+
+  if (provider === MobileCoverageProvider.OpenCellID) {
+    const sites = dedupeOpenCellIdSites(cache.openCellId.flatMap((entry) => entry.data))
+    return filterOpenCellIdSites(sites, openCellIdOperator).map((site) => ({
+      center: [site.lat, site.lon] as WaypointCoordinates,
+      rangeMeters: site.rangeMeters,
+    }))
+  }
+
+  if (provider === MobileCoverageProvider.OSMOverpass) {
+    const towers = dedupeOverpassTowers(cache.osmOverpass.flatMap((entry) => entry.data))
+    return filterOverpassTowers(towers, osmOperator).map((tower) => ({
+      center: [tower.lat, tower.lon] as WaypointCoordinates,
+      rangeMeters: overpassRangeMeters(tower.tags),
+    }))
+  }
+
+  return []
+}

--- a/src/libs/baseStation/openCellId.ts
+++ b/src/libs/baseStation/openCellId.ts
@@ -1,0 +1,190 @@
+import { isElectron } from '@/libs/utils'
+import type { CachedOpenCellIdSite, CoverageBbox } from '@/types/baseStation'
+import type { WaypointCoordinates } from '@/types/mission'
+
+import {
+  openCellIdCoverageBboxAround,
+  sortCoverageBboxesByDistance,
+  tiledCoverageBboxes,
+  unionCoverageBboxes,
+} from './coverageBbox'
+
+// Keyed browser endpoint caps at ~4 km²; standalone's no-key ajax endpoint rejects around 25 km²,
+// so we use smaller tiles on Lite and larger ones on standalone.
+const OPENCELLID_KEYED_TILE_HALF_SIDE_KM = 0.95
+const OPENCELLID_KEYED_FOREGROUND_TILE_COUNT = 9
+const OPENCELLID_LITE_TILE_HALF_SIDE_KM = 1
+const OPENCELLID_STANDALONE_TILE_HALF_SIDE_KM = 2
+const OPENCELLID_STANDALONE_FOREGROUND_TILE_COUNT = 1
+
+export type OpenCellIdSite = CachedOpenCellIdSite
+
+/**
+ * Detect upstream error messages that signal a bad/missing OpenCellID API key so the caller can
+ * mark the key as invalid instead of treating the failure as a generic network error.
+ * @param {string} message Upstream error message.
+ * @returns {boolean} true when the message looks like an auth failure.
+ */
+export const isOpenCellIdInvalidApiKeyError = (message: string): boolean =>
+  /invalid.*key|api key.*invalid|missing.*key|key required|unauthorized|forbidden/i.test(message)
+
+/**
+ * `Promise.allSettled`-style mapper bounded by `concurrency`.
+ * @param {T[]} items Inputs.
+ * @param {number} concurrency Max in-flight workers.
+ * @param {(item: T) => Promise<R>} mapper Per-item async mapper.
+ * @returns {Promise<PromiseSettledResult<R>[]>} Settled results, in input order.
+ */
+export const mapWithConcurrency = async <T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<R>
+): Promise<PromiseSettledResult<R>[]> => {
+  const settled: PromiseSettledResult<R>[] = new Array(items.length)
+  let nextIndex = 0
+
+  const worker = async (): Promise<void> => {
+    while (nextIndex < items.length) {
+      const currentIndex = nextIndex++
+      try {
+        settled[currentIndex] = {
+          status: 'fulfilled',
+          value: await mapper(items[currentIndex]),
+        }
+      } catch (error) {
+        settled[currentIndex] = {
+          status: 'rejected',
+          reason: error,
+        }
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => worker()))
+  return settled
+}
+
+/* eslint-disable jsdoc/require-jsdoc -- Inline transport DTOs; field meanings follow upstream docs. */
+type OpenCellIdResponse = {
+  cells?: Array<{
+    lat: number
+    lon: number
+    range?: number
+    radio?: string
+    mcc?: number
+    mnc?: number
+    lac?: number
+    cellid?: number
+    samples?: number
+    averageSignalStrength?: number
+  }>
+  error?: string
+  code?: number
+}
+
+export type OpenCellIdFetchResult = {
+  sites: OpenCellIdSite[]
+  fetchedBbox: CoverageBbox
+}
+/* eslint-enable jsdoc/require-jsdoc */
+
+const fetchOpenCellIdTile = async (
+  bbox: CoverageBbox,
+  apiKey: string,
+  signal: AbortSignal
+): Promise<OpenCellIdSite[]> => {
+  const url =
+    `https://opencellid.org/cell/getInArea?key=${encodeURIComponent(apiKey)}` +
+    `&BBOX=${bbox.south},${bbox.west},${bbox.north},${bbox.east}` +
+    `&format=json&limit=50`
+  const res = await fetch(url, { signal })
+  if (!res.ok) throw new Error(`OpenCellID HTTP ${res.status}`)
+  const data = (await res.json()) as OpenCellIdResponse
+  // `code: 1` ("No cells found") is HTTP 200 + an `error` field; treat as empty, not failure.
+  if (data.error && data.code !== 1) throw new Error(`OpenCellID: ${data.error}`)
+  return (data.cells ?? []).map<OpenCellIdSite>((c) => ({
+    lat: c.lat,
+    lon: c.lon,
+    rangeMeters: c.range ?? 1000,
+    radio: c.radio,
+    mcc: c.mcc,
+    mnc: c.mnc,
+    lac: c.lac,
+    cellId: c.cellid,
+    samples: c.samples,
+    averageSignalStrength: c.averageSignalStrength,
+  }))
+}
+
+const fetchOpenCellIdTileInElectron = async (bbox: CoverageBbox, apiKey: string): Promise<OpenCellIdSite[]> => {
+  const cells = await window.electronAPI?.fetchNearbyOpenCellIdCells({
+    west: bbox.west,
+    south: bbox.south,
+    east: bbox.east,
+    north: bbox.north,
+    apiKey: apiKey || undefined,
+  })
+  if (!cells) throw new Error('OpenCellID standalone bridge unavailable')
+  return cells.map<OpenCellIdSite>((c) => ({
+    lat: c.lat,
+    lon: c.lon,
+    rangeMeters: c.range ?? 1000,
+    radio: c.radio,
+    mcc: c.mcc,
+    mnc: c.mnc,
+    lac: c.lac,
+    cellId: c.cellId,
+    samples: c.samples,
+    averageSignalStrength: c.averageSignalStrength,
+  }))
+}
+
+/**
+ * Fetch OpenCellID sites covering the area around `center`. Splits the area into tiles
+ * sized to fit each backend's per-call limit (keyed browser, Lite no-key, standalone
+ * Electron bridge) and runs them concurrently.
+ * @param {WaypointCoordinates} center Center coordinate.
+ * @param {string} apiKey Trimmed OpenCellID API key, or empty for keyless mode.
+ * @param {AbortSignal} signal Cancellation signal.
+ * @returns {Promise<OpenCellIdFetchResult>} Deduped sites and the union of the fetched tiles.
+ */
+export const fetchOpenCellIdSites = async (
+  center: WaypointCoordinates,
+  apiKey: string,
+  signal: AbortSignal
+): Promise<OpenCellIdFetchResult> => {
+  const [lat, lng] = center
+  const coverageArea = openCellIdCoverageBboxAround(lat, lng)
+  const usesApiKey = apiKey.trim().length > 0
+  const tileHalfSideKm = usesApiKey
+    ? OPENCELLID_KEYED_TILE_HALF_SIDE_KM
+    : isElectron()
+    ? OPENCELLID_STANDALONE_TILE_HALF_SIDE_KM
+    : OPENCELLID_LITE_TILE_HALF_SIDE_KM
+  const tiles = tiledCoverageBboxes(coverageArea, lat, tileHalfSideKm)
+  const selectedTiles = usesApiKey
+    ? sortCoverageBboxesByDistance(center, tiles).slice(0, OPENCELLID_KEYED_FOREGROUND_TILE_COUNT)
+    : isElectron()
+    ? sortCoverageBboxesByDistance(center, tiles).slice(0, OPENCELLID_STANDALONE_FOREGROUND_TILE_COUNT)
+    : tiles
+  const tileFetcher = isElectron()
+    ? (bbox: CoverageBbox) => fetchOpenCellIdTileInElectron(bbox, apiKey)
+    : (bbox: CoverageBbox) => fetchOpenCellIdTile(bbox, apiKey, signal)
+  const settled = await mapWithConcurrency(selectedTiles, usesApiKey ? 4 : isElectron() ? 2 : 4, tileFetcher)
+  const fulfilled = settled.filter((r): r is PromiseFulfilledResult<OpenCellIdSite[]> => r.status === 'fulfilled')
+  // If every tile failed, surface the first error so the operator gets a real diagnostic
+  // (invalid key, network down, …) instead of a silent empty heatmap.
+  if (fulfilled.length === 0) {
+    const firstReject = settled.find((r): r is PromiseRejectedResult => r.status === 'rejected')
+    if (firstReject) throw firstReject.reason
+  }
+  const uniqueSites = new Map<string, OpenCellIdSite>()
+  for (const site of fulfilled.flatMap((r) => r.value)) {
+    const key = `${site.lat.toFixed(6)}:${site.lon.toFixed(6)}:${Math.round(site.rangeMeters)}`
+    if (!uniqueSites.has(key)) uniqueSites.set(key, site)
+  }
+  return {
+    sites: [...uniqueSites.values()],
+    fetchedBbox: unionCoverageBboxes(selectedTiles),
+  }
+}

--- a/src/libs/baseStation/overpass.ts
+++ b/src/libs/baseStation/overpass.ts
@@ -1,0 +1,202 @@
+import type { CachedOpenCellIdSite, CachedOverpassTower, CoverageBbox } from '@/types/baseStation'
+
+import { openCellIdOperatorLabel, overpassTechnologies } from './mobileCoverage'
+
+export type OverpassTower = CachedOverpassTower
+
+export const OSM_DEFAULT_DIRECTIONAL_BEAMWIDTH = 90
+
+/** Approximate width of a label glyph at {@link OSM_LABEL_FONT_SIZE_PX}, used to fit text to an arc. */
+export const OSM_LABEL_CHAR_WIDTH_PX = 5.7
+
+/** Distinct colors used to differentiate operators when none is selected. */
+export const OSM_OPERATOR_COLORS = ['#38BDF8', '#22C55E', '#A855F7', '#F59E0B', '#EF4444', '#14B8A6']
+
+const parseTagNumber = (tags: Record<string, string>, ...keys: string[]): number | null => {
+  for (const key of keys) {
+    const value = tags[key]
+    if (!value) continue
+    const parsed = parseFloat(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return null
+}
+
+const pickTagValue = (tags: Record<string, string>, ...keys: string[]): string | null => {
+  for (const key of keys) {
+    const value = tags[key]?.trim()
+    if (value) return value
+  }
+  return null
+}
+
+const formatHeightLabel = (height: string): string => (/^[\d.]+$/.test(height) ? `${height}m` : height)
+
+const normalizeAngle = (angle: number): number => ((angle % 360) + 360) % 360
+
+/**
+ * Generation labels (`2G`, `3G`, `4G`, `5G`) inferred from OSM technology tags.
+ * @param {Record<string, string>} tags Overpass tags.
+ * @returns {string[]} Deduped generation labels (empty when none can be inferred).
+ */
+export const overpassTechnologyGenerations = (tags: Record<string, string>): string[] => {
+  const technologies = overpassTechnologies(tags)
+  const generations = technologies.flatMap((tech) => {
+    if (tech.includes('nr') || tech.includes('5g')) return ['5G']
+    if (tech.includes('lte')) return ['4G']
+    if (tech.includes('umts') || tech.includes('wcdma') || tech.includes('hspa') || tech.includes('hsupa'))
+      return ['3G']
+    if (tech.includes('gsm') || tech.includes('edge') || tech.includes('gprs')) return ['2G']
+    return []
+  })
+  return [...new Set(generations)]
+}
+
+/**
+ * Compact technology label for an OSM tower, preferring generation names when available and
+ * falling back to the raw uppercased technology list otherwise.
+ * @param {Record<string, string>} tags Overpass tags.
+ * @returns {string | null} Display label, or null when nothing can be inferred.
+ */
+export const overpassTechnologyLabel = (tags: Record<string, string>): string | null => {
+  const generations = overpassTechnologyGenerations(tags)
+  if (generations.length > 0) return generations.join('/')
+  const technologies = overpassTechnologies(tags)
+  if (technologies.length === 0) return null
+  return technologies.map((tech) => tech.toUpperCase()).join('/')
+}
+
+/**
+ * Read the antenna bearing from any of the common OSM tag aliases, normalized to [0, 360).
+ * @param {Record<string, string>} tags Overpass tags.
+ * @returns {number | null} Bearing in degrees, or null when not declared.
+ */
+export const overpassBearing = (tags: Record<string, string>): number | null => {
+  const parsed = parseTagNumber(tags, 'communications_transponder:bearing', 'antenna:direction', 'direction', 'bearing')
+  return parsed === null ? null : normalizeAngle(parsed)
+}
+
+/**
+ * Resolve the antenna beamwidth from OSM tags, defaulting to a directional 90° when a bearing is
+ * declared but no beamwidth, and to 360° (omni) when there's no bearing.
+ * @param {Record<string, string>} tags Overpass tags.
+ * @param {number | null} bearing Resolved bearing.
+ * @returns {number} Beamwidth in degrees.
+ */
+export const overpassBeamwidth = (tags: Record<string, string>, bearing: number | null): number => {
+  const parsed = parseTagNumber(tags, 'beamwidth', 'antenna:beamwidth')
+  if (parsed !== null && parsed > 0 && parsed <= 360) return parsed
+  return bearing === null ? 360 : OSM_DEFAULT_DIRECTIONAL_BEAMWIDTH
+}
+
+/**
+ * Build the human-readable label parts for an OSM tower (operator, technology, mast type, height).
+ * @param {OverpassTower} tower Overpass tower.
+ * @returns {string[]} Ordered label parts; the joined form is rim-fitted later.
+ */
+export const overpassLabelParts = (tower: OverpassTower): string[] => {
+  const parts = [tower.operator ?? 'Unknown operator']
+  const technologyLabel = overpassTechnologyLabel(tower.tags)
+  const manMade = pickTagValue(tower.tags, 'man_made')
+  const height = pickTagValue(tower.tags, 'height')
+
+  if (technologyLabel) parts.push(technologyLabel)
+  if (manMade) parts.push(manMade)
+  if (height) parts.push(formatHeightLabel(height))
+  return parts
+}
+
+/**
+ * Pick the longest prefix of `parts` that fits inside `maxWidthPx` when joined with " - ".
+ * Falls back to truncating the first part with an ellipsis when even that doesn't fit.
+ * @param {string[]} parts Ordered label parts.
+ * @param {number} maxWidthPx Maximum rendered width.
+ * @returns {string} Best-fit label.
+ */
+export const fitLabelToArc = (parts: string[], maxWidthPx: number): string => {
+  for (let count = parts.length; count > 0; count--) {
+    const candidate = parts.slice(0, count).join(' - ')
+    if (candidate.length * OSM_LABEL_CHAR_WIDTH_PX <= maxWidthPx) return candidate
+  }
+  const fallback = parts[0]
+  const maxChars = Math.max(8, Math.floor(maxWidthPx / OSM_LABEL_CHAR_WIDTH_PX) - 1)
+  return fallback.length > maxChars ? `${fallback.slice(0, maxChars)}…` : fallback
+}
+
+/**
+ * Build the label parts for an OpenCellID site (operator MCC/MNC, radio, range, cell id).
+ * @param {CachedOpenCellIdSite} site OpenCellID site.
+ * @returns {string[]} Ordered label parts.
+ */
+export const openCellIdLabelParts = (site: CachedOpenCellIdSite): string[] => {
+  const parts: string[] = []
+  const operator = openCellIdOperatorLabel(site)
+  if (operator) parts.push(operator)
+  if (site.radio) parts.push(site.radio.toUpperCase())
+  parts.push(`${Math.round(site.rangeMeters)}m`)
+  if (site.cellId !== undefined) parts.push(`CID ${site.cellId}`)
+  return parts
+}
+
+/**
+ * Stable per-operator color, picked from {@link OSM_OPERATOR_COLORS} via a string-hash on the
+ * operator name, so the same operator always paints the same hue across reloads.
+ * @param {string | null} operator Operator name.
+ * @returns {string} Hex color from the palette.
+ */
+export const operatorColor = (operator: string | null): string => {
+  if (!operator) return OSM_OPERATOR_COLORS[0]
+  const hash = [...operator].reduce((acc, char) => acc + char.charCodeAt(0), 0)
+  return OSM_OPERATOR_COLORS[hash % OSM_OPERATOR_COLORS.length]
+}
+
+/* eslint-disable jsdoc/require-jsdoc -- Inline transport DTOs; field meanings follow upstream docs. */
+type OverpassNode = { id?: number; lat?: number; lon?: number; tags?: Record<string, string> }
+
+type OverpassResponse = { elements?: OverpassNode[] }
+
+type ResolvedOverpassNode = { id: number; lat: number; lon: number; tags?: Record<string, string> }
+/* eslint-enable jsdoc/require-jsdoc */
+
+/**
+ * Fetch mobile-phone tower nodes from the public Overpass API for `bbox`.
+ * @param {CoverageBbox} bbox Bounding box.
+ * @param {AbortSignal} signal Cancellation signal.
+ * @returns {Promise<OverpassTower[]>} Deduped towers.
+ */
+export const fetchOverpassTowers = async (bbox: CoverageBbox, signal: AbortSignal): Promise<OverpassTower[]> => {
+  const region = `(${bbox.south},${bbox.west},${bbox.north},${bbox.east})`
+  const query =
+    `[out:json][timeout:25];` +
+    // Limit the overlay to mobile-phone infrastructure so the map reflects cellular coverage
+    // rather than every generic communications site in the area.
+    `(node["communication:mobile_phone"]${region};` +
+    `node["technology:mobile_phone"]${region};);` +
+    `out body;`
+  const res = await fetch('https://overpass-api.de/api/interpreter', {
+    method: 'POST',
+    headers: { 'Content-Type': 'text/plain' },
+    body: query,
+    signal,
+  })
+  if (!res.ok) throw new Error(`Overpass HTTP ${res.status}`)
+  const data = (await res.json()) as OverpassResponse
+  const seenIds = new Set<number>()
+  return (data.elements ?? [])
+    .filter(
+      (e): e is ResolvedOverpassNode =>
+        typeof e.id === 'number' && typeof e.lat === 'number' && typeof e.lon === 'number'
+    )
+    .filter((e) => {
+      if (seenIds.has(e.id)) return false
+      seenIds.add(e.id)
+      return true
+    })
+    .map<OverpassTower>((e) => ({
+      id: e.id,
+      lat: e.lat,
+      lon: e.lon,
+      operator: e.tags?.operator?.trim() || null,
+      tags: e.tags ?? {},
+    }))
+}

--- a/src/libs/cosmos.ts
+++ b/src/libs/cosmos.ts
@@ -1,5 +1,6 @@
 import { isBrowser } from 'browser-or-node'
 
+import type { NearbyOpenCellIdCell, OpenCellIdBboxRequest } from '@/types/baseStation'
 import { type ElectronLog } from '@/types/electron-general'
 import { ElectronStorageDB } from '@/types/general'
 import type { ElectronSDLJoystickControllerStateEventData } from '@/types/joystick'
@@ -206,6 +207,14 @@ declare global {
        * @returns Promise containing subnet information
        */
       getInfoOnSubnets: () => Promise<NetworkInfo[]>
+      // The IPC handler does not currently accept an `AbortSignal`, so the renderer cannot
+      // cancel an in-flight call — wait for it to settle and discard the result if needed.
+      /**
+       * Fetch nearby OpenCellID cells from the main process, bypassing browser CORS limits.
+       * @param {OpenCellIdBboxRequest} bbox Geographic bounding box plus an optional API key.
+       * @returns {Promise<NearbyOpenCellIdCell[]>} Cells inside `bbox`, possibly empty.
+       */
+      fetchNearbyOpenCellIdCells: (bbox: OpenCellIdBboxRequest) => Promise<NearbyOpenCellIdCell[]>
       /**
        * Fast TCP port probe used as a pre-filter during vehicle discovery
        * @param host IPv4 address to probe

--- a/src/libs/map/utils-map.ts
+++ b/src/libs/map/utils-map.ts
@@ -20,6 +20,7 @@ const defaultUnfollowDragThresholdPx = 150
 export enum WhoToFollow {
   HOME = 'Home',
   VEHICLE = 'Vehicle',
+  BASE_STATION = 'BaseStation',
 }
 
 /**

--- a/src/stores/mission.ts
+++ b/src/stores/mission.ts
@@ -56,6 +56,7 @@ export const useMissionStore = defineStore('mission', () => {
   const showChecklistBeforeArm = useBlueOsStorage('cockpit-show-checklist-before-arm', true)
   const showGridOnMissionPlanning = useBlueOsStorage('cockpit-show-grid-on-mission-planning', false)
   const showMissionEstimates = useBlueOsStorage('cockpit-show-mission-estimates', true)
+  const showMissionPathSignalStrength = useBlueOsStorage('cockpit-show-mission-path-signal-strength', false)
   const defaultCruiseSpeed = useBlueOsStorage<number>('cockpit-default-cruise-speed', 1)
   const cruiseSpeed = ref<number>(Number(defaultCruiseSpeed.value))
   const userLastMapTileProvider = useBlueOsStorage<MapTileProvider>(
@@ -663,6 +664,7 @@ export const useMissionStore = defineStore('mission', () => {
     showChecklistBeforeArm,
     showGridOnMissionPlanning,
     showMissionEstimates,
+    showMissionPathSignalStrength,
     addCommandToWaypoint,
     removeCommandFromWaypoint,
     updateWaypointCommand,

--- a/src/types/baseStation.ts
+++ b/src/types/baseStation.ts
@@ -228,6 +228,10 @@ export type BaseStationConfig = {
    * invisible.
    */
   coverageOpacity: number
+  /**
+   * Whether the projected signal/coverage overlays should be rendered on the map.
+   */
+  showSignalOnMap: boolean
 }
 
 /**
@@ -319,6 +323,7 @@ export const DEFAULT_BASE_STATION_CONFIG: BaseStationConfig = {
   },
   coverageColor: '#3B82F6',
   coverageOpacity: 1,
+  showSignalOnMap: true,
 }
 
 export const DEFAULT_MOBILE_COVERAGE_CACHE: MobileCoverageCache = {

--- a/src/types/baseStation.ts
+++ b/src/types/baseStation.ts
@@ -1,5 +1,65 @@
 import type { WaypointCoordinates } from '@/types/mission'
 
+/**
+ * Topside computer mount type. Mobile is typically a laptop or tablet, fixed is a stationary
+ * computer at the base station.
+ */
+export enum TopSideComputerType {
+  Mobile = 'Mobile',
+  Fixed = 'Fixed',
+}
+
+/**
+ * Communication link type between the topside (base station) and the vehicle.
+ */
+export enum BaseStationCommsType {
+  Tethered = 'Tethered',
+  MobileData = 'Mobile data (4G/5G)',
+  RadioLink = 'Radio link',
+}
+
+/**
+ * Radio base station product family, used to seed antenna defaults.
+ */
+export enum RadioBaseStationKind {
+  BlueRobotics = 'Blue Robotics BaseStation',
+  Custom = 'Custom',
+}
+
+/**
+ * Antenna form factor. Determines the shape of the coverage drawn on the map (full circle
+ * for omni, sector/cone for directional ones) and seeds gain/beamwidth/range defaults.
+ */
+export enum AntennaType {
+  Omni = 'Omnidirectional',
+  Panel = 'Panel',
+  Yagi = 'Yagi',
+}
+
+export type AntennaSpec = {
+  /**
+   * Antenna form factor.
+   */
+  type: AntennaType
+  /**
+   * Antenna gain in dBi.
+   */
+  gain: number
+  /**
+   * Horizontal beamwidth in degrees. Use 360 for omnidirectional antennas.
+   */
+  beamwidth: number
+  /**
+   * Practical communication range in meters used to draw the coverage on the map.
+   */
+  range: number
+  /**
+   * Bearing/azimuth of the antenna boresight in degrees, where 0 = north and angles grow clockwise.
+   * Ignored for omnidirectional antennas.
+   */
+  bearing: number
+}
+
 export type BaseStationConfig = {
   /**
    * Whether the base station is placed on the map. False until the user sets a position.
@@ -9,9 +69,131 @@ export type BaseStationConfig = {
    * Geographical position of the base station as [latitude, longitude].
    */
   position: WaypointCoordinates | null
+  /**
+   * Topside computer mount type.
+   */
+  topSideComputerType: TopSideComputerType
+  /**
+   * Whether to keep the base-station position synced with the operator's GPS (browser Geolocation API).
+   */
+  trackByGps: boolean
+  /**
+   * Communication link type between the topside and the vehicle.
+   */
+  commsType: BaseStationCommsType
+  /**
+   * Radio base station product family. Only used when {@link commsType} is RadioLink.
+   */
+  radioBaseStationKind: RadioBaseStationKind
+  /**
+   * Antenna parameters used to draw coverage. Only used when {@link commsType} is RadioLink.
+   */
+  antenna: AntennaSpec
+  /**
+   * Height of the base-station antenna above ground in meters. Map coverage scales with √height using
+   * the radio-horizon model (see {@link baseStationAntennaHeightRangeMultiplier}).
+   */
+  baseStationAntennaHeightMeters: number
+  /**
+   * Whether the vehicle mounts the BlueBoat Antenna and Accessory Mast (vehicle-side extender).
+   * When true, map coverage uses {@link BLUEBOAT_ANTENNA_MAST_RANGE_MULTIPLIER}× the entered range.
+   */
+  vehicleHasBlueBoatAntennaMast: boolean
+  /**
+   * Tether length in meters used to draw coverage. Only used when {@link commsType} is Tethered.
+   */
+  tetherLengthMeters: number
+  /**
+   * Transmitter power in milliwatts. Drives a Friis-based range scaling
+   * (range ∝ √P_t) when the operator picks a Custom radio.
+   */
+  txPowerMilliwatts: number
+  /**
+   * Hex color used to render the projected antenna signal coverage on the map.
+   */
+  coverageColor: string
+  /**
+   * Multiplier (0..1) applied to the coverage fill opacity. 1.0 keeps the default look, 0 makes it
+   * invisible.
+   */
+  coverageOpacity: number
+}
+
+/**
+ * Factory antenna specs derived from the BlueBoat BaseStation and Directional Antenna Kit guides.
+ * Range values are the practical (rest-of-world) ranges from BR's tested data; gain values are
+ * the rest-of-world recommended values that account for connector loss.
+ *
+ * Sources: bluerobotics.com/store/boat/blueboat-components-spares/basestation and
+ * bluerobotics.com/learn/directional-antenna-guide.
+ */
+export const ANTENNA_FACTORY_DEFAULTS: Record<AntennaType, Omit<AntennaSpec, 'bearing'>> = {
+  [AntennaType.Omni]: { type: AntennaType.Omni, gain: 7, beamwidth: 360, range: 250 },
+  [AntennaType.Panel]: { type: AntennaType.Panel, gain: 12, beamwidth: 40, range: 500 },
+  [AntennaType.Yagi]: { type: AntennaType.Yagi, gain: 16, beamwidth: 25, range: 800 },
+}
+
+/**
+ * BlueRobotics BaseStation TX power (Microhard pMDDL/pDDL 900 MHz, 1 W max).
+ */
+export const BLUE_ROBOTICS_TX_POWER_MW = 1000
+
+/**
+ * Communication range multiplier with the BlueBoat Antenna and Accessory Mast on the vehicle.
+ * @see https://bluerobotics.com/store/boat/blueboat-accessories/blueboat-antenna-and-accessory-mast/
+ */
+export const BLUEBOAT_ANTENNA_MAST_RANGE_MULTIPLIER = 1.75
+
+/**
+ * Reference base-station antenna height (m). Factory range values assume roughly this height on a
+ * typical tripod or short mast.
+ */
+export const DEFAULT_BASE_STATION_ANTENNA_HEIGHT_METERS = 1
+
+const MIN_BASE_STATION_ANTENNA_HEIGHT_METERS = 0.5
+const MAX_BASE_STATION_ANTENNA_HEIGHT_METERS = 50
+
+/**
+ * Range multiplier from base-station antenna height. Over flat water/terrain, radio horizon distance
+ * scales as √h (d_km ≈ 4.12·√h with standard 4/3 Earth-radius refraction), so practical range grows
+ * with the square root of height relative to {@link DEFAULT_BASE_STATION_ANTENNA_HEIGHT_METERS}.
+ * @param {number} heightMeters Antenna height above ground in meters.
+ * @returns {number} Multiplier applied to the entered range for map coverage.
+ */
+export const baseStationAntennaHeightRangeMultiplier = (heightMeters: number): number => {
+  const clamped = Math.min(
+    MAX_BASE_STATION_ANTENNA_HEIGHT_METERS,
+    Math.max(MIN_BASE_STATION_ANTENNA_HEIGHT_METERS, heightMeters)
+  )
+  return Math.sqrt(clamped / DEFAULT_BASE_STATION_ANTENNA_HEIGHT_METERS)
+}
+
+/**
+ * Practical antenna range (m) used for map coverage, including height and vehicle mast adjustments.
+ * @param {BaseStationConfig} config Current base-station configuration.
+ * @returns {number} Range in meters for overlay geometry.
+ */
+export const effectiveAntennaRangeMeters = (config: BaseStationConfig): number => {
+  if (config.commsType !== BaseStationCommsType.RadioLink) return config.antenna.range
+
+  let range = config.antenna.range * baseStationAntennaHeightRangeMultiplier(config.baseStationAntennaHeightMeters)
+  if (config.vehicleHasBlueBoatAntennaMast) range *= BLUEBOAT_ANTENNA_MAST_RANGE_MULTIPLIER
+
+  return Math.max(1, Math.round(range))
 }
 
 export const DEFAULT_BASE_STATION_CONFIG: BaseStationConfig = {
   enabled: false,
   position: null,
+  topSideComputerType: TopSideComputerType.Fixed,
+  trackByGps: false,
+  commsType: BaseStationCommsType.RadioLink,
+  radioBaseStationKind: RadioBaseStationKind.BlueRobotics,
+  antenna: { ...ANTENNA_FACTORY_DEFAULTS[AntennaType.Omni], bearing: 0 },
+  baseStationAntennaHeightMeters: DEFAULT_BASE_STATION_ANTENNA_HEIGHT_METERS,
+  vehicleHasBlueBoatAntennaMast: false,
+  tetherLengthMeters: 150,
+  txPowerMilliwatts: BLUE_ROBOTICS_TX_POWER_MW,
+  coverageColor: '#3B82F6',
+  coverageOpacity: 1,
 }

--- a/src/types/baseStation.ts
+++ b/src/types/baseStation.ts
@@ -36,6 +36,36 @@ export enum AntennaType {
   Yagi = 'Yagi',
 }
 
+/**
+ * Source of the cellular coverage overlay shown when {@link BaseStationCommsType.MobileData} is selected.
+ */
+export enum MobileCoverageProvider {
+  OpenCellID = 'OpenCellID',
+  OSMOverpass = 'OSM Overpass',
+  Custom = 'Custom overlay',
+}
+
+export type MobileCoverageConfig = {
+  /**
+   * Active coverage data provider.
+   */
+  provider: MobileCoverageProvider
+  /**
+   * OpenCellID API key. Required when {@link provider} is {@link MobileCoverageProvider.OpenCellID}.
+   */
+  openCellIdApiKey: string
+  /**
+   * Leaflet `TileLayer` URL template (with `{z}/{x}/{y}` placeholders). Required when
+   * {@link provider} is {@link MobileCoverageProvider.Custom}.
+   */
+  customTileUrl: string
+  /**
+   * OSM operator name to filter by when {@link provider} is {@link MobileCoverageProvider.OSMOverpass}.
+   * Empty string keeps all operators.
+   */
+  osmOperator: string
+}
+
 export type AntennaSpec = {
   /**
    * Antenna form factor.
@@ -103,6 +133,10 @@ export type BaseStationConfig = {
    * Tether length in meters used to draw coverage. Only used when {@link commsType} is Tethered.
    */
   tetherLengthMeters: number
+  /**
+   * Cellular coverage overlay configuration. Only used when {@link commsType} is MobileData.
+   */
+  mobileCoverage: MobileCoverageConfig
   /**
    * Transmitter power in milliwatts. Drives a Friis-based range scaling
    * (range ∝ √P_t) when the operator picks a Custom radio.
@@ -194,6 +228,12 @@ export const DEFAULT_BASE_STATION_CONFIG: BaseStationConfig = {
   vehicleHasBlueBoatAntennaMast: false,
   tetherLengthMeters: 150,
   txPowerMilliwatts: BLUE_ROBOTICS_TX_POWER_MW,
+  mobileCoverage: {
+    provider: MobileCoverageProvider.OpenCellID,
+    openCellIdApiKey: '',
+    customTileUrl: '',
+    osmOperator: '',
+  },
   coverageColor: '#3B82F6',
   coverageOpacity: 1,
 }

--- a/src/types/baseStation.ts
+++ b/src/types/baseStation.ts
@@ -1,0 +1,17 @@
+import type { WaypointCoordinates } from '@/types/mission'
+
+export type BaseStationConfig = {
+  /**
+   * Whether the base station is placed on the map. False until the user sets a position.
+   */
+  enabled: boolean
+  /**
+   * Geographical position of the base station as [latitude, longitude].
+   */
+  position: WaypointCoordinates | null
+}
+
+export const DEFAULT_BASE_STATION_CONFIG: BaseStationConfig = {
+  enabled: false,
+  position: null,
+}

--- a/src/types/baseStation.ts
+++ b/src/types/baseStation.ts
@@ -1,11 +1,11 @@
 import type { WaypointCoordinates } from '@/types/mission'
 
 /**
- * Topside computer mount type. Mobile is typically a laptop or tablet, fixed is a stationary
- * computer at the base station.
+ * Topside computer mount type. Portable means the base station may move during deployment,
+ * while fixed stays at a stationary location.
  */
 export enum TopSideComputerType {
-  Mobile = 'Mobile',
+  Portable = 'Portable',
   Fixed = 'Fixed',
 }
 
@@ -45,6 +45,16 @@ export enum MobileCoverageProvider {
   Custom = 'Custom overlay',
 }
 
+export const MOBILE_COVERAGE_FETCH_DROP_MIME = 'application/x-cockpit-mobile-coverage-fetch'
+
+/**
+ * Visualization mode for the mobile coverage overlay.
+ */
+export enum MobileCoverageDisplayMode {
+  Heatmap = 'Heatmap',
+  CoverageRings = 'Coverage rings',
+}
+
 export type MobileCoverageConfig = {
   /**
    * Active coverage data provider.
@@ -55,6 +65,10 @@ export type MobileCoverageConfig = {
    */
   openCellIdApiKey: string
   /**
+   * Selected OpenCellID operator/network code label. Empty string keeps all returned networks.
+   */
+  openCellIdOperator: string
+  /**
    * Leaflet `TileLayer` URL template (with `{z}/{x}/{y}` placeholders). Required when
    * {@link provider} is {@link MobileCoverageProvider.Custom}.
    */
@@ -64,7 +78,66 @@ export type MobileCoverageConfig = {
    * Empty string keeps all operators.
    */
   osmOperator: string
+  /**
+   * Visualization mode for OpenCellID overlays.
+   */
+  displayMode: MobileCoverageDisplayMode
+  /**
+   * Opacity multiplier (0..1) applied to mobile coverage overlays.
+   */
+  overlayOpacity: number
+  /**
+   * Show the operator/technology labels rendered along the rim of each coverage ring.
+   */
+  showRingLabels: boolean
+  /**
+   * Heatmap intensity (0..1). Scales the heat radius so 0 keeps a tight, low-opacity blob and
+   * 1 spreads it out to roughly match the coverage rings.
+   */
+  heatmapIntensity: number
 }
+
+/* eslint-disable jsdoc/require-jsdoc -- Self-describing geo bbox in WGS84 degrees. */
+export type CoverageBbox = { south: number; west: number; north: number; east: number }
+/* eslint-enable jsdoc/require-jsdoc */
+
+/* eslint-disable jsdoc/require-jsdoc -- OpenCellID transport DTO; fields mirror the upstream API. */
+export type CachedOpenCellIdSite = {
+  lat: number
+  lon: number
+  rangeMeters: number
+  radio?: string
+  mcc?: number
+  mnc?: number
+  lac?: number
+  cellId?: number
+  samples?: number
+  averageSignalStrength?: number
+}
+/* eslint-enable jsdoc/require-jsdoc */
+
+/* eslint-disable jsdoc/require-jsdoc -- OSM Overpass transport DTO; fields mirror the upstream API. */
+export type CachedOverpassTower = {
+  id: number
+  lat: number
+  lon: number
+  operator: string | null
+  tags: Record<string, string>
+}
+/* eslint-enable jsdoc/require-jsdoc */
+
+/* eslint-disable jsdoc/require-jsdoc -- Generic cache envelope; fields are self-describing. */
+export type CachedMobileCoverageEntry<T> = {
+  bbox: CoverageBbox
+  fetchedAtMs: number
+  data: T[]
+}
+
+export type MobileCoverageCache = {
+  openCellId: CachedMobileCoverageEntry<CachedOpenCellIdSite>[]
+  osmOverpass: CachedMobileCoverageEntry<CachedOverpassTower>[]
+}
+/* eslint-enable jsdoc/require-jsdoc */
 
 export type AntennaSpec = {
   /**
@@ -95,6 +168,10 @@ export type BaseStationConfig = {
    * Whether the base station is placed on the map. False until the user sets a position.
    */
   enabled: boolean
+  /**
+   * Optional label shown under the marker when non-empty.
+   */
+  name: string
   /**
    * Geographical position of the base station as [latitude, longitude].
    */
@@ -218,6 +295,7 @@ export const effectiveAntennaRangeMeters = (config: BaseStationConfig): number =
 
 export const DEFAULT_BASE_STATION_CONFIG: BaseStationConfig = {
   enabled: false,
+  name: '',
   position: null,
   topSideComputerType: TopSideComputerType.Fixed,
   trackByGps: false,
@@ -231,11 +309,21 @@ export const DEFAULT_BASE_STATION_CONFIG: BaseStationConfig = {
   mobileCoverage: {
     provider: MobileCoverageProvider.OpenCellID,
     openCellIdApiKey: '',
+    openCellIdOperator: '',
     customTileUrl: '',
     osmOperator: '',
+    displayMode: MobileCoverageDisplayMode.Heatmap,
+    overlayOpacity: 0.3,
+    showRingLabels: true,
+    heatmapIntensity: 0.5,
   },
   coverageColor: '#3B82F6',
   coverageOpacity: 1,
+}
+
+export const DEFAULT_MOBILE_COVERAGE_CACHE: MobileCoverageCache = {
+  openCellId: [],
+  osmOverpass: [],
 }
 
 /**

--- a/src/types/baseStation.ts
+++ b/src/types/baseStation.ts
@@ -237,3 +237,36 @@ export const DEFAULT_BASE_STATION_CONFIG: BaseStationConfig = {
   coverageColor: '#3B82F6',
   coverageOpacity: 1,
 }
+
+/**
+ * Bounding box payload accepted by the OpenCellID `getInArea` endpoint, plus the API key the
+ * caller wants to use (omitted to fall back to the anonymous public endpoint).
+ */
+/* eslint-disable jsdoc/require-jsdoc -- Field names mirror the OpenCellID HTTP contract. */
+export type OpenCellIdBboxRequest = {
+  west: number
+  south: number
+  east: number
+  north: number
+  apiKey?: string
+}
+/* eslint-enable jsdoc/require-jsdoc */
+
+/**
+ * Single OpenCellID cell record after normalization. `range` is the published reach in meters
+ * and is preserved so callers can render proportionally sized rings or weight heatmaps.
+ */
+/* eslint-disable jsdoc/require-jsdoc -- Field names mirror the OpenCellID HTTP contract. */
+export type NearbyOpenCellIdCell = {
+  lat: number
+  lon: number
+  range?: number
+  radio?: string
+  mcc?: number
+  mnc?: number
+  lac?: number
+  cellId?: number
+  samples?: number
+  averageSignalStrength?: number
+}
+/* eslint-enable jsdoc/require-jsdoc */

--- a/src/types/shims.d.ts
+++ b/src/types/shims.d.ts
@@ -11,6 +11,7 @@ interface Navigator {
 
 declare module '@vue-leaflet/vue-leaflet'
 declare module 'gamepad.js'
+declare module 'leaflet.heat'
 declare module 'vuetify'
 declare module 'vuetify/lib/components'
 declare module 'vuetify/lib/directives'

--- a/src/types/shims.d.ts
+++ b/src/types/shims.d.ts
@@ -11,7 +11,6 @@ interface Navigator {
 
 declare module '@vue-leaflet/vue-leaflet'
 declare module 'gamepad.js'
-declare module 'leaflet.heat'
 declare module 'vuetify'
 declare module 'vuetify/lib/components'
 declare module 'vuetify/lib/directives'

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -106,7 +106,7 @@
       />
     </div>
     <div
-      v-show="!interfaceStore.isMainMenuVisible"
+      v-show="!interfaceStore.isMainMenuVisible && !interfaceStore.isConfigPanelVisible"
       class="absolute flex flex-col left-10 rounded-[10px] max-h-[80vh] overflow-y-auto z-[200]"
       :style="[interfaceStore.globalGlassMenuStyles, { height: 'auto', maxHeight: calculatedHeight, width: '320px' }]"
     >
@@ -618,6 +618,7 @@
   </SideConfigPanel>
   <HomePositionSettingHelp v-model="showHomePositionNotSetDialog" />
   <PoiManager ref="poiManagerRef" />
+  <BaseStationConfigPanel />
   <BaseStationContextPopup />
   <PoiMapArrows
     :map-ready="mapReady"
@@ -679,6 +680,7 @@ import { type InstanceType, computed, nextTick, onMounted, onUnmounted, ref, sha
 import blueboatMarkerImage from '@/assets/blueboat-marker.avif'
 import brov2MarkerImage from '@/assets/brov2-marker.avif'
 import genericVehicleMarkerImage from '@/assets/generic-vehicle-marker.avif'
+import BaseStationConfigPanel from '@/components/BaseStationConfigPanel.vue'
 import BaseStationContextPopup from '@/components/BaseStationContextPopup.vue'
 import ContextMenu from '@/components/mission-planning/ContextMenu.vue'
 import HomePositionSettingHelp from '@/components/mission-planning/HomePositionSettingHelp.vue'

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -619,7 +619,7 @@
   </SideConfigPanel>
   <HomePositionSettingHelp v-model="showHomePositionNotSetDialog" />
   <PoiManager ref="poiManagerRef" />
-  <BaseStationConfigPanel />
+  <BaseStationConfigPanel is-mission-planning-context />
   <BaseStationContextPopup />
   <PoiMapArrows
     :map-ready="mapReady"
@@ -627,8 +627,11 @@
     :show-poi-arrows="true"
     :show-home-arrow="true"
     :show-vehicle-arrow="true"
+    :show-base-station-arrow="baseStationStore.config.enabled"
     :vehicle-position="vehiclePosition"
     :home="home"
+    :base-station="baseStationStore.config.enabled ? baseStationStore.config.position ?? undefined : undefined"
+    :base-station-color="baseStationStore.config.coverageColor"
     :map-center="mapCenter"
     :zoom="zoom"
     :target-follower="targetFollower"
@@ -695,6 +698,7 @@ import RadialMenu, { type RadialMenuItem } from '@/components/RadialMenu.vue'
 import SideConfigPanel from '@/components/SideConfigPanel.vue'
 import { useBaseStation } from '@/composables/baseStation/useBaseStation'
 import { useBaseStationOverlay } from '@/composables/baseStation/useBaseStationOverlay'
+import { useMissionPathSignal } from '@/composables/baseStation/useMissionPathSignal'
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { provideMapContext } from '@/composables/map/useMapContext'
 import { useSnackbar } from '@/composables/snackbar'
@@ -705,6 +709,7 @@ import {
   useMissionEstimates,
 } from '@/composables/useMissionEstimates'
 import { useOfflineTiles } from '@/composables/useOfflineTiles'
+import { buildMissionPathDisplaySegments, MISSION_COVERAGE_RISK_COLORS } from '@/libs/baseStation/missionPathSignal'
 import { MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import { MavCmd } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import type { NoiseTileOptions } from '@/libs/map/map-tile-fallback'
@@ -744,6 +749,8 @@ const interfaceStore = useAppInterfaceStore()
 const widgetStore = useWidgetManagerStore()
 const baseStationStore = useBaseStation()
 const missionEstimates = useMissionEstimates()
+const { isPathSignalAvailable: isMissionPathSignalAvailable, mobileCoverageCircles: missionMobileCoverageCircles } =
+  useMissionPathSignal()
 const { height: windowHeight } = useWindowSize()
 
 const { showDialog, closeDialog } = useInteractionDialog()
@@ -1292,6 +1299,7 @@ const clearCurrentMission = (): void => {
     planningMap.value?.removeLayer(missionWaypointsPolyline.value)
     missionWaypointsPolyline.value = null
   }
+  removeMissionPathSignalLayer()
   clearSurveyPath()
   selectedSurveyId.value = ''
   lastSelectedSurveyId.value = ''
@@ -2793,6 +2801,7 @@ const clearSurveyPath = (): void => {
   surveyEdgeAddMarkers.forEach((marker) => marker.remove())
   surveyPolygonVertexesMarkers.value = []
   surveyPolygonVertexesPositions.value = []
+  renderMissionPathSignal()
 }
 
 watch([isCreatingSurvey, isCreatingSimplePath], (isCreatingNow) => {
@@ -2875,6 +2884,7 @@ const checkAndRemoveSurveyPath = (): void => {
   surveyPathLayer.value = null
   surveyTurnaroundLayers.value.forEach((layer) => planningMap.value?.removeLayer(layer as unknown as L.Layer))
   surveyTurnaroundLayers.value = []
+  renderMissionPathSignal()
 }
 
 const createSurveyPath = (): void => {
@@ -2925,6 +2935,8 @@ const createSurveyPath = (): void => {
         }).addTo(toRaw(planningMap.value)!)
       )
     }
+
+    renderMissionPathSignal()
   } catch (error) {
     showDialog({
       variant: 'error',
@@ -3970,6 +3982,8 @@ onUnmounted(() => {
   stopTileFallbackWatcher?.()
   stopTileFallbackWatcher = undefined
 
+  removeMissionPathSignalLayer()
+
   // Reset the map context so descendants stop reacting to the destroyed instance
   mapContext.mapReady.value = false
   mapContext.map.value = undefined
@@ -4122,9 +4136,89 @@ watch(zoom, () => {
 })
 
 const missionWaypointsPolyline = shallowRef<L.Polyline | null>(null)
+const missionPathSignalLayer = shallowRef<L.LayerGroup | null>(null)
+const waypointPolylineBaseStyle: L.PolylineOptions = { opacity: 1, color: '#3388ff', weight: 3 }
+const surveyPathLayerBaseStyle: L.PolylineOptions = { color: '#2563EB', weight: 3, opacity: 0.8 }
 
 const getMissionPathLatLngs = (): L.LatLng[] =>
   missionStore.currentPlanningWaypoints.map((waypoint) => L.latLng(waypoint.coordinates[0], waypoint.coordinates[1]))
+
+const flattenPolylineCoordinates = (polyline: L.Polyline): WaypointCoordinates[] => {
+  const latlngs = polyline.getLatLngs()
+  if (!latlngs.length) return []
+  const flat = latlngs[0] instanceof L.LatLng ? (latlngs as L.LatLng[]) : (latlngs as L.LatLng[][]).flat()
+  return flat.map((latlng) => [latlng.lat, latlng.lng] as WaypointCoordinates)
+}
+
+const getMissionCoveragePathCoordinates = (): WaypointCoordinates[] => {
+  if (surveyPathLayer.value) {
+    return flattenPolylineCoordinates(surveyPathLayer.value)
+  }
+  return missionStore.currentPlanningWaypoints.map((waypoint) => waypoint.coordinates)
+}
+
+const restoreMissionPathLineStyles = (): void => {
+  if (missionWaypointsPolyline.value) {
+    missionWaypointsPolyline.value.setStyle(waypointPolylineBaseStyle)
+  }
+  if (surveyPathLayer.value) {
+    surveyPathLayer.value.setStyle(surveyPathLayerBaseStyle)
+  }
+}
+
+const removeMissionPathSignalLayer = (): void => {
+  if (!missionPathSignalLayer.value) return
+  missionPathSignalLayer.value.clearLayers()
+  planningMap.value?.removeLayer(missionPathSignalLayer.value)
+  missionPathSignalLayer.value = null
+}
+
+const renderMissionPathSignalImmediate = (): void => {
+  if (!planningMap.value) return
+  removeMissionPathSignalLayer()
+
+  if (!missionStore.showMissionPathSignalStrength || !isMissionPathSignalAvailable.value) {
+    restoreMissionPathLineStyles()
+    return
+  }
+
+  const pathCoordinates = getMissionCoveragePathCoordinates()
+  if (pathCoordinates.length < 2) {
+    restoreMissionPathLineStyles()
+    return
+  }
+
+  const isSurveyPath = !!surveyPathLayer.value
+  const displaySegments = buildMissionPathDisplaySegments(
+    baseStationStore.config,
+    pathCoordinates,
+    missionMobileCoverageCircles.value
+  )
+
+  if (missionWaypointsPolyline.value) {
+    missionWaypointsPolyline.value.setStyle({ opacity: 0 })
+  }
+  if (surveyPathLayer.value) {
+    surveyPathLayer.value.setStyle({ opacity: 0 })
+  }
+
+  missionPathSignalLayer.value = L.layerGroup()
+  for (const segment of displaySegments) {
+    const polyline = L.polyline([segment.start, segment.end], {
+      color: MISSION_COVERAGE_RISK_COLORS[segment.risk],
+      weight: 3,
+      opacity: isSurveyPath ? 0.8 : 1,
+      interactive: false,
+      ...(isSurveyPath ? { className: 'survey-path' } : {}),
+    })
+    polyline.addTo(missionPathSignalLayer.value)
+  }
+  missionPathSignalLayer.value.addTo(planningMap.value)
+}
+
+// Coalesces redraws caused by survey edits, waypoint drags, and config changes within the
+// same animation frame; long enough to flatten typed-input bursts, short enough to feel live.
+const renderMissionPathSignal = useDebounceFn(renderMissionPathSignalImmediate, 100)
 
 watch(
   () => missionStore.currentPlanningWaypoints.map((waypoint) => waypoint.coordinates.slice()),
@@ -4143,8 +4237,31 @@ watch(
     } else {
       missionWaypointsPolyline.value.setLatLngs(missionPathLatLngs)
     }
+
+    renderMissionPathSignal()
   },
   { immediate: true, deep: true }
+)
+
+watch(
+  () => [
+    isMissionPathSignalAvailable.value,
+    missionMobileCoverageCircles.value,
+    missionStore.showMissionPathSignalStrength,
+    baseStationStore.config.enabled,
+    baseStationStore.config.position,
+    baseStationStore.config.commsType,
+    baseStationStore.config.antenna,
+    baseStationStore.config.baseStationAntennaHeightMeters,
+    baseStationStore.config.vehicleHasBlueBoatAntennaMast,
+    baseStationStore.config.mobileCoverage.provider,
+    baseStationStore.config.mobileCoverage.openCellIdOperator,
+    baseStationStore.config.mobileCoverage.osmOperator,
+  ],
+  () => {
+    renderMissionPathSignal()
+  },
+  { deep: true }
 )
 
 // Create polyline for the vehicle path using a dedicated Canvas renderer to prevent performance issues

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -2020,6 +2020,9 @@ const targetFollower = new TargetFollower(
 )
 targetFollower.setTrackableTarget(WhoToFollow.VEHICLE, () => vehiclePosition.value)
 targetFollower.setTrackableTarget(WhoToFollow.HOME, () => home.value)
+targetFollower.setTrackableTarget(WhoToFollow.BASE_STATION, () =>
+  baseStationStore.config.enabled ? baseStationStore.config.position ?? undefined : undefined
+)
 
 const addSurveyPolygonToMap = (survey: Survey): void => {
   if (!planningMap.value) return

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="mission-planning" :style="glassMenuCssVars">
-    <div id="planningMap" ref="planningMap" class="relative" />
+    <div id="planningMap" class="relative" />
     <v-tooltip location="top" text="Generate waypoints">
       <template #activator="{ props }">
         <div
@@ -583,6 +583,9 @@
     @place-point-of-interest="openPoiDialog"
     @add-waypoint-at-cursor="addWaypointFromContextMenu"
     @clear-vehicle-path-history="clearVehiclePathHistory"
+    @place-base-station="placeBaseStationFromContextMenu"
+    @configure-base-station="baseStationStore.configPanelOpen = true"
+    @remove-base-station="baseStationStore.remove()"
   />
   <Teleport to="#planningMap">
     <RadialMenu
@@ -615,6 +618,7 @@
   </SideConfigPanel>
   <HomePositionSettingHelp v-model="showHomePositionNotSetDialog" />
   <PoiManager ref="poiManagerRef" />
+  <BaseStationContextPopup />
   <PoiMapArrows
     :map-ready="mapReady"
     :force-full-screen="true"
@@ -675,6 +679,7 @@ import { type InstanceType, computed, nextTick, onMounted, onUnmounted, ref, sha
 import blueboatMarkerImage from '@/assets/blueboat-marker.avif'
 import brov2MarkerImage from '@/assets/brov2-marker.avif'
 import genericVehicleMarkerImage from '@/assets/generic-vehicle-marker.avif'
+import BaseStationContextPopup from '@/components/BaseStationContextPopup.vue'
 import ContextMenu from '@/components/mission-planning/ContextMenu.vue'
 import HomePositionSettingHelp from '@/components/mission-planning/HomePositionSettingHelp.vue'
 import MissionEstimatesPanel from '@/components/mission-planning/MissionEstimates.vue'
@@ -685,6 +690,8 @@ import PoiManager from '@/components/poi/PoiManager.vue'
 import PoiMapArrows from '@/components/poi/PoiMapArrows.vue'
 import RadialMenu, { type RadialMenuItem } from '@/components/RadialMenu.vue'
 import SideConfigPanel from '@/components/SideConfigPanel.vue'
+import { useBaseStation } from '@/composables/baseStation/useBaseStation'
+import { useBaseStationOverlay } from '@/composables/baseStation/useBaseStationOverlay'
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { provideMapContext } from '@/composables/map/useMapContext'
 import { useSnackbar } from '@/composables/snackbar'
@@ -732,6 +739,7 @@ const missionStore = useMissionStore()
 const vehicleStore = useMainVehicleStore()
 const interfaceStore = useAppInterfaceStore()
 const widgetStore = useWidgetManagerStore()
+const baseStationStore = useBaseStation()
 const missionEstimates = useMissionEstimates()
 const { height: windowHeight } = useWindowSize()
 
@@ -918,6 +926,8 @@ const downloadMissionFromVehicle = async (): Promise<void> => {
 const planningMap = shallowRef<Map | undefined>()
 const mapContext = provideMapContext()
 const { mapReady } = mapContext
+
+useBaseStationOverlay(planningMap, mapReady)
 
 const mapCenter = ref<WaypointCoordinates>(missionStore.userLastMapCenter ?? missionStore.defaultMapCenter)
 const zoom = ref(missionStore.userLastMapZoom ?? missionStore.defaultMapZoom)
@@ -1951,6 +1961,12 @@ const hideContextMenu = (): void => {
 const clearVehiclePathHistory = (): void => {
   missionStore.clearVehicleHistory()
   openSnackbar({ message: 'Vehicle path history cleared', variant: 'success' })
+}
+
+const placeBaseStationFromContextMenu = (): void => {
+  if (!currentCursorGeoCoordinates.value) return
+  baseStationStore.setPosition(currentCursorGeoCoordinates.value)
+  baseStationStore.configPanelOpen = true
 }
 
 const setHomePosition = async (): Promise<void> => {

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -586,6 +586,7 @@
     @place-base-station="placeBaseStationFromContextMenu"
     @configure-base-station="baseStationStore.configPanelOpen = true"
     @remove-base-station="baseStationStore.remove()"
+    @toggle-base-station-signal-visibility="baseStationStore.toggleSignalVisibility()"
   />
   <Teleport to="#planningMap">
     <RadialMenu


### PR DESCRIPTION
This PR was split into three others to ease the review:

#2810 - Base Station: Add map marker and radio/tether coverage
#2811 - Base Station: Add mobile-data coverage overlays
#2812 - Base Station: Add offscreen indicators and mission-path comms coloring
