### PR TITLE
Fix Snapshots system not allowing more than 1000 captures per session

### DIFF
--- a/src/components/mini-widgets/SnapshotTool.vue
+++ b/src/components/mini-widgets/SnapshotTool.vue
@@ -348,7 +348,7 @@ const fireTimedSnapshot = async (): Promise<void> => {
 
 watch(isTakingTimedSnapshot, (newValue) => {
   if (newValue) {
-    fireTimedSnapshot()
+    fireTimedSnapshot().catch((err) => console.error('Timed snapshot capture failed:', err))
     openSnackbar({
       message: `Timed snapshot started. This will capture the selected interfaces every ${timedSnapshotInterval.value} seconds until you press the camera button again.`,
       variant: 'info',
@@ -357,7 +357,7 @@ watch(isTakingTimedSnapshot, (newValue) => {
 
     // Capture subsequent timed snapshots
     shotInterval = setInterval(() => {
-      fireTimedSnapshot()
+      fireTimedSnapshot().catch((err) => console.error('Timed snapshot capture failed:', err))
       timerProgress.value = 0
     }, timedSnapshotInterval.value * 1000)
 

--- a/src/stores/snapshot.ts
+++ b/src/stores/snapshot.ts
@@ -124,24 +124,41 @@ export const useSnapshotStore = defineStore('snapshot', () => {
     video.style.display = 'none'
     document.body.appendChild(video)
 
-    await video.play()
-    const { width = video.videoWidth, height = video.videoHeight } = track.getSettings()
-    video.width = width
-    video.height = height
+    let playTimeout: ReturnType<typeof setTimeout> | undefined
+    try {
+      await Promise.race([
+        video.play(),
+        new Promise<never>((_, reject) => {
+          playTimeout = setTimeout(
+            () => reject(new Error(`Timed out starting playback for stream '${streamName}'`)),
+            5000
+          )
+        }),
+      ])
+      const { width = video.videoWidth, height = video.videoHeight } = track.getSettings()
+      video.width = width
+      video.height = height
 
-    const canvas = document.createElement('canvas')
-    canvas.width = width
-    canvas.height = height
-    const ctx = canvas.getContext('2d')
-    if (!ctx) throw new Error('Could not get 2D context')
-    ctx.drawImage(video, 0, 0, width, height)
+      const canvas = document.createElement('canvas')
+      canvas.width = width
+      canvas.height = height
+      const ctx = canvas.getContext('2d')
+      if (!ctx) throw new Error('Could not get 2D context')
+      ctx.drawImage(video, 0, 0, width, height)
 
-    video.pause()
-    document.body.removeChild(video)
-
-    return new Promise<Blob>((resolve, reject) => {
-      canvas.toBlob((blob) => (blob ? resolve(blob) : reject(new Error('Canvas toBlob failed'))), 'image/jpeg', 0.9)
-    })
+      return await new Promise<Blob>((resolve, reject) => {
+        canvas.toBlob((blob) => (blob ? resolve(blob) : reject(new Error('Canvas toBlob failed'))), 'image/jpeg', 0.9)
+      })
+    } finally {
+      clearTimeout(playTimeout)
+      // Critical: detach the MediaStream and force the underlying WebMediaPlayer
+      // to be released. Without this, Chromium accumulates WebMediaPlayers
+      // (hard cap 1000/frame) and play() silently stalls after the limit.
+      video.pause()
+      video.srcObject = null
+      video.load()
+      video.remove()
+    }
   }
 
   const captureWorkspaceElectron = async (): Promise<Blob> => {

--- a/src/stores/snapshot.ts
+++ b/src/stores/snapshot.ts
@@ -185,7 +185,8 @@ export const useSnapshotStore = defineStore('snapshot', () => {
 
   const createThumbnail = (blob: Blob, width: number, height: number): Promise<Blob> => {
     const img = document.createElement('img')
-    img.src = URL.createObjectURL(blob)
+    const objectUrl = URL.createObjectURL(blob)
+    img.src = objectUrl
     img.width = width
     img.height = height
 
@@ -200,6 +201,7 @@ export const useSnapshotStore = defineStore('snapshot', () => {
         ctx.drawImage(img, 0, 0, width, height)
         canvas.toBlob(
           (thumbnailBlob) => {
+            URL.revokeObjectURL(objectUrl)
             if (thumbnailBlob) {
               resolve(thumbnailBlob)
             } else {
@@ -210,7 +212,10 @@ export const useSnapshotStore = defineStore('snapshot', () => {
           0.9
         )
       }
-      img.onerror = () => reject(new Error('Image load failed'))
+      img.onerror = () => {
+        URL.revokeObjectURL(objectUrl)
+        reject(new Error('Image load failed'))
+      }
     })
   }
 


### PR DESCRIPTION
Each timed snapshot created a hidden `<video>` element, grabbed one frame from the camera stream, then removed the element. But removing the element doesn't actually free the underlying video player — Chromium just marks it for cleanup "whenever."

Chromium has a hard limit of **1000 video players per page**. The players quietly piled up until we hit the cap. At that point, starting a new player silently failed, the capture hung with no error, and the timer kept ticking but nothing was being saved. Only a full app restart fixed it.

That's why it always died at ~1000 captures regardless of speed.

## How it was fixed

- **Release the video player after each capture** — explicitly detach the stream (`srcObject = null` + `load()` + `remove()`) so Chromium frees it immediately instead of leaving it for lazy cleanup.
- **Added a 5-second timeout on `play()`** — if a player ever stalls, we now reject with a clear error instead of hanging forever.
- **Plugged a smaller leak** in the thumbnail code (an object URL that was never freed).
- **Made interval errors visible** — the timer was swallowing any rejection silently; now it logs them.

Net effect: video players no longer accumulate, the 1000 ceiling is never reached, and timed snapshots run indefinitely.

We can also see the benefits on the resource usage. Before it would surge 1-2GB after about 20 minutes, with a dropping frame-rate. Now it's like this:

<img width="400" src="https://github.com/user-attachments/assets/45c8c3a2-935e-4bff-80b6-1c25bbbc7f8b" />

Putting on fast-track as it fixes an important functionality that is currently broken.

Fix #2744