### PR TITLE
.github: claude-pr-review.yml: stop allowing delayed reviews

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -2,7 +2,7 @@ name: Claude PR Review
 
 on:
   pull_request_target:
-    types: [opened, reopened, ready_for_review]
+    types: [opened]
 
 concurrency:
   group: claude-pr-review-${{ github.event.pull_request.number }}


### PR DESCRIPTION
Initial reviews are assumed to be before other reviews, and the `reopened` and `ready_for_review` triggers can be occur after previous reviews have already happened, including from Claude.

This also removes the ability for non-member/collaborator users to indefinitely use tokens by repeatedly reopening a PR or cycling between marking it as draft and ready.