### PR TITLE
Introduce Data Lake Raw Logs (a.k.a CSV and JSON logs)

### DIFF
--- a/src/components/MainMenu.vue
+++ b/src/components/MainMenu.vue
@@ -236,6 +236,7 @@ import ConfigurationMissionView from '@/views/ConfigurationMissionView.vue'
 import ConfigurationUIView from '@/views/ConfigurationUIView.vue'
 import ConfigurationVideoView from '@/views/ConfigurationVideoView.vue'
 import ToolsDataLakeView from '@/views/ToolsDataLakeView.vue'
+import ToolsLogsView from '@/views/ToolsLogsView.vue'
 import ToolsMAVLinkView from '@/views/ToolsMAVLinkView.vue'
 
 const route = useRoute()
@@ -434,6 +435,12 @@ const toolsMenu = computed(() => {
       title: 'Data-lake',
       componentName: SubMenuComponentName.ToolsDataLake,
       component: markRaw(ToolsDataLakeView) as SubMenuComponent,
+    },
+    {
+      icon: 'mdi-file-chart-outline',
+      title: 'Data Logs',
+      componentName: SubMenuComponentName.ToolsLogs,
+      component: markRaw(ToolsLogsView) as SubMenuComponent,
     },
   ]
 

--- a/src/libs/data-lake-logging.ts
+++ b/src/libs/data-lake-logging.ts
@@ -1,0 +1,672 @@
+import { format } from 'date-fns'
+
+import {
+  getDataLakeVariableData,
+  getDataLakeVariableInfo,
+  listenDataLakeVariable,
+  unlistenDataLakeVariable,
+} from './actions/data-lake'
+import { IndexedDbStore } from './indexed-db-store'
+import { settingsManager } from './settings-management'
+
+export const recordedDataLakeVariablesKey = 'cockpit-data-lake-recorded-variables'
+const exportVariableKeySetting = 'cockpit-data-lake-export-variable-key'
+const logIntervalKey = 'cockpit-data-lake-log-interval'
+const defaultLogInterval = 1000
+
+// How often buffered points are flushed to IndexedDB as a single batched entry. Batching keeps
+// high-frequency raw-mode logging from overwhelming IndexedDB; at most this much data is buffered
+// in memory and would be lost on a hard crash/reload.
+const flushIntervalMs = 250
+/**
+ * How variable keys are labeled in exported CSV and JSON files
+ */
+export type DataLakeExportVariableKey = 'id' | 'short-id' | 'name'
+
+/**
+ * Logging cadence: a fixed interval in milliseconds, or 'raw' to log on every variable change
+ */
+export type DataLakeLogInterval = number | 'raw'
+
+/**
+ * A single recorded data point for selected data lake variables
+ */
+export interface DataLakeLogPoint {
+  /**
+   * Universal Linux epoch time (milliseconds since January 1st, 1970, UTC)
+   */
+  epoch: number
+  /**
+   * Raw variable values keyed by data lake variable ID
+   */
+  data: Record<string, string | number | boolean | undefined>
+}
+
+/**
+ * A sequence of recorded data lake log points
+ */
+export type DataLakeLog = DataLakeLogPoint[]
+
+/**
+ * Information about a recorded data session
+ */
+export interface DataLakeSessionInfo {
+  /**
+   * Unique identifier for the session
+   */
+  id: string
+  /**
+   * Identifier of the Cockpit run that produced the session
+   */
+  bootId: number
+  /**
+   * Start time of the session (epoch ms)
+   */
+  startTime: number
+  /**
+   * End time of the session (epoch ms)
+   */
+  endTime: number
+  /**
+   * Formatted date/time string
+   */
+  dateTimeFormatted: string
+  /**
+   * Number of data points in the session
+   */
+  dataPointCount: number
+  /**
+   * Duration of the session in seconds
+   */
+  durationSeconds: number
+  /**
+   * Whether this is the current active session
+   */
+  isCurrentSession: boolean
+}
+
+/**
+ * Lightweight session metadata persisted alongside the raw log points
+ */
+interface DataLakeSessionRecord {
+  /**
+   * Unique identifier for the session
+   */
+  id: string
+  /**
+   * Identifier of the Cockpit run that produced the session
+   */
+  bootId: number
+  /**
+   * Start time of the session (epoch ms)
+   */
+  startTime: number
+  /**
+   * Time of the most recent point in the session (epoch ms)
+   */
+  endTime: number
+  /**
+   * Number of data points recorded in the session
+   */
+  dataPointCount: number
+}
+
+/**
+ * Records raw data lake variable values to a dedicated IndexedDB store
+ */
+export class DataLakeLogger {
+  private isLogging = false
+  private _recordedVariableIds?: string[]
+  private _exportVariableKey?: DataLakeExportVariableKey
+  private _logInterval?: DataLakeLogInterval
+  private intervalTimer: ReturnType<typeof setTimeout> | null = null
+  private flushTimer: ReturnType<typeof setInterval> | null = null
+  private rawListeners: Record<string, string> = {}
+  private pendingPoints: DataLakeLogPoint[] = []
+
+  // Epoch of the last raw-mode point buffered, used to detect when a new session begins so it can be
+  // seeded with a baseline snapshot of every recorded variable.
+  private lastRawActivityEpoch: number | null = null
+
+  // Identifies the current Cockpit run, so each restart starts a fresh session even without a time gap.
+  private readonly bootId = Date.now()
+
+  // Monotonic per-run counter that keeps log-point keys unique even within the same millisecond.
+  private logPointSequence = 0
+
+  // Metadata of the session currently being written, kept in memory and mirrored to sessionsDB.
+  private currentSession: DataLakeSessionRecord | null = null
+
+  static logsDB = new IndexedDbStore({
+    name: 'Cockpit - Data Lake Logs',
+    storeName: 'cockpit-data-lake-logs-db',
+    version: 1,
+    description: 'Raw data lake variable logs for CSV and JSON export.',
+  })
+
+  static sessionsDB = new IndexedDbStore({
+    name: 'Cockpit - Data Lake Sessions',
+    storeName: 'cockpit-data-lake-sessions-db',
+    version: 1,
+    description: 'Metadata for recorded data lake sessions (point count and time range).',
+  })
+
+  static SESSION_GAP_THRESHOLD_MS = 5 * 60 * 1000
+
+  // ID of the session the running logger is currently writing to; only this one is "current".
+  private static activeSessionId: string | null = null
+
+  /**
+   * Build an IndexedDB key range covering all log-point keys of a session.
+   *
+   * Log-point keys are `boot=<bootId>;epoch=<epoch>;seq=<seq>`. Because bootId and epoch are
+   * fixed-width (13-digit) millisecond timestamps, lexicographic key order matches numeric order, so
+   * a bounded string range selects exactly the session's points (same bootId, epoch within range).
+   * @param {DataLakeSessionInfo} session - Session whose key range is needed
+   * @returns {IDBKeyRange} Range covering the session's log-point keys
+   */
+  private static sessionKeyRange(session: DataLakeSessionInfo): IDBKeyRange {
+    const lowerKey = `boot=${session.bootId};epoch=${session.startTime}`
+    const upperKey = `boot=${session.bootId};epoch=${session.endTime}\uffff`
+    return IDBKeyRange.bound(lowerKey, upperKey)
+  }
+
+  /**
+   * @param {string} variableId - Data lake variable ID
+   * @returns {string} Human-readable variable name for export
+   */
+  static getVariableExportName(variableId: string): string {
+    const name = getDataLakeVariableInfo(variableId)?.name ?? variableId
+
+    if (variableId.includes('mavlink/') && name.includes('(')) {
+      return name.substring(0, name.lastIndexOf('(')).trim()
+    }
+
+    return name
+  }
+
+  /**
+   * Return the last path segment of a slash-separated variable ID
+   * @param {string} variableId - Data lake variable ID
+   * @returns {string} Final segment of the variable ID, or the full ID when no slashes are present
+   */
+  static shortVariableId(variableId: string): string {
+    const lastSlashIndex = variableId.lastIndexOf('/')
+    if (lastSlashIndex === -1) {
+      return variableId
+    }
+
+    return variableId.substring(lastSlashIndex + 1)
+  }
+
+  /**
+   * @param {string} variableId - Data lake variable ID
+   * @param {DataLakeExportVariableKey} keyMode - How variable keys should be labeled in exports
+   * @returns {string} Export key for the variable
+   */
+  static getExportVariableKey(variableId: string, keyMode: DataLakeExportVariableKey): string {
+    if (keyMode === 'name') {
+      return DataLakeLogger.getVariableExportName(variableId)
+    }
+
+    if (keyMode === 'short-id') {
+      return DataLakeLogger.shortVariableId(variableId)
+    }
+
+    return variableId
+  }
+
+  /**
+   * Build a stable variable-ID-to-export-key map for a whole log. When two variable IDs would
+   * produce the same export key, both fall back to their full (always unique) IDs.
+   * @param {string[]} variableIds - All variable IDs present in the log
+   * @param {DataLakeExportVariableKey} keyMode - How variable keys should be labeled in exports
+   * @returns {Map<string, string>} Map from variable ID to its export key
+   */
+  static buildExportKeyMap(variableIds: string[], keyMode: DataLakeExportVariableKey): Map<string, string> {
+    const desiredKeys = new Map<string, string>()
+    const desiredKeyCounts = new Map<string, number>()
+
+    for (const variableId of variableIds) {
+      const desiredKey = DataLakeLogger.getExportVariableKey(variableId, keyMode)
+      desiredKeys.set(variableId, desiredKey)
+      desiredKeyCounts.set(desiredKey, (desiredKeyCounts.get(desiredKey) ?? 0) + 1)
+    }
+
+    const exportKeyMap = new Map<string, string>()
+    for (const [variableId, desiredKey] of desiredKeys) {
+      const isColliding = (desiredKeyCounts.get(desiredKey) ?? 0) > 1
+      exportKeyMap.set(variableId, isColliding ? variableId : desiredKey)
+    }
+
+    return exportKeyMap
+  }
+
+  /**
+   * Re-key a log point's data for export using a precomputed export-key map
+   * @param {Record<string, string | number | boolean | undefined>} data - Log data keyed by variable ID
+   * @param {Map<string, string>} exportKeyMap - Map from variable ID to export key
+   * @returns {Record<string, string | number | boolean | undefined>} Log data keyed for export
+   */
+  static applyExportKeyMap(
+    data: Record<string, string | number | boolean | undefined>,
+    exportKeyMap: Map<string, string>
+  ): Record<string, string | number | boolean | undefined> {
+    const exportedData: Record<string, string | number | boolean | undefined> = {}
+
+    for (const [variableId, value] of Object.entries(data)) {
+      exportedData[exportKeyMap.get(variableId) ?? variableId] = value
+    }
+
+    return exportedData
+  }
+
+  /**
+   * @param {DataLakeLog} log - Log to inspect
+   * @returns {string[]} All unique variable IDs present across the log
+   */
+  static collectVariableIds(log: DataLakeLog): string[] {
+    const variableIds = new Set<string>()
+    log.forEach((logPoint) => Object.keys(logPoint.data).forEach((variableId) => variableIds.add(variableId)))
+    return [...variableIds]
+  }
+
+  /**
+   * @returns {string[]} IDs of data lake variables selected for recording
+   */
+  get recordedVariableIds(): string[] {
+    if (this._recordedVariableIds === undefined) {
+      const savedValue = settingsManager.getKeyValue(recordedDataLakeVariablesKey) as string[] | undefined
+      this._recordedVariableIds = savedValue ?? []
+    }
+    return this._recordedVariableIds
+  }
+
+  /**
+   * @param {string[]} value - Variable IDs to record
+   */
+  set recordedVariableIds(value: string[]) {
+    this._recordedVariableIds = value
+    settingsManager.setKeyValue(recordedDataLakeVariablesKey, value)
+  }
+
+  /**
+   * @returns {DataLakeExportVariableKey} How variable keys are labeled in exports
+   */
+  get exportVariableKey(): DataLakeExportVariableKey {
+    if (this._exportVariableKey === undefined) {
+      const savedValue = settingsManager.getKeyValue(exportVariableKeySetting) as DataLakeExportVariableKey | undefined
+      this._exportVariableKey = savedValue ?? 'id'
+    }
+    return this._exportVariableKey
+  }
+
+  /**
+   * @param {DataLakeExportVariableKey} value - How variable keys are labeled in exports
+   */
+  set exportVariableKey(value: DataLakeExportVariableKey) {
+    this._exportVariableKey = value
+    settingsManager.setKeyValue(exportVariableKeySetting, value)
+  }
+
+  /**
+   * @returns {DataLakeLogInterval} Log interval in milliseconds, or 'raw' for change-driven logging
+   */
+  get logInterval(): DataLakeLogInterval {
+    if (this._logInterval === undefined) {
+      const savedValue = settingsManager.getKeyValue(logIntervalKey) as DataLakeLogInterval | undefined
+      this._logInterval = savedValue ?? defaultLogInterval
+    }
+    return this._logInterval
+  }
+
+  /**
+   * @param {DataLakeLogInterval} value - Log interval in milliseconds, or 'raw' for change-driven logging
+   */
+  set logInterval(value: DataLakeLogInterval) {
+    if (value === this.logInterval) return
+
+    this._logInterval = value
+    settingsManager.setKeyValue(logIntervalKey, value)
+
+    if (this.shouldBeLogging()) {
+      // A config change closes the current session; flush leftovers into it, then the next point
+      // opens a fresh session with the new config.
+      this.flushPendingPoints()
+      this.currentSession = null
+      DataLakeLogger.activeSessionId = null
+      this.applyLoggingMode()
+    }
+  }
+
+  /**
+   * Toggle whether a data lake variable should be recorded. IDs are only ever added or removed
+   * here, in direct response to the user's selection; nothing prunes the list automatically.
+   * @param {string} variableId - Data lake variable ID
+   * @param {boolean} recorded - Whether the variable should be recorded
+   */
+  setVariableRecorded(variableId: string, recorded: boolean): void {
+    const currentIds = [...this.recordedVariableIds]
+
+    if (recorded && !currentIds.includes(variableId)) {
+      this.recordedVariableIds = [...currentIds, variableId]
+    } else if (!recorded) {
+      this.recordedVariableIds = currentIds.filter((id) => id !== variableId)
+    }
+
+    // Interval logging reads the recorded list on every tick, but raw logging holds per-variable
+    // listeners that must be rebuilt whenever the selection changes.
+    if (this.shouldBeLogging() && this.logInterval === 'raw') {
+      this.applyLoggingMode()
+    }
+  }
+
+  /**
+   * Start recording. Re-reads the recorded selection from settings on each fresh start, so a
+   * stop/start cycle applies external changes. No-op when already running.
+   */
+  startLogging(): void {
+    if (this.isLogging) return
+
+    this.isLogging = true
+    this._recordedVariableIds = undefined
+    this.applyLoggingMode()
+  }
+
+  /**
+   * Stop recording and tear down the timer/listeners.
+   */
+  stopLogging(): void {
+    if (!this.isLogging) return
+
+    this.isLogging = false
+    this.teardownLogging()
+  }
+
+  /**
+   * @returns {boolean} True if logging should continue
+   */
+  shouldBeLogging(): boolean {
+    return this.isLogging
+  }
+
+  /**
+   * Persist all buffered points as a single batched IndexedDB entry and update the session metadata
+   * once. No-op when the buffer is empty.
+   */
+  private flushPendingPoints(): void {
+    if (this.pendingPoints.length === 0) return
+
+    const batch = this.pendingPoints
+    this.pendingPoints = []
+
+    const firstEpoch = batch[0].epoch
+    const lastEpoch = batch[batch.length - 1].epoch
+    const key = `boot=${this.bootId};epoch=${firstEpoch};seq=${this.logPointSequence++}`
+
+    DataLakeLogger.logsDB.setItem(key, batch).catch((error) => {
+      console.error('Failed to store data lake log points:', error)
+    })
+
+    this.updateCurrentSession(firstEpoch, lastEpoch, batch.length)
+  }
+
+  /**
+   * Advance the current session's metadata for a freshly flushed batch, starting a new session when
+   * the gap since the last point exceeds the threshold (a restart already starts with no session).
+   * @param {number} firstEpoch - Epoch of the first point in the batch
+   * @param {number} lastEpoch - Epoch of the last point in the batch
+   * @param {number} pointCount - Number of points in the batch
+   */
+  private updateCurrentSession(firstEpoch: number, lastEpoch: number, pointCount: number): void {
+    if (!this.currentSession || firstEpoch - this.currentSession.endTime > DataLakeLogger.SESSION_GAP_THRESHOLD_MS) {
+      this.currentSession = {
+        id: `session-${firstEpoch}`,
+        bootId: this.bootId,
+        startTime: firstEpoch,
+        endTime: lastEpoch,
+        dataPointCount: pointCount,
+      }
+    } else {
+      this.currentSession.endTime = lastEpoch
+      this.currentSession.dataPointCount += pointCount
+    }
+
+    DataLakeLogger.activeSessionId = this.currentSession.id
+    DataLakeLogger.sessionsDB.setItem(this.currentSession.id, { ...this.currentSession }).catch((error) => {
+      console.error('Failed to update data lake session record:', error)
+    })
+  }
+
+  /**
+   * Snapshot the current value of every recorded variable, keyed by variable ID.
+   * @returns {Record<string, string | number | boolean | undefined>} Cloned current values
+   */
+  private snapshotRecordedValues(): Record<string, string | number | boolean | undefined> {
+    const data: Record<string, string | number | boolean | undefined> = {}
+    for (const variableId of this.recordedVariableIds) {
+      data[variableId] = getDataLakeVariableData(variableId)
+    }
+
+    return structuredClone(data)
+  }
+
+  /**
+   * Buffer a point snapshotting the current value of every recorded variable (interval mode)
+   */
+  private bufferSnapshotPoint(): void {
+    if (this.recordedVariableIds.length === 0) return
+
+    this.pendingPoints.push({ epoch: Date.now(), data: this.snapshotRecordedValues() })
+  }
+
+  /**
+   * Tear down any active logging and restart it in the currently configured mode
+   */
+  private applyLoggingMode(): void {
+    this.teardownLogging()
+    if (!this.shouldBeLogging()) return
+
+    // Buffered points are flushed to IndexedDB in batches to keep write pressure low.
+    this.flushTimer = setInterval(() => this.flushPendingPoints(), flushIntervalMs)
+
+    // Raw mode buffers only the variable that changed, so each change becomes its own single-value point.
+    if (this.logInterval === 'raw') {
+      this.lastRawActivityEpoch = null
+      for (const variableId of this.recordedVariableIds) {
+        this.rawListeners[variableId] = listenDataLakeVariable(variableId, (value) => {
+          const epoch = Date.now()
+          // Variables only emit on change, so one that hasn't changed since before a session would be
+          // missing from it. Seed each new session's first point with a full baseline snapshot so every
+          // recorded variable is present; later points stay sparse single-value changes.
+          const startsNewSession =
+            this.lastRawActivityEpoch === null ||
+            epoch - this.lastRawActivityEpoch > DataLakeLogger.SESSION_GAP_THRESHOLD_MS
+          this.pendingPoints.push(
+            startsNewSession ? { epoch, data: this.snapshotRecordedValues() } : { epoch, data: { [variableId]: value } }
+          )
+          this.lastRawActivityEpoch = epoch
+        })
+      }
+      return
+    }
+
+    const interval = this.logInterval
+    const logRoutine = (): void => {
+      this.bufferSnapshotPoint()
+      if (this.shouldBeLogging() && this.logInterval !== 'raw') {
+        this.intervalTimer = setTimeout(logRoutine, interval)
+      }
+    }
+    logRoutine()
+  }
+
+  /**
+   * Stop the timers, remove all raw-mode listeners, and flush any buffered points.
+   */
+  private teardownLogging(): void {
+    if (this.intervalTimer) {
+      clearTimeout(this.intervalTimer)
+      this.intervalTimer = null
+    }
+
+    if (this.flushTimer) {
+      clearInterval(this.flushTimer)
+      this.flushTimer = null
+    }
+
+    for (const [variableId, listenerId] of Object.entries(this.rawListeners)) {
+      unlistenDataLakeVariable(variableId, listenerId)
+    }
+    this.rawListeners = {}
+
+    this.flushPendingPoints()
+  }
+
+  /**
+   * Get all recorded data sessions
+   * @returns {Promise<DataLakeSessionInfo[]>} Detected sessions, newest first
+   */
+  static async getDataSessions(): Promise<DataLakeSessionInfo[]> {
+    const records: DataLakeSessionRecord[] = []
+    await DataLakeLogger.sessionsDB.iterate<DataLakeSessionRecord, void>((record) => {
+      if (record?.id !== undefined) records.push(record)
+    })
+
+    return records
+      .map((record) => ({
+        id: record.id,
+        bootId: record.bootId,
+        startTime: record.startTime,
+        endTime: record.endTime,
+        dateTimeFormatted: format(new Date(record.startTime), 'LLL dd, yyyy - HH:mm:ss'),
+        dataPointCount: record.dataPointCount,
+        durationSeconds: Math.round((record.endTime - record.startTime) / 1000),
+        isCurrentSession: record.id === DataLakeLogger.activeSessionId,
+      }))
+      .sort((a, b) => b.startTime - a.startTime)
+  }
+
+  /**
+   * Build a log from a session's stored data points
+   * @param {DataLakeSessionInfo} session - Session to export
+   * @returns {Promise<DataLakeLog>} Log points in chronological order
+   */
+  static async generateLogFromSession(session: DataLakeSessionInfo): Promise<DataLakeLog> {
+    // Native key-range query fetches only this session's batches, in ascending (chronological) key order.
+    const batches = await DataLakeLogger.logsDB.getAll<DataLakeLog>(DataLakeLogger.sessionKeyRange(session))
+
+    const log: DataLakeLog = []
+    for (const batch of batches) {
+      if (Array.isArray(batch)) {
+        log.push(...batch.filter((point) => point?.epoch !== undefined && point.data !== undefined))
+      }
+    }
+
+    return log
+  }
+
+  /**
+   * Remove the log points and metadata records of the given sessions, deleting each session's points
+   * with a single native key-range delete.
+   * @param {DataLakeSessionInfo[]} sessions - Sessions to delete
+   */
+  private static async removeSessions(sessions: DataLakeSessionInfo[]): Promise<void> {
+    if (sessions.length === 0) return
+
+    await Promise.all([
+      ...sessions.map((session) => DataLakeLogger.logsDB.removeRange(DataLakeLogger.sessionKeyRange(session))),
+      ...sessions.map((session) => DataLakeLogger.sessionsDB.removeItem(session.id)),
+    ])
+  }
+
+  /**
+   * Delete all log points belonging to a session
+   * @param {DataLakeSessionInfo} session - Session to delete
+   */
+  static async deleteDataSession(session: DataLakeSessionInfo): Promise<void> {
+    await DataLakeLogger.removeSessions([session])
+  }
+
+  /**
+   * Delete sessions older than the given number of days
+   * @param {number} daysOld - Age threshold in days
+   * @returns {Promise<number>} Number of deleted sessions
+   */
+  static async deleteOldDataSessions(daysOld = 1): Promise<number> {
+    const cutoffDate = new Date()
+    cutoffDate.setDate(cutoffDate.getDate() - daysOld)
+    const cutoffMs = cutoffDate.getTime()
+
+    const sessions = await DataLakeLogger.getDataSessions()
+    const sessionsToDelete = sessions.filter((session) => session.endTime < cutoffMs && !session.isCurrentSession)
+
+    await DataLakeLogger.removeSessions(sessionsToDelete)
+
+    return sessionsToDelete.length
+  }
+
+  /**
+   * Convert a data lake log to JSON
+   * @param {DataLakeLog} log - Log to serialize
+   * @returns {string} JSON string
+   */
+  toJson(log: DataLakeLog): string {
+    const exportKeyMap = DataLakeLogger.buildExportKeyMap(
+      DataLakeLogger.collectVariableIds(log),
+      this.exportVariableKey
+    )
+    const exportedLog = log.map((logPoint) => ({
+      ...logPoint,
+      data: DataLakeLogger.applyExportKeyMap(logPoint.data, exportKeyMap),
+    }))
+
+    return JSON.stringify(exportedLog, null, 2)
+  }
+
+  /**
+   * Convert a data lake log to CSV. Each stored point becomes a row; columns for variables that did
+   * not change in that point carry forward their most recent value (so raw logs have many repeats).
+   * @param {DataLakeLog} log - Log to serialize
+   * @returns {string} CSV string
+   */
+  toCsv(log: DataLakeLog): string {
+    if (log.length === 0) return ''
+
+    const exportKeyMap = DataLakeLogger.buildExportKeyMap(
+      DataLakeLogger.collectVariableIds(log),
+      this.exportVariableKey
+    )
+    const exportedLog = log.map((logPoint) => ({
+      ...logPoint,
+      data: DataLakeLogger.applyExportKeyMap(logPoint.data, exportKeyMap),
+    }))
+
+    const escapeCSV = (value: string | number | boolean | undefined | null): string => {
+      if (value === undefined || value === null) return ''
+      const str = String(value).trim()
+      if (str.includes('"') || str.includes(',') || str.includes('\n') || str.includes('\r')) {
+        return `"${str.replace(/"/g, '""')}"`
+      }
+      return str
+    }
+
+    const sortedExportKeys = [...new Set(exportKeyMap.values())].sort()
+    const headers = ['epoch', 'timestamp', ...sortedExportKeys.map((key) => escapeCSV(key))]
+
+    const latestValues = new Map<string, string | number | boolean | undefined>()
+    const rows = exportedLog.map((logPoint) => {
+      for (const [exportKey, value] of Object.entries(logPoint.data)) {
+        latestValues.set(exportKey, value)
+      }
+
+      const timestamp = new Date(logPoint.epoch).toISOString()
+      const values = sortedExportKeys.map((exportKey) => escapeCSV(latestValues.get(exportKey)))
+      return [logPoint.epoch, escapeCSV(timestamp), ...values].join(',')
+    })
+
+    return [headers.join(','), ...rows].join('\n')
+  }
+}
+
+export const dataLakeLogger = new DataLakeLogger()

--- a/src/libs/indexed-db-store.ts
+++ b/src/libs/indexed-db-store.ts
@@ -1,0 +1,188 @@
+/**
+ * Configuration for an {@link IndexedDbStore}.
+ */
+interface IndexedDbStoreConfig {
+  /**
+   * IndexedDB database name
+   */
+  name: string
+  /**
+   * Object store name inside the database
+   */
+  storeName: string
+  /**
+   * Database schema version (positive integer); drives IndexedDB's upgrade flow. Defaults to 1.
+   */
+  version?: number
+  /**
+   * Human-readable description. IndexedDB has no native description, so this is metadata only and
+   * does not affect storage; kept for parity/documentation.
+   */
+  description?: string
+}
+
+/**
+ * Minimal promise-based key-value store backed directly by IndexedDB.
+ *
+ * Exposes a subset of the localforage instance API (`getItem`, `setItem`, `removeItem`, `keys`,
+ * `iterate`) so it can be used as a near drop-in replacement, without the localforage dependency.
+ */
+export class IndexedDbStore {
+  private readonly dbName: string
+  private readonly storeName: string
+  private readonly version?: number
+  /**
+   * Metadata only — IndexedDB has no native database description; kept for parity/documentation.
+   */
+  readonly description?: string
+  private dbPromise: Promise<IDBDatabase> | null = null
+
+  /**
+   * @param {IndexedDbStoreConfig} config - Database, object store, and optional version/description
+   */
+  constructor(config: IndexedDbStoreConfig) {
+    this.dbName = config.name
+    this.storeName = config.storeName
+    this.version = config.version
+    this.description = config.description
+  }
+
+  /**
+   * Open (and cache) the database connection, creating the object store on first use.
+   *
+   * Probes the current version first and only ever upgrades — never requests a lower version (which
+   * would throw on a database that already exists at a higher version, e.g. one created by another
+   * library). The object store is created via a version bump when missing.
+   * @returns {Promise<IDBDatabase>} The open database
+   */
+  private openDb(): Promise<IDBDatabase> {
+    if (this.dbPromise) return this.dbPromise
+
+    const ensureStore = (db: IDBDatabase): void => {
+      if (!db.objectStoreNames.contains(this.storeName)) db.createObjectStore(this.storeName)
+    }
+
+    this.dbPromise = new Promise<IDBDatabase>((resolve, reject) => {
+      const probe = indexedDB.open(this.dbName)
+      probe.onupgradeneeded = () => ensureStore(probe.result)
+      probe.onerror = () => reject(probe.error)
+      probe.onsuccess = () => {
+        const db = probe.result
+        const storeMissing = !db.objectStoreNames.contains(this.storeName)
+        const targetVersion = Math.max(this.version ?? 0, db.version + (storeMissing ? 1 : 0))
+
+        if (!storeMissing && targetVersion <= db.version) {
+          resolve(db)
+          return
+        }
+
+        db.close()
+        const upgrade = indexedDB.open(this.dbName, targetVersion)
+        upgrade.onupgradeneeded = () => ensureStore(upgrade.result)
+        upgrade.onerror = () => reject(upgrade.error)
+        upgrade.onblocked = () => reject(new Error(`Opening IndexedDB database "${this.dbName}" was blocked.`))
+        upgrade.onsuccess = () => resolve(upgrade.result)
+      }
+    })
+    return this.dbPromise
+  }
+
+  /**
+   * Run a transaction against the object store.
+   * @param {IDBTransactionMode} mode - Transaction mode
+   * @param {(store: IDBObjectStore) => IDBRequest} operation - Builds the request to run
+   * @returns {Promise<T>} Resolves with the request result once the transaction completes
+   */
+  private async run<T>(mode: IDBTransactionMode, operation: (store: IDBObjectStore) => IDBRequest): Promise<T> {
+    const db = await this.openDb()
+    return new Promise<T>((resolve, reject) => {
+      const transaction = db.transaction(this.storeName, mode)
+      const request = operation(transaction.objectStore(this.storeName))
+      transaction.onabort = () => reject(transaction.error)
+      transaction.onerror = () => reject(transaction.error)
+      transaction.oncomplete = () => resolve(request.result as T)
+    })
+  }
+
+  /**
+   * @param {string} key - Item key
+   * @returns {Promise<T | null>} The stored value, or null when the key is absent
+   */
+  async getItem<T>(key: string): Promise<T | null> {
+    const value = await this.run<T | undefined>('readonly', (store) => store.get(key))
+    return value === undefined ? null : value
+  }
+
+  /**
+   * @param {string} key - Item key
+   * @param {T} value - Value to store
+   * @returns {Promise<T>} The stored value
+   */
+  async setItem<T>(key: string, value: T): Promise<T> {
+    await this.run('readwrite', (store) => store.put(value, key))
+    return value
+  }
+
+  /**
+   * @param {string} key - Item key to remove
+   */
+  async removeItem(key: string): Promise<void> {
+    await this.run('readwrite', (store) => store.delete(key))
+  }
+
+  /**
+   * @returns {Promise<string[]>} All keys in the store
+   */
+  async keys(): Promise<string[]> {
+    const keys = await this.run<IDBValidKey[]>('readonly', (store) => store.getAllKeys())
+    return keys as string[]
+  }
+
+  /**
+   * Read all values, optionally restricted to a key range (efficient native range query).
+   * @param {IDBKeyRange} [query] - Key range to restrict results to
+   * @returns {Promise<T[]>} The matching values, in ascending key order
+   */
+  async getAll<T>(query?: IDBKeyRange): Promise<T[]> {
+    return this.run<T[]>('readonly', (store) => store.getAll(query))
+  }
+
+  /**
+   * Delete every entry whose key falls within the given range, in a single native operation.
+   * @param {IDBKeyRange} query - Key range to delete
+   */
+  async removeRange(query: IDBKeyRange): Promise<void> {
+    await this.run('readwrite', (store) => store.delete(query))
+  }
+
+  /**
+   * Iterate over every entry in insertion order. Returning a non-undefined value from the iteratee
+   * stops the iteration early and resolves with that value (matching localforage's behavior).
+   * @param {(value: T, key: string, iterationNumber: number) => U | void} iteratee - Per-entry callback
+   * @returns {Promise<U | void>} The early-return value, if any
+   */
+  async iterate<T, U>(iteratee: (value: T, key: string, iterationNumber: number) => U | void): Promise<U | void> {
+    const db = await this.openDb()
+    return new Promise<U | void>((resolve, reject) => {
+      const transaction = db.transaction(this.storeName, 'readonly')
+      const request = transaction.objectStore(this.storeName).openCursor()
+      let iterationNumber = 1
+
+      request.onsuccess = () => {
+        const cursor = request.result
+        if (!cursor) {
+          resolve()
+          return
+        }
+
+        const result = iteratee(cursor.value as T, cursor.key as string, iterationNumber++)
+        if (result !== undefined) {
+          resolve(result)
+          return
+        }
+        cursor.continue()
+      }
+      request.onerror = () => reject(request.error)
+    })
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ import VueVirtualScroller from 'vue-virtual-scroller'
 
 import { initializeActionAutoRun } from '@/libs/actions/auto-run'
 import { app_version } from '@/libs/cosmos'
+import { dataLakeLogger } from '@/libs/data-lake-logging'
 import eventTracker, {
   defaultShareHardwareDetails,
   getSystemInfoForTelemetry,
@@ -98,6 +99,9 @@ initializeActionAutoRun()
 
 // Start logging as soon as the app is loaded to always have telemetry for videos
 datalogger.startLogging('cockpit-telemetry-logging')
+
+// Start recording selected data lake variables for CSV/JSON export (seeds from the overlay on first run)
+dataLakeLogger.startLogging()
 
 // If the app has successfully loaded, announce that so the console capture can be stopped
 window.dispatchEvent(new CustomEvent('cockpit-app-loaded'))

--- a/src/stores/appInterface.ts
+++ b/src/stores/appInterface.ts
@@ -33,6 +33,7 @@ export enum SubMenuComponentName {
   SettingsMAVLink = 'settings-mavlink',
   ToolsMAVLink = 'tools-mavlink',
   ToolsDataLake = 'tools-datalake',
+  ToolsLogs = 'tools-logs',
 }
 
 export const useAppInterfaceStore = defineStore('responsive', {

--- a/src/utils/data-lake-recorded-variables-migration.ts
+++ b/src/utils/data-lake-recorded-variables-migration.ts
@@ -1,0 +1,78 @@
+import { getDataLakeVariableData } from '@/libs/actions/data-lake'
+import { datalogger, DatalogVariable } from '@/libs/sensors-logging'
+import { findDataLakeVariablesIdsInString } from '@/libs/utils-data-lake'
+
+/**
+ * Maps each predefined video-overlay telemetry variable to the MAVLink message/field(s) that carry the
+ * same measurement.
+ *
+ * Overlay variables are vehicle-store values rendered as formatted strings (with units); the data-lake
+ * equivalents are the raw, base-unit MAVLink fields, which is what a raw data log should contain. Each
+ * field is later expanded into a full `/mavlink/<systemId>/1/<message>/<field>` ID. Instantaneous power
+ * is derived (voltage × current), so it maps to both source fields instead of a single value. Overlay
+ * variables with no data-lake source (Mission name, Time, Date) are intentionally omitted.
+ */
+const overlayVariableToMavlinkFields: Partial<Record<DatalogVariable, string[]>> = {
+  [DatalogVariable.roll]: ['ATTITUDE/roll'],
+  [DatalogVariable.pitch]: ['ATTITUDE/pitch'],
+  [DatalogVariable.heading]: ['ATTITUDE/yaw'],
+  [DatalogVariable.depth]: ['AHRS2/altitude'],
+  [DatalogVariable.mode]: ['HEARTBEAT/custom_mode'],
+  [DatalogVariable.batteryVoltage]: ['SYS_STATUS/voltage_battery'],
+  [DatalogVariable.batteryCurrent]: ['SYS_STATUS/current_battery'],
+  [DatalogVariable.gpsVisibleSatellites]: ['GPS_RAW_INT/satellites_visible'],
+  [DatalogVariable.gpsFixType]: ['GPS_RAW_INT/fix_type'],
+  [DatalogVariable.latitude]: ['GLOBAL_POSITION_INT/lat'],
+  [DatalogVariable.longitude]: ['GLOBAL_POSITION_INT/lon'],
+  [DatalogVariable.instantaneousPower]: ['SYS_STATUS/voltage_battery', 'SYS_STATUS/current_battery'],
+}
+
+const datalogVariableNames = new Set<string>(Object.values(DatalogVariable))
+
+/**
+ * Resolve the main vehicle's MAVLink system ID, falling back to the default (1) when no vehicle has
+ * been seen yet (e.g. on a fresh first run before any heartbeat arrives).
+ * @returns {number} The main vehicle system ID
+ */
+const mainVehicleSystemId = (): number => {
+  const systemId = Number(getDataLakeVariableData('autopilotSystemId'))
+  return Number.isFinite(systemId) && systemId > 0 ? systemId : 1
+}
+
+/**
+ * Resolve one video-overlay grid entry to the data-lake variable IDs it should record.
+ *
+ * Overlay entries come in three shapes: predefined telemetry names (e.g. "Roll"), custom messages with
+ * `{{ id }}` templates, and data-lake variable IDs dragged in directly.
+ * @param {string} entry - A single overlay grid entry
+ * @param {number} systemId - The main vehicle system ID used to build predefined MAVLink IDs
+ * @returns {string[]} The data-lake variable IDs the entry maps to (empty when it has no equivalent)
+ */
+const overlayEntryToDataLakeIds = (entry: string, systemId: number): string[] => {
+  const trimmedEntry = entry.trim()
+  if (trimmedEntry.length === 0) return []
+
+  if (datalogVariableNames.has(trimmedEntry)) {
+    const mavlinkFields = overlayVariableToMavlinkFields[trimmedEntry as DatalogVariable] ?? []
+    return mavlinkFields.map((field) => `/mavlink/${systemId}/1/${field}`)
+  }
+
+  const templateIds = findDataLakeVariablesIdsInString(trimmedEntry)
+  if (templateIds.length > 0) return templateIds
+
+  return [trimmedEntry]
+}
+
+/**
+ * Collect every data-lake variable ID referenced by the current video-overlay configuration. Used to
+ * seed the data lake recording list on first run so logging is useful out of the box.
+ * @returns {string[]} Unique data-lake variable IDs, in overlay order
+ */
+export const collectOverlayRecordedVariableIds = (): string[] => {
+  const systemId = mainVehicleSystemId()
+  const ids = Object.values(datalogger.telemetryDisplayData)
+    .flat()
+    .flatMap((entry) => overlayEntryToDataLakeIds(entry, systemId))
+
+  return [...new Set(ids)]
+}

--- a/src/utils/migrations.ts
+++ b/src/utils/migrations.ts
@@ -1,5 +1,7 @@
+import { recordedDataLakeVariablesKey } from '@/libs/data-lake-logging'
 import { shareHardwareDetailsKey } from '@/libs/external-telemetry/event-tracking'
 import { settingsManager } from '@/libs/settings-management'
+import { collectOverlayRecordedVariableIds } from '@/utils/data-lake-recorded-variables-migration'
 
 // Tracks which one-off migrations have already run, keyed by migration name.
 const migrationsKey = 'cockpit-migrations'
@@ -60,9 +62,32 @@ const migrateLegacyTelemetryOptOutToHardwareSharing = (): void => {
 }
 
 /**
+ * Seed the data lake recording list from the video-overlay variables on first run.
+ *
+ * When nothing is selected yet, pre-selects the variables already shown on the overlay. This runs
+ * before the data lake logger starts, so the seeded selection is picked up on its first start. Runs
+ * once and never again, even if the user later clears the list.
+ */
+const migrateRecordedVariablesFromOverlay = (): void => {
+  const migrationName = 'recorded-variables-from-overlay'
+  if (hasMigrationRun(migrationName)) return
+
+  const existingSelection = settingsManager.getKeyValue(recordedDataLakeVariablesKey) as string[] | undefined
+  if (existingSelection === undefined || existingSelection.length === 0) {
+    const overlayIds = collectOverlayRecordedVariableIds()
+    if (overlayIds.length > 0) {
+      settingsManager.setKeyValue(recordedDataLakeVariablesKey, overlayIds)
+    }
+  }
+
+  markMigrationAsRun(migrationName)
+}
+
+/**
  * Run all migrations
  */
 export function runMigrations(): void {
   migrateRenameOfLocalStorageKeys()
   migrateLegacyTelemetryOptOutToHardwareSharing()
+  migrateRecordedVariablesFromOverlay()
 }

--- a/src/utils/migrations.ts
+++ b/src/utils/migrations.ts
@@ -1,6 +1,28 @@
 import { shareHardwareDetailsKey } from '@/libs/external-telemetry/event-tracking'
 import { settingsManager } from '@/libs/settings-management'
 
+// Tracks which one-off migrations have already run, keyed by migration name.
+const migrationsKey = 'cockpit-migrations'
+
+/**
+ * @param {string} name - Migration identifier
+ * @returns {boolean} Whether the migration has already run
+ */
+export const hasMigrationRun = (name: string): boolean => {
+  const migrations = (settingsManager.getKeyValue(migrationsKey) as Record<string, boolean> | undefined) ?? {}
+  return migrations[name] === true
+}
+
+/**
+ * Mark a migration as run so it never executes again.
+ * @param {string} name - Migration identifier
+ */
+export const markMigrationAsRun = (name: string): void => {
+  const migrations = (settingsManager.getKeyValue(migrationsKey) as Record<string, boolean> | undefined) ?? {}
+  migrations[name] = true
+  settingsManager.setKeyValue(migrationsKey, migrations)
+}
+
 /**
  * Migrate old localStorage keys to new ones
  */

--- a/src/views/ToolsDataLakeView.vue
+++ b/src/views/ToolsDataLakeView.vue
@@ -6,7 +6,10 @@
         <ExpansiblePanel no-top-divider no-bottom-divider :is-expanded="!interfaceStore.isOnPhoneScreen">
           <template #title>Variables monitor</template>
           <template #info>
-            <p>View, manage, and create data lake variables.</p>
+            <p>
+              View, manage, and create data lake variables. Use the Record checkbox to include a variable in CSV/JSON
+              data logs.
+            </p>
           </template>
           <template #content>
             <div class="flex justify-center flex-col ml-2 mb-8 mt-2 w-full h-full">
@@ -101,11 +104,25 @@
                       </div>
                     </td>
                     <td>
-                      <div class="flex items-center justify-end h-[42px] -mr-2">
+                      <div class="flex items-center justify-end h-[42px] gap-1 -mr-2">
+                        <v-tooltip text="Record to data logs">
+                          <template #activator="{ props: tooltipProps }">
+                            <v-checkbox
+                              v-bind="tooltipProps"
+                              :model-value="recordedVariableIds.includes(item.id)"
+                              density="compact"
+                              hide-details
+                              color="white"
+                              class="record-checkbox flex-none"
+                              @update:model-value="(recorded) => handleRecordToggle(item.id, recorded)"
+                              @click.stop
+                            />
+                          </template>
+                        </v-tooltip>
                         <v-btn
                           v-if="isCompoundVariable(item.id)"
                           variant="outlined"
-                          class="rounded-full mx-1"
+                          class="rounded-full"
                           icon="mdi-pencil"
                           size="x-small"
                           @click="editCompoundVariable(item.id)"
@@ -113,7 +130,7 @@
                         <v-btn
                           v-if="isUserDefinedVariable(item.id)"
                           variant="outlined"
-                          class="rounded-full mx-1"
+                          class="rounded-full"
                           icon="mdi-pencil"
                           size="x-small"
                           @click="editUserDefinedVariable(item.id)"
@@ -122,7 +139,7 @@
                           v-if="isCompoundVariable(item.id) || isUserDefinedVariable(item.id)"
                           variant="outlined"
                           color="error"
-                          class="rounded-full mx-1"
+                          class="rounded-full"
                           icon="mdi-delete"
                           size="x-small"
                           @click="deleteVariable(item.id)"
@@ -183,6 +200,7 @@ import {
   getAllTransformingFunctions,
   TransformingFunction,
 } from '@/libs/actions/data-lake-transformations'
+import { dataLakeLogger } from '@/libs/data-lake-logging'
 import { copyToClipboard } from '@/libs/utils'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 
@@ -207,8 +225,15 @@ const tableHeaders = [
   { title: 'Type', align: 'center', key: 'type', width: '100px', fixed: true },
   { title: 'Source', align: 'center', key: 'source', width: '120px', fixed: true },
   { title: 'Current Value', align: 'start', key: 'value', width: '220px', fixed: true },
-  { title: 'Actions', align: 'end', key: 'actions', width: '100px', fixed: true },
+  { title: 'Actions', align: 'end', key: 'actions', width: '160px', fixed: true },
 ] as const
+
+const recordedVariableIds = ref<string[]>([...dataLakeLogger.recordedVariableIds])
+
+const handleRecordToggle = (variableId: string, recorded: boolean | null): void => {
+  dataLakeLogger.setVariableRecorded(variableId, recorded ?? false)
+  recordedVariableIds.value = [...dataLakeLogger.recordedVariableIds]
+}
 
 const copiedId = ref<string | null>(null)
 const handleCopy = async (id: string): Promise<void> => {
@@ -434,5 +459,10 @@ watch(showNewFunctionDialog, (show) => {
 
 :deep(.v-data-table__wrapper) {
   flex-grow: 1;
+}
+
+.record-checkbox :deep(.v-selection-control) {
+  min-height: auto;
+  justify-content: center;
 }
 </style>

--- a/src/views/ToolsDataLakeView.vue
+++ b/src/views/ToolsDataLakeView.vue
@@ -74,8 +74,8 @@
 
                         <v-tooltip location="top">
                           <template #activator="{ props: tooltipProps }">
-                            <div v-bind="tooltipProps" class="w-[440px]">
-                              <ScrollingText :text="item.name" max-width="440px" align="left" :pause-on-hover="false" />
+                            <div v-bind="tooltipProps" class="w-[390px]">
+                              <ScrollingText :text="item.name" max-width="390px" align="left" :pause-on-hover="false" />
                             </div>
                           </template>
                           <span>{{ item.name }}</span>
@@ -84,41 +84,27 @@
                     </td>
                     <td>
                       <div class="flex items-center justify-center rounded-xl mx-1">
-                        <p class="w-[100px] whitespace-nowrap overflow-hidden text-ellipsis text-center">
+                        <p class="w-[70px] whitespace-nowrap overflow-hidden text-ellipsis text-center">
                           {{ item.type }}
                         </p>
                       </div>
                     </td>
                     <td>
                       <div class="flex items-center justify-center rounded-xl mx-1">
-                        <p class="w-[120px] whitespace-nowrap overflow-hidden text-ellipsis text-center">
+                        <p class="w-[115px] whitespace-nowrap overflow-hidden text-ellipsis text-center">
                           {{ item.source }}
                         </p>
                       </div>
                     </td>
                     <td>
                       <div class="flex items-center justify-start rounded-xl mx-1">
-                        <p class="w-[220px] whitespace-nowrap overflow-hidden text-ellipsis text-left font-mono">
+                        <p class="w-[200px] whitespace-nowrap overflow-hidden text-ellipsis text-left font-mono">
                           {{ parsedCurrentValue(item.id) }}
                         </p>
                       </div>
                     </td>
                     <td>
                       <div class="flex items-center justify-end h-[42px] gap-1 -mr-2">
-                        <v-tooltip text="Record to data logs">
-                          <template #activator="{ props: tooltipProps }">
-                            <v-checkbox
-                              v-bind="tooltipProps"
-                              :model-value="recordedVariableIds.includes(item.id)"
-                              density="compact"
-                              hide-details
-                              color="white"
-                              class="record-checkbox flex-none"
-                              @update:model-value="(recorded) => handleRecordToggle(item.id, recorded)"
-                              @click.stop
-                            />
-                          </template>
-                        </v-tooltip>
                         <v-btn
                           v-if="isCompoundVariable(item.id)"
                           variant="outlined"
@@ -146,11 +132,24 @@
                         />
                       </div>
                     </td>
+                    <td>
+                      <div class="flex items-center justify-center rounded-xl mx-1">
+                        <v-checkbox
+                          :model-value="recordedVariableIds.includes(item.id)"
+                          density="compact"
+                          hide-details
+                          color="white"
+                          class="record-checkbox flex-none"
+                          @update:model-value="(recorded) => handleRecordToggle(item.id, recorded)"
+                          @click.stop
+                        />
+                      </div>
+                    </td>
                   </tr>
                 </template>
                 <template #no-data>
                   <tr>
-                    <td colspan="5" class="text-center flex items-center justify-center h-[50px] w-full">
+                    <td colspan="6" class="text-center flex items-center justify-center h-[50px] w-full">
                       <p class="text-[16px] ml-[170px] w-full">No data lake variables found</p>
                     </td>
                   </tr>
@@ -221,11 +220,20 @@ interface DataLakeVariableWithSource extends DataLakeVariable {
 }
 
 const tableHeaders = [
-  { title: 'Name', align: 'start', key: 'name', width: '220px', fixed: true, headerProps: { class: 'pl-10' } },
-  { title: 'Type', align: 'center', key: 'type', width: '100px', fixed: true },
-  { title: 'Source', align: 'center', key: 'source', width: '120px', fixed: true },
-  { title: 'Current Value', align: 'start', key: 'value', width: '220px', fixed: true },
-  { title: 'Actions', align: 'end', key: 'actions', width: '160px', fixed: true },
+  { title: 'Name', align: 'start', key: 'name', width: '390px', fixed: true, headerProps: { class: 'pl-10' } },
+  { title: 'Type', align: 'center', key: 'type', width: '70px', fixed: true },
+  { title: 'Source', align: 'center', key: 'source', width: '115px', fixed: true },
+  { title: 'Current Value', align: 'start', key: 'value', width: '200px', fixed: true },
+  { title: 'Actions', align: 'end', key: 'actions', width: '70px', fixed: true },
+  {
+    title: 'Record',
+    align: 'center',
+    key: 'record',
+    width: '30px',
+    fixed: true,
+    sortable: true,
+    value: (item: DataLakeVariableWithSource) => (recordedVariableIds.value.includes(item.id) ? 1 : 0),
+  },
 ] as const
 
 const recordedVariableIds = ref<string[]>([...dataLakeLogger.recordedVariableIds])

--- a/src/views/ToolsLogsView.vue
+++ b/src/views/ToolsLogsView.vue
@@ -1,0 +1,403 @@
+<template>
+  <BaseConfigurationView>
+    <template #title>Data Logs</template>
+    <template #content>
+      <div
+        class="max-h-[85vh] overflow-y-auto -mr-4"
+        :class="interfaceStore.isOnSmallScreen ? 'max-w-[70vw]' : 'max-w-[40vw]'"
+      >
+        <ExpansiblePanel :is-expanded="true" no-top-divider>
+          <template #title>
+            <div class="flex justify-between items-center w-full">
+              <span>Data Sessions</span>
+              <div class="flex items-center gap-2">
+                <span class="text-sm text-gray-300 cursor-pointer" @click.stop="refreshSessions">
+                  <v-tooltip text="Refresh sessions">
+                    <template #activator="{ props }">
+                      <v-icon v-bind="props" :class="{ 'animate-spin': isLoading }">mdi-refresh</v-icon>
+                    </template>
+                  </v-tooltip>
+                </span>
+                <span class="text-sm text-gray-300 cursor-pointer" @click.stop="deleteOldSessions">
+                  <v-tooltip text="Delete sessions older than 24 hours">
+                    <template #activator="{ props }">
+                      <v-icon v-bind="props">mdi-delete-sweep</v-icon>
+                    </template>
+                  </v-tooltip>
+                </span>
+                <span class="text-sm text-gray-300 cursor-pointer" @click.stop="showSettingsDialog = true">
+                  <v-tooltip text="Data export settings">
+                    <template #activator="{ props }">
+                      <v-icon v-bind="props" size="20">mdi-cog</v-icon>
+                    </template>
+                  </v-tooltip>
+                </span>
+              </div>
+            </div>
+          </template>
+          <template #info>
+            Raw data lake variables are recorded while Cockpit is running. Select which variables to record from the
+            Data Lake table, then download session logs here in JSON or CSV format.
+          </template>
+          <template #content>
+            <div v-if="isLoading" class="flex justify-center items-center py-8">
+              <v-progress-circular indeterminate color="white" />
+            </div>
+            <div v-else-if="sessions.length === 0" class="text-center py-8 text-gray-400">
+              No data sessions found. Select variables to record in the Data Lake table.
+            </div>
+            <v-data-table
+              v-else
+              :items="sessions"
+              density="compact"
+              theme="dark"
+              :headers="headers"
+              :row-props="rowProps"
+              class="w-full max-h-[60%] rounded-md bg-[#FFFFFF11]"
+            >
+              <template #item.dateTimeFormatted="{ item }">
+                <div class="flex items-center gap-2" :class="{ 'line-through': isDeleting(item) }">
+                  <span>{{ item.dateTimeFormatted }}</span>
+                  <div v-if="item.isCurrentSession" class="current-session-indicator" />
+                </div>
+              </template>
+              <template #item.dataPointCount="{ item }">
+                <span :class="{ 'line-through': isDeleting(item) }"
+                  >{{ item.dataPointCount.toLocaleString() }} points</span
+                >
+              </template>
+              <template #item.durationSeconds="{ item }">
+                <span :class="{ 'line-through': isDeleting(item) }">{{ formatDuration(item.durationSeconds) }}</span>
+              </template>
+              <template #item.actions="{ item }">
+                <div class="flex justify-end items-center space-x-2">
+                  <v-progress-circular v-if="isDeleting(item)" indeterminate size="20" width="2" color="white" />
+                  <template v-else>
+                    <v-menu>
+                      <template #activator="{ props }">
+                        <div
+                          v-bind="props"
+                          class="cursor-pointer icon-btn mdi mdi-download"
+                          :class="{ 'opacity-50': isDownloading === item.id }"
+                        />
+                      </template>
+                      <v-list density="compact" class="bg-[#333]">
+                        <v-list-item @click="downloadSession(item, 'json')">
+                          <v-list-item-title class="flex items-center gap-2">
+                            <v-icon size="small">mdi-code-json</v-icon>
+                            Download as JSON
+                          </v-list-item-title>
+                        </v-list-item>
+                        <v-list-item @click="downloadSession(item, 'csv')">
+                          <v-list-item-title class="flex items-center gap-2">
+                            <v-icon size="small">mdi-file-delimited</v-icon>
+                            Download as CSV
+                          </v-list-item-title>
+                        </v-list-item>
+                      </v-list>
+                    </v-menu>
+                    <div
+                      class="cursor-pointer icon-btn mdi mdi-delete"
+                      :class="{ 'opacity-50 pointer-events-none': item.isCurrentSession }"
+                      @click="!item.isCurrentSession && deleteSession(item)"
+                    />
+                  </template>
+                </div>
+              </template>
+            </v-data-table>
+          </template>
+        </ExpansiblePanel>
+      </div>
+
+      <v-dialog v-model="showSettingsDialog" max-width="460px">
+        <v-card class="rounded-lg export-settings-card text-white" :style="interfaceStore.globalGlassMenuStyles">
+          <v-card-title class="d-flex align-center py-4">
+            <span class="text-h6 font-weight-bold">Data export settings</span>
+            <v-spacer />
+            <v-tooltip location="bottom" max-width="360px">
+              <template #activator="{ props }">
+                <v-icon v-bind="props" size="small">mdi-information-outline</v-icon>
+              </template>
+              <div class="text-caption">
+                <p class="font-weight-bold mb-1">Column labels</p>
+                <p class="mb-1">How each variable's column is named in the exported files.</p>
+                <ul class="pl-4 mb-2">
+                  <li><strong>Variable ID</strong> — full data-lake path (e.g. /mavlink/1/1/ATTITUDE/roll).</li>
+                  <li><strong>Short variable ID</strong> — only the last segment (e.g. roll).</li>
+                  <li><strong>Variable name</strong> — human-readable name (e.g. Roll).</li>
+                </ul>
+                <p class="mb-2">
+                  If two variables would end up with the same label, both fall back to their full IDs so columns stay
+                  unique.
+                </p>
+                <p class="font-weight-bold mb-1">Logging interval</p>
+                <ul class="pl-4">
+                  <li><strong>Raw</strong> — a row is recorded whenever any selected variable changes.</li>
+                  <li><strong>Fixed interval</strong> — all selected variables are sampled every N milliseconds.</li>
+                </ul>
+              </div>
+            </v-tooltip>
+          </v-card-title>
+          <v-card-text class="px-6">
+            <p class="text-sm mb-1 font-weight-medium">Column labels</p>
+            <p class="text-sm mb-2">How variable columns are labeled in CSV and JSON files.</p>
+            <v-radio-group v-model="exportVariableKey" density="compact" hide-details>
+              <v-radio label="Variable ID" value="id" />
+              <v-radio label="Short variable ID" value="short-id" />
+              <v-radio label="Variable name" value="name" />
+            </v-radio-group>
+
+            <p class="text-sm mt-5 mb-1 font-weight-medium">Logging interval</p>
+            <p class="text-sm mb-2">How often selected variables are recorded.</p>
+            <v-radio-group v-model="loggingMode" density="compact" hide-details>
+              <v-radio label="Raw (record on every value change)" value="raw" />
+              <div class="flex items-center gap-2">
+                <v-radio label="Fixed interval" value="interval" />
+                <v-text-field
+                  v-model.number="intervalMs"
+                  type="number"
+                  density="compact"
+                  hide-details
+                  variant="underlined"
+                  suffix="ms"
+                  class="max-w-[120px]"
+                  min="1"
+                  :disabled="loggingMode !== 'interval'"
+                />
+              </div>
+            </v-radio-group>
+          </v-card-text>
+          <v-divider class="mx-6" />
+          <v-card-actions class="px-6 pb-4">
+            <v-spacer />
+            <v-btn variant="text" @click="showSettingsDialog = false">Close</v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-dialog>
+    </template>
+  </BaseConfigurationView>
+</template>
+
+<script setup lang="ts">
+// @ts-nocheck
+// TODO: As of now Vuetify does not export the necessary types for VDataTable, so we can't fix the type error.
+
+import { format } from 'date-fns'
+import { saveAs } from 'file-saver'
+import { onBeforeMount, onBeforeUnmount, ref, watch } from 'vue'
+
+import ExpansiblePanel from '@/components/ExpansiblePanel.vue'
+import { useSnackbar } from '@/composables/snackbar'
+import {
+  type DataLakeExportVariableKey,
+  type DataLakeSessionInfo,
+  DataLakeLogger,
+  dataLakeLogger,
+} from '@/libs/data-lake-logging'
+import { useAppInterfaceStore } from '@/stores/appInterface'
+
+import BaseConfigurationView from './BaseConfigurationView.vue'
+
+const interfaceStore = useAppInterfaceStore()
+const { openSnackbar } = useSnackbar()
+
+const sessions = ref<DataLakeSessionInfo[]>([])
+const showSettingsDialog = ref(false)
+const exportVariableKey = ref<DataLakeExportVariableKey>(dataLakeLogger.exportVariableKey)
+watch(exportVariableKey, (value) => {
+  dataLakeLogger.exportVariableKey = value
+})
+
+const intervalMs = ref(typeof dataLakeLogger.logInterval === 'number' ? dataLakeLogger.logInterval : 1000)
+const loggingMode = ref<'raw' | 'interval'>(dataLakeLogger.logInterval === 'raw' ? 'raw' : 'interval')
+watch([loggingMode, intervalMs], () => {
+  if (loggingMode.value === 'raw') {
+    dataLakeLogger.logInterval = 'raw'
+  } else if (intervalMs.value >= 1) {
+    dataLakeLogger.logInterval = intervalMs.value
+  }
+})
+
+const isLoading = ref(false)
+const isDownloading = ref<string | null>(null)
+const deletingSessionIds = ref<string[]>([])
+let refreshInterval: ReturnType<typeof setInterval> | null = null
+
+const isDeleting = (session: DataLakeSessionInfo): boolean => deletingSessionIds.value.includes(session.id)
+
+/**
+ * Argument Vuetify's data table passes to its `row-props` callback.
+ */
+interface SessionRowProps {
+  /**
+   * The session rendered by the row.
+   */
+  item: DataLakeSessionInfo
+}
+
+const rowProps = ({ item }: SessionRowProps): Record<string, string> => ({
+  class: isDeleting(item) ? 'session-row--deleting' : '',
+})
+
+const headers = [
+  { title: 'Date/Time', key: 'dateTimeFormatted', sortable: true },
+  { title: 'Data Points', key: 'dataPointCount', sortable: true },
+  { title: 'Duration', key: 'durationSeconds', sortable: true },
+  { title: 'Actions', key: 'actions', align: 'end', sortable: false },
+]
+
+const formatDuration = (seconds: number): string => {
+  if (seconds < 60) {
+    return `${seconds}s`
+  }
+  const minutes = Math.floor(seconds / 60)
+  const remainingSeconds = seconds % 60
+  if (minutes < 60) {
+    return `${minutes}m ${remainingSeconds}s`
+  }
+  const hours = Math.floor(minutes / 60)
+  const remainingMinutes = minutes % 60
+  return `${hours}h ${remainingMinutes}m`
+}
+
+const refreshSessions = async (): Promise<void> => {
+  isLoading.value = true
+  try {
+    sessions.value = await DataLakeLogger.getDataSessions()
+  } catch (error) {
+    openSnackbar({ message: 'Failed to load data sessions', variant: 'error' })
+  } finally {
+    isLoading.value = false
+  }
+}
+
+// Background refresh: reads the lightweight sessions table, so a full reassignment is cheap and
+// always reflects new/finalized sessions (e.g. after a mode change starts a fresh session).
+const lightRefresh = async (): Promise<void> => {
+  try {
+    sessions.value = await DataLakeLogger.getDataSessions()
+  } catch (error) {
+    // Silently fail on background refresh
+  }
+}
+
+onBeforeMount(async () => {
+  await refreshSessions()
+  refreshInterval = setInterval(lightRefresh, 1000)
+})
+
+onBeforeUnmount(() => {
+  if (refreshInterval) {
+    clearInterval(refreshInterval)
+    refreshInterval = null
+  }
+})
+
+const downloadSession = async (session: DataLakeSessionInfo, formatType: 'json' | 'csv'): Promise<void> => {
+  if (isDownloading.value) return
+
+  isDownloading.value = session.id
+  try {
+    openSnackbar({ message: 'Generating log file...', variant: 'info', duration: 2000 })
+
+    const log = await DataLakeLogger.generateLogFromSession(session)
+
+    if (log.length === 0) {
+      openSnackbar({ message: 'No data points found in session', variant: 'warning' })
+      return
+    }
+
+    let content: string
+    let mimeType: string
+    let extension: string
+
+    if (formatType === 'json') {
+      content = dataLakeLogger.toJson(log)
+      mimeType = 'application/json'
+      extension = 'json'
+    } else {
+      content = dataLakeLogger.toCsv(log)
+      mimeType = 'text/csv'
+      extension = 'csv'
+    }
+
+    const blob = new Blob([content], { type: mimeType })
+    const dateStr = format(new Date(session.startTime), 'yyyy-MM-dd_HH-mm-ss')
+    const fileName = `Cockpit_Data_Log_${dateStr}.${extension}`
+    saveAs(blob, fileName)
+
+    openSnackbar({ message: `Downloaded ${fileName}`, variant: 'success' })
+  } catch (error) {
+    openSnackbar({ message: 'Failed to download session', variant: 'error' })
+  } finally {
+    isDownloading.value = null
+  }
+}
+
+const deleteSession = async (session: DataLakeSessionInfo): Promise<void> => {
+  if (session.isCurrentSession) {
+    openSnackbar({ message: 'Cannot delete the current active session', variant: 'warning' })
+    return
+  }
+  if (isDeleting(session)) return
+
+  deletingSessionIds.value = [...deletingSessionIds.value, session.id]
+  try {
+    await DataLakeLogger.deleteDataSession(session)
+    sessions.value = sessions.value.filter((s) => s.id !== session.id)
+    openSnackbar({ message: 'Session deleted', variant: 'success' })
+  } catch (error) {
+    openSnackbar({ message: 'Failed to delete session', variant: 'error' })
+  } finally {
+    deletingSessionIds.value = deletingSessionIds.value.filter((id) => id !== session.id)
+  }
+}
+
+const deleteOldSessions = async (): Promise<void> => {
+  try {
+    const deletedCount = await DataLakeLogger.deleteOldDataSessions(1)
+    if (deletedCount > 0) {
+      await refreshSessions()
+      openSnackbar({ message: `Deleted ${deletedCount} old session(s)`, variant: 'success' })
+    } else {
+      openSnackbar({ message: 'No old sessions to delete', variant: 'info' })
+    }
+  } catch (error) {
+    openSnackbar({ message: 'Failed to delete old sessions', variant: 'error' })
+  }
+}
+</script>
+
+<style scoped>
+.current-session-indicator {
+  width: 8px;
+  height: 8px;
+  margin-top: 2px;
+  border-radius: 50%;
+  background-color: #ef4444;
+  animation: blink 1.5s infinite;
+}
+
+@keyframes blink {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
+}
+
+.session-row--deleting {
+  opacity: 0.5;
+}
+
+.export-settings-card,
+.export-settings-card :deep(.v-label),
+.export-settings-card :deep(.v-selection-control__input),
+.export-settings-card :deep(.v-field__input),
+.export-settings-card :deep(.v-text-field__suffix) {
+  color: #ffffff;
+  opacity: 1;
+}
+</style>


### PR DESCRIPTION
# Data Logs

Introduce the long-waiter **Raw Data Logs** feature to record selected data-lake variables over time and download them as **CSV or JSON** for analysis. Unlike the video-overlay telemetry (formatted strings with units), this captures the **raw values** of the variables a user picks.


https://github.com/user-attachments/assets/894d6845-5d13-4c5f-ae2b-19a873ebb157



## How it works

- **Pick variables:** toggle recording per variable in **Tools → Data-lake**. The choice persists and only changes when the user changes it.
- **Record:** selected variables are logged continuously while Cockpit runs.
- **Sessions:** recordings are grouped into sessions (a new one starts on restart, config change, or a long pause). Each shows date/time, point count, and duration.
- **Download:** in **Tools → Data Logs**, export any session as CSV/JSON, or delete sessions.

## Decisions

- **Two modes:** *fixed interval* (sample every N ms) or *raw* (record on every change).
- **Formats:** JSON stores only what changed (compact); CSV repeats the latest value across columns (spreadsheet-friendly).
- **Column labels:** full ID, short name, or display name — colliding labels fall back to full IDs.
- **Config change = new session**, so each session is internally consistent.
- **First-run seeding:** if the user has never picked variables, the variables already shown on the video overlay are pre-selected. Predefined telemetry maps to its raw MAVLink variables (instantaneous power maps to voltage + current), custom-message templates contribute their referenced ids, and directly-added data-lake ids carry over. Runs once and never again.

## Sample recordings

[Cockpit_Data_Log_2026-06-12_10-18-59.csv](https://github.com/user-attachments/files/28880551/Cockpit_Data_Log_2026-06-12_10-18-59.csv)
[Cockpit_Data_Log_2026-06-12_10-18-59.json](https://github.com/user-attachments/files/28880552/Cockpit_Data_Log_2026-06-12_10-18-59.json)


Closes #2238