### PR TITLE
.github: ci.yml: add AWS uploads for stable releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,14 @@ jobs:
           # Make keychain name available to electron-builder
           echo "CSC_KEYCHAIN_NAME=${KEYCHAIN_NAME}" >> $GITHUB_ENV
 
+      - name: Configure AWS Credentials (for Stable Release)
+        uses: aws-actions/configure-aws-credentials@v6
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') && success()
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
       - name: Deploy (macOS - Release Build)
         if: (matrix.os == 'macos-15-intel' || matrix.os == 'macos-15') && github.event_name != 'pull_request'
         env:
@@ -259,6 +267,12 @@ jobs:
           tag: ${{ github.ref }}
           overwrite: true
           prerelease: true
+
+      - name: Upload AWS Build (of Stable Release)
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') && success()
+        # Upload to version-less file, to provide static URLs for the latest stable release build
+        run: |
+          aws s3 cp dist/Cockpit-${{ matrix.suffix }}-${{ matrix.arch }}-${{ env.VERSION }}.${{ matrix.uploadExtension }} s3://br-www-docs/cockpit/releases/stable/Cockpit-${{ matrix.suffix }}-${{ matrix.arch }}.${{ matrix.uploadExtension }}
 
   deploy-flatpak:
     needs: test
@@ -341,6 +355,20 @@ jobs:
           tag: ${{ github.ref }}
           overwrite: true
           prerelease: true
+
+      - name: Configure AWS Credentials (for Stable Release)
+        uses: aws-actions/configure-aws-credentials@v6
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') && success()
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload AWS Build (of Stable Release)
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') && success()
+        # Upload to version-less file, to provide static URLs for the latest stable release build
+        run: |
+          aws s3 cp dist/Cockpit-${{ matrix.suffix }}-${{ matrix.arch }}-${{ env.VERSION }}.${{ matrix.extension }} s3://br-www-docs/cockpit/releases/stable/Cockpit-${{ matrix.suffix }}-${{ matrix.arch }}.${{ matrix.extension }}
 
   deploy-blueos-extension:
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,6 @@ jobs:
           tag: ${{ github.ref }}
           overwrite: true
           prerelease: true
-          file_glob: true
 
       - name: Upload diff release (mac-only)
         uses: svenstaro/upload-release-action@v2
@@ -250,7 +249,6 @@ jobs:
           tag: ${{ github.ref }}
           overwrite: true
           prerelease: true
-          file_glob: true
 
       - name: Upload latest metadata release
         uses: svenstaro/upload-release-action@v2
@@ -261,7 +259,6 @@ jobs:
           tag: ${{ github.ref }}
           overwrite: true
           prerelease: true
-          file_glob: true
 
   deploy-flatpak:
     needs: test
@@ -344,7 +341,6 @@ jobs:
           tag: ${{ github.ref }}
           overwrite: true
           prerelease: true
-          file_glob: true
 
   deploy-blueos-extension:
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,35 +76,40 @@ jobs:
         - os: macos-15-intel
           suffix: mac
           arch: x64
-          extension: dmg
+          buildExtension: dmg
+          uploadExtension: dmg
           latestMetadataName: latest-mac.yml
           deployCommand: deploy:electron:mac:x64
 
         - os: macos-15
           suffix: mac
           arch: arm64
-          extension: dmg
+          buildExtension: dmg
+          uploadExtension: dmg
           latestMetadataName: latest-mac-arm64.yml
           deployCommand: deploy:electron:mac:arm64
 
         - os: ubuntu-latest
           suffix: linux
           arch: x86_64
-          extension: AppImage
+          buildExtension: AppImage
+          uploadExtension: AppImage.tar.gz
           latestMetadataName: latest-linux.yml
           deployCommand: deploy:electron
 
         - os: ubuntu-24-arm
           suffix: linux
           arch: arm64
-          extension: AppImage
+          buildExtension: AppImage
+          uploadExtension: AppImage.tar.gz
           latestMetadataName: latest-linux-arm64.yml
           deployCommand: deploy:electron
 
         - os: windows-latest
           suffix: win
           arch: x64
-          extension: exe
+          buildExtension: exe
+          uploadExtension: exe
           latestMetadataName: latest.yml
           deployCommand: deploy:electron:windows
 
@@ -214,46 +219,27 @@ jobs:
         if: matrix.suffix == 'linux'
         run: |
           cd dist
-          chmod +x Cockpit-${{ matrix.suffix }}-${{ matrix.arch }}-${{ env.VERSION }}.AppImage
-          tar -czvf Cockpit-${{ matrix.suffix }}-${{ matrix.arch }}-${{ env.VERSION }}.AppImage.tar.gz \
-            Cockpit-${{ matrix.suffix }}-${{ matrix.arch }}-${{ env.VERSION }}.AppImage
+          chmod +x Cockpit-${{ matrix.suffix }}-${{ matrix.arch }}-${{ env.VERSION }}.${{ matrix.buildExtension }}
+          tar -czvf Cockpit-${{ matrix.suffix }}-${{ matrix.arch }}-${{ env.VERSION }}.${{ matrix.uploadExtension }} \
+            Cockpit-${{ matrix.suffix }}-${{ matrix.arch }}-${{ env.VERSION }}.${{ matrix.buildExtension }}
 
       - name: Upload binary artifact
-        if: matrix.suffix != 'linux'
         uses: actions/upload-artifact@v4
         with:
-          name: Cockpit-${{ matrix.suffix }}-${{ matrix.arch }}-${{ env.VERSION }}.${{ matrix.extension }}
-          path: dist/Cockpit-${{ matrix.suffix }}-${{ matrix.arch }}-${{ env.VERSION }}.${{ matrix.extension }}
+          name: Cockpit-${{ matrix.suffix }}-${{ matrix.arch }}-${{ env.VERSION }}.${{ matrix.uploadExtension }}
+          path: dist/Cockpit-${{ matrix.suffix }}-${{ matrix.arch }}-${{ env.VERSION }}.${{ matrix.uploadExtension }}
           if-no-files-found: error
 
       - name: Upload binary release
         uses: svenstaro/upload-release-action@v2
-        if: matrix.suffix != 'linux' && startsWith(github.ref, 'refs/tags/') && success()
+        if: startsWith(github.ref, 'refs/tags/') && success()
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: dist/Cockpit-${{ matrix.suffix }}-${{ matrix.arch }}-${{ env.VERSION }}.${{ matrix.extension }}
+          file: dist/Cockpit-${{ matrix.suffix }}-${{ matrix.arch }}-${{ env.VERSION }}.${{ matrix.uploadExtension }}
           tag: ${{ github.ref }}
           overwrite: true
           prerelease: true
           file_glob: true
-
-      - name: Upload tar.gz artifact (Linux)
-        if: matrix.suffix == 'linux'
-        uses: actions/upload-artifact@v4
-        with:
-          name: Cockpit-${{ matrix.suffix }}-${{ matrix.arch }}-${{ env.VERSION }}.AppImage.tar.gz
-          path: dist/Cockpit-${{ matrix.suffix }}-${{ matrix.arch }}-${{ env.VERSION }}.AppImage.tar.gz
-          if-no-files-found: error
-
-      - name: Upload tar.gz release (Linux)
-        uses: svenstaro/upload-release-action@v2
-        if: matrix.suffix == 'linux' && startsWith(github.ref, 'refs/tags/') && success()
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: dist/Cockpit-${{ matrix.suffix }}-${{ matrix.arch }}-${{ env.VERSION }}.AppImage.tar.gz
-          tag: ${{ github.ref }}
-          overwrite: true
-          prerelease: true
 
       - name: Upload diff release (mac-only)
         uses: svenstaro/upload-release-action@v2
@@ -342,14 +328,14 @@ jobs:
         run: |
           mv dist/Cockpit-${{ matrix.suffix }}-aarch64-${{ env.VERSION }}.${{ matrix.extension }} dist/Cockpit-${{ matrix.suffix }}-${{ matrix.arch }}-${{ env.VERSION }}.${{ matrix.extension }}
 
-      - name: Upload Artifact
+      - name: Upload PR Artifact
         uses: actions/upload-artifact@v4
         with:
           name: Cockpit-${{ matrix.suffix }}-${{ matrix.arch }}-${{ env.VERSION }}.${{ matrix.extension }}
           path: dist/Cockpit-${{ matrix.suffix }}-${{ matrix.arch }}-${{ env.VERSION }}.${{ matrix.extension }}
           if-no-files-found: error
 
-      - name: Upload Release
+      - name: Upload Release Artifact
         uses: svenstaro/upload-release-action@v2
         if: startsWith(github.ref, 'refs/tags/') && success()
         with:


### PR DESCRIPTION
- Copies release files to AWS S3
    - Fixes #2701 
        - Per internal discussion, using the `cockpit/releases/stable/` path instead of bare `cockpit`
    - New secrets are already available in the BR org
    - New workflow steps mostly copied from [our docs repo](https://github.com/bluerobotics/Cockpit-docs/blob/latest/.github/workflows/deploy.yml)
    - @voorloopnul will the `br-www-docs` bucket work for adding files to `cockpit/releases/stable/` instead of `cockpit/docs/`?
        - Not sure if that's invalid (i.e. needs a different bucket name), and/or if the path structure needs to be created in AWS first
- Cleans up extension handling for electron deployments, to simplify `.AppImage.tar.gz` upload variant
    - @rafaellehmkuhl this adds `file_glob: true` to the `tar.gz` upload - is that a problem?
- Clarifies naming of Flatpack Artifact upload steps (to avoid confusion)
- Skips the `.zip` output for macOS, to match the existing files that were manually added to AWS
    - @rafaellehmkuhl was this intentional on your part, or an oversight?