### PR TITLE
Allow timed snapshots above 1Hz frequency and block 0s interval

### DIFF
--- a/src/components/mini-widgets/SnapshotTool.vue
+++ b/src/components/mini-widgets/SnapshotTool.vue
@@ -348,7 +348,7 @@ const fireTimedSnapshot = async (): Promise<void> => {
 
 watch(isTakingTimedSnapshot, (newValue) => {
   if (newValue) {
-    fireTimedSnapshot()
+    fireTimedSnapshot().catch((err) => console.error('Timed snapshot capture failed:', err))
     openSnackbar({
       message: `Timed snapshot started. This will capture the selected interfaces every ${timedSnapshotInterval.value} seconds until you press the camera button again.`,
       variant: 'info',
@@ -357,7 +357,7 @@ watch(isTakingTimedSnapshot, (newValue) => {
 
     // Capture subsequent timed snapshots
     shotInterval = setInterval(() => {
-      fireTimedSnapshot()
+      fireTimedSnapshot().catch((err) => console.error('Timed snapshot capture failed:', err))
       timerProgress.value = 0
     }, timedSnapshotInterval.value * 1000)
 

--- a/src/components/mini-widgets/SnapshotTool.vue
+++ b/src/components/mini-widgets/SnapshotTool.vue
@@ -166,9 +166,8 @@
         hide-details
         theme="dark"
         class="w-[90%] mt-2"
-        :min="1"
-        step="1"
-        @update:model-value="(val) => (timedSnapshotInterval = parseInt(val))"
+        :min="0.1"
+        step="0.1"
       />
       <div class="flex w-[90%] justify-end items-center mt-4 border-t-[1px] border-t-[#FFFFFF11]">
         <v-btn

--- a/src/components/mini-widgets/SnapshotTool.vue
+++ b/src/components/mini-widgets/SnapshotTool.vue
@@ -50,7 +50,7 @@
         'text-green-500 -ml-[33px]': !isTakingTimedSnapshot,
       }"
       size="22"
-      @click="isTakingTimedSnapshot = !isTakingTimedSnapshot"
+      @click="toggleTimedSnapshot"
     />
   </div>
   <v-dialog v-model="widgetStore.miniWidgetManagerVars(miniWidget.hash).configMenuOpen" width="500">
@@ -163,11 +163,13 @@
         type="number"
         density="compact"
         variant="outlined"
-        hide-details
+        hide-details="auto"
         theme="dark"
         class="w-[90%] mt-2"
-        :min="0.1"
-        step="0.1"
+        :min="MIN_TIMED_SNAPSHOT_INTERVAL_SEC"
+        :step="MIN_TIMED_SNAPSHOT_INTERVAL_SEC"
+        :rules="timedSnapshotIntervalRules"
+        @blur="normalizeTimedSnapshotInterval"
       />
       <div class="flex w-[90%] justify-end items-center mt-4 border-t-[1px] border-t-[#FFFFFF11]">
         <v-btn
@@ -335,6 +337,38 @@ const handleSelectSnapshotTriggerType = (type: 'single' | 'timed'): void => {
   snapshotTypeIcon.value = type === 'timed' ? 'mdi-timer-outline' : 'mdi-video-image'
   miniWidget.value.options.snapshotTriggerType = type
   isSnapshotMenuOpen.value = false
+}
+
+const MIN_TIMED_SNAPSHOT_INTERVAL_SEC = 0.1
+
+const isValidTimedSnapshotInterval = (v: unknown): boolean =>
+  typeof v === 'number' && Number.isFinite(v) && v >= MIN_TIMED_SNAPSHOT_INTERVAL_SEC
+
+const timedSnapshotIntervalRules = [
+  (v: unknown): boolean | string =>
+    isValidTimedSnapshotInterval(v) || `Must be at least ${MIN_TIMED_SNAPSHOT_INTERVAL_SEC} seconds.`,
+]
+
+const normalizeTimedSnapshotInterval = (): void => {
+  if (!isValidTimedSnapshotInterval(timedSnapshotInterval.value)) {
+    timedSnapshotInterval.value = MIN_TIMED_SNAPSHOT_INTERVAL_SEC
+  }
+}
+
+const toggleTimedSnapshot = (): void => {
+  if (isTakingTimedSnapshot.value) {
+    isTakingTimedSnapshot.value = false
+    return
+  }
+  if (!isValidTimedSnapshotInterval(timedSnapshotInterval.value)) {
+    openSnackbar({
+      message: `Timed snapshot interval must be at least ${MIN_TIMED_SNAPSHOT_INTERVAL_SEC} seconds.`,
+      variant: 'error',
+      duration: 3000,
+    })
+    return
+  }
+  isTakingTimedSnapshot.value = true
 }
 
 let progressInterval: ReturnType<typeof setInterval> | null = null

--- a/src/stores/snapshot.ts
+++ b/src/stores/snapshot.ts
@@ -177,7 +177,7 @@ export const useSnapshotStore = defineStore('snapshot', () => {
   }
 
   const snapshotFilename = (streamName: string, missionName = 'Cockpit'): string => {
-    const timeString = format(new Date(), 'LLL dd, yyyy - HH꞉mm꞉ss O')
+    const timeString = format(new Date(), 'LLL dd, yyyy - HH꞉mm꞉ss.SSS O')
     const safeMissionName = sanitizeFilenameComponent(missionName) || 'Cockpit'
     const safeStreamName = sanitizeFilenameComponent(streamName) || 'workspace'
     return `${safeMissionName} (${timeString}) #${safeStreamName}.jpeg`

--- a/src/stores/snapshot.ts
+++ b/src/stores/snapshot.ts
@@ -124,24 +124,41 @@ export const useSnapshotStore = defineStore('snapshot', () => {
     video.style.display = 'none'
     document.body.appendChild(video)
 
-    await video.play()
-    const { width = video.videoWidth, height = video.videoHeight } = track.getSettings()
-    video.width = width
-    video.height = height
+    let playTimeout: ReturnType<typeof setTimeout> | undefined
+    try {
+      await Promise.race([
+        video.play(),
+        new Promise<never>((_, reject) => {
+          playTimeout = setTimeout(
+            () => reject(new Error(`Timed out starting playback for stream '${streamName}'`)),
+            5000
+          )
+        }),
+      ])
+      const { width = video.videoWidth, height = video.videoHeight } = track.getSettings()
+      video.width = width
+      video.height = height
 
-    const canvas = document.createElement('canvas')
-    canvas.width = width
-    canvas.height = height
-    const ctx = canvas.getContext('2d')
-    if (!ctx) throw new Error('Could not get 2D context')
-    ctx.drawImage(video, 0, 0, width, height)
+      const canvas = document.createElement('canvas')
+      canvas.width = width
+      canvas.height = height
+      const ctx = canvas.getContext('2d')
+      if (!ctx) throw new Error('Could not get 2D context')
+      ctx.drawImage(video, 0, 0, width, height)
 
-    video.pause()
-    document.body.removeChild(video)
-
-    return new Promise<Blob>((resolve, reject) => {
-      canvas.toBlob((blob) => (blob ? resolve(blob) : reject(new Error('Canvas toBlob failed'))), 'image/jpeg', 0.9)
-    })
+      return await new Promise<Blob>((resolve, reject) => {
+        canvas.toBlob((blob) => (blob ? resolve(blob) : reject(new Error('Canvas toBlob failed'))), 'image/jpeg', 0.9)
+      })
+    } finally {
+      clearTimeout(playTimeout)
+      // Critical: detach the MediaStream and force the underlying WebMediaPlayer
+      // to be released. Without this, Chromium accumulates WebMediaPlayers
+      // (hard cap 1000/frame) and play() silently stalls after the limit.
+      video.pause()
+      video.srcObject = null
+      video.load()
+      video.remove()
+    }
   }
 
   const captureWorkspaceElectron = async (): Promise<Blob> => {

--- a/src/stores/snapshot.ts
+++ b/src/stores/snapshot.ts
@@ -185,7 +185,8 @@ export const useSnapshotStore = defineStore('snapshot', () => {
 
   const createThumbnail = (blob: Blob, width: number, height: number): Promise<Blob> => {
     const img = document.createElement('img')
-    img.src = URL.createObjectURL(blob)
+    const objectUrl = URL.createObjectURL(blob)
+    img.src = objectUrl
     img.width = width
     img.height = height
 
@@ -200,6 +201,7 @@ export const useSnapshotStore = defineStore('snapshot', () => {
         ctx.drawImage(img, 0, 0, width, height)
         canvas.toBlob(
           (thumbnailBlob) => {
+            URL.revokeObjectURL(objectUrl)
             if (thumbnailBlob) {
               resolve(thumbnailBlob)
             } else {
@@ -210,7 +212,10 @@ export const useSnapshotStore = defineStore('snapshot', () => {
           0.9
         )
       }
-      img.onerror = () => reject(new Error('Image load failed'))
+      img.onerror = () => {
+        URL.revokeObjectURL(objectUrl)
+        reject(new Error('Image load failed'))
+      }
     })
   }
 


### PR DESCRIPTION
Tested here and 10Hz captures are now completely possible.

Fix #2745 
Fix #2746 
To be merged after #2749 