### PR TITLE
Fix editability of some data-lake variables

### DIFF
--- a/src/components/DataLakeVariableDialog.vue
+++ b/src/components/DataLakeVariableDialog.vue
@@ -2,11 +2,14 @@
   <v-dialog :model-value="modelValue" max-width="560px" @update:model-value="emit('update:modelValue', $event)">
     <v-card class="rounded-lg" :style="interfaceStore.globalGlassMenuStyles">
       <v-card-title class="text-h6 font-weight-bold py-4 text-center">
-        {{ editMode ? 'Edit Variable' : 'New Variable' }}
+        {{ valueOnlyEditMode ? 'Edit Variable Value' : editMode ? 'Edit Variable' : 'New Variable' }}
       </v-card-title>
       <v-card-text class="px-8">
         <div class="flex flex-col gap-4">
-          <div class="flex items-center gap-2">
+          <div v-if="valueOnlyEditMode" class="text-sm text-gray-300">
+            {{ variable.name }}
+          </div>
+          <div v-if="!valueOnlyEditMode" class="flex items-center gap-2">
             <v-text-field
               v-model="variable.id"
               label="Variable ID"
@@ -28,6 +31,7 @@
             />
           </div>
           <v-text-field
+            v-if="!valueOnlyEditMode"
             v-model="variable.name"
             label="Variable Name"
             variant="outlined"
@@ -35,7 +39,7 @@
             density="compact"
             hide-details
           />
-          <div class="flex items-center gap-2">
+          <div v-if="!valueOnlyEditMode" class="flex items-center gap-2">
             <label class="text-sm">Variable Type: </label>
             <v-radio-group
               v-model="variable.type"
@@ -51,7 +55,7 @@
           </div>
           <v-text-field
             v-model="initialValue"
-            :label="`Initial Value (${variable.type})`"
+            :label="valueOnlyEditMode ? `Value (${variable.type})` : `Initial Value (${variable.type})`"
             variant="outlined"
             :error-messages="valueError"
             density="compact"
@@ -59,6 +63,7 @@
             @input="validateValue"
           />
           <v-textarea
+            v-if="!valueOnlyEditMode"
             v-model="variable.description"
             label="Description"
             variant="outlined"
@@ -68,12 +73,14 @@
             hide-details
           />
           <v-checkbox
+            v-if="!valueOnlyEditMode"
             v-model="variable.persistent"
             label="Persist variable between boots"
             hide-details
             class="-mb-4 -mt-2"
           />
           <v-checkbox
+            v-if="!valueOnlyEditMode"
             v-model="variable.persistValue"
             class="-my-4"
             hide-details
@@ -127,6 +134,11 @@ const emit = defineEmits<{
 
 const interfaceStore = useAppInterfaceStore()
 const editMode = computed(() => !!props.idVariableBeingEdited)
+const valueOnlyEditMode = computed(() => {
+  if (!editMode.value || !props.idVariableBeingEdited) return false
+  const variableInfo = getDataLakeVariableInfo(props.idVariableBeingEdited)
+  return variableInfo?.allowUserToChangeValue === true && variableInfo?.persistent == null
+})
 const isManualIdEnabled = ref(false)
 const modelValue = toRef(props, 'modelValue')
 
@@ -248,6 +260,9 @@ const validateValue = (): boolean => {
  * Whether the form is valid and can be submitted
  */
 const isValid = computed(() => {
+  if (valueOnlyEditMode.value) {
+    return initialValue.value !== '' && !valueError.value
+  }
   return !!variable.name.trim() && !!variable.id && !valueError.value
 })
 
@@ -276,15 +291,21 @@ const saveVariable = (): void => {
     }
   }
 
-  const newVariable = { ...variable, allowUserToChangeValue: true }
-
-  if (editMode.value) {
-    updateDataLakeVariableInfo(newVariable)
+  if (valueOnlyEditMode.value) {
     if (parsedValue !== undefined) {
-      setDataLakeVariableData(newVariable.id, parsedValue)
+      setDataLakeVariableData(variable.id, parsedValue)
     }
   } else {
-    createDataLakeVariable(newVariable, parsedValue)
+    const newVariable = { ...variable, allowUserToChangeValue: true }
+
+    if (editMode.value) {
+      updateDataLakeVariableInfo(newVariable)
+      if (parsedValue !== undefined) {
+        setDataLakeVariableData(newVariable.id, parsedValue)
+      }
+    } else {
+      createDataLakeVariable(newVariable, parsedValue)
+    }
   }
 
   emit('saved')

--- a/src/components/DataLakeVariableDialog.vue
+++ b/src/components/DataLakeVariableDialog.vue
@@ -112,6 +112,7 @@ import {
   updateDataLakeVariableInfo,
 } from '@/libs/actions/data-lake'
 import { machinizeString } from '@/libs/utils'
+import { isUserDefinedDataLakeVariable } from '@/libs/utils-data-lake'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 
 /**
@@ -137,7 +138,7 @@ const editMode = computed(() => !!props.idVariableBeingEdited)
 const valueOnlyEditMode = computed(() => {
   if (!editMode.value || !props.idVariableBeingEdited) return false
   const variableInfo = getDataLakeVariableInfo(props.idVariableBeingEdited)
-  return variableInfo?.allowUserToChangeValue === true && variableInfo?.persistent == null
+  return variableInfo?.allowUserToChangeValue === true && !isUserDefinedDataLakeVariable(props.idVariableBeingEdited)
 })
 const isManualIdEnabled = ref(false)
 const modelValue = toRef(props, 'modelValue')
@@ -296,7 +297,7 @@ const saveVariable = (): void => {
       setDataLakeVariableData(variable.id, parsedValue)
     }
   } else {
-    const newVariable = { ...variable, allowUserToChangeValue: true }
+    const newVariable = { ...variable, allowUserToChangeValue: true, userDefined: true }
 
     if (editMode.value) {
       updateDataLakeVariableInfo(newVariable)

--- a/src/components/DataLakeVariableDialog.vue
+++ b/src/components/DataLakeVariableDialog.vue
@@ -216,7 +216,7 @@ watch(modelValue, (isOpen) => {
       variable.description = variableInfo.description || ''
       variable.persistent = variableInfo.persistent
       variable.persistValue = variableInfo.persistValue
-      initialValue.value = currentValue ? currentValue.toString() : ''
+      initialValue.value = currentValue !== undefined ? String(currentValue) : ''
     }
   }
 })

--- a/src/components/DataLakeVariableDialog.vue
+++ b/src/components/DataLakeVariableDialog.vue
@@ -2,11 +2,14 @@
   <v-dialog :model-value="modelValue" max-width="560px" @update:model-value="emit('update:modelValue', $event)">
     <v-card class="rounded-lg" :style="interfaceStore.globalGlassMenuStyles">
       <v-card-title class="text-h6 font-weight-bold py-4 text-center">
-        {{ editMode ? 'Edit Variable' : 'New Variable' }}
+        {{ valueOnlyEditMode ? 'Edit Variable Value' : editMode ? 'Edit Variable' : 'New Variable' }}
       </v-card-title>
       <v-card-text class="px-8">
         <div class="flex flex-col gap-4">
-          <div class="flex items-center gap-2">
+          <div v-if="valueOnlyEditMode" class="text-sm text-gray-300">
+            {{ variable.name }}
+          </div>
+          <div v-if="!valueOnlyEditMode" class="flex items-center gap-2">
             <v-text-field
               v-model="variable.id"
               label="Variable ID"
@@ -28,6 +31,7 @@
             />
           </div>
           <v-text-field
+            v-if="!valueOnlyEditMode"
             v-model="variable.name"
             label="Variable Name"
             variant="outlined"
@@ -35,7 +39,7 @@
             density="compact"
             hide-details
           />
-          <div class="flex items-center gap-2">
+          <div v-if="!valueOnlyEditMode" class="flex items-center gap-2">
             <label class="text-sm">Variable Type: </label>
             <v-radio-group
               v-model="variable.type"
@@ -51,7 +55,7 @@
           </div>
           <v-text-field
             v-model="initialValue"
-            :label="`Initial Value (${variable.type})`"
+            :label="valueOnlyEditMode ? `Value (${variable.type})` : `Initial Value (${variable.type})`"
             variant="outlined"
             :error-messages="valueError"
             density="compact"
@@ -59,6 +63,7 @@
             @input="validateValue"
           />
           <v-textarea
+            v-if="!valueOnlyEditMode"
             v-model="variable.description"
             label="Description"
             variant="outlined"
@@ -68,12 +73,14 @@
             hide-details
           />
           <v-checkbox
+            v-if="!valueOnlyEditMode"
             v-model="variable.persistent"
             label="Persist variable between boots"
             hide-details
             class="-mb-4 -mt-2"
           />
           <v-checkbox
+            v-if="!valueOnlyEditMode"
             v-model="variable.persistValue"
             class="-my-4"
             hide-details
@@ -105,6 +112,7 @@ import {
   updateDataLakeVariableInfo,
 } from '@/libs/actions/data-lake'
 import { machinizeString } from '@/libs/utils'
+import { isSystemOwnedDataLakeVariable } from '@/libs/utils-data-lake'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 
 /**
@@ -127,6 +135,10 @@ const emit = defineEmits<{
 
 const interfaceStore = useAppInterfaceStore()
 const editMode = computed(() => !!props.idVariableBeingEdited)
+const valueOnlyEditMode = computed(() => {
+  if (!props.idVariableBeingEdited) return false
+  return isSystemOwnedDataLakeVariable(props.idVariableBeingEdited)
+})
 const isManualIdEnabled = ref(false)
 const modelValue = toRef(props, 'modelValue')
 
@@ -248,6 +260,9 @@ const validateValue = (): boolean => {
  * Whether the form is valid and can be submitted
  */
 const isValid = computed(() => {
+  if (valueOnlyEditMode.value) {
+    return initialValue.value !== '' && !valueError.value
+  }
   return !!variable.name.trim() && !!variable.id && !valueError.value
 })
 
@@ -277,15 +292,21 @@ const saveVariable = (): void => {
     }
   }
 
-  const newVariable = { ...variable, allowUserToChangeValue: true }
-
-  if (editMode.value) {
-    updateDataLakeVariableInfo(newVariable)
+  if (valueOnlyEditMode.value) {
     if (parsedValue !== undefined) {
-      setDataLakeVariableData(newVariable.id, parsedValue)
+      setDataLakeVariableData(variable.id, parsedValue)
     }
   } else {
-    createDataLakeVariable(newVariable, parsedValue)
+    const newVariable = { ...variable, allowUserToChangeValue: true, systemOwned: false }
+
+    if (editMode.value) {
+      updateDataLakeVariableInfo(newVariable)
+      if (parsedValue !== undefined) {
+        setDataLakeVariableData(newVariable.id, parsedValue)
+      }
+    } else {
+      createDataLakeVariable(newVariable, parsedValue)
+    }
   }
 
   emit('saved')

--- a/src/components/InputElementConfig.vue
+++ b/src/components/InputElementConfig.vue
@@ -520,6 +520,7 @@ const saveOrUpdateParameter = (): void => {
     description: futureDataLakeVariable.value?.description,
     persistent: true,
     allowUserToChangeValue: true,
+    systemOwned: false,
   }
   if (
     currentElement.value &&

--- a/src/components/TransformingFunctionDialog.vue
+++ b/src/components/TransformingFunctionDialog.vue
@@ -215,8 +215,10 @@ const saveTransformingFunction = (): void => {
   try {
     if (editingExistingFunction.value && props.editFunction) {
       const { ...otherProps } = newFunction.value
+      // The edited function is spread first so the fields the form does not show, the provenance stamp among them,
+      // survive the edit instead of turning a Cockpit-created function into the user's own.
       updateTransformingFunction({
-        id: props.editFunction.id,
+        ...props.editFunction,
         ...otherProps,
       })
     } else {
@@ -225,7 +227,8 @@ const saveTransformingFunction = (): void => {
         newFunction.value.name,
         newFunction.value.type,
         newFunction.value.expression,
-        newFunction.value.description
+        newFunction.value.description,
+        { systemOwned: false }
       )
     }
   } catch (error) {

--- a/src/components/custom-widget-elements/Checkbox.vue
+++ b/src/components/custom-widget-elements/Checkbox.vue
@@ -61,6 +61,7 @@ import {
   setDataLakeVariableData,
   unlistenDataLakeVariable,
 } from '@/libs/actions/data-lake'
+import { isCompoundDataLakeVariable } from '@/libs/actions/data-lake-transformations'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
 import { CustomWidgetElementOptions, CustomWidgetElementType } from '@/types/widgets'
 
@@ -107,7 +108,9 @@ const isConnected = computed(() => {
 })
 
 const isInput = computed(() => {
-  return miniWidget.value.options.dataLakeVariable?.allowUserToChangeValue === true
+  const variable = miniWidget.value.options.dataLakeVariable
+  if (variable === undefined) return false
+  return variable.allowUserToChangeValue === true && !isCompoundDataLakeVariable(variable.id)
 })
 
 const isInteractive = computed(() => {

--- a/src/components/custom-widget-elements/Dial.vue
+++ b/src/components/custom-widget-elements/Dial.vue
@@ -125,6 +125,7 @@ import {
   setDataLakeVariableData,
   unlistenDataLakeVariable,
 } from '@/libs/actions/data-lake'
+import { isCompoundDataLakeVariable } from '@/libs/actions/data-lake-transformations'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
 import { CustomWidgetElementOptions, CustomWidgetElementType } from '@/types/widgets'
 
@@ -194,7 +195,9 @@ const isConnected = computed(() => {
 })
 
 const isInput = computed(() => {
-  return miniWidget.value.options.dataLakeVariable?.allowUserToChangeValue === true
+  const variable = miniWidget.value.options.dataLakeVariable
+  if (variable === undefined) return false
+  return variable.allowUserToChangeValue === true && !isCompoundDataLakeVariable(variable.id)
 })
 
 const isInteractive = computed(() => {

--- a/src/components/custom-widget-elements/Dropdown.vue
+++ b/src/components/custom-widget-elements/Dropdown.vue
@@ -60,6 +60,7 @@ import {
   setDataLakeVariableData,
   unlistenDataLakeVariable,
 } from '@/libs/actions/data-lake'
+import { isCompoundDataLakeVariable } from '@/libs/actions/data-lake-transformations'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
 import { CustomWidgetElementOptions, CustomWidgetElementType, SelectorOption } from '@/types/widgets'
 
@@ -129,7 +130,9 @@ const isConnected = computed(() => {
 })
 
 const isInput = computed(() => {
-  return miniWidget.value.options.dataLakeVariable?.allowUserToChangeValue === true
+  const variable = miniWidget.value.options.dataLakeVariable
+  if (variable === undefined) return false
+  return variable.allowUserToChangeValue === true && !isCompoundDataLakeVariable(variable.id)
 })
 
 const isInteractive = computed(() => {

--- a/src/components/custom-widget-elements/Slider.vue
+++ b/src/components/custom-widget-elements/Slider.vue
@@ -67,6 +67,7 @@ import {
   setDataLakeVariableData,
   unlistenDataLakeVariable,
 } from '@/libs/actions/data-lake'
+import { isCompoundDataLakeVariable } from '@/libs/actions/data-lake-transformations'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
 import { CustomWidgetElementOptions, CustomWidgetElementType } from '@/types/widgets'
 
@@ -118,7 +119,9 @@ const isConnected = computed(() => {
 })
 
 const isInput = computed(() => {
-  return miniWidget.value.options.dataLakeVariable?.allowUserToChangeValue === true
+  const variable = miniWidget.value.options.dataLakeVariable
+  if (variable === undefined) return false
+  return variable.allowUserToChangeValue === true && !isCompoundDataLakeVariable(variable.id)
 })
 
 const isInteractive = computed(() => {

--- a/src/components/custom-widget-elements/Switch.vue
+++ b/src/components/custom-widget-elements/Switch.vue
@@ -61,6 +61,7 @@ import {
   setDataLakeVariableData,
   unlistenDataLakeVariable,
 } from '@/libs/actions/data-lake'
+import { isCompoundDataLakeVariable } from '@/libs/actions/data-lake-transformations'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
 import { CustomWidgetElementOptions, CustomWidgetElementType } from '@/types/widgets'
 
@@ -99,7 +100,9 @@ const isConnected = computed(() => {
 })
 
 const isInput = computed(() => {
-  return miniWidget.value.options.dataLakeVariable?.allowUserToChangeValue === true
+  const variable = miniWidget.value.options.dataLakeVariable
+  if (variable === undefined) return false
+  return variable.allowUserToChangeValue === true && !isCompoundDataLakeVariable(variable.id)
 })
 
 const isInteractive = computed(() => {

--- a/src/libs/actions/data-lake-transformations.ts
+++ b/src/libs/actions/data-lake-transformations.ts
@@ -293,6 +293,17 @@ export const getAllTransformingFunctions = (): TransformingFunction[] => {
 }
 
 /**
+ * Whether a data lake variable is backed by a transforming function, which computes its value from an expression.
+ * Nobody writes such a variable, so a control that does — a joystick mapping or a widget element — has its write
+ * undone at the next evaluation, and should offer to read it rather than to set it.
+ * @param {string} id - ID of the variable
+ * @returns {boolean} True when a transforming function backs the variable
+ */
+export const isCompoundDataLakeVariable = (id: string): boolean => {
+  return globalTransformingFunctions.some((func) => func.id === id)
+}
+
+/**
  * Updates a transforming function
  * @param {TransformingFunction} func - The function to update
  * @throws {Error} If the id is empty, the expression is not a string, or no stored function has that id

--- a/src/libs/actions/data-lake-transformations.ts
+++ b/src/libs/actions/data-lake-transformations.ts
@@ -56,7 +56,11 @@ const loadTransformingFunctions = (): void => {
   const storedFunctions = transformingFunctions as TransformingFunction[]
   // Stored ids are normalised on the way in too, so an entry a previous version wrote as ' my id ' still
   // matches the trimmed id an update carries, instead of silently saving nothing.
-  globalTransformingFunctions = storedFunctions.filter((func) => isUsableTransformingFunction(func)).map(withTrimmedId)
+  // Ownership is assumed to be Cockpit's when unsaid, but an entry stored before the flag existed cannot be told
+  // apart from one the user wrote, so it is read as theirs and Cockpit reclaims its own through the setup routines.
+  globalTransformingFunctions = storedFunctions
+    .filter((func) => isUsableTransformingFunction(func))
+    .map((func) => ({ systemOwned: false, ...withTrimmedId(func) }))
   unusableTransformingFunctions = storedFunctions.filter((func) => !isUsableTransformingFunction(func))
   const droppedCount = unusableTransformingFunctions.length
   if (droppedCount > 0) {
@@ -259,7 +263,14 @@ export interface TransformingFunction {
   description?: string
   /** JavaScript expression that defines how to calculate the new variable */
   expression: string
+  /** Whether Cockpit created the function, rather than the user. Assumed when absent, as with any variable */
+  systemOwned?: boolean
+  /** Whether the user may change the expression from the Data Lake page, which Cockpit's are otherwise not */
+  allowUserToChangeValue?: boolean
 }
+
+/** Who a function belongs to and what the user may do with it, mirrored onto the data lake variable backing it */
+type TransformingFunctionFlags = Pick<TransformingFunction, 'systemOwned' | 'allowUserToChangeValue'>
 
 /**
  * Creates a new transforming function that listens to its dependencies
@@ -269,6 +280,7 @@ export interface TransformingFunction {
  * @param {'string' | 'number' | 'boolean'} type - Type of the new variable
  * @param {string} expression - Expression to calculate the variable's value
  * @param {string?} description - Description of the new variable
+ * @param {TransformingFunctionFlags?} flags - Who the function belongs to and what the user may do with it
  * @throws {Error} If the id is empty or the expression is not a string
  */
 export const createTransformingFunction = (
@@ -276,11 +288,34 @@ export const createTransformingFunction = (
   name: string,
   type: DataLakeVariableType,
   expression: string,
-  description?: string
+  description?: string,
+  flags?: TransformingFunctionFlags
 ): void => {
-  const transformingFunction = usableTransformingFunctionOrThrow({ name, id, type, expression, description })
+  const transformingFunction = usableTransformingFunctionOrThrow({ name, id, type, expression, description, ...flags })
   globalTransformingFunctions.push(transformingFunction)
-  createDataLakeVariable({ id: transformingFunction.id, name, type, description })
+  createDataLakeVariable({ id: transformingFunction.id, name, type, description, ...flags })
+  saveTransformingFunctions()
+}
+
+/**
+ * Creates a transforming function Cockpit owns, or, when one with that id is already stored, records that it is
+ * Cockpit's. Functions stored by a version that did not track this would otherwise pass as the user's own forever.
+ * The stored expression is left alone, since the user may have tuned it, and the write is idempotent, so the setup
+ * routines can call this on every boot.
+ * @param {TransformingFunction} func - The function Cockpit wants to exist
+ * @throws {Error} If the id is empty or the expression is not a string
+ */
+export const ensureCockpitTransformingFunction = (func: TransformingFunction): void => {
+  const flags = { systemOwned: true, allowUserToChangeValue: func.allowUserToChangeValue === true }
+  const stored = globalTransformingFunctions.find((f) => f.id === func.id)
+
+  if (stored === undefined) {
+    createTransformingFunction(func.id, func.name, func.type, func.expression, func.description, flags)
+    return
+  }
+
+  if (stored.systemOwned === true && stored.allowUserToChangeValue === flags.allowUserToChangeValue) return
+  Object.assign(stored, flags)
   saveTransformingFunctions()
 }
 

--- a/src/libs/actions/data-lake.ts
+++ b/src/libs/actions/data-lake.ts
@@ -77,10 +77,18 @@ export const createDataLakeVariable = (variable: DataLakeVariable, initialValue?
     console.warn(`Cockpit action variable with id '${variable.id}' already exists. Updating it.`)
   }
   dataLakeVariableInfo[variable.id] = variable
-  dataLakeVariableData[variable.id] = initialValue
 
-  // Initialize timestamp if initial value is provided
-  if (initialValue !== undefined) {
+  let valueToSet = initialValue
+  if (variable.persistValue) {
+    const savedValues = settingsManager.getKeyValue(persistentValuesKey)
+    if (savedValues && typeof savedValues === 'object' && savedValues[variable.id] !== undefined) {
+      valueToSet = savedValues[variable.id] as string | number | boolean
+    }
+  }
+  dataLakeVariableData[variable.id] = valueToSet
+
+  // Initialize timestamp if a value is being set
+  if (valueToSet !== undefined) {
     dataLakeVariableTimestamps[variable.id] = performance.now()
   }
 
@@ -88,7 +96,7 @@ export const createDataLakeVariable = (variable: DataLakeVariable, initialValue?
     savePersistentVariables()
   }
 
-  if (variable.persistValue && initialValue !== undefined) {
+  if (variable.persistValue && valueToSet !== undefined) {
     savePersistentValues()
   }
 

--- a/src/libs/actions/data-lake.ts
+++ b/src/libs/actions/data-lake.ts
@@ -49,9 +49,14 @@ const savePersistentVariables = (): void => {
   settingsManager.setKeyValue(persistentVariablesKey, persistentVariables)
 }
 
-// Save persistent values to localStorage
+const getPersistentValues = (): Record<string, string | number | boolean> => {
+  return settingsManager.getKeyValue<Record<string, string | number | boolean>>(persistentValuesKey) ?? {}
+}
+
+// Save persistent values to localStorage. Merges into the stored object instead of rebuilding it, as a call made
+// before every persistValue variable is registered would otherwise drop the values of the missing ones.
 const savePersistentValues = (): void => {
-  const persistentValuesObj: Record<string, string | number | boolean> = {}
+  const persistentValuesObj = getPersistentValues()
 
   Object.entries(dataLakeVariableInfo)
     .filter(([, variable]) => variable?.persistValue)
@@ -77,10 +82,18 @@ export const createDataLakeVariable = (variable: DataLakeVariable, initialValue?
     console.warn(`Cockpit action variable with id '${variable.id}' already exists. Updating it.`)
   }
   dataLakeVariableInfo[variable.id] = variable
-  dataLakeVariableData[variable.id] = initialValue
 
-  // Initialize timestamp if initial value is provided
-  if (initialValue !== undefined) {
+  let valueToSet = initialValue
+  if (variable.persistValue) {
+    const savedValue = getPersistentValues()[variable.id]
+    if (savedValue !== undefined) {
+      valueToSet = savedValue
+    }
+  }
+  dataLakeVariableData[variable.id] = valueToSet
+
+  // Initialize timestamp if a value is being set
+  if (valueToSet !== undefined) {
     dataLakeVariableTimestamps[variable.id] = performance.now()
   }
 
@@ -88,7 +101,7 @@ export const createDataLakeVariable = (variable: DataLakeVariable, initialValue?
     savePersistentVariables()
   }
 
-  if (variable.persistValue && initialValue !== undefined) {
+  if (variable.persistValue && valueToSet !== undefined) {
     savePersistentValues()
   }
 
@@ -151,7 +164,9 @@ export const deleteDataLakeVariable = (id: string): void => {
 
   // If variable had persistValue, update the persisted values
   if (variable && variable?.persistValue) {
-    savePersistentValues()
+    const persistentValues = getPersistentValues()
+    delete persistentValues[id]
+    settingsManager.setKeyValue(persistentValuesKey, persistentValues)
   }
 
   notifyDataLakeVariableInfoListeners()

--- a/src/libs/actions/data-lake.ts
+++ b/src/libs/actions/data-lake.ts
@@ -26,7 +26,9 @@ const loadPersistentVariables = (): void => {
 
   if (savedVariables && Array.isArray(savedVariables)) {
     savedVariables.forEach((variable) => {
-      dataLakeVariableInfo[variable.id] = variable
+      // Ownership is assumed to be Cockpit's when unsaid, but only the dialogs that create a variable on the user's
+      // behalf ever store one here, so an entry that predates the flag is theirs rather than Cockpit's.
+      dataLakeVariableInfo[variable.id] = { systemOwned: false, ...variable }
     })
   }
 

--- a/src/libs/joystick/protocols/predefined-resources.ts
+++ b/src/libs/joystick/protocols/predefined-resources.ts
@@ -14,16 +14,21 @@ export let mavlinkCameraZoomActionId: string | undefined = undefined
 export let mavlinkCameraFocusActionId: string | undefined = undefined
 
 export const setupMavlinkCameraResources = (): void => {
-  const commonVariableConfig = { type: 'number' as DataLakeVariableType, allowUserToChangeValue: true }
+  const commonVariableConfig = { type: 'number' as DataLakeVariableType }
+  const speedVariableConfig = {
+    type: 'number' as DataLakeVariableType,
+    allowUserToChangeValue: true,
+    persistValue: true,
+  }
   // Initialize camera zoom variables
   createDataLakeVariable({ id: 'camera-zoom-decrease', name: 'Camera Zoom Decrease', ...commonVariableConfig }, 0)
   createDataLakeVariable({ id: 'camera-zoom-increase', name: 'Camera Zoom Increase', ...commonVariableConfig }, 0)
-  createDataLakeVariable({ id: 'camera-zoom-speed', name: 'Camera Zoom Speed', ...commonVariableConfig }, 3)
+  createDataLakeVariable({ id: 'camera-zoom-speed', name: 'Camera Zoom Speed', ...speedVariableConfig }, 3)
 
   // Initialize camera focus variables
   createDataLakeVariable({ id: 'camera-focus-decrease', name: 'Camera Focus Decrease', ...commonVariableConfig }, 0)
   createDataLakeVariable({ id: 'camera-focus-increase', name: 'Camera Focus Increase', ...commonVariableConfig }, 0)
-  createDataLakeVariable({ id: 'camera-focus-speed', name: 'Camera Focus Speed', ...commonVariableConfig }, 3)
+  createDataLakeVariable({ id: 'camera-focus-speed', name: 'Camera Focus Speed', ...speedVariableConfig }, 3)
 
   // Initialize camera zoom transforming function
   try {

--- a/src/libs/joystick/protocols/predefined-resources.ts
+++ b/src/libs/joystick/protocols/predefined-resources.ts
@@ -42,15 +42,16 @@ export const joystickInputAxes: Record<(typeof joystickAxisConfig)[number]['key'
 
 const setupMavlinkCameraResources = (): void => {
   const commonVariableConfig = { type: 'number' as DataLakeVariableType, allowUserToChangeValue: true }
+  const speedVariableConfig = { ...commonVariableConfig, persistValue: true }
   // Initialize camera zoom variables
   createDataLakeVariable({ id: 'camera-zoom-decrease', name: 'Camera Zoom Decrease', ...commonVariableConfig }, 0)
   createDataLakeVariable({ id: 'camera-zoom-increase', name: 'Camera Zoom Increase', ...commonVariableConfig }, 0)
-  createDataLakeVariable({ id: 'camera-zoom-speed', name: 'Camera Zoom Speed', ...commonVariableConfig }, 3)
+  createDataLakeVariable({ id: 'camera-zoom-speed', name: 'Camera Zoom Speed', ...speedVariableConfig }, 3)
 
   // Initialize camera focus variables
   createDataLakeVariable({ id: 'camera-focus-decrease', name: 'Camera Focus Decrease', ...commonVariableConfig }, 0)
   createDataLakeVariable({ id: 'camera-focus-increase', name: 'Camera Focus Increase', ...commonVariableConfig }, 0)
-  createDataLakeVariable({ id: 'camera-focus-speed', name: 'Camera Focus Speed', ...commonVariableConfig }, 3)
+  createDataLakeVariable({ id: 'camera-focus-speed', name: 'Camera Focus Speed', ...speedVariableConfig }, 3)
 
   // Initialize camera zoom transforming function
   try {

--- a/src/libs/joystick/protocols/predefined-resources.ts
+++ b/src/libs/joystick/protocols/predefined-resources.ts
@@ -1,6 +1,6 @@
 import { getAllActionLinks, saveActionLink } from '@/libs/actions/action-links'
 import { createDataLakeVariable, DataLakeVariableType } from '@/libs/actions/data-lake'
-import { createTransformingFunction, getAllTransformingFunctions } from '@/libs/actions/data-lake-transformations'
+import { ensureCockpitTransformingFunction } from '@/libs/actions/data-lake-transformations'
 import {
   getAllMavlinkMessageActionConfigs,
   registerMavlinkMessageActionConfig,
@@ -55,38 +55,36 @@ const setupMavlinkCameraResources = (): void => {
 
   // Initialize camera zoom transforming function
   try {
-    const func = getAllTransformingFunctions().find((f) => f.id === 'camera-zoom')
-    if (!func) {
-      createTransformingFunction(
-        'camera-zoom',
-        'Camera Zoom',
-        'number',
-        getUnindentedString(`
-          const zoom = ({{camera-zoom-increase}} - {{camera-zoom-decrease}}) * {{camera-zoom-speed}}
-          return zoom < 0.05 && zoom > -0.05 ? 0 : Math.max(Math.min(1, zoom), -1)
-        `),
-        'Used to control the camera zoom. The value is the difference between {{camera-zoom-increase}} and {{camera-zoom-decrease}}, multiplied by {{camera-zoom-speed}}.'
-      )
-    }
+    ensureCockpitTransformingFunction({
+      id: 'camera-zoom',
+      name: 'Camera Zoom',
+      type: 'number',
+      expression: getUnindentedString(`
+        const zoom = ({{camera-zoom-increase}} - {{camera-zoom-decrease}}) * {{camera-zoom-speed}}
+        return zoom < 0.05 && zoom > -0.05 ? 0 : Math.max(Math.min(1, zoom), -1)
+      `),
+      description:
+        'Used to control the camera zoom. The value is the difference between {{camera-zoom-increase}} and {{camera-zoom-decrease}}, multiplied by {{camera-zoom-speed}}.',
+      allowUserToChangeValue: true,
+    })
   } catch (error) {
     console.error('Error creating camera zoom transforming function:', error)
   }
 
   // Initialize camera focus transforming function
   try {
-    const func = getAllTransformingFunctions().find((f) => f.id === 'camera-focus')
-    if (!func) {
-      createTransformingFunction(
-        'camera-focus',
-        'Camera Focus',
-        'number',
-        getUnindentedString(`
-          const focus = ({{camera-focus-increase}} - {{camera-focus-decrease}}) * {{camera-focus-speed}}
-          return focus < 0.05 && focus > -0.05 ? 0 : Math.max(Math.min(1, focus), -1)
-        `),
-        'Used to control the camera focus. The value is the difference between {{camera-focus-increase}} and {{camera-focus-decrease}}, multiplied by {{camera-focus-speed}}.'
-      )
-    }
+    ensureCockpitTransformingFunction({
+      id: 'camera-focus',
+      name: 'Camera Focus',
+      type: 'number',
+      expression: getUnindentedString(`
+        const focus = ({{camera-focus-increase}} - {{camera-focus-decrease}}) * {{camera-focus-speed}}
+        return focus < 0.05 && focus > -0.05 ? 0 : Math.max(Math.min(1, focus), -1)
+      `),
+      description:
+        'Used to control the camera focus. The value is the difference between {{camera-focus-increase}} and {{camera-focus-decrease}}, multiplied by {{camera-focus-speed}}.',
+      allowUserToChangeValue: true,
+    })
   } catch (error) {
     console.error('Error creating camera focus transforming function:', error)
   }
@@ -163,16 +161,14 @@ const setupJoystickAxesResources = (): void => {
     createDataLakeVariable({ id: axis.inputId, name: axis.name, ...commonVariableConfig }, 0)
 
     try {
-      const existing = getAllTransformingFunctions().find((f) => f.id === axis.outputId)
-      if (!existing) {
-        createTransformingFunction(
-          axis.outputId,
-          `${axis.name} Output`,
-          'number',
-          `{{${axis.inputId}}}`,
-          `Output value for MANUAL_CONTROL ${axis.name}.`
-        )
-      }
+      ensureCockpitTransformingFunction({
+        id: axis.outputId,
+        name: `${axis.name} Output`,
+        type: 'number',
+        expression: `{{${axis.inputId}}}`,
+        description: `Output value for MANUAL_CONTROL ${axis.name}.`,
+        allowUserToChangeValue: true,
+      })
     } catch (error) {
       console.error(`Error creating transforming function for ${axis.name}:`, error)
     }

--- a/src/libs/poi/poi-data-lake.ts
+++ b/src/libs/poi/poi-data-lake.ts
@@ -56,13 +56,17 @@ const ensureCoordinateFunction = (variableId: string, name: string, source: PoiC
   const existing = getAllTransformingFunctions().find((func) => func.id === variableId)
 
   if (existing) {
-    if (existing.expression !== expression || existing.name !== name) {
-      updateTransformingFunction({ ...existing, name, type: 'number', expression })
+    // The Cockpit flag is part of the comparison so POI functions stored before it existed stop passing as the
+    // user's own, which would offer them edit and delete actions the POI manager immediately undoes.
+    if (existing.expression !== expression || existing.name !== name || existing.systemOwned !== true) {
+      updateTransformingFunction({ ...existing, name, type: 'number', expression, systemOwned: true })
     }
     return
   }
 
-  createTransformingFunction(variableId, name, 'number', expression)
+  // Stored explicitly rather than left to the default, so the next boot reads it back as Cockpit's instead of
+  // taking it for a pre-flag entry and rewriting every POI function on startup.
+  createTransformingFunction(variableId, name, 'number', expression, undefined, { systemOwned: true })
 }
 
 /**

--- a/src/libs/utils-data-lake.ts
+++ b/src/libs/utils-data-lake.ts
@@ -1,4 +1,23 @@
+import { type DataLakeVariable } from '@/types/data-lake'
+
 import { getDataLakeVariableData, getDataLakeVariableInfo } from './actions/data-lake'
+
+/** ID prefix for variables created through the Data Lake menu. */
+export const userDefinedDataLakeVariableIdPrefix = 'user/custom/'
+
+const normalizeDataLakeVariableId = (id: string): string => id.trimStart().replace(/^\/+/, '')
+
+/**
+ * Whether a data lake variable was created by the user through the Data Lake menu.
+ * @param {string | DataLakeVariable} variableOrId Variable info or its ID
+ * @returns {boolean} True when the variable is user-defined
+ */
+export const isUserDefinedDataLakeVariable = (variableOrId: string | DataLakeVariable): boolean => {
+  const id = typeof variableOrId === 'string' ? variableOrId : variableOrId.id
+  const info = typeof variableOrId === 'string' ? getDataLakeVariableInfo(id) : variableOrId
+  const normalizedId = normalizeDataLakeVariableId(id)
+  return info?.userDefined === true || normalizedId.startsWith(userDefinedDataLakeVariableIdPrefix)
+}
 
 /**
  * Guess the type of a string

--- a/src/libs/utils-data-lake.ts
+++ b/src/libs/utils-data-lake.ts
@@ -1,6 +1,38 @@
 import { getDataLakeVariableData, getDataLakeVariableInfo } from './actions/data-lake'
 
 /**
+ * Whether Cockpit created a data lake variable, rather than the user. Assumed of any variable that does not say
+ * otherwise, since Cockpit creates almost every variable there is; the ones loaded from storage are told apart when
+ * read, as they predate this being recorded.
+ * @param {string} id ID of the variable
+ * @returns {boolean} True when Cockpit created the variable
+ */
+export const isSystemOwnedDataLakeVariable = (id: string): boolean => {
+  return getDataLakeVariableInfo(id)?.systemOwned !== false
+}
+
+/**
+ * Whether the user may change a data lake variable from the Data Lake page. Their own are always theirs to change;
+ * of Cockpit's, only the ones whose value or expression is meant to be set by the user.
+ * @param {string} id ID of the variable
+ * @returns {boolean} True when the variable may be changed by the user
+ */
+export const canUserChangeDataLakeVariable = (id: string): boolean => {
+  const info = getDataLakeVariableInfo(id)
+  if (info === undefined) return false
+  return info.systemOwned === false || info.allowUserToChangeValue === true
+}
+
+/**
+ * Whether the user may delete a data lake variable, which only their own ever are.
+ * @param {string} id ID of the variable
+ * @returns {boolean} True when the variable is the user's own
+ */
+export const canUserDeleteDataLakeVariable = (id: string): boolean => {
+  return getDataLakeVariableInfo(id) !== undefined && !isSystemOwnedDataLakeVariable(id)
+}
+
+/**
  * Guess the type of a string
  * @param {string} str The string to guess the type of
  * @returns {'boolean' | 'number' | 'string'} The guessed type of the string

--- a/src/libs/vehicle/mavlink/vehicle.ts
+++ b/src/libs/vehicle/mavlink/vehicle.ts
@@ -8,7 +8,7 @@ import {
   getDataLakeVariableInfo,
   setDataLakeVariableData,
 } from '@/libs/actions/data-lake'
-import { createTransformingFunction, getAllTransformingFunctions } from '@/libs/actions/data-lake-transformations'
+import { ensureCockpitTransformingFunction } from '@/libs/actions/data-lake-transformations'
 import { sendMavlinkMessage } from '@/libs/communication/mavlink'
 import type { MAVLinkMessageDictionary, Package, Type } from '@/libs/connection/m2r/messages/mavlink2rest'
 import {
@@ -1565,16 +1565,14 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
 
     // read-only clone of autopilotSystemId using old name, for legacy support
     try {
-      const existsAlready = getAllTransformingFunctions().find((f) => f.id === 'ardupilotSystemId')
-      if (!existsAlready) {
-        createTransformingFunction(
-          'ardupilotSystemId',
-          '(Legacy) ArduPilot System ID',
-          'number',
-          '{{autopilotSystemId}}',
-          "A read-only clone of the autopilot's system ID, for legacy support of the old variable name. New applications should use autopilotSystemId instead."
-        )
-      }
+      ensureCockpitTransformingFunction({
+        id: 'ardupilotSystemId',
+        name: '(Legacy) ArduPilot System ID',
+        type: 'number',
+        expression: '{{autopilotSystemId}}',
+        description:
+          "A read-only clone of the autopilot's system ID, for legacy support of the old variable name. New applications should use autopilotSystemId instead.",
+      })
     } catch (error) {
       console.error('Error creating ArduPilot system ID fallback:', error)
     }

--- a/src/tests/libs/actions/data-lake-transformations.test.ts
+++ b/src/tests/libs/actions/data-lake-transformations.test.ts
@@ -1,0 +1,67 @@
+import { expect, test, vi } from 'vitest'
+
+import { type TransformingFunction } from '@/libs/actions/data-lake-transformations'
+
+const transformingFunctionsKey = 'cockpit-transforming-functions'
+
+// A function stored by a Cockpit version that did not record who owned it, plus one the user actually made.
+const storage: Record<string, unknown> = {
+  [transformingFunctionsKey]: [
+    { id: 'camera-zoom', name: 'Camera Zoom', type: 'number', expression: '1' },
+    { id: 'user/compound/mine', name: 'Mine', type: 'number', expression: '2' },
+  ],
+}
+
+vi.mock('@/libs/settings-management', () => ({
+  settingsManager: {
+    getKeyValue: (key: string): unknown => storage[key],
+    setKeyValue: (key: string, value: unknown): void => {
+      storage[key] = structuredClone(value)
+    },
+  },
+}))
+
+const storedFunction = (id: string): TransformingFunction =>
+  (storage[transformingFunctionsKey] as TransformingFunction[]).find((func) => func.id === id) as TransformingFunction
+
+test("an already stored function is recorded as Cockpit's, keeping the expression the user may have tuned", async () => {
+  const { ensureCockpitTransformingFunction, getAllTransformingFunctions } = await import(
+    '@/libs/actions/data-lake-transformations'
+  )
+
+  ensureCockpitTransformingFunction({
+    id: 'camera-zoom',
+    name: 'Camera Zoom',
+    type: 'number',
+    expression: 'the default expression',
+    allowUserToChangeValue: true,
+  })
+
+  expect(storedFunction('camera-zoom')).toMatchObject({
+    expression: '1',
+    systemOwned: true,
+    allowUserToChangeValue: true,
+  })
+  // Read as the user's, since a pre-flag entry cannot be told from one they wrote, and assuming otherwise would
+  // take their own compound variables away from them.
+  expect(storedFunction('user/compound/mine').systemOwned).toBe(false)
+  expect(getAllTransformingFunctions()).toHaveLength(2)
+})
+
+test('a function Cockpit has not stored yet is created already recorded as its own', async () => {
+  const { ensureCockpitTransformingFunction } = await import('@/libs/actions/data-lake-transformations')
+
+  ensureCockpitTransformingFunction({
+    id: 'outputs/mavlink/axis-x',
+    name: 'Axis X Output',
+    type: 'number',
+    expression: '3',
+    allowUserToChangeValue: true,
+  })
+
+  expect(storedFunction('outputs/mavlink/axis-x')).toMatchObject({
+    expression: '3',
+    systemOwned: true,
+    allowUserToChangeValue: true,
+  })
+})

--- a/src/tests/libs/actions/data-lake-transformations.test.ts
+++ b/src/tests/libs/actions/data-lake-transformations.test.ts
@@ -65,3 +65,26 @@ test('a function Cockpit has not stored yet is created already recorded as its o
     allowUserToChangeValue: true,
   })
 })
+
+test('what is recorded reaches the data lake variable the page reads, which is what gates the actions', async () => {
+  const { ensureCockpitTransformingFunction, isCompoundDataLakeVariable } = await import(
+    '@/libs/actions/data-lake-transformations'
+  )
+  const { canUserChangeDataLakeVariable, canUserDeleteDataLakeVariable } = await import('@/libs/utils-data-lake')
+
+  const legacySystemId = { id: 'ardupilotSystemId', name: '(Legacy) ArduPilot System ID', type: 'number' as const }
+  ensureCockpitTransformingFunction({ ...legacySystemId, expression: '{{autopilotSystemId}}' })
+  // Claimed here too rather than relying on the first test having run, so this one passes on its own.
+  const cameraZoom = { id: 'camera-zoom', name: 'Camera Zoom', type: 'number' as const, expression: '1' }
+  ensureCockpitTransformingFunction({ ...cameraZoom, allowUserToChangeValue: true })
+
+  // Cockpit's compound variables are never the user's to delete, whether or not it may change them.
+  expect(canUserDeleteDataLakeVariable('ardupilotSystemId')).toBe(false)
+  expect(canUserDeleteDataLakeVariable('camera-zoom')).toBe(false)
+  expect(canUserChangeDataLakeVariable('camera-zoom')).toBe(true)
+  expect(canUserDeleteDataLakeVariable('user/compound/mine')).toBe(true)
+
+  // No control may write to a computed variable, however changeable the page considers it.
+  expect(isCompoundDataLakeVariable('camera-zoom')).toBe(true)
+  expect(isCompoundDataLakeVariable('camera-zoom-speed')).toBe(false)
+})

--- a/src/tests/libs/actions/data-lake.test.ts
+++ b/src/tests/libs/actions/data-lake.test.ts
@@ -3,8 +3,12 @@ import { expect, test, vi } from 'vitest'
 import { type DataLakeVariable } from '@/types/data-lake'
 
 const persistentValuesKey = 'cockpit-persistent-data-lake-values'
+const persistentVariablesKey = 'cockpit-persistent-data-lake-variables'
 const storage: Record<string, unknown> = {
   [persistentValuesKey]: { 'camera-zoom-speed': 7, 'camera-focus-speed': 5 },
+  // Stored by a Cockpit version that did not record who made a variable. Only the dialogs that create one on the
+  // user's behalf ever write to this key, since Cockpit's own are never `persistent`.
+  [persistentVariablesKey]: [{ id: 'user/custom/legacy', name: 'Legacy', type: 'number', persistent: true }],
 }
 
 vi.mock('@/libs/settings-management', () => ({
@@ -26,6 +30,13 @@ test('a saved value survives the registration of the persistValue variables that
 
   expect(getDataLakeVariableData('camera-zoom-speed')).toBe(7)
   expect(getDataLakeVariableData('camera-focus-speed')).toBe(5)
+})
+
+test("a variable stored before Cockpit recorded who made one is read back as the user's", async () => {
+  const { getDataLakeVariableInfo } = await import('@/libs/actions/data-lake')
+
+  // Assuming Cockpit's ownership, as everywhere else, would take the user's own variables away from them.
+  expect(getDataLakeVariableInfo('user/custom/legacy')?.systemOwned).toBe(false)
 })
 
 test('deleting a persistValue variable drops its stored value and nothing else', async () => {

--- a/src/tests/libs/actions/data-lake.test.ts
+++ b/src/tests/libs/actions/data-lake.test.ts
@@ -1,0 +1,39 @@
+import { expect, test, vi } from 'vitest'
+
+import { type DataLakeVariable } from '@/types/data-lake'
+
+const persistentValuesKey = 'cockpit-persistent-data-lake-values'
+const storage: Record<string, unknown> = {
+  [persistentValuesKey]: { 'camera-zoom-speed': 7, 'camera-focus-speed': 5 },
+}
+
+vi.mock('@/libs/settings-management', () => ({
+  settingsManager: {
+    getKeyValue: (key: string): unknown => storage[key],
+    setKeyValue: (key: string, value: unknown): void => {
+      storage[key] = structuredClone(value)
+    },
+  },
+}))
+
+const speedVariable = (id: string): DataLakeVariable => ({ id, name: id, type: 'number', persistValue: true })
+
+test('a saved value survives the registration of the persistValue variables that come after it', async () => {
+  const { createDataLakeVariable, getDataLakeVariableData } = await import('@/libs/actions/data-lake')
+
+  createDataLakeVariable(speedVariable('camera-zoom-speed'), 3)
+  createDataLakeVariable(speedVariable('camera-focus-speed'), 3)
+
+  expect(getDataLakeVariableData('camera-zoom-speed')).toBe(7)
+  expect(getDataLakeVariableData('camera-focus-speed')).toBe(5)
+})
+
+test('deleting a persistValue variable drops its stored value and nothing else', async () => {
+  const { createDataLakeVariable, deleteDataLakeVariable } = await import('@/libs/actions/data-lake')
+
+  createDataLakeVariable(speedVariable('some-other-speed'), 1)
+  deleteDataLakeVariable('some-other-speed')
+
+  expect(storage[persistentValuesKey]).not.toHaveProperty('some-other-speed')
+  expect(storage[persistentValuesKey]).toMatchObject({ 'camera-zoom-speed': 7, 'camera-focus-speed': 5 })
+})

--- a/src/tests/libs/utils-data-lake.test.ts
+++ b/src/tests/libs/utils-data-lake.test.ts
@@ -1,0 +1,42 @@
+import { expect, test, vi } from 'vitest'
+
+import { createDataLakeVariable } from '@/libs/actions/data-lake'
+import {
+  canUserChangeDataLakeVariable,
+  canUserDeleteDataLakeVariable,
+  isSystemOwnedDataLakeVariable,
+} from '@/libs/utils-data-lake'
+import { type DataLakeVariable } from '@/types/data-lake'
+
+vi.mock('@/libs/settings-management', () => ({
+  settingsManager: { getKeyValue: vi.fn(), setKeyValue: vi.fn() },
+}))
+
+const variable = (id: string, config: Partial<DataLakeVariable>): DataLakeVariable => ({
+  id,
+  name: id,
+  type: 'number',
+  ...config,
+})
+
+test("a variable that does not say who made it is Cockpit's, and one nobody made belongs to no one", () => {
+  createDataLakeVariable(variable('mavlink/1/1/VFR_HUD/heading', {}))
+
+  expect(isSystemOwnedDataLakeVariable('mavlink/1/1/VFR_HUD/heading')).toBe(true)
+  expect(canUserChangeDataLakeVariable('mavlink/1/1/VFR_HUD/heading')).toBe(false)
+  expect(canUserDeleteDataLakeVariable('mavlink/1/1/VFR_HUD/heading')).toBe(false)
+
+  expect(canUserChangeDataLakeVariable('never-created')).toBe(false)
+  expect(canUserDeleteDataLakeVariable('never-created')).toBe(false)
+})
+
+test('the user may change their own variables and the ones Cockpit lets them set, but delete only their own', () => {
+  createDataLakeVariable(variable('user/custom/mine', { systemOwned: false, allowUserToChangeValue: true }))
+  createDataLakeVariable(variable('camera-zoom-speed', { allowUserToChangeValue: true, persistValue: true }))
+
+  expect(canUserChangeDataLakeVariable('user/custom/mine')).toBe(true)
+  expect(canUserChangeDataLakeVariable('camera-zoom-speed')).toBe(true)
+
+  expect(canUserDeleteDataLakeVariable('user/custom/mine')).toBe(true)
+  expect(canUserDeleteDataLakeVariable('camera-zoom-speed')).toBe(false)
+})

--- a/src/types/data-lake.ts
+++ b/src/types/data-lake.ts
@@ -35,6 +35,10 @@ export interface DataLakeVariable {
    * Whether the variable's value should be allowed to be changed by the user
    */
   allowUserToChangeValue?: boolean
+  /**
+   * Whether the variable was created by the user through the Data Lake menu
+   */
+  userDefined?: boolean
 }
 
 /**

--- a/src/types/data-lake.ts
+++ b/src/types/data-lake.ts
@@ -32,9 +32,15 @@ export interface DataLakeVariable {
    */
   persistValue?: boolean
   /**
-   * Whether the variable's value should be allowed to be changed by the user
+   * Whether the user may set the variable's value: by hand from the Data Lake page, and, when the variable is not a
+   * compound one, through a joystick mapping or a widget element
    */
   allowUserToChangeValue?: boolean
+  /**
+   * Whether Cockpit created the variable, rather than the user. Cockpit creates almost every variable there is, so
+   * this is assumed when absent, and the few places that create one on the user's behalf set it to false
+   */
+  systemOwned?: boolean
 }
 
 /**

--- a/src/views/ConfigurationJoystickView.vue
+++ b/src/views/ConfigurationJoystickView.vue
@@ -665,7 +665,7 @@ import JoystickCalibration from '@/components/joysticks/JoystickCalibration.vue'
 import JoystickPS from '@/components/joysticks/JoystickPS.vue'
 import { useSnackbar } from '@/composables/snackbar'
 import { getDataLakeVariableInfo } from '@/libs/actions/data-lake'
-import { getAllTransformingFunctions } from '@/libs/actions/data-lake-transformations'
+import { getAllTransformingFunctions, isCompoundDataLakeVariable } from '@/libs/actions/data-lake-transformations'
 import { getArdupilotVersion, getMavlink2RestVersion } from '@/libs/blueos'
 import { JoystickModel } from '@/libs/joystick/manager'
 import { actionDisplayName } from '@/libs/joystick/protocols/cockpit-actions'
@@ -853,6 +853,7 @@ const filteredAndSortedJoystickActions = computed((): JoystickAction[] => {
 
 const filteredAndSortedAxisActions = computed((): JoystickAction[] => {
   return controllerStore.availableAxesActions.filter((action: JoystickAction) => {
+    if (isCompoundDataLakeVariable(action.id)) return false
     const dataLakeVariableInfo = getDataLakeVariableInfo(action.id)
     if (!dataLakeVariableInfo) return true
     return dataLakeVariableInfo.allowUserToChangeValue && dataLakeVariableInfo.type === 'number'

--- a/src/views/ToolsDataLakeView.vue
+++ b/src/views/ToolsDataLakeView.vue
@@ -111,12 +111,12 @@
                           @click="editCompoundVariable(item.id)"
                         />
                         <v-btn
-                          v-if="isUserDefinedVariable(item.id)"
+                          v-if="isUserDefinedVariable(item.id) || isUserEditableVariable(item.id)"
                           variant="outlined"
                           class="rounded-full mx-1"
                           icon="mdi-pencil"
                           size="x-small"
-                          @click="editUserDefinedVariable(item.id)"
+                          @click="editVariable(item.id)"
                         />
                         <v-btn
                           v-if="isCompoundVariable(item.id) || isUserDefinedVariable(item.id)"
@@ -346,15 +346,15 @@ const openNewVariableDialog = (): void => {
 }
 
 /**
- * Opens the dialog to edit an existing variable
+ * Opens the dialog to edit a user-defined or user-editable variable
  * @param {string} variableId The ID of the variable to edit
  */
-const editUserDefinedVariable = (variableId: string): void => {
+const editVariable = (variableId: string): void => {
   const variable = availableDataLakeVariables.value.find((v) => v.id === variableId)
-  if (variable && isUserDefinedVariable(variableId)) {
+  if (variable && (isUserDefinedVariable(variableId) || isUserEditableVariable(variableId))) {
     idVariableBeingEdited = variableId
     showVariableDialog.value = true
-  } else if (variable && !isUserDefinedVariable(variableId)) {
+  } else if (variable) {
     openSnackbar({ message: `Variable with ID ${variableId} is not editable`, variant: 'error' })
   } else {
     openSnackbar({ message: `Variable with ID ${variableId} not found`, variant: 'error' })
@@ -395,6 +395,10 @@ const isCompoundVariable = (id: string): boolean => {
 
 const isUserDefinedVariable = (id: string): boolean => {
   return availableDataLakeVariables.value.find((v) => v.id === id)?.persistent != null
+}
+
+const isUserEditableVariable = (id: string): boolean => {
+  return availableDataLakeVariables.value.find((v) => v.id === id)?.allowUserToChangeValue === true
 }
 
 const editCompoundVariable = (id: string): void => {

--- a/src/views/ToolsDataLakeView.vue
+++ b/src/views/ToolsDataLakeView.vue
@@ -184,6 +184,7 @@ import {
   TransformingFunction,
 } from '@/libs/actions/data-lake-transformations'
 import { copyToClipboard } from '@/libs/utils'
+import { isUserDefinedDataLakeVariable } from '@/libs/utils-data-lake'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 
 import BaseConfigurationView from './BaseConfigurationView.vue'
@@ -394,7 +395,7 @@ const isCompoundVariable = (id: string): boolean => {
 }
 
 const isUserDefinedVariable = (id: string): boolean => {
-  return availableDataLakeVariables.value.find((v) => v.id === id)?.persistent != null
+  return isUserDefinedDataLakeVariable(id)
 }
 
 const isUserEditableVariable = (id: string): boolean => {

--- a/src/views/ToolsDataLakeView.vue
+++ b/src/views/ToolsDataLakeView.vue
@@ -83,10 +83,21 @@
                       </div>
                     </td>
                     <td>
-                      <div class="flex items-center justify-center rounded-xl mx-1">
+                      <div class="flex items-center justify-center gap-1 rounded-xl mx-1">
                         <p class="w-[70px] whitespace-nowrap overflow-hidden text-ellipsis text-center">
                           {{ item.type }}
                         </p>
+                        <div class="w-[16px] shrink-0">
+                          <v-tooltip
+                            v-if="isCompoundVariable(item.id)"
+                            location="top"
+                            text="Compound variable: its value is calculated from an expression"
+                          >
+                            <template #activator="{ props: tooltipProps }">
+                              <span v-bind="tooltipProps" class="mdi mdi-function-variant text-gray-400" />
+                            </template>
+                          </v-tooltip>
+                        </div>
                       </div>
                     </td>
                     <td>
@@ -106,7 +117,7 @@
                     <td>
                       <div class="flex items-center justify-end h-[42px] gap-1 -mr-2">
                         <v-btn
-                          v-if="isCompoundVariable(item.id)"
+                          v-if="isCompoundVariable(item.id) && canEditVariable(item.id)"
                           variant="outlined"
                           class="rounded-full"
                           icon="mdi-pencil"
@@ -114,15 +125,15 @@
                           @click="editCompoundVariable(item.id)"
                         />
                         <v-btn
-                          v-if="isUserDefinedVariable(item.id)"
+                          v-if="!isCompoundVariable(item.id) && canEditVariable(item.id)"
                           variant="outlined"
                           class="rounded-full"
                           icon="mdi-pencil"
                           size="x-small"
-                          @click="editUserDefinedVariable(item.id)"
+                          @click="editVariable(item.id)"
                         />
                         <v-btn
-                          v-if="isCompoundVariable(item.id) || isUserDefinedVariable(item.id)"
+                          v-if="canDeleteVariable(item.id)"
                           variant="outlined"
                           color="error"
                           class="rounded-full"
@@ -197,17 +208,23 @@ import {
 import {
   deleteTransformingFunction,
   getAllTransformingFunctions,
+  isCompoundDataLakeVariable,
   TransformingFunction,
 } from '@/libs/actions/data-lake-transformations'
 import { dataLakeLogger } from '@/libs/data-lake-logging'
 import { copyToClipboard } from '@/libs/utils'
+import {
+  canUserChangeDataLakeVariable,
+  canUserDeleteDataLakeVariable,
+  isSystemOwnedDataLakeVariable,
+} from '@/libs/utils-data-lake'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 
 import BaseConfigurationView from './BaseConfigurationView.vue'
 
 const interfaceStore = useAppInterfaceStore()
 
-type VariableSource = 'Compound' | 'Cockpit internal' | 'User defined'
+type VariableSource = 'Cockpit internal' | 'User defined'
 
 /**
  * DataLakeVariable with source type
@@ -221,7 +238,7 @@ interface DataLakeVariableWithSource extends DataLakeVariable {
 
 const tableHeaders = [
   { title: 'Name', align: 'start', key: 'name', width: '390px', fixed: true, headerProps: { class: 'pl-10' } },
-  { title: 'Type', align: 'center', key: 'type', width: '70px', fixed: true },
+  { title: 'Type', align: 'center', key: 'type', width: '92px', fixed: true },
   { title: 'Source', align: 'center', key: 'source', width: '115px', fixed: true },
   { title: 'Current Value', align: 'start', key: 'value', width: '200px', fixed: true },
   { title: 'Actions', align: 'end', key: 'actions', width: '70px', fixed: true },
@@ -319,15 +336,7 @@ const searchQuery = ref('')
  * @returns {VariableSource} Source type
  */
 const getVariableSource = (id: string): VariableSource => {
-  if (isCompoundVariable(id)) {
-    return 'Compound'
-  }
-
-  if (isUserDefinedVariable(id)) {
-    return 'User defined'
-  }
-
-  return 'Cockpit internal'
+  return isSystemOwnedDataLakeVariable(id) ? 'Cockpit internal' : 'User defined'
 }
 
 const throttledSearchQuery = useThrottle(searchQuery, 300, true, true)
@@ -343,12 +352,16 @@ const filteredVariables = computed<DataLakeVariableWithSource[]>(() => {
 
   if (!throttledSearchQuery.value) return variables
 
+  const query = throttledSearchQuery.value.toLowerCase()
+
   return variables.filter((v) => {
     return (
-      v.name.toLowerCase().includes(throttledSearchQuery.value.toLowerCase()) ||
-      (v.description && v.description.toLowerCase().includes(throttledSearchQuery.value.toLowerCase())) ||
-      v.id.toLowerCase().includes(throttledSearchQuery.value.toLowerCase()) ||
-      v.source.toLowerCase().includes(throttledSearchQuery.value.toLowerCase())
+      v.name.toLowerCase().includes(query) ||
+      (v.description && v.description.toLowerCase().includes(query)) ||
+      v.id.toLowerCase().includes(query) ||
+      v.source.toLowerCase().includes(query) ||
+      // Searchable by the word the table no longer shows, since the "Add compound variable" button teaches it.
+      (isCompoundVariable(v.id) && 'compound'.startsWith(query))
     )
   })
 })
@@ -382,16 +395,16 @@ const openNewVariableDialog = (): void => {
 }
 
 /**
- * Opens the dialog to edit an existing variable
+ * Opens the dialog to edit a user-defined or user-editable variable
  * @param {string} variableId The ID of the variable to edit
  */
-const editUserDefinedVariable = (variableId: string): void => {
+const editVariable = (variableId: string): void => {
   const variable = availableDataLakeVariables.value.find((v) => v.id === variableId)
-  if (variable && isUserDefinedVariable(variableId)) {
+  if (variable && canEditVariable(variableId)) {
     logUserAction(`Opened edit dialog for data-lake variable '${variableId}'`)
     idVariableBeingEdited = variableId
     showVariableDialog.value = true
-  } else if (variable && !isUserDefinedVariable(variableId)) {
+  } else if (variable) {
     openSnackbar({ message: `Variable with ID ${variableId} is not editable`, variant: 'error' })
   } else {
     openSnackbar({ message: `Variable with ID ${variableId} not found`, variant: 'error' })
@@ -411,17 +424,20 @@ const handleVariableSaved = (): void => {
  * @param {string} id Variable ID
  */
 const deleteVariable = (id: string): void => {
+  if (!canDeleteVariable(id)) {
+    openSnackbar({ message: `Variable with ID ${id} cannot be deleted`, variant: 'error' })
+    return
+  }
+
   if (isCompoundVariable(id)) {
     const func = getAllTransformingFunctions().find((f) => f.id === id)
     if (func) {
       logUserAction(`Deleted compound variable '${id}'`)
       deleteTransformingFunction(func)
     }
-  } else if (isUserDefinedVariable(id)) {
+  } else {
     logUserAction(`Deleted data-lake variable '${id}'`)
     deleteDataLakeVariable(id)
-  } else {
-    openSnackbar({ message: `Variable with ID ${id} cannot be deleted`, variant: 'error' })
   }
 }
 
@@ -430,14 +446,23 @@ const showNewFunctionDialog = ref(false)
 const functionBeingEdited = ref<TransformingFunction | undefined>(undefined)
 
 const isCompoundVariable = (id: string): boolean => {
-  return getAllTransformingFunctions().some((func) => func.id === id)
+  return isCompoundDataLakeVariable(id)
 }
 
-const isUserDefinedVariable = (id: string): boolean => {
-  return availableDataLakeVariables.value.find((v) => v.id === id)?.persistent != null
+const canDeleteVariable = (id: string): boolean => {
+  return canUserDeleteDataLakeVariable(id)
+}
+
+const canEditVariable = (id: string): boolean => {
+  return canUserChangeDataLakeVariable(id)
 }
 
 const editCompoundVariable = (id: string): void => {
+  if (!canEditVariable(id)) {
+    openSnackbar({ message: `Variable with ID ${id} is not editable`, variant: 'error' })
+    return
+  }
+
   const func = getAllTransformingFunctions().find((f) => f.id === id)
   if (func) {
     logUserAction(`Opened edit dialog for compound variable '${id}'`)


### PR DESCRIPTION
## Why

Two problems on the Data Lake page, both coming from the same root cause: Cockpit had no way of knowing who created a variable, so the page guessed from the persistence flags.

- **Ownership was inferred from `persistent != null`**, which is true for any variable that sets the flag at all — including the internal ones that explicitly set `persistent: false`: every BlueOS variable, Camera Tilt, Autopilot System ID, Network Latency. Those were offered full edit and delete. For compound variables the page could not guess at all, since a transforming function Cockpit sets up looks exactly like one the user wrote, so **every** compound got both actions — the legacy ArduPilot System ID and the POI coordinates among them.
- **The camera zoom and focus speeds were unreachable.** They hold a setting the operator tunes, but the table only showed the edit button for variables it considered user-defined, so there was no way to change them from the UI. Their values also reset to `3` on every boot.

## What

**Cockpit records who created each variable,** through a new optional `systemOwned` flag on `DataLakeVariable` and on `TransformingFunction`. Cockpit creates almost every variable there is, so its ownership is what a variable says by staying quiet, and the three places that create one on the user's behalf say otherwise — the Data Lake dialog, the compound dialog and the custom-widget input config.

Anything read back from storage is taken as the user's instead, since it predates this being recorded. For plain variables that is provable: only those three places ever write to `cockpit-persistent-data-lake-variables`, as Cockpit never marks its own `persistent`. For compound ones it is the reading that cannot take a variable away from whoever made it, with Cockpit reclaiming its own through the setup routines. Without this, upgrading would hand every variable a user had already created over to Cockpit and remove their delete button.

Compound variables go through `ensureCockpitTransformingFunction()`, which creates the function or records that it is Cockpit's, leaving the expression the user may have tuned untouched. It is idempotent, so the setup routines call it on every boot, and it replaced the find/create dance that was duplicated across four call sites. The compound dialog carries the record through an edit instead of dropping it.

**Known limitation.** A widget input element stores a copy of the whole variable in its own options, and replays it at mount when no variable with that id is registered. A variable the user created with persistence switched off is not remembered anywhere else across a restart, so it comes back from that copy — and if the copy predates this flag it says nothing about who made it, so it is read as Cockpit's: no delete button, and the editor limited to its value. Both readings of an unflagged copy are guesses, and this is the one where nothing the app depends on can be deleted by mistake. Copies written from now on carry the flag, since the selector binds the live registry object.

**`allowUserToChangeValue` says what the user may set.** It was already the flag for "a joystick mapping or a widget element writes here"; it now reads as *the user may set this value, by hand from the Data Lake page, and — when the variable is not a compound one — through a control*. That is the single question the page asks: a variable is editable when it is the user's own, or when Cockpit marked it as theirs to set. Deletion stays stricter: only their own, never Cockpit's.

Marked as the user's to set: the camera zoom and focus speeds, the camera zoom and focus expressions, and the six MANUAL_CONTROL axis outputs — values and expressions that are tuned to fit the vehicle.

Editing one of Cockpit's **plain** variables opens the dialog limited to the value field, so it cannot rewrite the id, type or persistence the app depends on. A Cockpit **compound** stays fully editable in the compound dialog, name and expression included, by design — the expression is the thing meant to be tuned, and that matches what `master` already allowed.

**No control may write to a compound variable.** A compound is computed from its expression, so a write from a joystick or a widget element is undone at the next evaluation. The joystick *button* picker already excluded them; the *axis* picker and the custom widget input elements went by `allowUserToChangeValue` alone. Both now check as well. A widget element can still be pointed at a compound variable to display its value, it just stays read-only. This lands first, as its own commit, so no intermediate commit offers a compound as something to write to.

**Persisted values are actually restored.** `createDataLakeVariable` was unconditionally writing the default over whatever was in storage, so a `persistValue` variable never came back with the user's value. A saved value now wins over the initial one. `savePersistentValues` also merges into the stored object instead of rebuilding it from the variables registered so far — rebuilding dropped the values of variables not registered yet — and deleting a variable removes only its own key.

**The camera speeds persist,** now created with `persistValue: true`, so a tuned speed survives a reboot. The increase/decrease variables were left alone, since their value is written by whatever control is mapped to them.

Also along the way: the edit dialog filled the value field with a truthiness check, so a variable holding `0` or `false` opened with an empty field; and the Source column now answers who owns the variable instead of mixing that with whether it happens to be a compound one. Which rows are computed moved to an icon beside the type, the same `mdi-function-variant` the "Add compound variable" button uses, and searching for "compound" still finds them.

## Tests

Three unit test files: persisted-value restore and delete behaviour, plus a pre-flag stored variable being read back as the user's (`src/tests/libs/actions/data-lake.test.ts`); recording ownership on stored and new transforming functions, and it reaching the data lake variable the page reads (`src/tests/libs/actions/data-lake-transformations.test.ts`); and the edit/delete rules including the unmarked-means-Cockpit's default (`src/tests/libs/utils-data-lake.test.ts`).

**One window this does not close.** A compound variable Cockpit owns is only recorded as its own when the routine that creates it runs, and two of them run late: `ardupilotSystemId` when a MAVLink vehicle is instantiated, and the POI coordinate functions when a map component mounts. On the first boot after upgrading, the stored entries still carry nothing, so until that moment they read as *User defined* with a delete button. The record is persisted once written, so every later boot is correct from load. Neither is a regression — on `master` both are editable and deletable outright, with no window — and closing it means moving those two calls to bootstrap, which is a change of its own.

Fix #2774
Fix #2775

