### PR TITLE
Map: Add north indicator to map

### DIFF
--- a/src/components/map/MapNorthIndicator.vue
+++ b/src/components/map/MapNorthIndicator.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class="map-north-indicator" :style="interfaceStore.globalGlassMenuStyles" role="img" aria-label="North">
+    <v-icon class="map-north-indicator__arrow">mdi-navigation</v-icon>
+    <span class="map-north-indicator__label">N</span>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useAppInterfaceStore } from '@/stores/appInterface'
+
+const interfaceStore = useAppInterfaceStore()
+</script>
+
+<style scoped>
+.map-north-indicator {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 31px;
+  height: 42px;
+  border-radius: 4px;
+  pointer-events: none;
+  user-select: none;
+}
+
+.map-north-indicator__arrow {
+  font-size: 14px;
+}
+
+.map-north-indicator__label {
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1;
+}
+</style>

--- a/src/components/mission-planning/MissionEstimates.vue
+++ b/src/components/mission-planning/MissionEstimates.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-if="modelValue"
-    class="absolute right-4 bottom-36 rounded-[10px] px-3 py-2"
+    class="absolute right-[10px] bottom-[192px] rounded-[10px] px-3 py-2"
     :style="[interfaceStore.globalGlassMenuStyles, { width: '280px' }]"
   >
     <p class="text-sm font-semibold mb-[6px]">Mission estimates</p>

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -129,6 +129,7 @@
           </template>
         </v-tooltip>
       </v-speed-dial>
+      <MapNorthIndicator class="north-indicator" />
       <PoiMapArrows
         :map-ready="mapReady"
         :show-poi-arrows="widget.options.showPoiArrows"
@@ -285,6 +286,7 @@ import brov2MarkerImage from '@/assets/brov2-marker.avif'
 import genericVehicleMarkerImage from '@/assets/generic-vehicle-marker.avif'
 import ExpansiblePanel from '@/components/ExpansiblePanel.vue'
 import GlobalOriginDialog from '@/components/GlobalOriginDialog.vue'
+import MapNorthIndicator from '@/components/map/MapNorthIndicator.vue'
 import MissionChecklist from '@/components/MissionChecklist.vue'
 import PoiManager from '@/components/poi/PoiManager.vue'
 import PoiMapArrows from '@/components/poi/PoiMapArrows.vue'
@@ -2151,6 +2153,14 @@ watch(
 
 .bottom-button {
   bottom: v-bind('bottomButtonsDisplacement');
+}
+
+/* Static north reference, stacked just above the bottom-right zoom control. */
+.north-indicator {
+  position: absolute;
+  right: 10px;
+  bottom: calc(v-bind('bottomButtonsDisplacement') + 85px);
+  z-index: 1002;
 }
 
 .poi-marker-icon-widget {

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -542,6 +542,7 @@
         </template>
       </v-tooltip>
     </v-speed-dial>
+    <MapNorthIndicator class="north-indicator" />
     <v-progress-linear
       v-if="uploadingMission"
       :model-value="missionUploadProgress"
@@ -676,6 +677,7 @@ import { type InstanceType, computed, nextTick, onMounted, onUnmounted, ref, sha
 import blueboatMarkerImage from '@/assets/blueboat-marker.avif'
 import brov2MarkerImage from '@/assets/brov2-marker.avif'
 import genericVehicleMarkerImage from '@/assets/generic-vehicle-marker.avif'
+import MapNorthIndicator from '@/components/map/MapNorthIndicator.vue'
 import ContextMenu from '@/components/mission-planning/ContextMenu.vue'
 import HomePositionSettingHelp from '@/components/mission-planning/HomePositionSettingHelp.vue'
 import MissionEstimatesPanel from '@/components/mission-planning/MissionEstimates.vue'
@@ -4760,6 +4762,12 @@ watch(
   cursor: pointer;
 }
 
+/* Static north reference, stacked just above the bottom-right zoom control. */
+.north-indicator {
+  position: absolute;
+  right: 10px;
+  bottom: 136px;
+}
 /* Style the standard Leaflet scale control */
 :deep(.leaflet-control-scale) {
   position: absolute;


### PR DESCRIPTION
- Adds a static north indicator (an `mdi-navigation` arrow above an "N") as a shared glass element pinned just above the bottom-right zoom control.
- Renders in both the flight map widget and the mission-planning view, always visible regardless of zoom or map mode.
- Shifts the mission estimates panel up and right so it clears the new indicator.

<img width="659" height="493" alt="image" src="https://github.com/user-attachments/assets/0d69caa3-cfb0-4c05-8ef8-bb492683f5d9" />

Closes #2362