### PR TITLE
Add dynamic location POI support

### DIFF
--- a/src/components/poi/PoiManager.vue
+++ b/src/components/poi/PoiManager.vue
@@ -12,20 +12,80 @@
           <v-icon :size="22">mdi-close</v-icon>
         </v-btn>
       </div>
-      <div class="p-3">
-        <v-text-field v-model="newPoiName" label="Name" variant="outlined"></v-text-field>
-        <v-text-field v-model="newPoiDescription" label="Description" variant="outlined"></v-text-field>
+      <div class="p-3 -mt-6">
+        <v-text-field v-model="newPoiName" density="compact" label="Name" variant="outlined"></v-text-field>
 
-        <div class="grid grid-cols-2 gap-x-4">
-          <v-text-field v-model.number="newPoiLat" label="Latitude" variant="outlined" type="number" step="0.0000001" />
+        <div class="flex items-center justify-between mb-4 -mt-2">
+          <v-checkbox v-model="isDynamicPoi" label="Dynamic positioning" color="white" density="compact" hide-details />
+          <v-tooltip location="top" max-width="340">
+            <template #activator="{ props }">
+              <v-icon v-bind="props" size="20" class="mr-1 opacity-70 cursor-help">mdi-information-outline</v-icon>
+            </template>
+            <span>
+              Drives this POI's position from Data Lake variables instead of a fixed point — useful for tracking moving
+              entities such as other vehicles. Pick one numeric variable for latitude and one for longitude; the marker
+              then follows their values live. Values must be in decimal degrees: if your source uses another unit (e.g.
+              MAVLink degE7), create a compound variable to convert it first.
+            </span>
+          </v-tooltip>
+        </div>
+
+        <div v-if="!isDynamicPoi" class="grid grid-cols-2 gap-x-4">
+          <v-text-field
+            v-model.number="newPoiLat"
+            density="compact"
+            label="Latitude"
+            variant="outlined"
+            type="number"
+            step="0.0000001"
+          />
           <v-text-field
             v-model.number="newPoiLng"
+            density="compact"
             label="Longitude"
             variant="outlined"
             type="number"
             step="0.0000001"
           />
         </div>
+        <div v-else>
+          <v-autocomplete
+            v-model="dynamicLatVariableId"
+            :items="availableNumberVariables"
+            item-title="name"
+            item-value="id"
+            label="Latitude variable"
+            variant="outlined"
+            density="compact"
+            clearable
+            hide-details
+            class="mb-2"
+            theme="dark"
+          />
+          <v-autocomplete
+            v-model="dynamicLngVariableId"
+            :items="availableNumberVariables"
+            item-title="name"
+            item-value="id"
+            label="Longitude variable"
+            variant="outlined"
+            density="compact"
+            clearable
+            hide-details
+            class="mb-2"
+            theme="dark"
+          />
+          <div class="text-caption text-white opacity-60 mb-5">
+            Live position: {{ liveDynamicLat ?? '—' }}, {{ liveDynamicLng ?? '—' }}
+          </div>
+        </div>
+        <v-text-field
+          v-model="newPoiDescription"
+          density="compact"
+          label="Description"
+          variant="outlined"
+          class="mt-2"
+        ></v-text-field>
 
         <div class="mb-4">
           <div class="flex items-center gap-x-2 mb-4">
@@ -38,13 +98,20 @@
                 <v-icon>mdi-palette</v-icon>
               </v-btn>
             </div>
-            <v-text-field v-model="newPoiColor" label="Hex Color" hide-details variant="outlined" class="flex-grow" />
+            <v-text-field
+              v-model="newPoiColor"
+              density="compact"
+              label="Hex Color"
+              hide-details
+              variant="outlined"
+              class="flex-grow"
+            />
             <v-spacer />
             <div
               class="cursor-pointer hover:opacity-80 flex flex-col items-center"
               @click="isIconPickerOpen = !isIconPickerOpen"
             >
-              <v-icon :icon="newPoiIcon" size="48" :color="newPoiColor" />
+              <v-icon :icon="newPoiIcon" size="40" :color="newPoiColor" />
               <span class="text-white opacity-50 mx-2 text-xs mt-1">Click to change icon</span>
             </div>
           </div>
@@ -82,20 +149,29 @@
       </div>
     </template>
     <template #actions>
-      <v-btn v-if="editingPoiId" text @click="deletePoi">Delete</v-btn>
-      <v-spacer></v-spacer>
-      <v-btn text @click="savePoi">Save</v-btn>
+      <div class="flex w-full items-center justify-between my-1">
+        <v-btn v-if="editingPoiId" variant="text" @click="deletePoi">Delete</v-btn>
+        <v-spacer></v-spacer>
+        <v-btn variant="text" @click="savePoi">Save</v-btn>
+      </div>
     </template>
   </InteractionDialog>
 </template>
 
 <script setup lang="ts">
 import { v4 as uuid } from 'uuid'
-import { defineExpose, ref, watch } from 'vue'
+import { computed, defineExpose, onMounted, onUnmounted, ref, watch } from 'vue'
 
 import InteractionDialog from '@/components/InteractionDialog.vue'
 import { useInteractionDialog } from '@/composables/interactionDialog'
+import { useDataLakeVariable } from '@/composables/useDataLakeVariable'
+import {
+  getAllDataLakeVariablesInfo,
+  listenToDataLakeVariablesInfoChanges,
+  unlistenToDataLakeVariablesInfoChanges,
+} from '@/libs/actions/data-lake'
 import { useMissionStore } from '@/stores/mission'
+import type { DataLakeVariable } from '@/types/data-lake'
 import type { PointOfInterest, PointOfInterestCoordinates } from '@/types/mission'
 
 const missionStore = useMissionStore()
@@ -112,6 +188,40 @@ const newPoiLng = ref<number | null>(null)
 const isIconPickerOpen = ref(false)
 const iconSearchQuery = ref('')
 const isColorPickerOpen = ref(false)
+
+const isDynamicPoi = ref(false)
+const dynamicLatVariableId = ref<string | undefined>(undefined)
+const dynamicLngVariableId = ref<string | undefined>(undefined)
+
+const availableDataLakeVariables = ref<DataLakeVariable[]>([])
+let dataLakeVariableInfoListenerId: string | undefined = undefined
+const availableNumberVariables = computed(() =>
+  availableDataLakeVariables.value.filter((variable) => variable.type === 'number')
+)
+
+const { value: liveDynamicLatRaw } = useDataLakeVariable(() =>
+  isDynamicPoi.value ? dynamicLatVariableId.value : undefined
+)
+const { value: liveDynamicLngRaw } = useDataLakeVariable(() =>
+  isDynamicPoi.value ? dynamicLngVariableId.value : undefined
+)
+const liveDynamicLat = computed(() =>
+  typeof liveDynamicLatRaw.value === 'number' ? liveDynamicLatRaw.value : undefined
+)
+const liveDynamicLng = computed(() =>
+  typeof liveDynamicLngRaw.value === 'number' ? liveDynamicLngRaw.value : undefined
+)
+
+onMounted(() => {
+  availableDataLakeVariables.value = Object.values(getAllDataLakeVariablesInfo())
+  dataLakeVariableInfoListenerId = listenToDataLakeVariablesInfoChanges((variables) => {
+    availableDataLakeVariables.value = Object.values(variables)
+  })
+})
+
+onUnmounted(() => {
+  if (dataLakeVariableInfoListenerId) unlistenToDataLakeVariablesInfoChanges(dataLakeVariableInfoListenerId)
+})
 
 // Store original values for reverting changes if user cancels
 const originalPoiValues = ref<{
@@ -313,6 +423,9 @@ const openDialog = (coordinates?: PointOfInterestCoordinates | null, poiToEdit?:
     newPoiLng.value = Number(freshPoi.coordinates[1].toFixed(7))
     newPoiIcon.value = freshPoi.icon
     newPoiColor.value = freshPoi.color
+    isDynamicPoi.value = freshPoi.coordinateSource !== undefined
+    dynamicLatVariableId.value = freshPoi.coordinateSource?.latitudeVariableId
+    dynamicLngVariableId.value = freshPoi.coordinateSource?.longitudeVariableId
     dialogInitialCoordinates.value = null // Not needed for editing, and clear it
   } else if (coordinates) {
     editingPoiId.value = null
@@ -323,6 +436,9 @@ const openDialog = (coordinates?: PointOfInterestCoordinates | null, poiToEdit?:
     newPoiColor.value = getRandomColor()
     newPoiLat.value = coordinates[0] // Still useful to pre-fill for potential direct edit
     newPoiLng.value = coordinates[1] // Still useful to pre-fill for potential direct edit
+    isDynamicPoi.value = false
+    dynamicLatVariableId.value = undefined
+    dynamicLngVariableId.value = undefined
     dialogInitialCoordinates.value = [...coordinates] // Store for saving a new POI
   } else {
     showDialog({
@@ -371,6 +487,17 @@ const closeDialog = (): void => {
   newPoiColor.value = getRandomColor()
   isIconPickerOpen.value = false
   isColorPickerOpen.value = false
+  isDynamicPoi.value = false
+  dynamicLatVariableId.value = undefined
+  dynamicLngVariableId.value = undefined
+}
+
+// Builds a coordinate from the currently available live values, filling any unbound axis from the form/click position.
+const liveDynamicCoordinates = (): PointOfInterestCoordinates | undefined => {
+  if (liveDynamicLat.value === undefined && liveDynamicLng.value === undefined) return undefined
+  const fallbackLat = dialogInitialCoordinates.value?.[0] ?? newPoiLat.value ?? 0
+  const fallbackLng = dialogInitialCoordinates.value?.[1] ?? newPoiLng.value ?? 0
+  return [liveDynamicLat.value ?? fallbackLat, liveDynamicLng.value ?? fallbackLng]
 }
 
 const savePoi = (): void => {
@@ -379,7 +506,16 @@ const savePoi = (): void => {
     return
   }
 
-  if (newPoiLat.value === null || newPoiLng.value === null || isNaN(newPoiLat.value) || isNaN(newPoiLng.value)) {
+  if (isDynamicPoi.value) {
+    if (!dynamicLatVariableId.value && !dynamicLngVariableId.value) {
+      showDialog({
+        title: 'Invalid Variables',
+        message: 'Select at least one data-lake variable to drive the position.',
+        variant: 'error',
+      })
+      return
+    }
+  } else if (newPoiLat.value === null || newPoiLng.value === null || isNaN(newPoiLat.value) || isNaN(newPoiLng.value)) {
     showDialog({
       title: 'Invalid Coordinates',
       message: 'Latitude and Longitude must be valid numbers.',
@@ -387,6 +523,10 @@ const savePoi = (): void => {
     })
     return
   }
+
+  const coordinateSource = isDynamicPoi.value
+    ? { latitudeVariableId: dynamicLatVariableId.value, longitudeVariableId: dynamicLngVariableId.value }
+    : undefined
 
   if (editingPoiId.value) {
     // Get the current POI from store to preserve current coordinates
@@ -404,23 +544,32 @@ const savePoi = (): void => {
     // Clear original values since we're saving the changes
     originalPoiValues.value = null
 
+    // For dynamic POIs, keep current coordinates as the fallback; the data-lake engine drives the live position.
+    const updatedCoordinates = isDynamicPoi.value
+      ? liveDynamicCoordinates() ?? currentPoi.coordinates
+      : coordinatesChanged
+      ? ([newPoiLat.value, newPoiLng.value] as PointOfInterestCoordinates)
+      : currentPoi.coordinates
+
     const poiUpdate: Partial<PointOfInterest> = {
       name: newPoiName.value,
       description: newPoiDescription.value,
-      // Use current store coordinates unless user specifically changed them in the form
-      coordinates: coordinatesChanged
-        ? ([newPoiLat.value, newPoiLng.value] as PointOfInterestCoordinates)
-        : currentPoi.coordinates,
+      coordinates: updatedCoordinates,
       icon: newPoiIcon.value,
       color: newPoiColor.value,
+      coordinateSource,
       timestamp: Date.now(),
     }
     missionStore.updatePointOfInterest(editingPoiId.value, poiUpdate)
   } else {
     // For new POIs, prioritize dialogInitialCoordinates if they exist (meaning they were passed on openDialog)
     // Otherwise, use the (potentially user-modified) coordinates from the form.
-    const coordinatesToSave =
-      dialogInitialCoordinates.value ?? ([newPoiLat.value, newPoiLng.value] as PointOfInterestCoordinates)
+    // For dynamic POIs, seed from the current live values so the marker doesn't jump before the first update.
+    const coordinatesToSave = isDynamicPoi.value
+      ? liveDynamicCoordinates() ??
+        dialogInitialCoordinates.value ??
+        ([newPoiLat.value ?? 0, newPoiLng.value ?? 0] as PointOfInterestCoordinates)
+      : dialogInitialCoordinates.value ?? ([newPoiLat.value, newPoiLng.value] as PointOfInterestCoordinates)
 
     if (!coordinatesToSave) {
       // This case should ideally not be reached if openDialog is called correctly with coordinates for new POIs.
@@ -441,6 +590,7 @@ const savePoi = (): void => {
       coordinates: coordinatesToSave,
       icon: newPoiIcon.value,
       color: newPoiColor.value,
+      coordinateSource,
       timestamp: Date.now(),
     }
     missionStore.addPointOfInterest(newPoi)
@@ -493,9 +643,9 @@ defineExpose({
 }
 
 .color-picker-button {
-  width: 54px !important;
-  height: 54px !important;
-  min-width: 54px !important;
+  width: 40px !important;
+  height: 40px !important;
+  min-width: 40px !important;
   border-radius: 4px !important;
 }
 

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -1950,7 +1950,7 @@ const poiIconConfig = (poi: PointOfInterest): L.DivIconOptions => {
 
   return {
     html: poiIconHtml,
-    className: 'poi-marker-icon-widget',
+    className: `poi-marker-icon-widget${poi.coordinateSource ? ' poi-marker-dynamic' : ''}`,
     iconSize: [32, 32], // Match the actual container size
     iconAnchor: [16, 32], // Center horizontally, bottom vertically (like a pin)
   }
@@ -1961,7 +1961,11 @@ const addPoiMarkerToMapWidget = (poi: PointOfInterest): void => {
 
   const poiMarkerIcon = L.divIcon(poiIconConfig(poi))
 
-  const marker = L.marker(poi.coordinates as LatLngTuple, { icon: poiMarkerIcon, draggable: true }).addTo(map.value)
+  // Dynamic POIs follow data-lake variables, so manual dragging is disabled.
+  const marker = L.marker(poi.coordinates as LatLngTuple, {
+    icon: poiMarkerIcon,
+    draggable: poi.coordinateSource === undefined,
+  }).addTo(map.value)
 
   const tooltipContent = `
     <strong>${poi.name}</strong><br>
@@ -2009,6 +2013,12 @@ const updatePoiMarkerOnMapWidget = (poi: PointOfInterest): void => {
   marker.setLatLng(poi.coordinates as LatLngTuple)
 
   marker.setIcon(L.divIcon(poiIconConfig(poi)))
+
+  if (poi.coordinateSource) {
+    marker.dragging?.disable()
+  } else {
+    marker.dragging?.enable()
+  }
 
   const updatedTooltipContent = `
     <strong>${poi.name}</strong><br>
@@ -2259,6 +2269,20 @@ watch(
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
   border: 1px solid rgba(255, 255, 255, 0.7);
   z-index: 1;
+}
+
+.poi-marker-dynamic .poi-marker-background {
+  animation: poi-dynamic-glow 1.8s ease-in-out infinite;
+}
+
+@keyframes poi-dynamic-glow {
+  0%,
+  100% {
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 0 2.5px 0 rgba(255, 255, 255, 0.125);
+  }
+  50% {
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 0 2.5px 2.5px rgba(255, 255, 255, 0.225);
+  }
 }
 
 .poi-tooltip-widget {

--- a/src/stores/mission.ts
+++ b/src/stores/mission.ts
@@ -1,5 +1,5 @@
 import * as turf from '@turf/turf'
-import { useStorage } from '@vueuse/core'
+import { useStorage, useThrottleFn } from '@vueuse/core'
 import { defineStore } from 'pinia'
 import { computed, reactive, ref, watch } from 'vue'
 
@@ -7,10 +7,12 @@ import { defaultMapFallbackBaseColor, defaultMapFallbackNoiseIntensity } from '@
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { useBlueOsStorage } from '@/composables/settingsSyncer'
 import { askForUsername } from '@/composables/usernamePrompDialog'
+import { getDataLakeVariableData, listenDataLakeVariable, unlistenDataLakeVariable } from '@/libs/actions/data-lake'
 import { generateSessionSeed } from '@/libs/map/map-tile-fallback'
 import { eventCategoriesDefaultMapping } from '@/libs/slide-to-confirm'
 import {
   AltitudeReferenceType,
+  DynamicPoiSubscription,
   MapTileProvider,
   MapTileProviderPreference,
   MissionCommand,
@@ -258,6 +260,123 @@ export const useMissionStore = defineStore('mission', () => {
     }
     updatePointOfInterest(id, { coordinates: newCoordinates })
   }
+
+  // Dynamic POIs: subscribe to data-lake variables and feed their coordinates into the store at the user-configured
+  // vehicle position update rate (Settings -> Mission -> "Max. vehicle position update rate"), mirroring the throttle
+  // used for the vehicle marker.
+  const dynamicPoiSubscriptions: Record<string, DynamicPoiSubscription> = {}
+  const dynamicPoiPendingCoordinates: Record<string, PointOfInterestCoordinates> = {}
+
+  const readDynamicPoiCoordinates = (poi: PointOfInterest): PointOfInterestCoordinates | undefined => {
+    const source = poi.coordinateSource
+    if (!source) return undefined
+    // Unbound axes fall back to the stored coordinate; flushDynamicPoiUpdates then no-ops via its equality check.
+    const lat = source.latitudeVariableId
+      ? Number(getDataLakeVariableData(source.latitudeVariableId))
+      : poi.coordinates[0]
+    const lng = source.longitudeVariableId
+      ? Number(getDataLakeVariableData(source.longitudeVariableId))
+      : poi.coordinates[1]
+    if (!isFinite(lat) || !isFinite(lng)) return undefined
+    return [lat, lng]
+  }
+
+  const queueDynamicPoiUpdate = (poiId: string): void => {
+    const poi = pointsOfInterest.value.find((p) => p.id === poiId)
+    if (!poi) return
+    const coordinates = readDynamicPoiCoordinates(poi)
+    if (coordinates) dynamicPoiPendingCoordinates[poiId] = coordinates
+  }
+
+  const flushDynamicPoiUpdates = (): void => {
+    for (const [poiId, coordinates] of Object.entries(dynamicPoiPendingCoordinates)) {
+      delete dynamicPoiPendingCoordinates[poiId]
+      const poi = pointsOfInterest.value.find((p) => p.id === poiId)
+      if (!poi) continue
+      if (poi.coordinates[0] === coordinates[0] && poi.coordinates[1] === coordinates[1]) continue
+      movePointOfInterest(poiId, coordinates)
+    }
+  }
+
+  const teardownDynamicPoiSubscription = (poiId: string): void => {
+    const subscription = dynamicPoiSubscriptions[poiId]
+    if (!subscription) return
+    subscription.listeners.forEach(([variableId, listenerId]) => unlistenDataLakeVariable(variableId, listenerId))
+    delete dynamicPoiSubscriptions[poiId]
+    delete dynamicPoiPendingCoordinates[poiId]
+  }
+
+  const reconcileDynamicPoiSubscriptions = (): void => {
+    const pois = pointsOfInterest.value
+
+    // Drop subscriptions for POIs that were removed, made static, or had their bound variables changed.
+    for (const poiId of Object.keys(dynamicPoiSubscriptions)) {
+      const poi = pois.find((p) => p.id === poiId)
+      const source = poi?.coordinateSource
+      const subscription = dynamicPoiSubscriptions[poiId]
+      const isUnchanged =
+        source !== undefined &&
+        source.latitudeVariableId === subscription.latVariableId &&
+        source.longitudeVariableId === subscription.lngVariableId
+      if (!isUnchanged) teardownDynamicPoiSubscription(poiId)
+    }
+
+    // Open subscriptions for newly dynamic POIs.
+    for (const poi of pois) {
+      const source = poi.coordinateSource
+      if (!source || (!source.latitudeVariableId && !source.longitudeVariableId)) continue
+      if (dynamicPoiSubscriptions[poi.id]) continue
+
+      const listeners: DynamicPoiSubscription['listeners'] = []
+      const onValue = (): void => {
+        queueDynamicPoiUpdate(poi.id)
+        flushDynamicPoiUpdatesThrottled()
+      }
+      const variableIds = [source.latitudeVariableId, source.longitudeVariableId].filter(
+        (id): id is string => id !== undefined
+      )
+      variableIds.forEach((variableId) => {
+        listeners.push([variableId, listenDataLakeVariable(variableId, onValue)])
+      })
+
+      dynamicPoiSubscriptions[poi.id] = {
+        listeners,
+        latVariableId: source.latitudeVariableId,
+        lngVariableId: source.longitudeVariableId,
+      }
+      // Seed from current values, in case they already exist in the data-lake.
+      queueDynamicPoiUpdate(poi.id)
+      flushDynamicPoiUpdatesThrottled()
+    }
+  }
+
+  let flushDynamicPoiUpdatesThrottled = useThrottleFn(
+    flushDynamicPoiUpdates,
+    mainVehicleStore.vehiclePositionMaxSampleRate,
+    true,
+    true
+  )
+  // Recreate the throttle when the rate changes; mirrors how the vehicle marker handles the same setting in
+  // mainVehicle.ts. Any trailing call still pending on the previous throttle is dropped — acceptable here because
+  // the buffer is coalesced and any in-flight value is re-derived by the next listener tick.
+  watch(
+    () => mainVehicleStore.vehiclePositionMaxSampleRate,
+    (ms) => {
+      flushDynamicPoiUpdatesThrottled = useThrottleFn(flushDynamicPoiUpdates, ms, true, true)
+    }
+  )
+
+  // Reconcile only when the dynamic bindings change (not on every coordinate tick), keeping value updates off this watcher.
+  watch(
+    () =>
+      pointsOfInterest.value.map((poi) => ({
+        id: poi.id,
+        latVariableId: poi.coordinateSource?.latitudeVariableId,
+        lngVariableId: poi.coordinateSource?.longitudeVariableId,
+      })),
+    () => reconcileDynamicPoiSubscriptions(),
+    { deep: true, immediate: true }
+  )
 
   const clearMission = (): void => {
     currentPlanningWaypoints.splice(0)

--- a/src/types/mission.ts
+++ b/src/types/mission.ts
@@ -252,6 +252,44 @@ export type PointOfInterestIcon = string
 export type PointOfInterestColor = string
 
 /**
+ * Data-lake variable bindings that drive a Point of Interest's coordinates at runtime.
+ * When a variable id is set, the corresponding coordinate component follows that variable's value.
+ */
+export interface PointOfInterestCoordinateSource {
+  /**
+   * Data-lake variable id feeding the latitude.
+   */
+  latitudeVariableId?: string
+  /**
+   * Data-lake variable id feeding the longitude.
+   */
+  longitudeVariableId?: string
+}
+
+/**
+ * A registered data-lake listener for a dynamic POI, as a [variableId, listenerId] pair.
+ */
+export type DynamicPoiListenerHandle = [variableId: string, listenerId: string]
+
+/**
+ * Tracks the active data-lake subscription that drives a dynamic Point of Interest.
+ */
+export interface DynamicPoiSubscription {
+  /**
+   * Active data-lake listener handles for this POI.
+   */
+  listeners: DynamicPoiListenerHandle[]
+  /**
+   * Latitude variable id the subscription was built for.
+   */
+  latVariableId?: string
+  /**
+   * Longitude variable id the subscription was built for.
+   */
+  lngVariableId?: string
+}
+
+/**
  * Interface representing a Point of Interest (POI) on the map.
  */
 export interface PointOfInterest {
@@ -281,6 +319,11 @@ export interface PointOfInterest {
   color: PointOfInterestColor
   /** Timestamp of creation or last update */
   timestamp: number
+  /**
+   * When set, the POI coordinates are driven at runtime by data-lake variables.
+   * The stored `coordinates` then act as the last-known/fallback position.
+   */
+  coordinateSource?: PointOfInterestCoordinateSource
 }
 
 /**

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -4346,7 +4346,7 @@ const poiIconConfig = (poi: PointOfInterest): L.DivIconOptions => {
 
   return {
     html: poiIconHtml,
-    className: 'poi-marker-icon',
+    className: `poi-marker-icon${poi.coordinateSource ? ' poi-marker-dynamic' : ''}`,
     iconSize: [32, 32], // Match the actual container size
     iconAnchor: [16, 32], // Center horizontally, bottom vertically (like a pin)
   }
@@ -4358,9 +4358,11 @@ const addPoiMarkerToPlanningMap = (poi: PointOfInterest): void => {
 
   const poiMarkerIcon = L.divIcon(poiIconConfig(poi))
 
-  const marker = L.marker(poi.coordinates as LatLngTuple, { icon: poiMarkerIcon, draggable: true }).addTo(
-    planningMap.value
-  )
+  // Dynamic POIs follow data-lake variables, so manual dragging is disabled.
+  const marker = L.marker(poi.coordinates as LatLngTuple, {
+    icon: poiMarkerIcon,
+    draggable: poi.coordinateSource === undefined,
+  }).addTo(planningMap.value)
 
   const tooltipContent = `
     <strong>${poi.name}</strong><br>
@@ -4402,6 +4404,12 @@ const updatePoiMarkerOnPlanningMap = (poi: PointOfInterest): void => {
   marker.setLatLng(poi.coordinates as LatLngTuple)
 
   marker.setIcon(L.divIcon(poiIconConfig(poi)))
+
+  if (poi.coordinateSource) {
+    marker.dragging?.disable()
+  } else {
+    marker.dragging?.enable()
+  }
 
   const updatedTooltipContent = `
     <strong>${poi.name}</strong><br>
@@ -4761,6 +4769,20 @@ watch(
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
   border: 1px solid rgba(255, 255, 255, 0.7);
   z-index: 1;
+}
+
+.poi-marker-dynamic .poi-marker-background {
+  animation: poi-dynamic-glow 1.8s ease-in-out infinite;
+}
+
+@keyframes poi-dynamic-glow {
+  0%,
+  100% {
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 0 2.5px 0 rgba(255, 255, 255, 0.125);
+  }
+  50% {
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 0 2.5px 2.5px rgba(255, 255, 255, 0.225);
+  }
 }
 
 .poi-tooltip {


### PR DESCRIPTION
- POIs only support a fixed, manually-edited coordinate, so the map cannot reflect moving entities such as other vehicles.
- Adds an optional `coordinateSource` to `PointOfInterest`, binding latitude and/or longitude to numeric data-lake variables.
- Mission store subscribes bound POIs and pushes new positions through `useThrottleFn` at the user-configured "Max. vehicle position update rate" (Settings -> Mission), matching the throttle that already guards the vehicle marker so dynamic POIs cost no more than a moving vehicle.
- `PoiManager` dialog gains a "Dynamic positioning" toggle, per-axis variable selectors, a live preview, and an info tooltip noting that values must be decimal degrees (e.g. MAVLink degE7 needs a compound variable to convert).
- Dynamic POI markers are non-draggable and carry a faint pulsing glow on both the Map widget and the Mission Planning map.

https://github.com/user-attachments/assets/41b6bf6d-3855-48a0-9f93-7cda7594a782

## Testing with a mouse-tracking compound variable

To exercise the feature without external data sources, create two compound variables in **Data Lake -> New Compound Variable**. Click the pencil to enable manual ID editing and set the IDs and types exactly as below.

**Variable 1** - ID: `user/poi-test/mouse-lat`, Name: `Mouse Lat`, Type: `Number`

```javascript
if (!window.__poiMouseProbe) {
  const LAT_ID = 'user/poi-test/mouse-lat'
  const LNG_ID = 'user/poi-test/mouse-lng'
  const state = { lat: 0, lng: 0, xIsFirst: true }
  window.__poiMouseProbe = state

  const parse = (img) => {
    let segs
    try {
      segs = new URL(img.src, location.href).pathname.split('/').filter((s) => /^\d+$/.test(s))
    } catch (e) {
      return null
    }
    if (segs.length < 3) return null
    const last3 = segs.slice(-3).map(Number)
    return { z: last3[0], a: last3[1], b: last3[2], rect: img.getBoundingClientRect() }
  }

  const worldToLatLng = (wx, wy, z) => {
    const size = 256 * Math.pow(2, z)
    const lng = (wx / size) * 360 - 180
    const n = Math.PI - (2 * Math.PI * wy) / size
    const lat = (180 / Math.PI) * Math.atan(Math.sinh(n))
    return [lat, lng]
  }

  window.addEventListener('mousemove', (e) => {
    const container = e.target && e.target.closest && e.target.closest('.leaflet-container')
    if (!container || !window.cockpit) return
    const tiles = [...container.querySelectorAll('img.leaflet-tile')]
      .map(parse)
      .filter((t) => t && t.rect.width > 0)
    if (!tiles.length) return

    for (const p of tiles) {
      for (const q of tiles) {
        if (p === q || p.z !== q.z) continue
        if (Math.abs(p.rect.top - q.rect.top) < 2 && Math.abs(p.rect.left - q.rect.left) > 2) {
          if (p.a !== q.a && p.b === q.b) state.xIsFirst = true
          else if (p.b !== q.b && p.a === q.a) state.xIsFirst = false
        }
      }
    }

    const tile = tiles.find(
      (t) =>
        e.clientX >= t.rect.left && e.clientX <= t.rect.right && e.clientY >= t.rect.top && e.clientY <= t.rect.bottom
    )
    if (!tile) return

    const col = state.xIsFirst ? tile.a : tile.b
    const row = state.xIsFirst ? tile.b : tile.a
    const scale = 256 / tile.rect.width
    const wx = col * 256 + (e.clientX - tile.rect.left) * scale
    const wy = row * 256 + (e.clientY - tile.rect.top) * scale
    const ll = worldToLatLng(wx, wy, tile.z)
    state.lat = ll[0]
    state.lng = ll[1]
    window.cockpit.setDataLakeVariableData(LAT_ID, ll[0])
    window.cockpit.setDataLakeVariableData(LNG_ID, ll[1])
  })
}
return window.__poiMouseProbe.lat
```

**Variable 2** - ID: `user/poi-test/mouse-lng`, Name: `Mouse Lng`, Type: `Number`

```javascript
return window.__poiMouseProbe ? window.__poiMouseProbe.lng : 0
```

Then on the Map widget (or Mission Planning), create a POI, toggle **Dynamic positioning**, pick `Mouse Lat` for Latitude variable and `Mouse Lng` for Longitude variable, and move the cursor over the map - the marker follows it with the pulsing glow, throttled to the configured vehicle position update rate.

Closes #2692