### PR TITLE
Improve system logger performance

### DIFF
--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -90,6 +90,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('link-data', (_event, data) => callback(data))
   },
   systemLog: (level: string, message: string) => ipcRenderer.send('system-log', { level, message }),
+  systemLogBatch: (events: { level: string; message: string }[]) => ipcRenderer.send('system-log-batch', { events }),
   getElectronLogs: () => ipcRenderer.invoke('get-electron-logs'),
   getCurrentElectronLogInfo: () => ipcRenderer.invoke('get-current-electron-log-info'),
   getElectronLogContent: (logName: string) => ipcRenderer.invoke('get-electron-log-content', logName),

--- a/src/electron/services/electron-log.ts
+++ b/src/electron/services/electron-log.ts
@@ -194,9 +194,8 @@ export const setupElectronLogService = (): void => {
     }
   })
 
-  // Set up system logging IPC handler
-  ipcMain.on('system-log', (_event, { level, message }) => {
-    // Add [Renderer] tag and handle objects properly
+  // Add the [Renderer] tag and route a single renderer log message to the matching electron-log level.
+  const logRendererMessage = (level: string, message: any): void => {
     let processedMessage = ''
     try {
       if (typeof message === 'object' && message !== null) {
@@ -231,5 +230,12 @@ export const setupElectronLogService = (): void => {
         originalLoggerFunctions.log(taggedMessage)
         break
     }
+  }
+
+  // Set up system logging IPC handlers (single message and batched).
+  ipcMain.on('system-log', (_event, { level, message }) => logRendererMessage(level, message))
+  ipcMain.on('system-log-batch', (_event, { events }) => {
+    if (!Array.isArray(events)) return
+    events.forEach((event) => logRendererMessage(event?.level, event?.message))
   })
 }

--- a/src/libs/cosmos.ts
+++ b/src/libs/cosmos.ts
@@ -372,6 +372,18 @@ declare global {
        */
       systemLog: (level: string, message: string) => void
       /**
+       * Send a batch of log messages to electron-log in a single IPC call
+       * @param events - The log events to send, each with a level and message
+       */
+      systemLogBatch: (
+        events: {
+          /** The log level (error, warn, info, debug, trace, log) */
+          level: string
+          /** The message to log */
+          message: string
+        }[]
+      ) => void
+      /**
        * Get a list of all electron logs
        */
       getElectronLogs: () => Promise<ElectronLog[]>

--- a/src/libs/system-logging.ts
+++ b/src/libs/system-logging.ts
@@ -40,6 +40,11 @@ type LogEvent = {
   msg: string
 }
 
+type LogBatchEvent = {
+  level: string
+  message: string
+}
+
 const initialDatetime = new Date()
 export interface SystemLog {
   initialDate: string
@@ -54,22 +59,61 @@ const currentSystemLog: SystemLog = {
 }
 /* eslint-enable jsdoc/require-jsdoc */
 
-const saveLogEventInDB = (event: LogEvent): void => {
+// Buffer log events and flush them in batches, to avoid one IPC message (Electron) or one IndexedDB write
+// (web) per console call. During logging bursts the per-call overhead is the dominant cost on the renderer.
+const logFlushIntervalMs = 250
+const maxBufferedEventsBeforeFlush = 100
+
+let bufferedElectronEvents: LogBatchEvent[] = []
+let electronFlushTimeout: ReturnType<typeof setTimeout> | undefined
+let dbFlushTimeout: ReturnType<typeof setTimeout> | undefined
+
+const flushElectronLogs = (): void => {
+  if (electronFlushTimeout) {
+    clearTimeout(electronFlushTimeout)
+    electronFlushTimeout = undefined
+  }
+  if (bufferedElectronEvents.length === 0) return
+  const batch = bufferedElectronEvents
+  bufferedElectronEvents = []
   try {
-    currentSystemLog.events.push(event)
+    window.electronAPI?.systemLogBatch?.(batch)
+  } catch (error) {
+    // We do not want to log this error, as it would create an infinite loop
+  }
+}
+
+const flushDBLogs = (): void => {
+  if (dbFlushTimeout) {
+    clearTimeout(dbFlushTimeout)
+    dbFlushTimeout = undefined
+  }
+  try {
     cockpitSytemLogsDB.setItem(fileName, currentSystemLog)
   } catch (error) {
     // We do not want to log this error, as it would create an infinite loop
   }
 }
 
-const sendLogToElectron = (level: string, message: string): void => {
+const saveLogEventInDB = (event: LogEvent): void => {
   try {
-    if (window.electronAPI?.systemLog) {
-      window.electronAPI.systemLog(level, message)
+    currentSystemLog.events.push(event)
+    if (currentSystemLog.events.length % maxBufferedEventsBeforeFlush === 0) {
+      flushDBLogs()
+    } else if (!dbFlushTimeout) {
+      dbFlushTimeout = setTimeout(flushDBLogs, logFlushIntervalMs)
     }
   } catch (error) {
     // We do not want to log this error, as it would create an infinite loop
+  }
+}
+
+const sendLogToElectron = (level: string, message: string): void => {
+  bufferedElectronEvents.push({ level, message })
+  if (bufferedElectronEvents.length >= maxBufferedEventsBeforeFlush) {
+    flushElectronLogs()
+  } else if (!electronFlushTimeout) {
+    electronFlushTimeout = setTimeout(flushElectronLogs, logFlushIntervalMs)
   }
 }
 
@@ -121,4 +165,7 @@ if (enableSystemLogging) {
       }
     }
   })
+
+  // Flush whatever is still buffered before the window goes away, so the last events aren't lost.
+  window.addEventListener('beforeunload', isRunningInElectron ? flushElectronLogs : flushDBLogs)
 }

--- a/src/libs/system-logging.ts
+++ b/src/libs/system-logging.ts
@@ -129,6 +129,53 @@ if (enableSystemLogging) {
     To disable system logging go to "Settings" -> "Dev".
   `)
 
+  const persistLogEvent = (level: string, message: string): void => {
+    if (isRunningInElectron) {
+      sendLogToElectron(level, message)
+    } else {
+      saveLogEventInDB({ epoch: Date.now(), level, msg: message })
+    }
+  }
+
+  // Repeated-log suppressor: collapses identical consecutive messages (same level + text) into a single entry
+  // plus a "repeated N times" summary, so a tight loop logging the same thing doesn't flood the log. It is
+  // intentionally O(1): only the previous message is remembered (one string comparison per call), with no map,
+  // hashing, or history, so it never becomes a bottleneck during bursts — and it skips the persist work
+  // entirely for suppressed duplicates.
+  const repeatSummaryDelayMs = 1000
+  let lastLevel: string | undefined
+  let lastMessage: string | undefined
+  let suppressedRepeatCount = 0
+  let repeatSummaryTimeout: ReturnType<typeof setTimeout> | undefined
+
+  const flushRepeatSummary = (): void => {
+    if (repeatSummaryTimeout) {
+      clearTimeout(repeatSummaryTimeout)
+      repeatSummaryTimeout = undefined
+    }
+    if (suppressedRepeatCount > 0 && lastLevel !== undefined) {
+      const times = suppressedRepeatCount === 1 ? 'time' : 'times'
+      persistLogEvent(lastLevel, `↑ previous message repeated ${suppressedRepeatCount} more ${times}`)
+    }
+    suppressedRepeatCount = 0
+    // Reset so a message that recurs after the summary is shown fresh instead of being suppressed forever.
+    lastLevel = undefined
+    lastMessage = undefined
+  }
+
+  const captureLogEvent = (level: string, message: string): void => {
+    if (level === lastLevel && message === lastMessage) {
+      suppressedRepeatCount += 1
+      if (!repeatSummaryTimeout) repeatSummaryTimeout = setTimeout(flushRepeatSummary, repeatSummaryDelayMs)
+      return
+    }
+    // Different message: report any pending repeats of the previous one first, then emit this one.
+    flushRepeatSummary()
+    lastLevel = level
+    lastMessage = message
+    persistLogEvent(level, message)
+  }
+
   const oldConsoleFunction = {
     error: console.error,
     warn: console.warn,
@@ -158,14 +205,17 @@ if (enableSystemLogging) {
         }
       })
 
-      if (isRunningInElectron) {
-        sendLogToElectron(level, wholeMessage)
-      } else {
-        saveLogEventInDB({ epoch: new Date().getTime(), level: level, msg: wholeMessage })
-      }
+      captureLogEvent(level, wholeMessage)
     }
   })
 
   // Flush whatever is still buffered before the window goes away, so the last events aren't lost.
-  window.addEventListener('beforeunload', isRunningInElectron ? flushElectronLogs : flushDBLogs)
+  window.addEventListener('beforeunload', () => {
+    flushRepeatSummary()
+    if (isRunningInElectron) {
+      flushElectronLogs()
+    } else {
+      flushDBLogs()
+    }
+  })
 }


### PR DESCRIPTION
## Summary

Improves the performance of the system logger, which previously did one IPC message (Standalone) or one IndexedDB write (Lite) per `console` call — the dominant renderer cost during logging bursts.

## Changes

- **Batch system log writes instead of per-call IO**: console events are buffered and flushed together (every 250ms or every 100 events), with a `beforeunload` flush so nothing is lost on exit. Adds a `systemLogBatch` IPC channel for Electron and switches IndexedDB persistence to batched writes.
- **Collapse repeated consecutive log messages**: an O(1) suppressor folds identical consecutive messages (same level + text) into the first entry plus a "repeated N times" summary, so tight loops no longer flood the log. Only the previous message is remembered (one string comparison per call), and suppressed duplicates skip the persist work entirely.