### PR TITLE
Widgets: Fix framerate drop on dragging components

### DIFF
--- a/src/components/WidgetHugger.vue
+++ b/src/components/WidgetHugger.vue
@@ -61,6 +61,7 @@
 import { useElementHover, useWindowSize } from '@vueuse/core'
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, toRefs, watch } from 'vue'
 
+import { useWidgetGeometry } from '@/composables/useWidgetGeometry'
 import { constrain } from '@/libs/utils'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
 import type { Point2D, SizeRect2D } from '@/types/general'
@@ -110,9 +111,6 @@ watch(
   },
   { immediate: true }
 )
-
-watch(position, (newPosition) => (widget.value.position = newPosition))
-watch(size, (newSize) => (widget.value.size = newSize))
 
 const allowMoving = toRefs(props).allowMoving
 const allowResizing = toRefs(props).allowResizing
@@ -170,6 +168,9 @@ watch([hoveringWidgetOrOverlay, allowMoving], () => {
 
 const draggingWidget = ref(false)
 const isResizing = ref(false)
+
+const { syncPositionToWidget, syncSizeToWidget } = useWidgetGeometry(widget, position, size, draggingWidget, isResizing)
+
 const resizeHandle = ref<EventTarget | null>(null)
 const getViewSize = (): {
   /**
@@ -303,11 +304,14 @@ const handleEnd = (): void => {
   if (!outerWidgetRef.value) return
   if (draggingWidget.value) {
     draggingWidget.value = false
+    syncPositionToWidget()
     outerWidgetRef.value.style.cursor = 'grab'
     document.documentElement.classList.remove('widget-dragging')
   } else if (isResizing.value) {
     isResizing.value = false
     resizeHandle.value = null
+    syncPositionToWidget()
+    syncSizeToWidget()
   }
 }
 
@@ -546,5 +550,9 @@ const highlighted = computed(() => widgetStore.widgetManagerVars(widget.value.ha
 
 html.widget-dragging iframe {
   pointer-events: none !important;
+}
+
+iframe.widget-dragging-self {
+  visibility: hidden;
 }
 </style>

--- a/src/components/widgets/IFrame.vue
+++ b/src/components/widgets/IFrame.vue
@@ -41,6 +41,7 @@
             ref="iframe"
             :src="toBeUsedURL"
             :style="collapsibleIframeStyle"
+            :class="{ 'widget-dragging-self': widgetDragging }"
             frameborder="0"
             @load="loadFinished"
           />
@@ -81,6 +82,7 @@
             ref="iframe"
             :src="toBeUsedURL"
             :style="iframeStyle"
+            :class="{ 'widget-dragging-self': widgetDragging }"
             frameborder="0"
             @load="loadFinished"
           />
@@ -229,10 +231,11 @@
 
 <script setup lang="ts">
 import { useElementSize, useWindowSize } from '@vueuse/core'
-import { computed, onBeforeMount, onBeforeUnmount, ref, toRefs, watch } from 'vue'
+import { computed, inject, onBeforeMount, onBeforeUnmount, ref, toRefs, watch } from 'vue'
 
 import { defaultBlueOsAddress } from '@/assets/defaults'
 import { openSnackbar } from '@/composables/snackbar'
+import { widgetDraggingKey, widgetLivePositionKey, widgetLiveSizeKey } from '@/composables/useWidgetGeometry'
 import { getDataLakeVariableData, listenDataLakeVariable, unlistenDataLakeVariable } from '@/libs/actions/data-lake'
 import { isValidURL } from '@/libs/utils'
 import { useAppInterfaceStore } from '@/stores/appInterface'
@@ -252,6 +255,9 @@ const props = defineProps<{
   widget: Widget
 }>()
 const widget = toRefs(props).widget
+const livePosition = inject(widgetLivePositionKey, null)
+const liveSize = inject(widgetLiveSizeKey, null)
+const widgetDragging = inject(widgetDraggingKey, null)
 
 const { width: windowWidth, height: windowHeight } = useWindowSize()
 const collapsedHeaderHeightPx = 42
@@ -674,11 +680,13 @@ const collapsibleIframeStyle = computed<string>(() => {
 
 // Full widget rect, used to position the teleported content box and its status overlay.
 const widgetRectStyle = computed<string>(() => {
+  const position = livePosition?.value ?? widget.value.position
+  const size = liveSize?.value ?? widget.value.size
   let newStyle = ''
-  newStyle = newStyle.concat(' ', `left: ${widget.value.position.x * windowWidth.value}px;`)
-  newStyle = newStyle.concat(' ', `top: ${widget.value.position.y * windowHeight.value}px;`)
-  newStyle = newStyle.concat(' ', `width: ${widget.value.size.width * windowWidth.value}px;`)
-  newStyle = newStyle.concat(' ', `height: ${widget.value.size.height * windowHeight.value}px;`)
+  newStyle = newStyle.concat(' ', `left: ${position.x * windowWidth.value}px;`)
+  newStyle = newStyle.concat(' ', `top: ${position.y * windowHeight.value}px;`)
+  newStyle = newStyle.concat(' ', `width: ${size.width * windowWidth.value}px;`)
+  newStyle = newStyle.concat(' ', `height: ${size.height * windowHeight.value}px;`)
 
   if (widgetStore.editingMode) {
     newStyle = newStyle.concat(' ', 'pointer-events:none; border:0;')
@@ -690,7 +698,8 @@ const widgetRectStyle = computed<string>(() => {
 })
 
 const iframeStyle = computed<string>(() => {
-  return buildContentStyle(widget.value.size.width * windowWidth.value, widget.value.size.height * windowHeight.value)
+  const size = liveSize?.value ?? widget.value.size
+  return buildContentStyle(size.width * windowWidth.value, size.height * windowHeight.value)
 })
 
 const iframeOpacity = computed<number>(() => {
@@ -706,7 +715,7 @@ function loadFinished(): void {
 }
 
 watch(
-  widget,
+  () => widget.value.options,
   () => {
     if (widgetStore.widgetManagerVars(widget.value.hash).configMenuOpen === false) {
       if (validateURL(toBeUsedURL.value) !== true) {

--- a/src/composables/useWidgetGeometry.ts
+++ b/src/composables/useWidgetGeometry.ts
@@ -1,0 +1,60 @@
+import type { InjectionKey, Ref } from 'vue'
+import { provide, watch } from 'vue'
+
+import type { Point2D, SizeRect2D } from '@/types/general'
+import type { Widget } from '@/types/widgets'
+
+export const widgetLivePositionKey: InjectionKey<Ref<Point2D>> = Symbol('widgetLivePosition')
+export const widgetLiveSizeKey: InjectionKey<Ref<SizeRect2D>> = Symbol('widgetLiveSize')
+export const widgetDraggingKey: InjectionKey<Ref<boolean>> = Symbol('widgetDragging')
+
+/**
+ * Manages a widget's geometry: keeps live position/size refs decoupled from the persisted widget while dragging or
+ * resizing, and exposes the live values to descendants (e.g. teleported iframes) that cannot rely on stale
+ * widget.position during a gesture.
+ * @param {Ref<Widget>} widget - Persisted widget reference
+ * @param {Ref<Point2D>} position - Live position updated during drag
+ * @param {Ref<SizeRect2D>} size - Live size updated during resize
+ * @param {Ref<boolean>} draggingWidget - Whether the widget is being dragged
+ * @param {Ref<boolean>} isResizing - Whether the widget is being resized
+ * @returns {{ syncPositionToWidget: () => void, syncSizeToWidget: () => void }} Flush helpers for drag/resize end
+ */
+export function useWidgetGeometry(
+  widget: Ref<Widget>,
+  position: Ref<Point2D>,
+  size: Ref<SizeRect2D>,
+  draggingWidget: Ref<boolean>,
+  isResizing: Ref<boolean>
+): {
+  /**
+   * Persists the current local position to the widget model
+   */
+  syncPositionToWidget: () => void
+  /**
+   * Persists the current local size to the widget model
+   */
+  syncSizeToWidget: () => void
+} {
+  const syncPositionToWidget = (): void => {
+    widget.value.position = { ...position.value }
+  }
+
+  const syncSizeToWidget = (): void => {
+    widget.value.size = { ...size.value }
+  }
+
+  watch(position, (newPosition) => {
+    if (draggingWidget.value || isResizing.value) return
+    widget.value.position = newPosition
+  })
+  watch(size, (newSize) => {
+    if (draggingWidget.value || isResizing.value) return
+    widget.value.size = newSize
+  })
+
+  provide(widgetLivePositionKey, position)
+  provide(widgetLiveSizeKey, size)
+  provide(widgetDraggingKey, draggingWidget)
+
+  return { syncPositionToWidget, syncSizeToWidget }
+}


### PR DESCRIPTION
**Cause:**
* Every `mousemove` during a drag mutated `widget.position` on the persisted profile, firing the `useBlueOsStorage` deep watcher and running `prettyFormat` over the entire `cockpit-views-group-v1` profile at pointer frequency (~40 Hz), starving the main thread and tanking FPS — most visibly with cross-origin iframe widgets whose compositor also repaints each frame.

**Fix approach:**
- New `useWidgetGeometry` composable holds widget position and size in local refs, deferring writes to the persisted widget until `handleEnd` (drag/resize release).
- Teleported `IFrame` widgets follow the live position/size via `provide`/`inject`, so the iframe still tracks the shell during drag without observing the now-deferred persisted widget.
- Embedded iframes get `visibility: hidden` while `html.widget-dragging` is set to skip cross-origin compositor repaints, and `IFrame`'s deep `watch(widget)` is narrowed to `widget.options` so URL revalidation no longer reacts to unrelated mutations.

Closes #2530