### PR TITLE
Fix cruise speed control on mission runtime

### DIFF
--- a/src/components/mini-widgets/MiniMissionControlPanel.vue
+++ b/src/components/mini-widgets/MiniMissionControlPanel.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     ref="miniMissionControlPanel"
-    class="flex justify-around px-2 py-1 text-center rounded-lg w-[220px] h-9 align-center text-white bg-slate-800/60"
+    class="flex justify-around px-2 py-1 text-center rounded-lg w-[252px] h-9 align-center text-white bg-slate-800/60"
   >
     <div
       class="flex gap-1 items-center overflow-hidden"
@@ -50,6 +50,38 @@
           />
         </template>
       </v-tooltip>
+      <v-menu :close-on-content-click="false" location="top" offset="8">
+        <template #activator="{ props: speedProps }">
+          <v-tooltip location="top" open-delay="800" text="Cruise speed">
+            <template #activator="{ props: speedTooltipProps }">
+              <v-btn
+                v-bind="{ ...speedProps, ...speedTooltipProps }"
+                size="x-small"
+                icon="mdi-speedometer"
+                variant="text"
+                class="text-[16px]"
+                :disabled="!vehicleStore.isVehicleOnline"
+              />
+            </template>
+          </v-tooltip>
+        </template>
+        <div class="flex flex-col p-3 rounded-lg w-[210px] text-white" :style="interfaceStore.globalGlassMenuStyles">
+          <div class="flex justify-between items-center mb-1 text-xs">
+            <span>Cruise speed</span>
+            <span class="font-bold">{{ liveCruiseSpeed.toFixed(1) }} m/s</span>
+          </div>
+          <v-slider
+            v-model="liveCruiseSpeed"
+            :min="0.1"
+            :max="5"
+            :step="0.1"
+            color="white"
+            density="compact"
+            hide-details
+            @update:model-value="handleCruiseSpeedInput"
+          />
+        </div>
+      </v-menu>
       <v-tooltip location="top" open-delay="800" text="Return to home">
         <template #activator="{ props: homeProps }">
           <v-btn
@@ -73,14 +105,16 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref, watch } from 'vue'
 
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { openSnackbar } from '@/composables/snackbar'
+import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useMissionStore } from '@/stores/mission'
 
 const { showDialog, closeDialog } = useInteractionDialog()
+const interfaceStore = useAppInterfaceStore()
 const missionStore = useMissionStore()
 const vehicleStore = useMainVehicleStore()
 
@@ -88,6 +122,23 @@ const currentWaypointOnMission = computed<string>((): string => {
   const wpIndex = missionStore.currentWaypointOnMission
   return wpIndex > 0 ? wpIndex.toString() : '--'
 })
+
+const liveCruiseSpeed = ref<number>(Number(missionStore.cruiseSpeed))
+watch(
+  () => missionStore.cruiseSpeed,
+  (newSpeed) => (liveCruiseSpeed.value = Number(newSpeed))
+)
+
+// Debounce live speed commands so dragging the slider doesn't flood the vehicle with DO_CHANGE_SPEED.
+let cruiseSpeedDebounce: ReturnType<typeof setTimeout> | undefined
+const handleCruiseSpeedInput = (value: number): void => {
+  if (cruiseSpeedDebounce) clearTimeout(cruiseSpeedDebounce)
+  cruiseSpeedDebounce = setTimeout(() => {
+    missionStore.applyCruiseSpeed(value).catch((err) => {
+      openSnackbar({ message: `Failed to set cruise speed: ${(err as Error).message}`, variant: 'error' })
+    })
+  }, 300)
+}
 
 const handleReturnHome = (): void => {
   showDialog({

--- a/src/components/widgets/MissionControlPanel.vue
+++ b/src/components/widgets/MissionControlPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-w-[280px] min-h-[95px] flex items-end">
+  <div class="min-w-[290px] min-h-[95px] flex items-end">
     <div
       class="w-full rounded-lg overflow-hidden -mt-2"
       :class="[isWrapped ? 'h-[42px]' : 'h-full']"
@@ -71,6 +71,41 @@
                 </template>
               </v-tooltip>
               <v-divider vertical class="h-[25px] mt-[3px] mx-1 opacity-10" />
+              <v-menu :close-on-content-click="false" location="top" offset="8">
+                <template #activator="{ props: speedProps }">
+                  <v-tooltip location="top" open-delay="800" text="Cruise speed">
+                    <template #activator="{ props: speedTooltipProps }">
+                      <v-btn
+                        v-bind="{ ...speedProps, ...speedTooltipProps }"
+                        size="x-small"
+                        icon="mdi-speedometer"
+                        variant="text"
+                        class="text-[18px]"
+                        :disabled="!vehicleStore.isVehicleOnline"
+                      />
+                    </template>
+                  </v-tooltip>
+                </template>
+                <div
+                  class="flex flex-col p-3 rounded-lg w-[210px] text-white"
+                  :style="interfaceStore.globalGlassMenuStyles"
+                >
+                  <div class="flex justify-between items-center mb-1 text-xs">
+                    <span>Cruise speed</span>
+                    <span class="font-bold">{{ liveCruiseSpeed.toFixed(1) }} m/s</span>
+                  </div>
+                  <v-slider
+                    v-model="liveCruiseSpeed"
+                    :min="0.1"
+                    :max="5"
+                    :step="0.1"
+                    color="white"
+                    density="compact"
+                    hide-details
+                    @update:model-value="handleCruiseSpeedInput"
+                  />
+                </div>
+              </v-menu>
               <v-tooltip location="top" open-delay="800" text="Return to home">
                 <template #activator="{ props: homeProps }">
                   <v-btn
@@ -78,7 +113,7 @@
                     size="x-small"
                     icon="mdi-home-circle"
                     variant="text"
-                    class="text-[19px] mr-1"
+                    class="text-[18px] mr-1"
                     :disabled="!vehicleStore.isVehicleOnline"
                     @click.stop="handleReturnHome"
                   />
@@ -126,7 +161,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeMount, ref, toRefs } from 'vue'
+import { computed, onBeforeMount, ref, toRefs, watch } from 'vue'
 
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { openSnackbar } from '@/composables/snackbar'
@@ -156,6 +191,23 @@ const currentWaypointOnMission = computed<string>((): string => {
   const wpIndex = missionStore.currentWaypointOnMission
   return wpIndex > 0 ? wpIndex.toString() : '--'
 })
+
+const liveCruiseSpeed = ref<number>(Number(missionStore.cruiseSpeed))
+watch(
+  () => missionStore.cruiseSpeed,
+  (newSpeed) => (liveCruiseSpeed.value = Number(newSpeed))
+)
+
+// Debounce live speed commands so dragging the slider doesn't flood the vehicle with DO_CHANGE_SPEED.
+let cruiseSpeedDebounce: ReturnType<typeof setTimeout> | undefined
+const handleCruiseSpeedInput = (value: number): void => {
+  if (cruiseSpeedDebounce) clearTimeout(cruiseSpeedDebounce)
+  cruiseSpeedDebounce = setTimeout(() => {
+    missionStore.applyCruiseSpeed(value).catch((err) => {
+      openSnackbar({ message: `Failed to set cruise speed: ${(err as Error).message}`, variant: 'error' })
+    })
+  }, 300)
+}
 
 const toggleWrapContainer = (): void => {
   isWrapped.value = !isWrapped.value

--- a/src/libs/vehicle/mavlink/vehicle.ts
+++ b/src/libs/vehicle/mavlink/vehicle.ts
@@ -1598,6 +1598,15 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
   }
 
   /**
+   * Set the cruise (ground) speed live, applied immediately for the remainder of the active mission.
+   * @param {number} speedMps - Target ground speed in meters per second
+   * @returns {Promise<void>} A promise that resolves when the command is acknowledged
+   */
+  async setCruiseSpeed(speedMps: number): Promise<void> {
+    await this.sendCommandLong(MavCmd.MAV_CMD_DO_CHANGE_SPEED, 1, speedMps, -1, 0)
+  }
+
+  /**
    * Getter for current mission seq
    * @returns {number | undefined} Current mission seq, or undefined if n/a
    */

--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -1021,6 +1021,15 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     await mainVehicle.value.setMissionCurrent(seq)
   }
 
+  /**
+   * Set the cruise (ground) speed live on the vehicle
+   * @param {number} speedMps - Target ground speed in meters per second
+   */
+  async function setCruiseSpeed(speedMps: number): Promise<void> {
+    if (!mainVehicle.value) throw new Error('No vehicle available to set cruise speed.')
+    await mainVehicle.value.setCruiseSpeed(speedMps)
+  }
+
   return {
     arm,
     takeoff,
@@ -1039,6 +1048,7 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     pauseMission,
     returnHome,
     setMissionCurrent,
+    setCruiseSpeed,
     getCurrentVehicleName,
     mainVehicle,
     globalAddress,

--- a/src/stores/mission.ts
+++ b/src/stores/mission.ts
@@ -57,6 +57,7 @@ export const useMissionStore = defineStore('mission', () => {
   const showGridOnMissionPlanning = useBlueOsStorage('cockpit-show-grid-on-mission-planning', false)
   const showMissionEstimates = useBlueOsStorage('cockpit-show-mission-estimates', true)
   const defaultCruiseSpeed = useBlueOsStorage<number>('cockpit-default-cruise-speed', 1)
+  const cruiseSpeed = ref<number>(Number(defaultCruiseSpeed.value))
   const userLastMapTileProvider = useBlueOsStorage<MapTileProvider>(
     'cockpit-user-last-map-tile-provider',
     'Esri World Imagery'
@@ -495,12 +496,27 @@ export const useMissionStore = defineStore('mission', () => {
 
   let didAutoEndCurrentRun = false
 
+  /**
+   * Applies the active cruise speed to the vehicle as a live command.
+   * @param {number} [speedMps] - Speed to apply; defaults to the current active cruise speed
+   * @returns {Promise<void>}
+   */
+  const applyCruiseSpeed = async (speedMps: number = cruiseSpeed.value): Promise<void> => {
+    const speed = Number(speedMps)
+    if (!Number.isFinite(speed) || speed <= 0) return
+    cruiseSpeed.value = speed
+    if (!mainVehicleStore.isVehicleOnline) return
+    await mainVehicleStore.setCruiseSpeed(speed)
+  }
+
   // Allow executing missions
   const executeMissionOnVehicle = async (): Promise<boolean> => {
     try {
       mainVehicleStore.clearReachedMissionItems()
       didAutoEndCurrentRun = false
       await mainVehicleStore.startMission()
+      // Re-apply the cruise speed on every start/resume so it is not lost after a pause cycle.
+      await applyCruiseSpeed().catch((err) => console.error('Failed to apply cruise speed on mission start:', err))
       return true
     } catch (error) {
       return false
@@ -650,6 +666,8 @@ export const useMissionStore = defineStore('mission', () => {
     removeCommandFromWaypoint,
     updateWaypointCommand,
     defaultCruiseSpeed,
+    cruiseSpeed,
+    applyCruiseSpeed,
     userLastMapTileProvider,
     defaultMapTileProvider,
     mapFallbackBaseColor,

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -788,10 +788,11 @@ const uploadMissionToVehicle = async (): Promise<void> => {
 
   missionItemsToUpload.unshift(homeWaypoint)
 
-  // Commit the local cruise speed back to the store so the chosen value persists across sessions.
+  // Commit the local cruise speed back to the store so the chosen value persists across sessions and mission restarts.
   missionStore.defaultCruiseSpeed = localCruiseSpeed.value
+  missionStore.cruiseSpeed = localCruiseSpeed.value
 
-  if (localCruiseSpeed.value !== 1 && missionItemsToUpload.length > 1) {
+  if (localCruiseSpeed.value > 0 && missionItemsToUpload.length > 1) {
     const firstMissionItem = missionItemsToUpload[1]
     const existing = Array.isArray(firstMissionItem.commands) ? firstMissionItem.commands : []
 


### PR DESCRIPTION
**Problem**
Mission cruise speed was applied only as a single `DO_CHANGE_SPEED` mission item at WP1, so a paused-then-resumed mission reverted to the autopilot's default speed — the unreliable behavior reported in #2405.

**Fix** 
* Sends `DO_CHANGE_SPEED` as a standalone ground-speed `COMMAND_LONG` and reapplies it on every mission start/resume, so the chosen speed survives pause/resume instead of being consumed once.
* Tracks the active cruise speed in the mission store as the single source of truth, seeded from the planned value and honoring a deliberate 1 m/s on upload.
* Adds a live cruise-speed slider popover to the mission-control widget and mini-widget, letting the speed be changed at any time during a run (#1487).

![Mission control widget cruise-speed button](https://raw.githubusercontent.com/ArturoManzoli/cockpit/pr-assets-cruise-speed/docs/pr-assets/widget-speed-button.png)

![Mission control widget cruise-speed slider](https://raw.githubusercontent.com/ArturoManzoli/cockpit/pr-assets-cruise-speed/docs/pr-assets/widget-speed-slider.png)

![Mini mission control cruise-speed slider](https://raw.githubusercontent.com/ArturoManzoli/cockpit/pr-assets-cruise-speed/docs/pr-assets/mini-widget-speed-slider.png)

Closes #2405
Closes #1487