### PR TITLE
Remove vehicle position history from the BlueOS sync

### DIFF
--- a/src/stores/mission.ts
+++ b/src/stores/mission.ts
@@ -181,7 +181,7 @@ export const useMissionStore = defineStore('mission', () => {
     redoStack.length = 0
     syncCounts()
   }
-  const persistedPositionHistory = useBlueOsStorage<WaypointCoordinates[]>('cockpit-vehicle-position-history', [])
+  const persistedPositionHistory = useStorage<WaypointCoordinates[]>('cockpit-vehicle-position-history', [])
   const isVehiclePositionHistoryPersistent = useBlueOsStorage('cockpit-vehicle-position-history-persistent', true)
   const vehiclePositionHistory = ref<WaypointCoordinates[]>([...persistedPositionHistory.value])
   // Revision counter for `vehiclePositionHistory` mutations.


### PR DESCRIPTION
The vehicle position history is not a setting, but an ephemeral state, so it should not be synced. It is also a very long, constantly-changing list, so syncing it never settles - it keeps re-syncing on every position update, which has a huge chance of hurting both network and performance (which I believe is indeed happening for long missions).

Changing to store it in the local storage only.