### PR TITLE
Fix 'center on' speed dial menu location on non-fullscreen maps

### DIFF
--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -342,7 +342,7 @@ const mapCenter = ref<WaypointCoordinates>(missionStore.userLastMapCenter ?? mis
 const home = ref()
 const mapId = computed(() => `map-${widget.value.hash}`)
 const showButtons = computed(
-  () => isMouseOver.value || downloadMenuOpen.value || widgetStore.isFullScreen(widget.value)
+  () => isMouseOver.value || downloadMenuOpen.value || speedDialOpen.value || widgetStore.isFullScreen(widget.value)
 )
 const mapReady = ref(false)
 const mapWaypoints = ref<Waypoint[]>([])
@@ -647,10 +647,6 @@ watch(showButtons, () => {
     map.value.removeControl(layerControl)
     removeScaleControl()
   }
-})
-
-watch(isMouseOver, () => {
-  showButtons.value = isMouseOver.value
 })
 
 // Watch for grid overlay option changes


### PR DESCRIPTION
**Problem:**

- When the Map widget was not fullscreen, `showButtons` dropped as the pointer left the widget to reach the teleported speed-dial submenu, unmounting the activator so Vuetify's connected popup lost its anchor and jumped to the viewport corner (and the items vanished while the dial stayed open).

**Fix:**

- Track `speedDialOpen` in `showButtons` so the activator stays mounted while the dial is open, keeping the menu anchored to the button (and removed the dead watcher that wrote to the read-only `showButtons` computed).

Closes #2757