### PR TITLE
Widget Manager: Fix repeated onMounted warnings on window resize

### DIFF
--- a/src/stores/widgetManager.ts
+++ b/src/stores/widgetManager.ts
@@ -47,6 +47,8 @@ import {
 } from '@/types/widgets'
 const { showDialog } = useInteractionDialog()
 
+const { height: windowHeight } = useWindowSize()
+
 const viewsGroupKey = 'cockpit-views-group-v1'
 
 export const useWidgetManagerStore = defineStore('widget-manager', () => {
@@ -329,7 +331,6 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
   // eslint-disable-next-line jsdoc/require-jsdoc
   const widgetClearanceForVisibleArea = (widget: Widget): { top: number; bottom: number } => {
     const clearances = { top: 0, bottom: 0 }
-    const { height: windowHeight } = useWindowSize()
 
     const widgetTopEdgePixels = windowHeight.value * widget.position.y
     const topBarStartPixels = currentTopBarHeightPixels.value


### PR DESCRIPTION
**Problem:**

- `widgetClearanceForVisibleArea` called `useWindowSize()` on every invocation, and the helper runs inside a `Map.vue` computed, so vueuse re-registered an `onMounted` hook with no active component instance on each call.
- On window resize the computed re-evaluated repeatedly, flooding the renderer console with `onMounted is called when there is no active component instance` warnings (hundreds per resize).

**Fix:**

- Create `useWindowSize()` once at module scope (matching the app-interface store) and reuse the reactive `windowHeight` ref in the helper, so the composable's lifecycle hooks are registered a single time instead of per call.

Closes #2456