### PR TITLE
Add console viewer

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -101,6 +101,9 @@
   <UpdateNotification v-if="isElectron()" />
   <ArchitectureWarning v-if="isElectron()" />
   <SnackbarContainer />
+  <FloatingWrapper v-model="devStore.showConsole" title="Console">
+    <ConsoleViewer :logging-enabled="devStore.enableSystemLogging" />
+  </FloatingWrapper>
   <SkullAnimation
     :is-visible="interfaceStore.showSkullAnimation"
     @animation-complete="interfaceStore.hideSkullAnimation"
@@ -120,8 +123,10 @@ import { computed, onBeforeMount, onBeforeUnmount, onMounted, ref, watch } from 
 
 import ArchitectureWarning from '@/components/ArchitectureWarning.vue'
 import CameraReplacementDialog from '@/components/CameraReplacementDialog.vue'
+import ConsoleViewer from '@/components/ConsoleViewer.vue'
 import DataPrivacyModal from '@/components/DataPrivacyModal.vue'
 import ExternalFeaturesDiscoveryModal from '@/components/ExternalFeaturesDiscoveryModal.vue'
+import FloatingWrapper from '@/components/FloatingWrapper.vue'
 import GlassModal from '@/components/GlassModal.vue'
 import SkullAnimation from '@/components/SkullAnimation.vue'
 import SnackbarContainer from '@/components/SnackbarContainer.vue'

--- a/src/components/ConsoleViewer.vue
+++ b/src/components/ConsoleViewer.vue
@@ -1,0 +1,258 @@
+<template>
+  <div
+    class="flex flex-col w-full h-full min-h-[200px] bg-[#00000033] rounded-lg overflow-hidden border border-[#FFFFFF11]"
+  >
+    <div class="flex items-center gap-2 flex-wrap px-2 py-1 border-b border-[#FFFFFF22]">
+      <v-text-field
+        v-model="searchText"
+        density="compact"
+        variant="outlined"
+        hide-details
+        placeholder="Filter…"
+        clearable
+        class="max-w-[240px]"
+      />
+      <v-btn
+        size="small"
+        variant="text"
+        icon
+        :color="invertSearch ? 'white' : 'grey'"
+        :title="invertSearch ? 'Excluding lines that match the filter' : 'Including lines that match the filter'"
+        @click="invertSearch = !invertSearch"
+      >
+        <v-icon>{{ invertSearch ? 'mdi-filter-minus' : 'mdi-filter' }}</v-icon>
+      </v-btn>
+      <div class="flex items-center gap-1 flex-wrap">
+        <v-chip
+          v-for="lvl in availableLevels"
+          :key="lvl"
+          size="x-small"
+          label
+          :variant="activeLevels.includes(lvl) ? 'flat' : 'outlined'"
+          :color="levelColor(lvl)"
+          class="cursor-pointer uppercase"
+          @click="toggleLevel(lvl)"
+        >
+          {{ lvl }}
+        </v-chip>
+      </div>
+      <v-spacer />
+      <span class="text-xs text-gray-400 whitespace-nowrap">{{ displayedEvents.length }} / {{ totalCount }}</span>
+      <v-btn
+        size="small"
+        variant="text"
+        icon
+        :color="autoScroll ? 'white' : 'grey'"
+        :title="autoScroll ? 'Auto-scroll on' : 'Auto-scroll paused'"
+        @click="toggleAutoScroll"
+      >
+        <v-icon>{{ autoScroll ? 'mdi-arrow-down-bold-box' : 'mdi-pause-box' }}</v-icon>
+      </v-btn>
+      <v-btn size="small" variant="text" class="text-white" icon title="Copy visible logs" @click="copyVisible">
+        <v-icon>mdi-content-copy</v-icon>
+      </v-btn>
+      <v-btn size="small" variant="text" class="text-white" icon title="Clear view" @click="clearView">
+        <v-icon>mdi-broom</v-icon>
+      </v-btn>
+    </div>
+
+    <div class="relative flex-1 min-h-0">
+      <RecycleScroller
+        ref="scrollerRef"
+        v-slot="{ item }"
+        class="h-full w-full font-mono text-xs py-1"
+        :items="displayedEvents"
+        :item-size="20"
+        key-field="id"
+        @scroll="onScroll"
+      >
+        <div class="flex items-center gap-2 h-[20px] leading-[20px] px-2">
+          <span class="shrink-0 text-gray-500">{{ formatTime(item.epoch) }}</span>
+          <span class="shrink-0 w-[42px] font-bold uppercase" :style="{ color: levelHex(item.level) }">{{
+            item.level
+          }}</span>
+          <span class="truncate text-gray-200" :title="item.msg">{{ item.msg }}</span>
+        </div>
+      </RecycleScroller>
+
+      <div
+        v-if="displayedEvents.length === 0"
+        class="absolute inset-0 flex items-center justify-center px-4 text-center text-sm text-gray-500 pointer-events-none"
+      >
+        <span v-if="!loggingEnabled">System logging is disabled — enable it above to capture console output.</span>
+        <span v-else>No log entries{{ isFiltering ? ' match the current filter' : ' captured yet' }}.</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, shallowRef, watch } from 'vue'
+
+import { type SystemLogViewerEvent, getRecentSystemLogEvents, subscribeToSystemLogEvents } from '@/libs/system-logging'
+
+defineProps<{
+  /**
+   * Whether system logging (console capture) is currently enabled. Used only to show a helpful empty state.
+   */
+  loggingEnabled?: boolean
+}>()
+
+// Keep the rendered/working set bounded so filtering and memory stay cheap regardless of log volume.
+const maxRows = 2000
+// Coalesce incoming events into a single reactive update at this cadence, instead of one render per log.
+const flushIntervalMs = 150
+
+const availableLevels = ['error', 'warn', 'info', 'debug', 'trace', 'log']
+
+// Master list is a plain (non-reactive) array; only the filtered result is reactive (shallow) for the scroller.
+let allEvents: SystemLogViewerEvent[] = []
+let pending: SystemLogViewerEvent[] = []
+const displayedEvents = shallowRef<SystemLogViewerEvent[]>([])
+const totalCount = ref(0)
+
+const searchText = ref('')
+const invertSearch = ref(false)
+const activeLevels = ref<string[]>([...availableLevels])
+const autoScroll = ref(true)
+const scrollerRef = ref<{
+  /** Root scroll element of the virtual scroller */
+  $el?: HTMLElement
+  /** Scrolls the virtual scroller to the bottom, when supported by the version in use */
+  scrollToBottom?: () => void
+} | null>(null)
+
+const isFiltering = computed(() => searchText.value.trim() !== '' || activeLevels.value.length < availableLevels.length)
+
+let unsubscribe: (() => void) | undefined
+let flushTimer: ReturnType<typeof setInterval> | undefined
+
+const matchesFilter = (event: SystemLogViewerEvent): boolean => {
+  if (!activeLevels.value.includes(event.level)) return false
+  const query = searchText.value.trim().toLowerCase()
+  if (query) {
+    const hit = event.msg.toLowerCase().includes(query)
+    if (invertSearch.value ? hit : !hit) return false
+  }
+  return true
+}
+
+const rebuildDisplayed = (): void => {
+  displayedEvents.value = allEvents.filter(matchesFilter)
+}
+
+const scrollToBottom = (): void => {
+  const scroller = scrollerRef.value
+  if (!scroller) return
+  if (typeof scroller.scrollToBottom === 'function') {
+    scroller.scrollToBottom()
+  } else if (scroller.$el) {
+    scroller.$el.scrollTop = scroller.$el.scrollHeight
+  }
+}
+
+const flush = (): void => {
+  if (pending.length === 0) return
+  allEvents = allEvents.concat(pending)
+  if (allEvents.length > maxRows) allEvents = allEvents.slice(allEvents.length - maxRows)
+  pending = []
+  totalCount.value = allEvents.length
+  // While paused (scrolled up), keep the rendered list frozen so the user can read it without it shifting as
+  // old events are evicted from the buffer. New events are still buffered and shown once following resumes.
+  if (!autoScroll.value) return
+  rebuildDisplayed()
+  nextTick(scrollToBottom)
+}
+
+// Follow only while pinned to the bottom: scrolling up (off the bottom edge) stops following entirely;
+// scrolling back to the bottom resumes it.
+const bottomThresholdPx = 16
+const onScroll = (): void => {
+  const el = scrollerRef.value?.$el
+  if (!el) return
+  autoScroll.value = el.scrollHeight - el.scrollTop - el.clientHeight <= bottomThresholdPx
+}
+
+const toggleLevel = (level: string): void => {
+  activeLevels.value = activeLevels.value.includes(level)
+    ? activeLevels.value.filter((l) => l !== level)
+    : [...activeLevels.value, level]
+}
+
+const toggleAutoScroll = (): void => {
+  autoScroll.value = !autoScroll.value
+  if (autoScroll.value) nextTick(scrollToBottom)
+}
+
+const clearView = (): void => {
+  allEvents = []
+  pending = []
+  totalCount.value = 0
+  displayedEvents.value = []
+}
+
+const copyVisible = (): void => {
+  const text = displayedEvents.value.map((e) => `${formatTime(e.epoch)} [${e.level}] ${e.msg}`).join('\n')
+  navigator.clipboard?.writeText(text)
+}
+
+const levelHexByLevel: Record<string, string> = {
+  error: '#ff6b6b',
+  warn: '#ffd166',
+  info: '#4dabf7',
+  debug: '#9aa0a6',
+  trace: '#b197fc',
+  log: '#e0e0e0',
+}
+const levelHex = (level: string): string => levelHexByLevel[level] ?? '#e0e0e0'
+
+const levelColor = (level: string): string => {
+  switch (level) {
+    case 'error':
+      return 'red'
+    case 'warn':
+      return 'amber'
+    case 'info':
+      return 'blue'
+    case 'trace':
+      return 'purple'
+    default:
+      return 'grey'
+  }
+}
+
+const formatTime = (epoch: number): string => {
+  const date = new Date(epoch)
+  const pad = (value: number, length = 2): string => String(value).padStart(length, '0')
+  return `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}.${pad(date.getMilliseconds(), 3)}`
+}
+
+watch([searchText, invertSearch, activeLevels], () => {
+  rebuildDisplayed()
+  if (autoScroll.value) nextTick(scrollToBottom)
+})
+
+// When following resumes (scrolled back to the bottom or toggled on), catch the view up to the latest events.
+watch(autoScroll, (following) => {
+  if (!following) return
+  rebuildDisplayed()
+  nextTick(scrollToBottom)
+})
+
+onMounted(() => {
+  allEvents = getRecentSystemLogEvents()
+  if (allEvents.length > maxRows) allEvents = allEvents.slice(allEvents.length - maxRows)
+  totalCount.value = allEvents.length
+  rebuildDisplayed()
+
+  unsubscribe = subscribeToSystemLogEvents((event) => pending.push(event))
+  flushTimer = setInterval(flush, flushIntervalMs)
+
+  nextTick(scrollToBottom)
+})
+
+onBeforeUnmount(() => {
+  unsubscribe?.()
+  if (flushTimer) clearInterval(flushTimer)
+})
+</script>

--- a/src/components/WidgetHugger.vue
+++ b/src/components/WidgetHugger.vue
@@ -1,14 +1,4 @@
 <template>
-  <div v-if="devStore.developmentMode" class="widgetOverlay dev-info">
-    <p>Position: {{ round(100 * widget.position.x, 2) }} x {{ round(100 * widget.position.y, 2) }} %</p>
-    <p>Size: {{ round(100 * widget.size.width, 2) }} x {{ round(100 * widget.size.height, 2) }} %</p>
-    <p>Position: {{ round(widget.position.x * windowWidth) }} x {{ round(widget.position.y * windowHeight) }} px</p>
-    <p>Size: {{ round(widget.size.width * windowWidth) }} x {{ round(widget.size.height * windowHeight) }} px</p>
-    <p>Client size: {{ innerWidgetRef?.clientWidth }} x {{ innerWidgetRef?.clientHeight }} px</p>
-    <p>Offset size: {{ innerWidgetRef?.offsetWidth }} x {{ innerWidgetRef?.offsetHeight }} px</p>
-    <p>Scroll size: {{ innerWidgetRef?.scrollWidth }} x {{ innerWidgetRef?.scrollHeight }} px</p>
-    <p v-for="[k, v] in Object.entries(widget?.options)" :key="k">{{ k }} (option): {{ v }}</p>
-  </div>
   <div
     ref="widgetOverlay"
     class="widgetOverlay"
@@ -71,8 +61,7 @@
 import { useElementHover, useWindowSize } from '@vueuse/core'
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, toRefs, watch } from 'vue'
 
-import { constrain, round } from '@/libs/utils'
-import { useDevelopmentStore } from '@/stores/development'
+import { constrain } from '@/libs/utils'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
 import type { Point2D, SizeRect2D } from '@/types/general'
 import { type Widget, isWidgetConfigurable, widgetHasOwnContextMenu, WidgetType } from '@/types/widgets'
@@ -166,8 +155,6 @@ const contextMenuItems = computed(() =>
     ? [{ item: 'Options', action: openWidgetConfig, icon: 'mdi-cog' }]
     : []
 )
-
-const devStore = useDevelopmentStore()
 
 const { width: windowWidth, height: windowHeight } = useWindowSize()
 
@@ -429,8 +416,6 @@ const cursorStyle = computed(() => {
   return 'grab'
 })
 
-const devInfoBlurLevel = computed(() => `${devStore.widgetDevInfoBlurLevel}px`)
-
 const isWidgetFullScreen = computed(() => widgetStore.isFullScreen(widget.value))
 
 const handleTopOffset = computed(() =>
@@ -454,20 +439,6 @@ const highlighted = computed(() => widgetStore.widgetManagerVars(widget.value.ha
   height: calc(v-bind('sizeStyle.height') + 2 * var(--overlayOverSize));
   user-select: none;
   display: v-bind('overlayDisplayStyle');
-}
-.dev-info {
-  background-color: rgba(255, 255, 255, 0.3);
-  backdrop-filter: blur(v-bind('devInfoBlurLevel'));
-  z-index: 1;
-  pointer-events: none;
-  position: absolute;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: auto;
-  text-shadow: 1ch;
-  flex-flow: column wrap;
 }
 .widgetOverlay.allowMoving {
   background-color: rgba(0, 0, 0, 0.1);

--- a/src/libs/system-logging.ts
+++ b/src/libs/system-logging.ts
@@ -59,6 +59,60 @@ const currentSystemLog: SystemLog = {
 }
 /* eslint-enable jsdoc/require-jsdoc */
 
+/**
+ * A single captured console event, as exposed to the in-app console viewer.
+ */
+export interface SystemLogViewerEvent {
+  /** Monotonic id, used as a stable key for virtualized rendering */
+  id: number
+  /** Time the event was captured (epoch ms) */
+  epoch: number
+  /** Console level (error, warn, info, debug, trace, log) */
+  level: string
+  /** The already-serialized message */
+  msg: string
+}
+
+// Bounded in-memory ring buffer of recent console events, used to feed the in-app console viewer live without
+// re-reading the persisted log. Capped so memory stays bounded regardless of how much is logged.
+const maxRecentLogEvents = 2000
+const recentLogEvents: SystemLogViewerEvent[] = []
+let logEventIdCounter = 0
+type SystemLogEventListener = (event: SystemLogViewerEvent) => void
+const systemLogEventListeners = new Set<SystemLogEventListener>()
+
+const recordLogEventForViewer = (level: string, msg: string): void => {
+  logEventIdCounter += 1
+  const event: SystemLogViewerEvent = { id: logEventIdCounter, epoch: Date.now(), level, msg }
+  recentLogEvents.push(event)
+  if (recentLogEvents.length > maxRecentLogEvents) recentLogEvents.shift()
+  systemLogEventListeners.forEach((listener) => {
+    try {
+      listener(event)
+    } catch {
+      // Never let a viewer listener throw back into the logging path (could cause an infinite loop)
+    }
+  })
+}
+
+/**
+ * Get a snapshot of the most recent in-memory console events.
+ * @returns {SystemLogViewerEvent[]} A copy of the current ring buffer
+ */
+export const getRecentSystemLogEvents = (): SystemLogViewerEvent[] => recentLogEvents.slice()
+
+/**
+ * Subscribe to live console events as they are captured.
+ * @param {SystemLogEventListener} listener - Called for each new event
+ * @returns {() => void} Unsubscribe function
+ */
+export const subscribeToSystemLogEvents = (listener: SystemLogEventListener): (() => void) => {
+  systemLogEventListeners.add(listener)
+  return () => {
+    systemLogEventListeners.delete(listener)
+  }
+}
+
 // Buffer log events and flush them in batches, to avoid one IPC message (Electron) or one IndexedDB write
 // (web) per console call. During logging bursts the per-call overhead is the dominant cost on the renderer.
 const logFlushIntervalMs = 250
@@ -130,6 +184,8 @@ if (enableSystemLogging) {
   `)
 
   const persistLogEvent = (level: string, message: string): void => {
+    // Feed the in-app console viewer (bounded in-memory buffer), independent of where logs are persisted.
+    recordLogEventForViewer(level, message)
     if (isRunningInElectron) {
       sendLogToElectron(level, message)
     } else {

--- a/src/stores/development.ts
+++ b/src/stores/development.ts
@@ -11,8 +11,6 @@ export const blueOsSettingsSyncEnablingKey = 'cockpit-enable-blueos-settings-syn
 export const showSplashScreenOnStartupKey = 'cockpit-show-splash-screen-on-startup'
 
 export const useDevelopmentStore = defineStore('development', () => {
-  const developmentMode = ref(false)
-  const widgetDevInfoBlurLevel = ref(3)
   // Whether the floating console window is open. Kept here (not in a view) so the console stays alive while
   // the user navigates away from the Dev settings menu.
   const showConsole = ref(false)
@@ -32,8 +30,6 @@ export const useDevelopmentStore = defineStore('development', () => {
   })
 
   return {
-    developmentMode,
-    widgetDevInfoBlurLevel,
     showConsole,
     enableSystemLogging,
     enableBlueOsSettingsSync,

--- a/src/stores/development.ts
+++ b/src/stores/development.ts
@@ -13,6 +13,9 @@ export const showSplashScreenOnStartupKey = 'cockpit-show-splash-screen-on-start
 export const useDevelopmentStore = defineStore('development', () => {
   const developmentMode = ref(false)
   const widgetDevInfoBlurLevel = ref(3)
+  // Whether the floating console window is open. Kept here (not in a view) so the console stays alive while
+  // the user navigates away from the Dev settings menu.
+  const showConsole = ref(false)
   const enableSystemLogging = useBlueOsStorage(systemLoggingEnablingKey, true)
   const enableBlueOsSettingsSync = useStorage(blueOsSettingsSyncEnablingKey, true)
   const showSplashScreenOnStartup = useStorage(showSplashScreenOnStartupKey, true)
@@ -31,6 +34,7 @@ export const useDevelopmentStore = defineStore('development', () => {
   return {
     developmentMode,
     widgetDevInfoBlurLevel,
+    showConsole,
     enableSystemLogging,
     enableBlueOsSettingsSync,
     shareHardwareDetails,

--- a/src/views/ConfigurationDevelopmentView.vue
+++ b/src/views/ConfigurationDevelopmentView.vue
@@ -10,14 +10,7 @@
           class="flex flex-col justify-between items-center w-full"
           :class="interfaceStore.isOnSmallScreen ? 'scale-[80%] mt-0 -mb-3' : 'scale-95 mt-4'"
         >
-          <div class="flex flex-row gap-x-[40px]">
-            <v-switch
-              v-model="devStore.developmentMode"
-              label="Development mode"
-              color="white"
-              hide-details
-              class="min-w-[155px]"
-            />
+          <div class="flex flex-row flex-wrap justify-start gap-x-[20px]">
             <v-switch
               v-model="devStore.enableBlueOsSettingsSync"
               label="BlueOS settings sync"
@@ -34,8 +27,6 @@
               class="min-w-[155px]"
               @update:model-value="reloadCockpitAndWarnUser()"
             />
-          </div>
-          <div class="flex flex-row w-full justify-start gap-x-[40px]">
             <v-switch
               v-model="devStore.showSplashScreenOnStartup"
               label="Show splashscreen on startup"
@@ -44,16 +35,6 @@
               class="min-w-[155px]"
             />
           </div>
-          <v-slider
-            v-model="devStore.widgetDevInfoBlurLevel"
-            label="Dev info blur level"
-            min="0"
-            max="10"
-            class="w-[350px]"
-            color="white"
-            step="1"
-            thumb-label="hover"
-          />
         </div>
         <ExpansiblePanel :is-expanded="!interfaceStore.isOnPhoneScreen" no-bottom-divider>
           <template #title>

--- a/src/views/ConfigurationDevelopmentView.vue
+++ b/src/views/ConfigurationDevelopmentView.vue
@@ -57,15 +57,26 @@
         </div>
         <ExpansiblePanel :is-expanded="!interfaceStore.isOnPhoneScreen" no-bottom-divider>
           <template #title>
-            <div class="flex justify-between">
+            <div class="flex justify-between items-center">
               <span>System logs</span>
-              <span class="text-sm text-gray-300 cursor-pointer" @click.stop="deleteOldLogs">
-                <v-tooltip text="Delete old logs">
-                  <template #activator="{ props }">
-                    <v-icon left class="mr-2" v-bind="props">mdi-delete-sweep</v-icon>
-                  </template>
-                </v-tooltip>
-              </span>
+              <div class="flex items-center gap-2">
+                <v-btn
+                  variant="outlined"
+                  color="white"
+                  size="small"
+                  prepend-icon="mdi-console-line"
+                  @click.stop="devStore.showConsole = true"
+                >
+                  Open console
+                </v-btn>
+                <span class="text-sm text-gray-300 cursor-pointer" @click.stop="deleteOldLogs">
+                  <v-tooltip text="Delete old logs">
+                    <template #activator="{ props }">
+                      <v-icon left class="mr-2" v-bind="props">mdi-delete-sweep</v-icon>
+                    </template>
+                  </v-tooltip>
+                </span>
+              </div>
             </div>
           </template>
           <template #content>


### PR DESCRIPTION
## Summary

Adds an in-app console viewer: a floating, filterable window that shows captured `console` output live, so logs can be inspected directly inside Cockpit without opening devtools or downloading the syslog. Also cleans up the now-unused legacy "development mode" / widget dev-info overlay.

## Changes

- **New `ConsoleViewer.vue`**: virtualized log list (`RecycleScroller`) that subscribes to live console events, with text filtering (and invert), per-level toggles, an entry counter, auto-scroll/follow that pauses when you scroll up, copy-visible, and clear-view. Rendering is coalesced on an interval and the working set is bounded to stay cheap regardless of log volume.
- **System logging exposes a live feed**: `system-logging.ts` now keeps a bounded in-memory ring buffer of recent events and exposes `getRecentSystemLogEvents()` / `subscribeToSystemLogEvents()` (plus the `SystemLogViewerEvent` type) to feed the viewer, independent of where logs are persisted.
- **Wired into the app**: hosted in a `FloatingWrapper` from `App.vue`, opened via an "Open console" button in Settings → Dev. Open state lives in the development store (`showConsole`) so it survives navigating away from the settings menu.
- **Cleanup**: removes the legacy `developmentMode` flag, the `widgetDevInfoBlurLevel` slider, and the `WidgetHugger` dev-info overlay that depended on them, since those are early days testing tools that are not used anymore.

To be merged after #2761