### PR TITLE
flatpak: Bundle libspeechd and enable speech-dispatcher for voice alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ We have dedicated builds for every Desktop platform, so make sure you're using t
 - **Linux**: `.AppImage`
 - **Steam OS**: `.Flatpak`
 
+> ℹ️ The Flatpak build uses the host's [speech-dispatcher](https://freebsoft.org/speechd) and a synthesizer like [espeak-ng](https://github.com/espeak-ng/espeak-ng) for voice alerts. These come pre-installed on most desktop Linux distros (Ubuntu, Fedora, Mint, etc.) and on SteamOS 3.7.13 and newer. On minimal installs that don't have them, install with your package manager (e.g. `sudo apt install speech-dispatcher espeak-ng` on Debian/Ubuntu).
+
 #### - Option 3: Install the BlueOS Extension (Lite version!)
 If you're using BlueOS, you can install Cockpit [from the Extensions page](https://blueos.cloud/docs/stable/usage/advanced/#extensions).
 

--- a/package.json
+++ b/package.json
@@ -209,8 +209,62 @@
         "--socket=pulseaudio",
         "--filesystem=/run/udev:ro",
         "--filesystem=~/Cockpit:create",
+        "--filesystem=xdg-run/speech-dispatcher",
         "--share=network",
-        "--talk-name=org.freedesktop.Notifications"
+        "--talk-name=org.freedesktop.Notifications",
+        "--talk-name=org.freedesktop.SpeechDispatcher"
+      ],
+      "modules": [
+        {
+          "name": "libspeechd",
+          "config-opts": [
+            "--disable-static",
+            "--with-ibmtts=no",
+            "--with-kali=no",
+            "--with-baratinoo=no",
+            "--with-voxin=no",
+            "--without-flite",
+            "--disable-python"
+          ],
+          "no-make-install": true,
+          "post-install": [
+            "cd ./src/api/c && make install"
+          ],
+          "cleanup": [
+            "*.la",
+            "*.a",
+            "/include"
+          ],
+          "sources": [
+            {
+              "type": "archive",
+              "url": "https://github.com/brailcom/speechd/releases/download/0.11.5/speech-dispatcher-0.11.5.tar.gz",
+              "sha512": "d6d880bce0ae5bc2a5d519ef7740c689ae8b4b0bb658379762810e4beae3e465a429fbe19f7c490e89db0ea6a36aedd4b2287ac9251b90059b5c2cb3c0dd8a28"
+            }
+          ],
+          "modules": [
+            {
+              "name": "dotconf",
+              "sources": [
+                {
+                  "type": "archive",
+                  "url": "https://github.com/williamh/dotconf/archive/refs/tags/v1.4.1.tar.gz",
+                  "sha512": "a6cada8621295b268d4b4fd85bc0c207e78324c9e84754ead2fdf6c1598ec8bdf626f9c24e66063d921c95d73e83b50ab50416a9b4c9a7a631392552ec46f55a"
+                },
+                {
+                  "type": "script",
+                  "commands": [
+                    "autoreconf -fiv"
+                  ],
+                  "dest-filename": "autogen.sh"
+                }
+              ],
+              "cleanup": [
+                "*"
+              ]
+            }
+          ]
+        }
       ],
       "runtime": "org.freedesktop.Platform",
       "runtimeVersion": "22.08",

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -20,6 +20,13 @@ import { setupWorkspaceService } from './services/workspace'
 // Setup the logger service as soon as possible to avoid different behaviors across runtime
 setupElectronLogService()
 
+// On Linux, Chromium gates its Web Speech API backend (used by the voice-alerts feature) behind
+// the `--enable-speech-dispatcher` switch. It must be set before `app.whenReady()` to take effect.
+// Harmless when speech-dispatcher / libspeechd is not available on the host.
+if (process.platform === 'linux') {
+  app.commandLine.appendSwitch('enable-speech-dispatcher')
+}
+
 export const ROOT_PATH = {
   dist: join(__dirname, '..'),
 }


### PR DESCRIPTION
## ⚠️  Not working! There's some piece still missing.

Chromium gates the Web Speech API behind the --enable-speech-dispatcher switch on Linux and dlopens libspeechd.so.2 at runtime. The 22.08 Electron BaseApp does not ship libspeechd, and the sandbox blocks the speech-dispatcher socket and D-Bus name, so voice alerts silently no-op on the Flatpak build while working on the AppImage.

Vendor libspeechd 0.11.5 (matching the version the BaseApp historically shipped on this runtime) into the Flatpak, expose xdg-run/speech-dispatcher and the SpeechDispatcher D-Bus name, and append the Chromium switch from the Electron main process so Cockpit can talk to the host's speech-dispatcher daemon. Also document the host-side deps next to the Flatpak download.

Fix #1834 