### PR TITLE
Improve feedbacks of the snapshot system

### DIFF
--- a/src/components/mini-widgets/SnapshotTool.vue
+++ b/src/components/mini-widgets/SnapshotTool.vue
@@ -171,6 +171,10 @@
         :rules="timedSnapshotIntervalRules"
         @blur="normalizeTimedSnapshotInterval"
       />
+      <div class="flex items-center justify-start w-[90%] mt-2">
+        <v-checkbox v-model="miniWidget.options.flashOnSnapshot" density="compact" hide-details theme="dark" />
+        <p class="ml-3 text-sm">Flash screen on capture (timed captures blink at most once per second)</p>
+      </div>
       <div class="flex w-[90%] justify-end items-center mt-4 border-t-[1px] border-t-[#FFFFFF11]">
         <v-btn
           class="w-auto text-uppercase mt-2 -mr-6"
@@ -280,12 +284,27 @@ const toInternalName = (externalId: string): string => {
   return videoStore.internalStreamNameFromExternal(externalId) ?? externalId
 }
 
+let timedFlashCounter = 0
+
+const maybeFlash = (isTimed: boolean): void => {
+  if (!miniWidget.value.options.flashOnSnapshot) return
+  // Cap timed blinks at ~1 Hz by decimating per capture count rather than wall-clock time.
+  // A time throttle whose window matches the interval (both ~1s) drops a blink whenever
+  // jitter pushes a capture just under the window; counting avoids that.
+  if (isTimed) {
+    const blinkEveryNCaptures = Math.max(1, Math.round(1 / timedSnapshotInterval.value))
+    const shouldFlash = timedFlashCounter % blinkEveryNCaptures === 0
+    timedFlashCounter++
+    if (!shouldFlash) return
+  }
+  flashEffect()
+}
+
 const handleSnapshotResult = (result: SnapshotResult, isTimed = false): void => {
   const { succeeded, failed } = result
 
   if (succeeded.length > 0 && failed.length === 0) {
-    flashEffect()
-    // Timed captures only surface errors/warnings to avoid spamming a success snackbar per shot.
+    maybeFlash(isTimed)
     if (!isTimed) {
       openSnackbar({ message: 'Snapshot recorded successfully.', variant: 'success', duration: 2000 })
     }
@@ -295,7 +314,7 @@ const handleSnapshotResult = (result: SnapshotResult, isTimed = false): void => 
   const failedNames = failed.map(toInternalName).join(', ')
 
   if (succeeded.length > 0 && failed.length > 0) {
-    flashEffect()
+    maybeFlash(isTimed)
     openSnackbar({
       message: `Snapshot captured, but failed for: ${failedNames}.`,
       variant: 'warning',
@@ -381,6 +400,7 @@ const fireTimedSnapshot = async (): Promise<void> => {
 
 watch(isTakingTimedSnapshot, (newValue) => {
   if (newValue) {
+    timedFlashCounter = 0
     fireTimedSnapshot().catch((err) => console.error('Timed snapshot capture failed:', err))
     openSnackbar({
       message: `Timed snapshot started. This will capture the selected interfaces every ${timedSnapshotInterval.value} seconds until you press the camera button again.`,
@@ -430,6 +450,7 @@ onBeforeMount(() => {
     captureWorkspace: true,
     snapshotTriggerType: 'single' as 'single' | 'timed',
     timedSnapshotInterval: 5,
+    flashOnSnapshot: true,
   }
   miniWidget.value.options = { ...defaultOptions, ...miniWidget.value.options }
   migrateSelectedStreamsToInternalNames()

--- a/src/components/mini-widgets/SnapshotTool.vue
+++ b/src/components/mini-widgets/SnapshotTool.vue
@@ -281,12 +281,15 @@ const toInternalName = (externalId: string): string => {
   return videoStore.internalStreamNameFromExternal(externalId) ?? externalId
 }
 
-const handleSnapshotResult = (result: SnapshotResult): void => {
+const handleSnapshotResult = (result: SnapshotResult, isTimed = false): void => {
   const { succeeded, failed } = result
 
   if (succeeded.length > 0 && failed.length === 0) {
     flashEffect()
-    openSnackbar({ message: 'Snapshot recorded successfully.', variant: 'success', duration: 2000 })
+    // Timed captures only surface errors/warnings to avoid spamming a success snackbar per shot.
+    if (!isTimed) {
+      openSnackbar({ message: 'Snapshot recorded successfully.', variant: 'success', duration: 2000 })
+    }
     return
   }
 
@@ -376,7 +379,7 @@ let shotInterval: ReturnType<typeof setInterval> | null = null
 
 const fireTimedSnapshot = async (): Promise<void> => {
   const result = await captureSnapshot()
-  handleSnapshotResult(result)
+  handleSnapshotResult(result, true)
 }
 
 watch(isTakingTimedSnapshot, (newValue) => {

--- a/src/components/mini-widgets/SnapshotTool.vue
+++ b/src/components/mini-widgets/SnapshotTool.vue
@@ -187,7 +187,6 @@
 <script setup lang="ts">
 import { computed, onBeforeMount, onMounted, ref, toRefs, watch } from 'vue'
 
-import { useInteractionDialog } from '@/composables/interactionDialog'
 import { openSnackbar } from '@/composables/snackbar'
 import { isElectron } from '@/libs/utils'
 import { useAppInterfaceStore } from '@/stores/appInterface'
@@ -197,7 +196,6 @@ import { useWidgetManagerStore } from '@/stores/widgetManager'
 import type { SnapshotResult } from '@/types/snapshot'
 import type { MiniWidget } from '@/types/widgets'
 
-const { showDialog } = useInteractionDialog()
 const snapshotStore = useSnapshotStore()
 const interfaceStore = useAppInterfaceStore()
 const widgetStore = useWidgetManagerStore()
@@ -239,8 +237,9 @@ const timedSnapshotInterval = computed({
   },
 })
 const isTakingTimedSnapshot = ref<boolean>(false)
-const isFailureDialogOpen = ref(false)
 const timerProgress = ref<number>(50)
+const SNAPSHOT_ERROR_SNACKBAR_DURATION = 8000
+const isSnapshotErrorSnackbarOpen = ref(false)
 
 const flashEffect = async (): Promise<void> => {
   const flashOverlay = document.createElement('div')
@@ -305,21 +304,19 @@ const handleSnapshotResult = (result: SnapshotResult, isTimed = false): void => 
     return
   }
 
-  if (isFailureDialogOpen.value) return
+  if (isSnapshotErrorSnackbarOpen.value) return
 
-  isFailureDialogOpen.value = true
-  showDialog({
-    title: 'Error taking snapshot',
+  isSnapshotErrorSnackbarOpen.value = true
+  openSnackbar({
     message:
       failed.length > 0
-        ? `Failed to capture: ${failedNames}. Make sure the streams have finished loading.`
+        ? `Failed to take snapshot for: ${failedNames}. Make sure the streams have finished loading.`
         : 'No sources available for capture. Make sure streams are connected or select specific ones in the widget settings.',
     variant: 'error',
-    persistent: false,
-    maxWidth: '550px',
-  }).finally(() => {
-    isFailureDialogOpen.value = false
+    duration: SNAPSHOT_ERROR_SNACKBAR_DURATION,
+    closeButton: true,
   })
+  setTimeout(() => (isSnapshotErrorSnackbarOpen.value = false), SNAPSHOT_ERROR_SNACKBAR_DURATION)
 }
 
 const handleTakeSnapshot = async (): Promise<void> => {

--- a/src/components/mini-widgets/SnapshotTool.vue
+++ b/src/components/mini-widgets/SnapshotTool.vue
@@ -256,6 +256,7 @@ const flashEffect = async (): Promise<void> => {
   flashOverlay.style.opacity = '0'
   flashOverlay.style.transition = 'opacity 0.1s ease'
   flashOverlay.style.zIndex = '9999'
+  flashOverlay.style.pointerEvents = 'none'
 
   document.body.appendChild(flashOverlay)
 

--- a/src/electron/services/workspace.ts
+++ b/src/electron/services/workspace.ts
@@ -9,6 +9,8 @@ export const setupWorkspaceService = (): void => {
     const win = BrowserWindow.fromWebContents(event.sender)
     if (!win) throw new Error('No window')
     const image = await win.capturePage(rect)
-    return image.toPNG()
+    // JPEG encodes ~5x faster than PNG and yields a smaller payload, which keeps the main
+    // process responsive during fast/timed captures (PNG encoding stalled the renderer).
+    return image.toJPEG(90)
   })
 }

--- a/src/stores/snapshot.ts
+++ b/src/stores/snapshot.ts
@@ -172,8 +172,8 @@ export const useSnapshotStore = defineStore('snapshot', () => {
       height: Math.floor(height),
     }
     // @ts-ignore: ignore TypeScript error on next line
-    const pngBuffer = await window.electronAPI!.captureWorkspace(rect)
-    return new Blob([pngBuffer], { type: 'image/png' })
+    const jpegBuffer = await window.electronAPI!.captureWorkspace(rect)
+    return new Blob([jpegBuffer], { type: 'image/jpeg' })
   }
 
   const snapshotFilename = (streamName: string, missionName = 'Cockpit'): string => {


### PR DESCRIPTION
Improves the UX feedback of the timed snapshot feature.

- **No success snackbars on timed snapshots** — a timed capture fires repeatedly, so the per-shot "Snapshot recorded successfully" snackbar was just noise. Success feedback now only shows for single captures; timed captures still surface errors and warnings.

- **Error dialog replaced with a long snackbar** — the blocking "Error taking snapshot" dialog interrupted the operator on every failed capture. It's now an 8-second error snackbar with a close button. It also won't stack: if an error snackbar is already showing, repeated failures don't open duplicates.

- **Configurable flash overlay on timed snapshots** — the full-screen flash made sense as confirmation for a single capture, but blinked the whole screen on every timed shot. It now fires at most at 1Hz on timed captures and can be disabled by the user.

- **Flash overlay no longer blocks mouse interactions** — It was full-screen and was blocking mouse usage during the blink.

To be merged after #2750.