### PR TITLE
Fix filename creation for non-integer UTC timezones offsets

### DIFF
--- a/src/electron/services/electron-log.ts
+++ b/src/electron/services/electron-log.ts
@@ -6,6 +6,8 @@ import { join } from 'path'
 
 import { type ElectronLog } from '@/types/electron-general'
 
+import { sanitizeFilenameComponent } from '../../libs/utils'
+
 // Import the same date format used in system-logging.ts
 const systemLogDateFormat = 'LLL dd, yyyy'
 const systemLogTimeFormat = 'HH꞉mm꞉ss O'
@@ -35,7 +37,10 @@ const getElectronLogsPath = (): string => {
  */
 export const setupElectronLogService = (): void => {
   // Configure file transport to create a new log file for each session
-  logger.transports.file.fileName = `Cockpit (${format(new Date(), systemLogDateTimeFormat)}).syslog`
+  // Sanitize because the `O` timezone token emits a real colon for non-integer UTC offsets (e.g. `GMT+5:30`), which is illegal on Windows and yields a 0KB file.
+  logger.transports.file.fileName = `Cockpit (${sanitizeFilenameComponent(
+    format(new Date(), systemLogDateTimeFormat)
+  )}).syslog`
   logger.transports.file.format = '[{y}-{m}-{d} {h}:{i}:{s}.{ms}] [{level}] {text}'
   logger.transports.file.maxSize = 10 * 1024 * 1024 // 10MB max file size
   logger.transports.file.archiveLog = (file) => file + '.old' // Archive old logs

--- a/src/libs/system-logging.ts
+++ b/src/libs/system-logging.ts
@@ -5,7 +5,7 @@ import localforage from 'localforage'
 import { settingsManager } from '@/libs/settings-management'
 import { systemLoggingEnablingKey } from '@/stores/development'
 
-import { isElectron } from './utils'
+import { isElectron, sanitizeFilenameComponent } from './utils'
 
 export const systemLogDateFormat = 'LLL dd, yyyy'
 export const systemLogTimeFormat = 'HH꞉mm꞉ss O'
@@ -20,7 +20,8 @@ export const cockpitSytemLogsDB = localforage.createInstance({
 })
 
 const initialTime = new Date()
-const fileName = `Cockpit (${format(initialTime, systemLogDateTimeFormat)}).syslog`
+// Sanitized to match the Electron syslog filename: the `O` timezone token emits a real colon for non-integer UTC offsets.
+const fileName = `Cockpit (${sanitizeFilenameComponent(format(initialTime, systemLogDateTimeFormat))}).syslog`
 
 /* eslint-disable jsdoc/require-jsdoc */
 

--- a/src/stores/snapshot.ts
+++ b/src/stores/snapshot.ts
@@ -177,7 +177,8 @@ export const useSnapshotStore = defineStore('snapshot', () => {
   }
 
   const snapshotFilename = (streamName: string, missionName = 'Cockpit'): string => {
-    const timeString = format(new Date(), 'LLL dd, yyyy - HH꞉mm꞉ss.SSS O')
+    // Sanitize because the `O` timezone token emits a real colon for non-integer UTC offsets (e.g. `GMT+5:30`), which is illegal on Windows and yields a 0KB file.
+    const timeString = sanitizeFilenameComponent(format(new Date(), 'LLL dd, yyyy - HH꞉mm꞉ss.SSS O'))
     const safeMissionName = sanitizeFilenameComponent(missionName) || 'Cockpit'
     const safeStreamName = sanitizeFilenameComponent(streamName) || 'workspace'
     return `${safeMissionName} (${timeString}) #${safeStreamName}.jpeg`

--- a/src/utils/video.ts
+++ b/src/utils/video.ts
@@ -1,5 +1,7 @@
 import { format } from 'date-fns'
 
+import { sanitizeFilenameComponent } from '../libs/utils'
+
 /**
  * Returns the filename for the video file.
  * Can be used with complete paths or just the filename. It will just replace the extension with .mp4.
@@ -9,7 +11,9 @@ import { format } from 'date-fns'
  * @returns {string} The filename for the video file.
  */
 export const videoFilename = (hash: string, creationDate: Date, missionName = 'Cockpit'): string => {
-  const timeString = format(creationDate, 'LLL dd, yyyy - HH꞉mm꞉ss O')
+  // Sanitize because the `O` timezone token renders non-integer UTC offsets with a real colon (e.g. `GMT+5:30`),
+  // which is illegal on Windows and gets parsed as an NTFS alternate data stream, yielding a 0KB output file.
+  const timeString = sanitizeFilenameComponent(format(creationDate, 'LLL dd, yyyy - HH꞉mm꞉ss O'))
   return `${missionName} (${timeString}) #${hash}.mp4`
 }
 


### PR DESCRIPTION
**Cause:**

- Generated filenames embedded date-fns' `O` timezone token without sanitizing it.
- Non-integer UTC offsets (e.g. IST `GMT+5:30`, Nepal `GMT+5:45`, Newfoundland `GMT-3:30`) render with a real colon.
- On Windows that colon in the path is parsed as an NTFS alternate data stream, so the written file ends up 0KB; macOS/Linux accept `:` as a normal filename character (which is why files recorded/exported on Windows still process fine there).
- Affects video recordings (`.mp4`), snapshots (`.jpeg` + thumbnail), and Electron system logs (`.syslog`).

**Fix:**

- Run the timestamp through `sanitizeFilenameComponent` in the video, snapshot, and Electron-log filename builders so the timezone colon becomes `_` (e.g. `GMT+5_30`).
- Leaves integer-offset zones, the `꞉` time separators, and derived `.ass`/`.jpeg` names unchanged, so there is no regression on macOS/Linux.

Closes #2764
