### PR TITLE
Fix iframe widgets from BlueOS extensions not loading

### DIFF
--- a/src/libs/blueos.ts
+++ b/src/libs/blueos.ts
@@ -54,6 +54,8 @@ const blueOsServiceUrl = (vehicleAddress: string, service: Service): string => {
     : `${protocol}//${vehicleAddress}:${port}`
 }
 
+const isAbsoluteUrl = (url: string): boolean => /^https?:\/\//i.test(url)
+
 const getServicesFromBlueOS = async (vehicleAddress: string): Promise<Service[]> => {
   const options = { timeout: defaultTimeout, retry: 0 }
   const rawData = await ky.get(`${protocol}//${vehicleAddress}/helper/v1.0/web_services`, options).json()
@@ -93,11 +95,14 @@ export const getWidgetsFromBlueOS = async (vehicleAddress: string): Promise<Exte
             ...extraJson.widgets.map((widget) => {
               const useExtPath = widget.useExtensionPathAsBaseUrl ?? false
               const iconUrl = widget.iconUrl ?? widget.iframeIcon ?? ''
+              // Legacy manifests serve paths relative to the extension's service, so resolve them against
+              // the service base URL (matching pre-18.0.0 behavior). Absolute URLs are kept as-is.
+              const resolveAgainstBase = (url: string): string => (isAbsoluteUrl(url) ? url : baseUrl + url)
 
               return {
                 ...widget,
-                iframeUrl: useExtPath ? extensionPath + widget.iframeUrl : widget.iframeUrl,
-                iframeIcon: useExtPath ? baseUrl + iconUrl : iconUrl,
+                iframeUrl: useExtPath ? extensionPath + widget.iframeUrl : resolveAgainstBase(widget.iframeUrl),
+                iframeIcon: useExtPath ? baseUrl + iconUrl : resolveAgainstBase(iconUrl),
               }
             })
           )

--- a/src/libs/blueos/schemas.ts
+++ b/src/libs/blueos/schemas.ts
@@ -23,6 +23,26 @@ const preprocessCamelCase = <T extends z.ZodTypeAny>(schema: T): z.ZodTypeAny =>
   return z.preprocess((val: Record<string, unknown>) => camelcaseKeys(val, { deep: true }), schema)
 }
 
+/**
+ * Creates a preprocessing Zod schema that fills canonical camelCase keys from legacy snake_case aliases.
+ * Only the listed keys are remapped (existing camelCase values win).
+ * @param {Record<string, string>} aliases Map of legacy snake_case key to canonical camelCase key
+ * @param {T} schema The Zod schema to validate against after remapping
+ * @returns {z.ZodTypeAny} The schema wrapped with alias preprocessing
+ */
+const withLegacyAliases = <T extends z.ZodTypeAny>(aliases: Record<string, string>, schema: T): z.ZodTypeAny => {
+  return z.preprocess((val) => {
+    if (typeof val !== 'object' || val === null) return val
+    const obj = { ...(val as Record<string, unknown>) }
+    for (const [legacyKey, canonicalKey] of Object.entries(aliases)) {
+      if (obj[canonicalKey] === undefined && obj[legacyKey] !== undefined) {
+        obj[canonicalKey] = obj[legacyKey]
+      }
+    }
+    return obj
+  }, schema)
+}
+
 // Zod schemas for external API responses
 const ServiceMetadataSchema = z
   .object({
@@ -43,20 +63,23 @@ export const ServiceSchema = preprocessCamelCase(
   })
 )
 
-const ExternalWidgetSetupInfoSchema = z
-  .object({
-    name: z.string(),
-    iframeUrl: z.string(),
-    iconUrl: z.string().optional(),
-    iframeIcon: z.string().optional(),
-    collapsibleContainerName: z.string().optional(),
-    version: z.string().optional(),
-    startCollapsed: z.boolean().optional(),
-    useExtensionPathAsBaseUrl: z.boolean().optional(),
-  })
-  .refine((data) => data.iconUrl !== undefined || data.iframeIcon !== undefined, {
-    message: 'Either iconUrl or iframeIcon must be provided',
-  })
+const ExternalWidgetSetupInfoSchema = withLegacyAliases(
+  { iframe_url: 'iframeUrl', iframe_icon: 'iframeIcon', icon_url: 'iconUrl' },
+  z
+    .object({
+      name: z.string(),
+      iframeUrl: z.string(),
+      iconUrl: z.string().optional(),
+      iframeIcon: z.string().optional(),
+      collapsibleContainerName: z.string().optional(),
+      version: z.string().optional(),
+      startCollapsed: z.boolean().optional(),
+      useExtensionPathAsBaseUrl: z.boolean().optional(),
+    })
+    .refine((data) => data.iconUrl !== undefined || data.iframeIcon !== undefined, {
+      message: 'Either iconUrl or iframeIcon must be provided',
+    })
+)
 
 const HttpRequestActionConfigSchema = z.object({
   name: z.string(),
@@ -111,10 +134,17 @@ const JoystickMapSuggestionGroupSchema = z.object({
   version: z.string().optional(),
 })
 
-export const ExtrasJsonSchema = z.object({
-  targetCockpitApiVersion: z.string(),
-  targetSystem: z.string(),
-  widgets: z.array(ExternalWidgetSetupInfoSchema).default([]),
-  actions: z.array(ActionConfigSchema).default([]),
-  joystickSuggestions: z.array(JoystickMapSuggestionGroupSchema).optional(),
-})
+export const ExtrasJsonSchema = withLegacyAliases(
+  {
+    target_cockpit_api_version: 'targetCockpitApiVersion',
+    target_system: 'targetSystem',
+    joystick_suggestions: 'joystickSuggestions',
+  },
+  z.object({
+    targetCockpitApiVersion: z.string(),
+    targetSystem: z.string(),
+    widgets: z.array(ExternalWidgetSetupInfoSchema).default([]),
+    actions: z.array(ActionConfigSchema).default([]),
+    joystickSuggestions: z.array(JoystickMapSuggestionGroupSchema).optional(),
+  })
+)


### PR DESCRIPTION
**Problem:**

- BlueOS-extension iframe widgets stopped appearing in the widget browser in Cockpit >= 18.0.0.

1 - The schema validation added in 18.0.0 (after deep camelCase preprocessing was removed) rejected legacy snake_case `cockpit_extras.json` manifests, so `ExtrasJsonSchema.parse` threw and every widget from the extension was silently discarded.
2 - Even when manifests parsed, relative `iframe_url`/`iframe_icon` paths were no longer prefixed with the extension service base URL, so the iframe loaded Cockpit itself and the widget icon was broken.

**Fix:**

1 - Alias legacy snake_case keys (`iframe_url`, `iframe_icon`, `target_*`) onto their canonical camelCase fields, remapping only the listed keys so freeform dictionaries like action headers stay untouched.
2 - Resolve relative `iframeUrl`/`iframeIcon` against the extension service base URL again (pre-18.0.0 behavior), keeping absolute URLs intact.

<img width="1496" height="1050" alt="image" src="https://github.com/user-attachments/assets/dea468d2-bd7c-4f5a-8ad9-8507afd391be" />

Closes #2752