### PR TITLE
Add live data-lake values on monaco editor tooltips

### DIFF
--- a/src/libs/monaco-manager.ts
+++ b/src/libs/monaco-manager.ts
@@ -24,8 +24,13 @@ import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker'
 import {
   type DataLakeVariable,
   getAllDataLakeVariablesInfo,
+  getDataLakeVariableData,
+  getDataLakeVariableInfo,
+  listenDataLakeVariable,
   listenToDataLakeVariablesInfoChanges,
+  unlistenDataLakeVariable,
 } from '@/libs/actions/data-lake'
+import { dataLakeInputRegex } from '@/libs/utils-data-lake'
 
 // =============================================================================
 // Types
@@ -234,6 +239,196 @@ function registerCompletionProviders(): void {
   monaco.languages.registerCompletionItemProvider('plaintext', dataLakeCompletionProvider)
 }
 
+// Matches getDataLakeVariableData('id') API calls, capturing the quoted variable id
+const dataLakeApiCallRegex = /getDataLakeVariableData\(\s*['"]([^'"]+)['"]\s*\)/g
+
+type DataLakeReference = {
+  /** The id of the referenced data lake variable */
+  variableId: string
+  /** The editor range that covers the reference */
+  range: monaco.Range
+}
+
+/**
+ * Find the data lake reference (mustache expression or getDataLakeVariableData() call) at a position.
+ * @param {monaco.editor.ITextModel} model - The editor model to inspect
+ * @param {monaco.IPosition} position - The position to test, typically the one under the pointer
+ * @returns {DataLakeReference | null} The variable id and its range, or null if none
+ */
+function findDataLakeReferenceAtPosition(
+  model: monaco.editor.ITextModel,
+  position: monaco.IPosition
+): DataLakeReference | null {
+  const lineContent = model.getLineContent(position.lineNumber)
+
+  for (const sourceRegex of [dataLakeInputRegex, dataLakeApiCallRegex]) {
+    const regex = new RegExp(sourceRegex.source, 'g')
+
+    let match: RegExpExecArray | null
+    while ((match = regex.exec(lineContent)) !== null) {
+      const startColumn = match.index + 1
+      const endColumn = startColumn + match[0].length
+
+      // Skip references the position is not over
+      if (position.column < startColumn || position.column > endColumn) continue
+
+      return {
+        variableId: match[1].trim(),
+        range: new monaco.Range(position.lineNumber, startColumn, position.lineNumber, endColumn),
+      }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Attach a tooltip that shows the live data lake value of the reference under the pointer.
+ * Unlike a static hover, it subscribes to the variable while shown so the displayed value
+ * keeps updating in real time, and unsubscribes once the pointer leaves the reference.
+ * @param {monaco.editor.IStandaloneCodeEditor} editor - The editor to attach the tooltip to
+ */
+function attachDataLakeLiveTooltip(editor: monaco.editor.IStandaloneCodeEditor): void {
+  const domNode = document.createElement('div')
+  const hoverBox = document.createElement('div')
+  // Self-contained dark tooltip styling; min/max width keeps it wide instead of collapsing per word
+  Object.assign(hoverBox.style, {
+    boxSizing: 'border-box',
+    minWidth: '220px',
+    maxWidth: '500px',
+    whiteSpace: 'normal',
+    padding: '6px 10px',
+    backgroundColor: '#1e1e1e',
+    color: '#cccccc',
+    border: '1px solid #454545',
+    borderRadius: '3px',
+    fontSize: '13px',
+    lineHeight: '1.4',
+    boxShadow: '0 2px 8px rgba(0, 0, 0, 0.4)',
+  } as Partial<CSSStyleDeclaration>)
+  const headerEl = document.createElement('div')
+  headerEl.style.fontWeight = 'bold'
+  const valueEl = document.createElement('div')
+  valueEl.style.marginTop = '4px'
+  const valueDataEl = document.createElement('span')
+  valueEl.append('Current value: ', valueDataEl)
+  const descriptionEl = document.createElement('div')
+  descriptionEl.style.marginTop = '6px'
+  descriptionEl.style.opacity = '0.7'
+  hoverBox.append(headerEl, valueEl, descriptionEl)
+  domNode.appendChild(hoverBox)
+
+  let widgetPosition: monaco.editor.IContentWidgetPosition | null = null
+  const widget: monaco.editor.IContentWidget = {
+    getId: () => 'data-lake.live-value-tooltip',
+    getDomNode: () => domNode,
+    getPosition: () => widgetPosition,
+    allowEditorOverflow: true,
+  }
+
+  let isShown = false
+  let shownKey: string | null = null
+  let listenerId: string | null = null
+  let listenedVariableId: string | null = null
+  let pendingFrame: number | null = null
+
+  const renderValue = (value: string | number | boolean | undefined): void => {
+    valueDataEl.textContent = value === undefined ? 'no value yet' : String(value)
+  }
+
+  const unsubscribe = (): void => {
+    if (listenedVariableId && listenerId) {
+      unlistenDataLakeVariable(listenedVariableId, listenerId)
+    }
+    listenerId = null
+    listenedVariableId = null
+    if (pendingFrame !== null) {
+      cancelAnimationFrame(pendingFrame)
+      pendingFrame = null
+    }
+  }
+
+  const hide = (): void => {
+    unsubscribe()
+    shownKey = null
+    if (isShown) {
+      editor.removeContentWidget(widget)
+      isShown = false
+    }
+  }
+
+  const show = (variableId: string, range: monaco.Range): void => {
+    unsubscribe()
+
+    const variableInfo = getDataLakeVariableInfo(variableId)
+    if (!variableInfo) {
+      headerEl.textContent = `Unknown data lake variable: ${variableId}`
+      valueEl.style.display = 'none'
+      descriptionEl.style.display = 'none'
+    } else {
+      headerEl.textContent = `${variableInfo.name || variableId} (${variableInfo.type})`
+      valueEl.style.display = ''
+      renderValue(getDataLakeVariableData(variableId))
+
+      // Subscribe so the value keeps updating live, coalescing bursts into a single frame
+      listenedVariableId = variableId
+      listenerId = listenDataLakeVariable(variableId, (value) => {
+        if (pendingFrame !== null) return
+        pendingFrame = requestAnimationFrame(() => {
+          pendingFrame = null
+          renderValue(value)
+        })
+      })
+
+      descriptionEl.style.display = variableInfo.description ? '' : 'none'
+      descriptionEl.textContent = variableInfo.description ?? ''
+    }
+
+    widgetPosition = {
+      position: { lineNumber: range.startLineNumber, column: range.startColumn },
+      preference: [
+        monaco.editor.ContentWidgetPositionPreference.ABOVE,
+        monaco.editor.ContentWidgetPositionPreference.BELOW,
+      ],
+    }
+
+    if (isShown) {
+      editor.layoutContentWidget(widget)
+    } else {
+      editor.addContentWidget(widget)
+      isShown = true
+    }
+  }
+
+  // Collect the editor-owned listeners so they are explicitly released on disposal
+  const disposables: monaco.IDisposable[] = []
+
+  disposables.push(
+    editor.onMouseMove((e) => {
+      const position = e.target.position
+      const model = editor.getModel()
+      const reference = position && model ? findDataLakeReferenceAtPosition(model, position) : null
+
+      if (!reference) {
+        hide()
+        return
+      }
+
+      const key = `${reference.variableId}@${reference.range.startLineNumber}:${reference.range.startColumn}`
+      if (key === shownKey) return
+
+      shownKey = key
+      show(reference.variableId, reference.range)
+    })
+  )
+
+  disposables.push(editor.onMouseLeave(() => hide()))
+  editor.onDidDispose(() => {
+    hide()
+    disposables.forEach((disposable) => disposable.dispose())
+  })
+}
+
 // =============================================================================
 // Public API
 // =============================================================================
@@ -271,6 +466,13 @@ export function createMonacoEditor(
   // Ensure Monaco is initialized
   initializeMonaco()
 
+  // Host hover/suggest widgets in a body-level node so they escape both ancestor `overflow: hidden`
+  // clipping and `transform` ancestors (e.g. vue-draggable-resizable), which break `position: fixed`.
+  const overflowWidgetsDomNode = document.createElement('div')
+  overflowWidgetsDomNode.className = 'monaco-editor'
+  overflowWidgetsDomNode.style.zIndex = '10000'
+  document.body.appendChild(overflowWidgetsDomNode)
+
   const editor = monaco.editor.create(container, {
     value: options.value,
     language: options.language,
@@ -283,10 +485,19 @@ export function createMonacoEditor(
     tabSize: 2,
     wordWrap: 'on',
     padding: { top: 12, bottom: 12 },
+    fixedOverflowWidgets: true,
+    overflowWidgetsDomNode,
     autoClosingBrackets: options.language === 'javascript' ? 'never' : 'languageDefined',
     autoClosingQuotes: options.language === 'javascript' ? 'never' : 'languageDefined',
     ...options.editorOverrides,
   })
+
+  editor.onDidDispose(() => {
+    overflowWidgetsDomNode.remove()
+  })
+
+  // Show live data lake values when hovering mustache expressions or getDataLakeVariableData() calls
+  attachDataLakeLiveTooltip(editor)
 
   // Register completion type for this editor's model
   const model = editor.getModel()


### PR DESCRIPTION
* Adds a content-widget tooltip on hover showing the variable name, type and description, with live variable value.

<img width="898" height="895" alt="image" src="https://github.com/user-attachments/assets/69fc1fa4-80cd-4039-90ef-c4a5516b2d39" />

Closes #2696