### PR TITLE
Fix home waypoint being placed on a survey creation

### DIFF
--- a/src/components/mission-planning/ContextMenu.vue
+++ b/src/components/mission-planning/ContextMenu.vue
@@ -162,8 +162,8 @@
           ></v-icon>
           <span class="text-white text-sm ml-4">Place point of interest</span>
         </v-list-item>
-        <v-divider />
-        <v-list-item class="flex items-center gap-x-2 pb-2" @click="handleSetHomePosition">
+        <v-divider v-if="canSetHome" />
+        <v-list-item v-if="canSetHome" class="flex items-center gap-x-2 pb-2" @click="handleSetHomePosition">
           <v-icon
             variant="text"
             icon="mdi-home-map-marker"
@@ -198,6 +198,7 @@
         <p class="text-[14px]">Waypoint {{ missionStore.getWaypointNumber(selectedWaypoint?.id as string) }}</p>
         <div>
           <v-icon
+            v-if="canSetHome"
             v-tooltip="'Set home waypoint'"
             variant="text"
             icon="mdi-home-map-marker"
@@ -305,6 +306,7 @@ const emit = defineEmits<{
 const menuType = computed(() => props.menuType)
 const selectedWaypoint = computed<Waypoint | undefined>(() => props.selectedWaypoint)
 const visible = computed(() => props.visible)
+const canSetHome = computed(() => !props.isCreatingSurvey && !props.isCreatingSimplePath)
 const angle = computed(() => props.surveys.find((survey) => survey.id === props.selectedSurveyId)?.surveyLinesAngle)
 
 const clampedPosition = ref({ x: 0, y: 0 })

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -212,7 +212,7 @@
           <p class="text-sm">{{ countdownToHideTips }}</p>
         </div>
         <div
-          v-if="home === undefined && !isSettingHomeWaypoint"
+          v-if="home === undefined && !isSettingHomeWaypoint && !isCreatingSurvey && !isCreatingSimplePath"
           class="flex justify-end ma-2"
           @click="handleAddHomeWaypointByClick"
           @dragstart="handleAddHomeWaypointByClick"
@@ -224,7 +224,7 @@
             <v-icon class="text-md ml-2">mdi-home-circle</v-icon>
           </p>
         </div>
-        <v-divider v-if="!isCreatingSimplePath" class="my-2" />
+        <v-divider v-if="!isCreatingSimplePath && !isCreatingSurvey" class="my-2" />
         <div v-if="isCreatingSurvey" class="flex flex-col">
           <p class="m-1 overflow-visible text-sm text-slate-200">Distance between lines (m)</p>
           <input
@@ -296,7 +296,7 @@
           </button>
         </div>
         <v-divider v-if="isCreatingSurvey" class="my-2" />
-        <div v-if="isCreatingSimplePath" class="flex flex-col w-full h-full p-2">
+        <div v-if="isCreatingSimplePath" class="flex flex-col w-full h-full p-2 -mt-[5px]">
           <p class="overflow-visible my-1 text-sm text-slate-200">Altitude (m)</p>
           <input v-model="currentWaypointAltitude" class="px-2 py-1 m-1 mx-5 rounded-sm bg-[#FFFFFF22]" />
           <p class="overflow-visible mt-2 text-sm text-slate-200">Altitude type:</p>
@@ -410,7 +410,7 @@
         </div>
         <v-divider v-if="isCreatingSimplePath || isCreatingSurvey" class="my-2" />
         <button
-          v-if="isCreatingSimplePath || isCreatingSurvey || missionStore.currentPlanningWaypoints.length > 0"
+          v-if="!isCreatingSimplePath && !isCreatingSurvey && missionStore.currentPlanningWaypoints.length > 0"
           :disabled="missionStore.currentPlanningWaypoints.length < 2 || !vehicleStore.isVehicleOnline"
           :class="{
             'bg-[#FFFFFF11] hover:bg-[#FFFFFF11] text-[#FFFFFF22] elevation-0':

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -3588,6 +3588,10 @@ onMounted(() => {
 
 const onMapClick = (e: L.LeafletMouseEvent): void => {
   hideContextMenu()
+
+  // The dedicated home-setting handler owns this click; bail so we don't also drop a survey vertex or waypoint here.
+  if (isSettingHomeWaypoint.value) return
+
   const oldWaypoint = selectedWaypoint.value
   if (oldWaypoint) {
     const oldMarker = waypointMarkers.value[oldWaypoint.id]


### PR DESCRIPTION
**Problem:**
* Clicking "Set home waypoint" while creating a survey/simple path set home and also dropped a survey vertex (or waypoint) at the same spot, leaving an undraggable home as a polygon vertex.

**Fix:**
- `onMapClick` now bails early when the home-setting flow is active, so the dedicated home handler is the sole consumer of that click.
- Suppress every "set home waypoint" affordance (panel button and both context menus) and the mission-upload button while a survey or simple path is being created.

Closes #2643