### PR TITLE
Add 90º re-fly option to surveys (photogrammetry crosshatch)

### DIFF
--- a/src/components/mission-planning/ContextMenu.vue
+++ b/src/components/mission-planning/ContextMenu.vue
@@ -53,27 +53,44 @@
         </v-tooltip>
       </div>
       <div id="button-3" class="orbit-button orbit-button-3">
-        <v-tooltip text="Swap start and end point of the survey">
+        <v-tooltip :text="crosshatchEnabled ? 'Disable 90° crosshatch re-fly' : 'Enable 90° crosshatch re-fly'">
           <template #activator="{ props: tooltipProps2 }">
             <v-btn
               v-bind="tooltipProps2"
+              variant="elevated"
+              icon="mdi-grid"
+              :style="{ backgroundColor: '#333333EE' }"
+              rounded="full"
+              size="x-small"
+              :color="crosshatchEnabled ? '#A855F7' : '#FFFFFF22'"
+              class="text-[13px] rotate-[200deg]"
+              @click="handleToggleCrosshatch"
+            ></v-btn>
+          </template>
+        </v-tooltip>
+      </div>
+      <div id="button-4" class="orbit-button orbit-button-4">
+        <v-tooltip text="Swap start and end point of the survey">
+          <template #activator="{ props: tooltipProps3 }">
+            <v-btn
+              v-bind="tooltipProps3"
               variant="elevated"
               icon="mdi-swap-horizontal"
               :style="{ backgroundColor: '#333333EE' }"
               rounded="full"
               size="x-small"
               color="#FFFFFF22"
-              class="text-[13px] rotate-[200deg]"
+              class="text-[13px] rotate-[230deg]"
               @click="handleSwapSurveyEntryExit"
             ></v-btn>
           </template>
         </v-tooltip>
       </div>
-      <div v-if="enableUndo" id="button-4" class="orbit-button orbit-button-4">
+      <div v-if="enableUndo" id="button-5" class="orbit-button orbit-button-5">
         <v-tooltip text="Edit survey's polygon">
-          <template #activator="{ props: tooltipProps3 }">
+          <template #activator="{ props: tooltipProps4 }">
             <v-btn
-              v-bind="tooltipProps3"
+              v-bind="tooltipProps4"
               variant="elevated"
               icon="mdi-pencil"
               :style="{ backgroundColor: '#333333EE' }"
@@ -81,7 +98,7 @@
               :disabled="undoIsInProgress"
               size="x-small"
               color="#FFFFFF22"
-              class="text-[13px] rotate-[230deg]"
+              class="text-[13px] rotate-[260deg]"
               @click="handleUndoGenerateWaypoints"
             ></v-btn>
           </template>
@@ -295,6 +312,7 @@ const emit = defineEmits<{
   (event: 'undoGeneratedWaypoints'): void
   (event: 'surveyLinesAngle', angle: number): void
   (event: 'regenerateSurveyWaypoints', angle: number): void
+  (event: 'toggleCrosshatch'): void
   (event: 'swapSurveyEntryExit'): void
   (event: 'removeWaypoint'): void
   (event: 'placePointOfInterest'): void
@@ -306,6 +324,9 @@ const menuType = computed(() => props.menuType)
 const selectedWaypoint = computed<Waypoint | undefined>(() => props.selectedWaypoint)
 const visible = computed(() => props.visible)
 const angle = computed(() => props.surveys.find((survey) => survey.id === props.selectedSurveyId)?.surveyLinesAngle)
+const crosshatchEnabled = computed(
+  () => props.surveys.find((survey) => survey.id === props.selectedSurveyId)?.crosshatch ?? false
+)
 
 const clampedPosition = ref({ x: 0, y: 0 })
 
@@ -387,6 +408,10 @@ const handleUndoGenerateWaypoints = (): void => {
 
 const handleSwapSurveyEntryExit = (): void => {
   emit('swapSurveyEntryExit')
+}
+
+const handleToggleCrosshatch = (): void => {
+  emit('toggleCrosshatch')
 }
 
 const handleDeleteSelectedSurvey = (): void => {
@@ -480,6 +505,11 @@ const handleOpenPanel = (): void => {
   animation-delay: 0.05s;
 }
 
+.orbit-button-5 {
+  animation: orbit-5 0.05s ease-out forwards;
+  animation-delay: 0.05s;
+}
+
 @keyframes orbit-1 {
   0% {
     transform: translate(-50%, -50%) rotate(0deg) translateX(0);
@@ -520,6 +550,17 @@ const handleOpenPanel = (): void => {
   }
   100% {
     transform: translate(-50%, -50%) rotate(-590deg) translateX(90px);
+    opacity: 1;
+  }
+}
+
+@keyframes orbit-5 {
+  0% {
+    transform: translate(-50%, -50%) rotate(0deg) translateX(0);
+    opacity: 0;
+  }
+  100% {
+    transform: translate(-50%, -50%) rotate(-620deg) translateX(90px);
     opacity: 1;
   }
 }

--- a/src/libs/map/utils-map.ts
+++ b/src/libs/map/utils-map.ts
@@ -203,13 +203,15 @@ export const fitMapToWaypoints = (
  * @param {number} linesAngle - The angle of the survey lines in degrees.
  * @param {number} turnaroundDistance - Distance in meters to extend (positive) or inset (negative) from the polygon
  *   boundary before turning. Positive values make the vehicle fly past the edges; negative values keep it away.
+ * @param {boolean} crosshatch - When true, appends a second pass rotated 90 degrees to form a crosshatch grid.
  * @returns {SurveyPath} The generated survey path and turnaround segments.
  */
 export const generateSurveyPath = (
   polygonPoints: L.LatLng[],
   distanceBetweenLines: number,
   linesAngle: number,
-  turnaroundDistance = 0
+  turnaroundDistance = 0,
+  crosshatch = false
 ): SurveyPath => {
   if (polygonPoints.length < 4) return { path: [], turnaroundSegments: [] }
 
@@ -232,6 +234,7 @@ export const generateSurveyPath = (
 
     const continuousPath: L.LatLng[] = []
     const turnaroundSegments: L.LatLng[][] = []
+    let crosshatchStartIndex: number | undefined
     let d = -diagonal
     let isReverse = false
 
@@ -327,7 +330,24 @@ export const generateSurveyPath = (
       turnaroundSegments.push([prevExitBoundary, prevExitTurnaround])
     }
 
-    return { path: continuousPath, turnaroundSegments }
+    if (crosshatch) {
+      const secondPass = generateSurveyPath(polygonPoints, distanceBetweenLines, linesAngle + 90, turnaroundDistance)
+      if (secondPass.path.length > 0) {
+        const passEnd = continuousPath[continuousPath.length - 1]
+        // Fly the second pass in whichever direction keeps the transit leg from the first pass short.
+        if (
+          passEnd &&
+          passEnd.distanceTo(secondPass.path[secondPass.path.length - 1]) < passEnd.distanceTo(secondPass.path[0])
+        ) {
+          secondPass.path.reverse()
+        }
+        crosshatchStartIndex = continuousPath.length
+        continuousPath.push(...secondPass.path)
+        turnaroundSegments.push(...secondPass.turnaroundSegments)
+      }
+    }
+
+    return { path: continuousPath, turnaroundSegments, crosshatchStartIndex }
   } catch (error) {
     console.error('Error in generateSurveyPath:', error)
     return { path: [], turnaroundSegments: [] }

--- a/src/types/mission.ts
+++ b/src/types/mission.ts
@@ -179,6 +179,11 @@ export interface Survey {
    */
   turnaroundDistance: number
   /**
+   * When true, the survey is flown a second time with the lines rotated 90 degrees, producing a
+   * crosshatch grid. Useful for photogrammetry coverage. Optional for backwards compatibility.
+   */
+  crosshatch?: boolean
+  /**
    * Executable mission waypoints.
    */
   waypoints: Waypoint[]
@@ -198,6 +203,10 @@ export interface SurveyPath {
    * Each entry is a polyline connecting boundary ↔ turnaround points.
    */
   turnaroundSegments: L.LatLng[][]
+  /**
+   * Index in `path` where the crosshatch second pass (rotated 90°) begins. Undefined when crosshatch is disabled.
+   */
+  crosshatchStartIndex?: number
 }
 
 // TODO - Replace leaflet types with agnostic types

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -69,6 +69,28 @@
         </div>
       </template>
     </v-tooltip>
+    <v-tooltip
+      location="top"
+      :text="surveyCrosshatch ? 'Disable 90° crosshatch re-fly' : 'Enable 90° crosshatch re-fly'"
+    >
+      <template #activator="{ props }">
+        <div
+          v-if="isCreatingSurvey && surveyPolygonVertexesPositions.length >= 3"
+          v-bind="props"
+          :style="confirmButtonStyle"
+          class="absolute mt-[72px] -ml-[150px] bg-transparent cursor-pointer elevation-4"
+          variant="text"
+          @click="surveyCrosshatch = !surveyCrosshatch"
+        >
+          <div
+            class="flex items-center justify-center w-8 h-8 border-2 rounded-full"
+            :class="surveyCrosshatch ? 'bg-[#A855F7]' : 'bg-[#333333EE]'"
+          >
+            <v-icon color="white" size="16">mdi-grid</v-icon>
+          </div>
+        </div>
+      </template>
+    </v-tooltip>
     <v-tooltip location="top" text="Clear survey">
       <template #activator="{ props }">
         <div
@@ -247,6 +269,17 @@
             class="px-2 py-1 mt-1 mb-2 mx-5 rounded-sm bg-[#FFFFFF22]"
             type="number"
           />
+          <v-checkbox
+            v-model="surveyCrosshatch"
+            label="Re-fly at 90° (crosshatch)"
+            theme="dark"
+            density="compact"
+            hide-details
+            class="mx-4"
+          />
+          <p class="mx-5 mb-2 text-[11px] opacity-70 text-slate-200">
+            Flies the area again at 90° for better photogrammetry coverage (≈doubles flight time).
+          </p>
           <p class="m-1 overflow-visible text-sm text-slate-200">Altitude (m)</p>
           <input
             v-model.number="currentWaypointAltitude"
@@ -578,6 +611,7 @@
     @toggle-simple-path="toggleSimplePath"
     @undo-generated-waypoints="undoGenerateWaypoints"
     @regenerate-survey-waypoints="regenerateSurveyWaypoints"
+    @toggle-crosshatch="toggleSurveyCrosshatch"
     @survey-lines-angle="onSurveyLinesAngleChange"
     @remove-waypoint="removeSelectedWaypoint"
     @place-point-of-interest="openPoiDialog"
@@ -1431,7 +1465,7 @@ const updateConfirmButtonPosition = (): void => {
     )
 
     confirmButtonStyle.value = {
-      left: `${pos.x + anchorToLeft}px`,
+      left: `${pos.x + anchorToLeft + 40}px`,
       top: `${pos.y + anchorToTop}px`,
     }
   } else {
@@ -2196,6 +2230,7 @@ const performUndo = (): void => {
     surveyPolygonVertexesPositions.value = removedSurvey.polygonCoordinates.map(([lat, lng]) => L.latLng(lat, lng))
     distanceBetweenSurveyLines.value = removedSurvey.distanceBetweenLines
     surveyLinesAngle.value = removedSurvey.surveyLinesAngle
+    surveyCrosshatch.value = removedSurvey.crosshatch ?? false
 
     clearSurveyPolygonUndoStack()
     const coords = removedSurvey.polygonCoordinates
@@ -2695,6 +2730,7 @@ const surveyPolygonVertexesMarkers = shallowRef<L.Marker[]>([])
 const rawDistanceBetweenSurveyLines = ref(10)
 const rawSurveyLinesAngle = ref(0)
 const rawTurnaroundDistance = ref(0)
+const surveyCrosshatch = ref(false)
 const existingWaypoints = ref<Waypoint[]>([])
 const surveyWaypoints = ref<Waypoint[]>([])
 
@@ -2729,14 +2765,23 @@ const onSurveyLinesAngleChange = (angle: number): void => {
 }
 
 const surveyPathLayer = shallowRef<L.Polyline | null>(null)
+const surveyCrosshatchPathLayer = shallowRef<L.Polyline | null>(null)
 const surveyTurnaroundLayers = shallowRef<L.Polyline[]>([])
 const surveyPolygonLayer = shallowRef<L.Polygon | null>(null)
+
+const removeSurveyCrosshatchPathLayer = (): void => {
+  if (surveyCrosshatchPathLayer.value) {
+    planningMap.value?.removeLayer(surveyCrosshatchPathLayer.value as unknown as L.Layer)
+    surveyCrosshatchPathLayer.value = null
+  }
+}
 
 const clearSurveyPath = (): void => {
   if (surveyPathLayer.value) {
     planningMap.value?.removeLayer(surveyPathLayer.value as unknown as L.Layer)
     surveyPathLayer.value = null
   }
+  removeSurveyCrosshatchPathLayer()
   surveyTurnaroundLayers.value.forEach((layer) => planningMap.value?.removeLayer(layer as unknown as L.Layer))
   surveyTurnaroundLayers.value = []
   if (surveyPolygonLayer.value) {
@@ -2832,6 +2877,7 @@ const checkAndRemoveSurveyPath = (): void => {
   if (surveyPolygonVertexesPositions.value.length >= 4 || !surveyPathLayer.value) return
   planningMap.value?.removeLayer(surveyPathLayer.value as unknown as L.Layer)
   surveyPathLayer.value = null
+  removeSurveyCrosshatchPathLayer()
   surveyTurnaroundLayers.value.forEach((layer) => planningMap.value?.removeLayer(layer as unknown as L.Layer))
   surveyTurnaroundLayers.value = []
 }
@@ -2848,7 +2894,8 @@ const createSurveyPath = (): void => {
       surveyPolygonVertexesPositions.value,
       distanceBetweenSurveyLines.value,
       adjustedAngle,
-      turnaroundDistance.value
+      turnaroundDistance.value,
+      surveyCrosshatch.value
     )
 
     if (result.path.length === 0) {
@@ -2863,16 +2910,30 @@ const createSurveyPath = (): void => {
     if (surveyPathLayer.value) {
       planningMap.value?.removeLayer(surveyPathLayer.value as unknown as L.Layer)
     }
+    removeSurveyCrosshatchPathLayer()
 
     surveyTurnaroundLayers.value.forEach((layer) => planningMap.value?.removeLayer(layer as unknown as L.Layer))
     surveyTurnaroundLayers.value = []
 
-    surveyPathLayer.value = L.polyline(result.path, {
+    const crosshatchStart = result.crosshatchStartIndex
+    const firstPassPath = crosshatchStart !== undefined ? result.path.slice(0, crosshatchStart) : result.path
+
+    surveyPathLayer.value = L.polyline(firstPassPath, {
       color: '#2563EB',
       weight: 3,
       opacity: 0.8,
       className: 'survey-path',
     }).addTo(toRaw(planningMap.value)!)
+
+    if (crosshatchStart !== undefined) {
+      // Include the last point of the first pass so the transit leg into the second pass is drawn.
+      surveyCrosshatchPathLayer.value = L.polyline(result.path.slice(Math.max(0, crosshatchStart - 1)), {
+        color: '#A855F7',
+        weight: 1,
+        opacity: 0.56,
+        className: 'survey-path-crosshatch',
+      }).addTo(toRaw(planningMap.value)!)
+    }
 
     if (result.turnaroundSegments.length > 0) {
       surveyTurnaroundLayers.value = result.turnaroundSegments.map((segment) =>
@@ -2906,7 +2967,7 @@ watch(
 )
 
 // Watch for changes in distanceBetweenSurveyLines, surveyLinesAngle, and turnaroundDistance
-watch([distanceBetweenSurveyLines, surveyLinesAngle, turnaroundDistance], () => createSurveyPath())
+watch([distanceBetweenSurveyLines, surveyLinesAngle, turnaroundDistance, surveyCrosshatch], () => createSurveyPath())
 
 const surveyEdgeAddMarkers: L.Marker[] = []
 
@@ -3058,7 +3119,8 @@ const generateWaypointsFromSurvey = (): void => {
     surveyPolygonVertexesPositions.value,
     distanceBetweenSurveyLines.value,
     adjustedAngle,
-    turnaroundDistance.value
+    turnaroundDistance.value,
+    surveyCrosshatch.value
   )
 
   if (!continuousPath.length) {
@@ -3103,6 +3165,7 @@ const generateWaypointsFromSurvey = (): void => {
     distanceBetweenLines: distanceBetweenSurveyLines.value,
     surveyLinesAngle: surveyLinesAngle.value,
     turnaroundDistance: turnaroundDistance.value,
+    crosshatch: surveyCrosshatch.value,
     waypoints: newSurveyWaypoints,
   }
 
@@ -3193,6 +3256,16 @@ const updateWaypointMarkers = (): void => {
   refreshSurveyEntryExitMarkers()
 }
 
+const toggleSurveyCrosshatch = (): void => {
+  if (!selectedSurvey.value) {
+    openSnackbar({ variant: 'error', message: 'No survey selected.', duration: 2000 })
+    return
+  }
+  missionStore.pushUndoSnapshot()
+  selectedSurvey.value.crosshatch = !selectedSurvey.value.crosshatch
+  regenerateSurveyWaypoints()
+}
+
 const regenerateSurveyWaypoints = (angle?: number): void => {
   if (!selectedSurveyId.value) {
     openSnackbar({ variant: 'error', message: 'No survey selected.', duration: 2000 })
@@ -3213,7 +3286,8 @@ const regenerateSurveyWaypoints = (angle?: number): void => {
       selectedSurvey.value.polygonCoordinates.map((coord) => L.latLng(coord[0], coord[1])),
       selectedSurvey.value.distanceBetweenLines,
       adjustedAngle,
-      selectedSurvey.value.turnaroundDistance
+      selectedSurvey.value.turnaroundDistance,
+      selectedSurvey.value.crosshatch
     )
 
     if (!continuousPath.length) {
@@ -3225,11 +3299,15 @@ const regenerateSurveyWaypoints = (angle?: number): void => {
       return
     }
 
+    const existingWaypoint = selectedSurvey.value.waypoints[0]
+    const surveyAltitude = existingWaypoint?.altitude ?? currentWaypointAltitude.value
+    const surveyAltitudeRefType = existingWaypoint?.altitudeReferenceType ?? currentWaypointAltitudeRefType.value
+
     const newWaypoints: Waypoint[] = continuousPath.map((latLng: L.LatLng) => ({
       id: uuid(),
       coordinates: [latLng.lat, latLng.lng],
-      altitude: currentWaypointAltitude.value,
-      altitudeReferenceType: currentWaypointAltitudeRefType.value,
+      altitude: surveyAltitude,
+      altitudeReferenceType: surveyAltitudeRefType,
       commands: makeDefaultNavCommands(),
     }))
 
@@ -3377,6 +3455,7 @@ const undoGenerateWaypoints = (): void => {
   surveyPolygonVertexesPositions.value = survey.polygonCoordinates.map(([lat, lng]) => L.latLng(lat, lng))
   distanceBetweenSurveyLines.value = survey.distanceBetweenLines
   surveyLinesAngle.value = survey.surveyLinesAngle
+  surveyCrosshatch.value = survey.crosshatch ?? false
 
   const firstWpCoords = survey.waypoints[0]?.coordinates
   if (firstWpCoords && survey.polygonCoordinates.length >= 3) {
@@ -3385,7 +3464,8 @@ const undoGenerateWaypoints = (): void => {
       surveyPolygonVertexesPositions.value,
       survey.distanceBetweenLines,
       adjustedAngle,
-      survey.turnaroundDistance
+      survey.turnaroundDistance,
+      survey.crosshatch
     )
     if (defaultPath.length >= 2) {
       const first = defaultPath[0]

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -1937,21 +1937,47 @@ const showContextMenu = (event: L.LeafletMouseEvent): void => {
   let x = event.originalEvent.clientX
   let y = event.originalEvent.clientY
 
-  if (contextMenuType.value === 'survey' && planningMap.value && selectedSurveyId.value) {
-    const container = planningMap.value.getContainer()
+  if (contextMenuType.value === 'survey' && planningMap.value && selectedSurvey.value) {
+    const map = toRaw(planningMap.value)!
+    const container = map.getContainer()
     const vw = container.clientWidth
     const vh = container.clientHeight
-    const edgeZone = 0.2
-    const pushTo = 0.33
-    const menuHalf = 140
+    const menuSize = 210
+    const gap = 40
 
-    if (x < vw * edgeZone) x = vw * pushTo
-    else if (x > vw * (1 - edgeZone)) x = vw * 0.87
-    if (y < vh * edgeZone) y = vh * pushTo
-    else if (y > vh * (1 - edgeZone)) y = vh * 0.8
+    const screenPoints = selectedSurvey.value.polygonCoordinates.map(([lat, lng]) =>
+      map.latLngToContainerPoint(L.latLng(lat, lng))
+    )
+    const minX = Math.min(...screenPoints.map((p) => p.x))
+    const maxX = Math.max(...screenPoints.map((p) => p.x))
+    const minY = Math.min(...screenPoints.map((p) => p.y))
+    const maxY = Math.max(...screenPoints.map((p) => p.y))
+    const centerX = (minX + maxX) / 2
+    const centerY = (minY + maxY) / 2
 
-    x -= menuHalf
-    y -= menuHalf
+    // Prefer the right side, 40px clear of the survey; only fall back to another side when it doesn't fit.
+    const placement =
+      vw - maxX >= menuSize + gap
+        ? { x: maxX + gap, y: centerY - menuSize / 2 }
+        : [
+            { freeSpace: minX, x: minX - gap - menuSize, y: centerY - menuSize / 2 },
+            { freeSpace: minY, x: centerX - menuSize / 2, y: minY - gap - menuSize },
+            { freeSpace: vh - maxY, x: centerX - menuSize / 2, y: maxY + gap },
+          ]
+            .filter((candidate) => candidate.freeSpace >= menuSize + gap)
+            .sort((a, b) => b.freeSpace - a.freeSpace)[0]
+
+    if (placement) {
+      x = placement.x
+      y = placement.y
+    } else {
+      // Survey fills most of the viewport: drop the menu into the emptiest horizontal corner.
+      x = vw - maxX > minX ? maxX + gap : minX - gap - menuSize
+      y = 0
+    }
+
+    x = Math.max(gap, Math.min(x, vw - menuSize - gap))
+    y = Math.max(gap, Math.min(y, vh - menuSize - gap))
   }
 
   contextMenuPosition.value = { x, y }


### PR DESCRIPTION
Survey planning only supported a single-direction lawnmower grid, but photogrammetry needs a perpendicular re-fly for reliable coverage of vertical surfaces (#2639).

- `generateSurveyPath` gains a crosshatch option that appends a second pass rotated 90°, flown in whichever direction minimizes the transit leg.
- Exposed via a creation-sidebar checkbox, an on-map round toggle, and a context-menu button; the re-fly previews as a distinct thin purple line and is persisted per survey.
- The survey context menu now opens in the clear margin beside the polygon (preferring the right) instead of over the survey it is editing.

https://github.com/user-attachments/assets/f49acee1-822e-4485-9747-86b8313e0f3f

Closes #2639