### PR TITLE
Add support for GeoTiff overlays

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "flowbite": "^2.2.1",
     "flowbite-vue": "^0.1.2",
     "fuse.js": "^7.0.0",
+    "geotiff": "^3.0.5",
     "gsap": "^3.11.3",
     "hammerjs": "^2.0.8",
     "haversine-distance": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "flowbite": "^2.2.1",
     "flowbite-vue": "^0.1.2",
     "fuse.js": "^7.0.0",
+    "geo-extent": "^1.5.0",
     "geotiff": "^3.0.5",
     "gsap": "^3.11.3",
     "hammerjs": "^2.0.8",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "fuse.js": "^7.0.0",
     "geo-extent": "^1.5.0",
     "geotiff": "^3.0.5",
+    "geotiff-epsg-code": "^0.3.1",
     "gsap": "^3.11.3",
     "hammerjs": "^2.0.8",
     "haversine-distance": "^1.2.1",

--- a/src/components/map/MapOverlaysDialog.vue
+++ b/src/components/map/MapOverlaysDialog.vue
@@ -1,0 +1,223 @@
+<template>
+  <v-dialog :model-value="modelValue" width="700" @update:model-value="emit('update:modelValue', $event)">
+    <v-card :style="interfaceStore.globalGlassMenuStyles">
+      <v-card-title class="text-lg text-center font-semibold mt-2">Map overlays (GeoTIFF)</v-card-title>
+      <v-icon icon="mdi-close" class="absolute top-3 right-5 mt-2" @click="emit('update:modelValue', false)" />
+      <v-card-text>
+        <div class="flex flex-col gap-y-3">
+          <div
+            v-if="!isElectron()"
+            class="flex items-start gap-x-2 p-2 rounded-sm bg-[#FFFFFF14] text-xs text-slate-200"
+          >
+            <v-icon icon="mdi-information-outline" size="16" class="mt-[2px]" />
+            <span>
+              In the browser (Lite) version, overlays are stored in limited browser storage that the browser may clear,
+              so very large surveys may fail to save or not persist. For large datasets or reliable storage, use the
+              Standalone (desktop) app.
+            </span>
+          </div>
+
+          <div class="flex items-center justify-between">
+            <p class="text-md">Loaded overlays</p>
+            <v-btn
+              class="bg-[#FFFFFF22]"
+              variant="plain"
+              size="small"
+              prepend-icon="mdi-file-plus-outline"
+              :loading="importingOverlays"
+              @click="addOverlays"
+            >
+              Add GeoTIFF
+            </v-btn>
+          </div>
+
+          <p v-if="missionStore.mapOverlays.length === 0" class="text-sm text-slate-400">
+            No overlays loaded. Use "Add GeoTIFF" to load a survey.
+          </p>
+
+          <div
+            v-for="overlay in missionStore.mapOverlays"
+            :key="overlay.id"
+            class="flex flex-col gap-y-2 p-3 rounded-sm bg-[#FFFFFF14]"
+          >
+            <div class="flex items-center justify-between gap-x-3">
+              <div class="flex items-center gap-x-2 min-w-0">
+                <v-progress-circular
+                  v-if="loadingIds.includes(overlay.id)"
+                  v-tooltip.bottom="'Rendering overlay…'"
+                  indeterminate
+                  size="16"
+                  width="2"
+                  color="white"
+                />
+                <div class="flex flex-col min-w-0">
+                  <span class="text-sm text-white truncate">{{ overlay.name }}</span>
+                  <span class="text-xs text-slate-400">{{ formatBytes(overlay.fileSize, 1) }}</span>
+                </div>
+              </div>
+              <div class="flex items-center gap-x-3 shrink-0">
+                <v-switch
+                  v-model="overlay.visible"
+                  label="Visible"
+                  color="white"
+                  hide-details
+                  density="compact"
+                  base-color="#FFFFFF33"
+                />
+                <v-icon
+                  v-tooltip.bottom="'Center map on overlay'"
+                  icon="mdi-image-filter-center-focus"
+                  size="18"
+                  color="white"
+                  class="cursor-pointer opacity-70 hover:opacity-100"
+                  @click="centerOnOverlay(overlay)"
+                />
+                <v-icon
+                  v-tooltip.bottom="'Remove overlay'"
+                  icon="mdi-trash-can-outline"
+                  size="18"
+                  color="white"
+                  class="cursor-pointer opacity-70 hover:opacity-100"
+                  @click="removeOverlay(overlay)"
+                />
+              </div>
+            </div>
+            <div class="flex items-center gap-x-4 flex-wrap">
+              <v-select
+                v-model="overlay.renderMode"
+                :items="renderModeOptions"
+                label="Render mode"
+                density="compact"
+                variant="outlined"
+                hide-details
+                class="w-[200px]"
+                theme="dark"
+              />
+              <div class="flex items-center gap-x-2 flex-1 min-w-[200px]">
+                <span class="text-sm text-slate-200 whitespace-nowrap">Opacity</span>
+                <v-slider
+                  v-model="overlay.opacity"
+                  :min="0"
+                  :max="1"
+                  :step="0.05"
+                  color="white"
+                  hide-details
+                  density="compact"
+                />
+                <span class="text-xs text-slate-200 w-10 text-right">{{ Math.round(overlay.opacity * 100) }}%</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </v-card-text>
+      <v-divider class="mx-8" />
+      <v-card-actions>
+        <div class="flex justify-end w-full pa-0 mr-2">
+          <v-btn color="white" @click="emit('update:modelValue', false)">Close</v-btn>
+        </div>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+import { openSnackbar } from '@/composables/snackbar'
+import {
+  deleteStoredOverlay,
+  importGeoTiffFile,
+  isGeoTiffFile,
+  OverlayStorageQuotaError,
+  pickGeoTiffFiles,
+} from '@/libs/map/overlay-import'
+import { formatBytes, isElectron } from '@/libs/utils'
+import { useAppInterfaceStore } from '@/stores/appInterface'
+import { useMissionStore } from '@/stores/mission'
+import type { MapOverlayMeta, MapOverlayRenderMode } from '@/types/mission'
+
+withDefaults(
+  defineProps<{
+    /**
+     * Whether the dialog is open.
+     */
+    modelValue: boolean
+    /**
+     * Ids of overlays currently rendering on the map, shown with a loading indicator.
+     */
+    loadingIds?: string[]
+  }>(),
+  { loadingIds: () => [] }
+)
+
+const emit = defineEmits<{
+  /**
+   * Emitted to update the dialog's open state.
+   */
+  (event: 'update:modelValue', value: boolean): void
+}>()
+
+const missionStore = useMissionStore()
+const interfaceStore = useAppInterfaceStore()
+
+const renderModeOptions: {
+  /**
+   * Label shown in the render-mode dropdown.
+   */
+  title: string
+  /**
+   * Render mode applied to the overlay.
+   */
+  value: MapOverlayRenderMode
+}[] = [
+  { title: 'Grayscale / RGB', value: 'grayscale' },
+  { title: 'Intensity', value: 'intensity' },
+  { title: 'Bathymetry', value: 'bathymetry' },
+]
+
+const importingOverlays = ref(false)
+
+const addOverlays = async (): Promise<void> => {
+  const files = await pickGeoTiffFiles()
+  if (files.length === 0) return
+
+  importingOverlays.value = true
+  let addedCount = 0
+  for (const file of files) {
+    if (!isGeoTiffFile(file)) {
+      openSnackbar({ message: `"${file.name}" is not a GeoTIFF file.`, variant: 'error', duration: 4000 })
+      continue
+    }
+    try {
+      missionStore.addMapOverlay(await importGeoTiffFile(file))
+      addedCount += 1
+    } catch (error) {
+      const message =
+        error instanceof OverlayStorageQuotaError
+          ? error.message
+          : `Failed to load "${file.name}". It may be an unsupported or corrupted GeoTIFF.`
+      openSnackbar({ message, variant: 'error', duration: 6000 })
+      console.error('Failed to import GeoTIFF overlay', file.name, error)
+    }
+  }
+  importingOverlays.value = false
+
+  if (addedCount > 0) {
+    openSnackbar({
+      message: `${addedCount} map overlay${addedCount > 1 ? 's' : ''} added.`,
+      variant: 'success',
+      duration: 3000,
+    })
+  }
+}
+
+const removeOverlay = async (overlay: MapOverlayMeta): Promise<void> => {
+  missionStore.removeMapOverlay(overlay.id)
+  await deleteStoredOverlay(overlay.id)
+}
+
+// Frame the map on the overlay but keep the dialog open so the user can keep adjusting overlay properties.
+const centerOnOverlay = (overlay: MapOverlayMeta): void => {
+  missionStore.requestMapOverlayFocus(overlay.id)
+}
+</script>

--- a/src/components/mission-planning/ContextMenu.vue
+++ b/src/components/mission-planning/ContextMenu.vue
@@ -162,6 +162,20 @@
           ></v-icon>
           <span class="text-white text-sm ml-4">Place point of interest</span>
         </v-list-item>
+        <v-divider />
+        <v-list-item class="flex items-center gap-x-2 pb-2" @click="handleOpenMapOverlays">
+          <v-icon
+            variant="text"
+            icon="mdi-image-plus"
+            rounded="full"
+            size="x-small"
+            color="white"
+            class="text-[16px]"
+          ></v-icon>
+          <span class="text-white text-sm ml-4">
+            {{ missionStore.mapOverlays.length > 0 ? 'Manage overlays' : 'Add overlay (GeoTIFF)' }}
+          </span>
+        </v-list-item>
         <v-divider v-if="canSetHome" />
         <v-list-item v-if="canSetHome" class="flex items-center gap-x-2 pb-2" @click="handleSetHomePosition">
           <v-icon
@@ -301,6 +315,7 @@ const emit = defineEmits<{
   (event: 'placePointOfInterest'): void
   (event: 'setHomePosition'): void
   (event: 'clearVehiclePathHistory'): void
+  (event: 'openMapOverlays'): void
 }>()
 
 const menuType = computed(() => props.menuType)
@@ -380,6 +395,11 @@ const handleToggleSimplePath = (): void => {
 
 const handlePlacePointOfInterest = (): void => {
   emit('placePointOfInterest')
+  emit('close')
+}
+
+const handleOpenMapOverlays = (): void => {
+  emit('openMapOverlays')
   emit('close')
 }
 

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -232,6 +232,7 @@
   </p>
 
   <PoiManager ref="poiManagerMapWidgetRef" />
+  <MapOverlaysDialog v-model="overlaysDialogOpen" :loading-ids="overlayLoadingIds" />
   <MissionChecklist
     :model-value="isMissionChecklistOpen"
     @confirmed="executeMissionOnVehicle"
@@ -284,6 +285,7 @@ import genericVehicleMarkerImage from '@/assets/generic-vehicle-marker.avif'
 import ExpansiblePanel from '@/components/ExpansiblePanel.vue'
 import GlobalOriginDialog from '@/components/GlobalOriginDialog.vue'
 import MapNorthIndicator from '@/components/map/MapNorthIndicator.vue'
+import MapOverlaysDialog from '@/components/map/MapOverlaysDialog.vue'
 import MissionChecklist from '@/components/MissionChecklist.vue'
 import PoiManager from '@/components/poi/PoiManager.vue'
 import PoiMapArrows from '@/components/poi/PoiMapArrows.vue'
@@ -565,6 +567,8 @@ const marineProfile = overlays['Marine Profile']
 
 // Syncs user-loaded GeoTIFF overlays (sonar/bathymetry surveys) onto this map
 const mapOverlays = useMapOverlays()
+const overlayLoadingIds = mapOverlays.loadingIds
+const overlaysDialogOpen = ref(false)
 
 // Replace failed tiles with a procedural noise background sampled by lat/lon
 const getTileFallbackOptions = (): NoiseTileOptions => ({
@@ -1436,6 +1440,12 @@ const menuItems = reactive([
     action: () => onMenuOptionSelect('place-poi'),
     icon: 'mdi-map-marker-plus',
   },
+  {
+    item: 'Add overlay (GeoTIFF)',
+    action: () => onMenuOptionSelect('add-overlay'),
+    icon: 'mdi-image-plus',
+    _isOverlay: true,
+  },
   { item: 'GoTo', action: () => onMenuOptionSelect('goto'), icon: 'mdi-crosshairs-gps' },
   {
     item: 'Set default map position',
@@ -1468,6 +1478,13 @@ const updateSkipToWpMenu = (): void => {
   }
 }
 
+const updateOverlayMenuLabel = (): void => {
+  const overlayItem = menuItems.find((item) => (item as any)._isOverlay === true)
+  if (overlayItem) {
+    overlayItem.item = missionStore.mapOverlays.length > 0 ? 'Manage overlays' : 'Add overlay (GeoTIFF)'
+  }
+}
+
 const openContextMenuAt = async (mouseEv: MouseEvent, wpIndex: number | null): Promise<void> => {
   if (contextMenuVisible.value) {
     contextMenuVisible.value = false
@@ -1476,6 +1493,7 @@ const openContextMenuAt = async (mouseEv: MouseEvent, wpIndex: number | null): P
 
   contextMenuSelectedWpIndex.value = wpIndex
   updateSkipToWpMenu()
+  updateOverlayMenuLabel()
   contextMenuVersion.value++
   contextMenuVisible.value = true
   await nextTick()
@@ -1591,6 +1609,10 @@ const onMenuOptionSelect = async (option: string): Promise<void> => {
 
     case 'set-default-map-position':
       setDefaultMapPosition()
+      break
+
+    case 'add-overlay':
+      overlaysDialogOpen.value = true
       break
 
     case 'place-poi':

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -263,8 +263,6 @@
 import { useDebounceFn, useElementHover } from '@vueuse/core'
 import { formatDistanceToNow } from 'date-fns'
 import L, { type LatLngTuple, LayersControlEvent, LeafletMouseEvent, Map } from 'leaflet'
-import { tileLayerOffline } from 'leaflet.offline'
-import { SaveStatus, savetiles } from 'leaflet.offline'
 import {
   computed,
   nextTick,
@@ -291,6 +289,7 @@ import PoiManager from '@/components/poi/PoiManager.vue'
 import PoiMapArrows from '@/components/poi/PoiMapArrows.vue'
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { provideMapContext } from '@/composables/map/useMapContext'
+import { useMapOverlays } from '@/composables/map/useMapOverlays'
 import { useMapTileLayers } from '@/composables/map/useMapTileLayers'
 import { openSnackbar } from '@/composables/snackbar'
 import { useOfflineTiles } from '@/composables/useOfflineTiles'
@@ -563,6 +562,9 @@ onBeforeMount(() => {
 const { osm, esri, baseMaps, overlays } = useMapTileLayers({ seamarks: true, marineProfile: true })
 const seamarks = overlays['Seamarks']
 const marineProfile = overlays['Marine Profile']
+
+// Syncs user-loaded GeoTIFF overlays (sonar/bathymetry surveys) onto this map
+const mapOverlays = useMapOverlays()
 
 // Replace failed tiles with a procedural noise background sampled by lat/lon
 const getTileFallbackOptions = (): NoiseTileOptions => ({
@@ -861,6 +863,9 @@ onMounted(async () => {
 
   mapReady.value = true
 
+  // Render any user-loaded GeoTIFF overlays and keep them in sync with the stored metadata
+  if (map.value) await mapOverlays.initOverlays(map.value, layerControl)
+
   // Apply the current showButtons state to the leaflet controls
   if (showButtons.value && map.value) {
     map.value.addControl(zoomControl)
@@ -900,6 +905,11 @@ watch(
   }
 )
 
+// Frame the map on a GeoTIFF overlay when requested from the configuration panel
+watch(
+  () => missionStore.mapOverlayFocusRequest.revision,
+  () => mapOverlays.zoomToOverlay(missionStore.mapOverlayFocusRequest.id)
+)
 const handleContextMenu = {
   open: async (event: MouseEvent): Promise<void> => {
     if (!map.value || isPinching.value || isDragging.value) return
@@ -1068,6 +1078,7 @@ onBeforeUnmount(() => {
   window.removeEventListener('keydown', onKeydown)
 
   detachTileFallbacks.forEach((detach) => detach())
+  mapOverlays.destroyOverlays()
 
   if (map.value) {
     map.value.off('contextmenu')

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -260,12 +260,11 @@
 </template>
 
 <script setup lang="ts">
-import 'leaflet-edgebuffer'
-
 import { useDebounceFn, useElementHover } from '@vueuse/core'
 import { formatDistanceToNow } from 'date-fns'
 import L, { type LatLngTuple, LayersControlEvent, LeafletMouseEvent, Map } from 'leaflet'
 import { tileLayerOffline } from 'leaflet.offline'
+import { SaveStatus, savetiles } from 'leaflet.offline'
 import {
   computed,
   nextTick,
@@ -292,6 +291,7 @@ import PoiManager from '@/components/poi/PoiManager.vue'
 import PoiMapArrows from '@/components/poi/PoiMapArrows.vue'
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { provideMapContext } from '@/composables/map/useMapContext'
+import { useMapTileLayers } from '@/composables/map/useMapTileLayers'
 import { openSnackbar } from '@/composables/snackbar'
 import { useOfflineTiles } from '@/composables/useOfflineTiles'
 import { MavCmd, MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
@@ -559,65 +559,10 @@ onBeforeMount(() => {
   targetFollower.enableAutoUpdate()
 })
 
-const tileBufferOptions = { edgeBufferTiles: 2, keepBuffer: 8, updateWhenIdle: false } as const
-
-// Configure the available map tile providers
-const osm = tileLayerOffline('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
-  maxZoom: 23,
-  maxNativeZoom: 19,
-  attribution: '© OpenStreetMap',
-  // Required by the OSM tile usage policy: tiles requested without a Referer are blocked (403R).
-  // See https://wiki.openstreetmap.org/wiki/Referer
-  referrerPolicy: 'strict-origin-when-cross-origin',
-  // CORS is required so the noise-fallback utility can read tile pixels via canvas
-  // to detect placeholder tiles that return HTTP 200.
-  crossOrigin: 'anonymous',
-  ...tileBufferOptions,
-})
-
-const esri = tileLayerOffline(
-  // `blankTile=false` makes ArcGIS return HTTP 404 for missing tiles instead of a
-  // "Map data not yet available" placeholder image. This lets the standard `tileerror`
-  // path drive our procedural-noise fallback.
-  'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}?blankTile=false',
-  {
-    maxZoom: 23,
-    maxNativeZoom: 19,
-    attribution: '© Esri World Imagery',
-    // CORS is required so the noise-fallback utility can read tile pixels via canvas
-    // to detect any remaining provider-side placeholders that still return HTTP 200.
-    crossOrigin: 'anonymous',
-    ...tileBufferOptions,
-  }
-)
-
-// Overlays
-const seamarks = tileLayerOffline('https://tiles.openseamap.org/seamark/{z}/{x}/{y}.png', {
-  maxZoom: 18,
-  attribution: '© OpenSeaMap contributors',
-  ...tileBufferOptions,
-})
-
-const marineProfile = L.tileLayer.wms('https://geoserver.openseamap.org/geoserver/gwc/service/wms', {
-  layers: 'gebco2021:gebco_2021',
-  format: 'image/png',
-  transparent: true,
-  version: '1.1.1',
-  attribution: '© GEBCO, OpenSeaMap',
-  tileSize: 256,
-  maxZoom: 19,
-  ...tileBufferOptions,
-})
-
-const baseMaps = {
-  'OpenStreetMap': osm,
-  'Esri World Imagery': esri,
-}
-
-const overlays = {
-  'Seamarks': seamarks,
-  'Marine Profile': marineProfile,
-}
+// Build the shared base maps and overlays (tile-provider definitions live in useMapTileLayers)
+const { osm, esri, baseMaps, overlays } = useMapTileLayers({ seamarks: true, marineProfile: true })
+const seamarks = overlays['Seamarks']
+const marineProfile = overlays['Marine Profile']
 
 // Replace failed tiles with a procedural noise background sampled by lat/lon
 const getTileFallbackOptions = (): NoiseTileOptions => ({

--- a/src/composables/map/useMapOverlays.ts
+++ b/src/composables/map/useMapOverlays.ts
@@ -1,0 +1,255 @@
+import L, { type Map as LeafletMap } from 'leaflet'
+import { type Ref, ref, watch } from 'vue'
+
+import { OVERLAY_RENDER_VERSION, renderGeoTiffImage } from '@/libs/map/geotiff-overlay'
+import {
+  type CachedOverlayRender,
+  getCachedOverlayRender,
+  mapOverlayStorage,
+  setCachedOverlayRender,
+} from '@/libs/map/overlay-storage'
+import { useMissionStore } from '@/stores/mission'
+import type { MapOverlayMeta } from '@/types/mission'
+
+const OVERLAY_PANE = 'geotiffOverlayPane'
+
+// Module-level so the rendered image is shared across every map instance: switching between the dashboard Map
+// widget and the Mission Planning view reuses the cached image instead of re-parsing the (potentially large)
+// raster. Backed by a persistent IndexedDB cache so it also survives app reloads. Entries are evicted when
+// their overlay is removed from the mission.
+const renderCache = new Map<string, CachedOverlayRender>()
+
+/**
+ * A materialized overlay: its live Leaflet layer plus the metadata signature it was built from.
+ */
+interface OverlayEntry {
+  /**
+   * The live Leaflet layer rendering the overlay.
+   */
+  layer: L.ImageOverlay
+  /**
+   * Snapshot of the metadata fields that require the layer to be rebuilt when they change.
+   */
+  signature: string
+}
+
+/**
+ * Return type of {@link useMapOverlays}.
+ */
+export interface UseMapOverlaysReturn {
+  /**
+   * Ids of overlays whose raster is currently being rendered (used to show loading indicators).
+   */
+  loadingIds: Ref<string[]>
+  /**
+   * Binds the registry to a Leaflet map (and optional layer control) and starts syncing overlays.
+   */
+  initOverlays: (map: LeafletMap, layerControl?: L.Control.Layers) => Promise<void>
+  /**
+   * Frames the map on the given overlay's bounds.
+   */
+  zoomToOverlay: (id: string) => void
+  /**
+   * Stops syncing and removes all overlay layers from the map.
+   */
+  destroyOverlays: () => void
+}
+
+// Fields whose change requires recreating the layer (the color function and label are baked in at build time).
+const overlaySignature = (meta: MapOverlayMeta): string => JSON.stringify([meta.name, meta.renderMode])
+
+/**
+ * Manages the lifecycle of GeoTIFF overlays on a single Leaflet map, keeping the rendered layers in sync with
+ * the persisted overlay metadata in the mission store. Shared by the dashboard Map widget and the Mission
+ * Planning view so the overlay behavior lives in one place.
+ * @returns {UseMapOverlaysReturn} Reactive loading state and methods to initialize, frame, and tear down the overlays.
+ */
+export const useMapOverlays = (): UseMapOverlaysReturn => {
+  const missionStore = useMissionStore()
+
+  const entries = new Map<string, OverlayEntry>()
+  const placeholders = new Map<string, L.LayerGroup>()
+  const loadingIds = ref<string[]>([])
+  let mapRef: LeafletMap | undefined
+  let controlRef: L.Control.Layers | undefined
+  let stopWatch: (() => void) | undefined
+  let reconcileChain: Promise<void> = Promise.resolve()
+
+  const ensurePane = (): void => {
+    if (!mapRef || mapRef.getPane(OVERLAY_PANE)) return
+    // Above the base tile pane (200) but below vector overlays/markers so mission data stays on top.
+    mapRef.createPane(OVERLAY_PANE).style.zIndex = '250'
+  }
+
+  const setLoading = (id: string, loading: boolean): void => {
+    const isTracked = loadingIds.value.includes(id)
+    if (loading && !isTracked) loadingIds.value = [...loadingIds.value, id]
+    else if (!loading && isTracked) loadingIds.value = loadingIds.value.filter((trackedId) => trackedId !== id)
+  }
+
+  // Show a spinner centered on the overlay's footprint while the raster renders, so the operator sees where the
+  // overlay will appear during the (potentially slow) parse.
+  const showPlaceholder = (meta: MapOverlayMeta): void => {
+    if (!mapRef || placeholders.has(meta.id)) return
+    const bounds = L.latLngBounds(meta.bounds)
+    const spinner = L.marker(bounds.getCenter(), {
+      pane: OVERLAY_PANE,
+      interactive: false,
+      icon: L.divIcon({
+        className: 'geotiff-overlay-spinner',
+        html: '<span class="mdi mdi-loading mdi-spin" style="font-size: 36px; color: #fff; text-shadow: 0 0 4px rgba(0, 0, 0, 0.7);"></span>',
+        iconSize: [40, 40],
+        iconAnchor: [20, 20],
+      }),
+    })
+    placeholders.set(meta.id, L.layerGroup([spinner]).addTo(mapRef))
+  }
+
+  const hidePlaceholder = (id: string): void => {
+    const group = placeholders.get(id)
+    if (!group) return
+    mapRef?.removeLayer(group)
+    placeholders.delete(id)
+  }
+
+  const removeEntry = (id: string): void => {
+    hidePlaceholder(id)
+    const entry = entries.get(id)
+    if (!entry) return
+    controlRef?.removeLayer(entry.layer)
+    mapRef?.removeLayer(entry.layer)
+    entries.delete(id)
+  }
+
+  const addEntry = async (meta: MapOverlayMeta): Promise<void> => {
+    if (!mapRef) return
+
+    const inMemory = renderCache.get(meta.id)
+    let render = inMemory && inMemory.renderMode === meta.renderMode ? inMemory : undefined
+    // In-memory hits are instant; the persistent-cache read and a full render both take time, so show the
+    // loading placeholder whenever the image isn't already in memory.
+    const showLoading = render === undefined
+
+    if (showLoading) {
+      setLoading(meta.id, true)
+      showPlaceholder(meta)
+    }
+    try {
+      // Tier 2: persistent IndexedDB cache (survives app reloads) — reads a small image instead of re-parsing
+      // the (potentially huge) raster.
+      if (!render) {
+        const persisted = await getCachedOverlayRender(meta.id)
+        if (persisted && persisted.renderMode === meta.renderMode && persisted.version === OVERLAY_RENDER_VERSION) {
+          render = persisted
+          renderCache.set(meta.id, render)
+        }
+      }
+
+      // Tier 3: render from the raw raster (the expensive path), then populate both caches.
+      if (!render) {
+        const blob = await mapOverlayStorage.getItem(meta.id)
+        if (!blob) {
+          console.warn(`Map overlay "${meta.name}" has no stored raster; skipping render.`)
+          return
+        }
+        const image = await renderGeoTiffImage(blob, meta.renderMode)
+        render = {
+          version: OVERLAY_RENDER_VERSION,
+          renderMode: meta.renderMode,
+          dataUrl: image.dataUrl,
+          bounds: image.bounds,
+        }
+        renderCache.set(meta.id, render)
+        await setCachedOverlayRender(meta.id, render)
+      }
+
+      // The map may have been torn down while the raster was rendering.
+      if (!mapRef) return
+
+      const layer = L.imageOverlay(render.dataUrl, L.latLngBounds(render.bounds), {
+        opacity: meta.opacity,
+        pane: OVERLAY_PANE,
+        interactive: false,
+      })
+      entries.set(meta.id, { layer, signature: overlaySignature(meta) })
+      controlRef?.addOverlay(layer, meta.name)
+      layer.addTo(mapRef)
+    } finally {
+      if (showLoading) {
+        hidePlaceholder(meta.id)
+        setLoading(meta.id, false)
+      }
+    }
+  }
+
+  // Only visible overlays are materialized as live layers; hidden ones keep just their metadata and stored
+  // bytes, so memory is bounded by what the operator is actually viewing.
+  const reconcile = async (): Promise<void> => {
+    if (!mapRef) return
+    const metas = missionStore.mapOverlays
+
+    // Reclaim cached renders for overlays that have been removed from the mission entirely (hidden ones keep
+    // their cache so re-showing stays instant).
+    const allIds = new Set(metas.map((meta) => meta.id))
+    for (const id of [...renderCache.keys()]) {
+      if (!allIds.has(id)) renderCache.delete(id)
+    }
+
+    const visibleIds = new Set(metas.filter((meta) => meta.visible).map((meta) => meta.id))
+
+    for (const id of [...entries.keys()]) {
+      if (!visibleIds.has(id)) removeEntry(id)
+    }
+
+    for (const meta of metas) {
+      if (!meta.visible) continue
+      const entry = entries.get(meta.id)
+      if (!entry) {
+        await addEntry(meta)
+      } else if (entry.signature !== overlaySignature(meta)) {
+        removeEntry(meta.id)
+        await addEntry(meta)
+      } else {
+        entry.layer.setOpacity?.(meta.opacity)
+      }
+    }
+  }
+
+  // Serialize reconciles so rapid metadata changes can't interleave layer creation/removal.
+  const scheduleReconcile = (): Promise<void> => {
+    reconcileChain = reconcileChain.then(reconcile).catch((error) => {
+      console.error('Failed to sync map overlays:', error)
+    })
+    return reconcileChain
+  }
+
+  const initOverlays = async (map: LeafletMap, layerControl?: L.Control.Layers): Promise<void> => {
+    mapRef = map
+    controlRef = layerControl
+    ensurePane()
+    await scheduleReconcile()
+    stopWatch = watch(
+      () => missionStore.mapOverlays,
+      () => scheduleReconcile(),
+      { deep: true }
+    )
+  }
+
+  const zoomToOverlay = (id: string): void => {
+    const meta = missionStore.mapOverlays.find((overlay) => overlay.id === id)
+    if (!meta || !mapRef) return
+    mapRef.fitBounds(L.latLngBounds(meta.bounds))
+  }
+
+  const destroyOverlays = (): void => {
+    stopWatch?.()
+    stopWatch = undefined
+    for (const id of [...entries.keys()]) removeEntry(id)
+    for (const id of [...placeholders.keys()]) hidePlaceholder(id)
+    loadingIds.value = []
+    mapRef = undefined
+    controlRef = undefined
+  }
+
+  return { loadingIds, initOverlays, zoomToOverlay, destroyOverlays }
+}

--- a/src/composables/map/useMapTileLayers.ts
+++ b/src/composables/map/useMapTileLayers.ts
@@ -1,0 +1,146 @@
+import 'leaflet-edgebuffer'
+
+import L from 'leaflet'
+import { tileLayerOffline } from 'leaflet.offline'
+
+import type { MapTileProvider } from '@/types/mission'
+
+const tileBufferOptions = { edgeBufferTiles: 2, keepBuffer: 8, updateWhenIdle: false } as const
+
+/**
+ * Which optional layers to build alongside the OSM/Esri base maps.
+ */
+export interface MapTileLayersOptions {
+  /**
+   * Build the OpenSeaMap seamarks overlay (dashboard Map widget).
+   */
+  seamarks?: boolean
+  /**
+   * Build the GEBCO marine-profile WMS overlay (dashboard Map widget).
+   */
+  marineProfile?: boolean
+  /**
+   * Build an extra always-on OSM layer drawn over the base map (Mission Planning view).
+   */
+  extraOsm?: boolean
+}
+
+/**
+ * The base maps, overlays and individual tile layers shared by the map views.
+ */
+export interface MapTileLayers {
+  /**
+   * Shared edge-buffer/keep-buffer options applied to every tile layer.
+   */
+  tileBufferOptions: typeof tileBufferOptions
+  /**
+   * OpenStreetMap base layer (offline-capable).
+   */
+  osm: L.TileLayer
+  /**
+   * Esri World Imagery base layer (offline-capable).
+   */
+  esri: L.TileLayer
+  /**
+   * OpenSeaMap seamarks overlay, when requested.
+   */
+  seamarks?: L.TileLayer
+  /**
+   * GEBCO marine-profile WMS overlay, when requested.
+   */
+  marineProfile?: L.TileLayer
+  /**
+   * Extra always-on OSM layer, when requested.
+   */
+  extraOsm?: L.TileLayer
+  /**
+   * Base maps keyed by their layer-control label.
+   */
+  baseMaps: Record<MapTileProvider, L.TileLayer>
+  /**
+   * Overlays keyed by their layer-control label.
+   */
+  overlays: Record<string, L.TileLayer>
+}
+
+/**
+ * Builds the base map and overlay tile layers shared by the dashboard Map widget and the Mission Planning view,
+ * so their tile-provider definitions live in one place. This is a plain factory (no Vue reactivity), safe to
+ * call from component setup or inside `onMounted`.
+ * @param {MapTileLayersOptions} [options] - Which optional overlays/extra layers to include.
+ * @returns {MapTileLayers} The created tile layers, base maps and overlays.
+ */
+export const useMapTileLayers = (options: MapTileLayersOptions = {}): MapTileLayers => {
+  const osm = tileLayerOffline('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    maxZoom: 23,
+    maxNativeZoom: 19,
+    attribution: '© OpenStreetMap',
+    // Required by the OSM tile usage policy: tiles requested without a Referer are blocked (403R).
+    // See https://wiki.openstreetmap.org/wiki/Referer
+    referrerPolicy: 'strict-origin-when-cross-origin',
+    // CORS is required so the noise-fallback utility can read tile pixels via canvas
+    // to detect placeholder tiles that return HTTP 200.
+    crossOrigin: 'anonymous',
+    ...tileBufferOptions,
+  })
+
+  const esri = tileLayerOffline(
+    // `blankTile=false` makes ArcGIS return HTTP 404 for missing tiles instead of a
+    // "Map data not yet available" placeholder image. This lets the standard `tileerror`
+    // path drive our procedural-noise fallback.
+    'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}?blankTile=false',
+    {
+      maxZoom: 23,
+      maxNativeZoom: 19,
+      attribution: '© Esri World Imagery',
+      // CORS is required so the noise-fallback utility can read tile pixels via canvas
+      // to detect any remaining provider-side placeholders that still return HTTP 200.
+      crossOrigin: 'anonymous',
+      ...tileBufferOptions,
+    }
+  )
+
+  const baseMaps: Record<MapTileProvider, L.TileLayer> = {
+    'OpenStreetMap': osm,
+    'Esri World Imagery': esri,
+  }
+
+  const layers: MapTileLayers = { tileBufferOptions, osm, esri, baseMaps, overlays: {} }
+
+  if (options.seamarks) {
+    layers.seamarks = tileLayerOffline('https://tiles.openseamap.org/seamark/{z}/{x}/{y}.png', {
+      maxZoom: 18,
+      attribution: '© OpenSeaMap contributors',
+      ...tileBufferOptions,
+    })
+    layers.overlays['Seamarks'] = layers.seamarks
+  }
+
+  if (options.marineProfile) {
+    layers.marineProfile = L.tileLayer.wms('https://geoserver.openseamap.org/geoserver/gwc/service/wms', {
+      layers: 'gebco2021:gebco_2021',
+      format: 'image/png',
+      transparent: true,
+      version: '1.1.1',
+      attribution: '© GEBCO, OpenSeaMap',
+      tileSize: 256,
+      maxZoom: 19,
+      ...tileBufferOptions,
+    })
+    layers.overlays['Marine Profile'] = layers.marineProfile
+  }
+
+  if (options.extraOsm) {
+    layers.extraOsm = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      maxZoom: 19,
+      attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+      // Required by the OSM tile usage policy: tiles requested without a Referer are blocked (403R).
+      // See https://wiki.openstreetmap.org/wiki/Referer
+      referrerPolicy: 'strict-origin-when-cross-origin',
+      crossOrigin: 'anonymous',
+      ...tileBufferOptions,
+    })
+  }
+
+  return layers
+}

--- a/src/libs/map/geotiff-overlay.ts
+++ b/src/libs/map/geotiff-overlay.ts
@@ -1,0 +1,284 @@
+import type { MapOverlayBounds, MapOverlayRenderMode } from '@/types/mission'
+
+// Cap on the rendered image's largest dimension. The raster is rasterized once to a static image; capping keeps
+// memory bounded for huge surveys while staying sharp at typical zoom levels.
+const MAX_OVERLAY_IMAGE_DIM = 4096
+
+// Bump whenever the rasterization/color logic changes, so persisted render caches produced by an older version
+// are treated as misses and regenerated instead of showing a stale image.
+export const OVERLAY_RENDER_VERSION = 1
+
+/**
+ * The rasterized GeoTIFF as a static image (PNG data URL) plus the geographic bounds it covers. This is the
+ * expensive-to-produce artifact; callers can cache it and cheaply build per-map Leaflet image overlays from it.
+ */
+export interface GeoTiffImage {
+  /**
+   * PNG data URL of the colorized raster.
+   */
+  dataUrl: string
+  /**
+   * WGS84 bounds of the raster as `[[south, west], [north, east]]`.
+   */
+  bounds: MapOverlayBounds
+}
+
+/**
+ * Maps a pixel's per-band values to an RGB color, or `null` for transparent (nodata) pixels.
+ */
+type RasterColorFn = (values: number[]) => [number, number, number] | null
+
+const clampByte = (value: number): number => (value < 0 ? 0 : value > 255 ? 255 : Math.round(value))
+
+const clamp01 = (value: number): number => (value < 0 ? 0 : value > 1 ? 1 : value)
+
+// Two-stop ramp: shallow (low value) -> light teal, deep (high value) -> dark navy.
+const depthColor = (t: number): [number, number, number] => {
+  const ratio = clamp01(t)
+  return [
+    Math.round(186 * (1 - ratio) + 4 * ratio),
+    Math.round(231 * (1 - ratio) + 38 * ratio),
+    Math.round(242 * (1 - ratio) + 84 * ratio),
+  ]
+}
+
+/**
+ * Builds the per-pixel color mapping for a render mode. 8-bit rasters are rendered as-is (true color for RGB,
+ * grey for single-band); higher bit-depth/float rasters are contrast-stretched per band by their min/max so they
+ * don't clamp to a solid white square. Nodata pixels map to `null` (transparent).
+ * @param {MapOverlayRenderMode} mode - The selected render mode.
+ * @param {number | null} noData - The raster's nodata value, if any.
+ * @param {number[] | undefined} mins - Per-band minimums (only needed/used for non-8-bit rasters).
+ * @param {number[] | undefined} maxs - Per-band maximums (only needed/used for non-8-bit rasters).
+ * @param {boolean} is8bit - Whether the raster is 8-bit (rendered as-is) or must be contrast-stretched.
+ * @param {number | null} alphaIndex - Band index holding per-pixel alpha, or `null` when the raster has none.
+ * @returns {RasterColorFn} A function mapping a pixel's band values to an RGB tuple or `null`.
+ */
+const buildColorFn = (
+  mode: MapOverlayRenderMode,
+  noData: number | null,
+  mins: number[] | undefined,
+  maxs: number[] | undefined,
+  is8bit: boolean,
+  alphaIndex: number | null
+): RasterColorFn => {
+  const isNoData = (value: number | null | undefined): boolean =>
+    value === null || value === undefined || Number.isNaN(value) || (noData !== null && value === noData)
+
+  // A zero alpha sample means the pixel is outside the raster's footprint, so it must be transparent in every
+  // render mode — otherwise the single-band modes paint that border with their lowest-value color.
+  const isTransparent = (values: number[]): boolean => alphaIndex !== null && values[alphaIndex] === 0
+
+  const scaleBand = (value: number, band: number): number => {
+    if (is8bit) return clampByte(value)
+    const min = mins?.[band]
+    const max = maxs?.[band]
+    if (typeof min === 'number' && typeof max === 'number' && max > min) {
+      return clampByte(((value - min) / (max - min)) * 255)
+    }
+    return clampByte(value)
+  }
+
+  const min0 = mins?.[0]
+  const max0 = maxs?.[0]
+  const hasRange0 = typeof min0 === 'number' && typeof max0 === 'number' && max0 > min0
+  const normalize0 = (value: number): number =>
+    hasRange0 ? (value - (min0 as number)) / ((max0 as number) - (min0 as number)) : value / 255
+
+  if (mode === 'bathymetry') {
+    return (values) => {
+      const value = values[0]
+      if (isTransparent(values) || isNoData(value)) return null
+      return depthColor(normalize0(value))
+    }
+  }
+
+  if (mode === 'intensity') {
+    return (values) => {
+      const value = values[0]
+      if (isTransparent(values) || isNoData(value)) return null
+      const grey = clampByte(clamp01(normalize0(value)) * 255)
+      return [grey, grey, grey]
+    }
+  }
+
+  // grayscale: render multi-band rasters as RGB(A), single-band as grey, scaling each band to 8-bit.
+  return (values) => {
+    if (isTransparent(values)) return null
+    if (values.length >= 3) {
+      const [r, g, b] = values
+      if (isNoData(r) && isNoData(g) && isNoData(b)) return null
+      return [scaleBand(r, 0), scaleBand(g, 1), scaleBand(b, 2)]
+    }
+    const value = values[0]
+    if (isNoData(value)) return null
+    const grey = scaleBand(value, 0)
+    return [grey, grey, grey]
+  }
+}
+
+// Locate the band holding per-pixel alpha via the TIFF ExtraSamples tag (1 = associated, 2 = unassociated alpha),
+// falling back to the conventional last band for RGBA / grey+alpha rasters that omit the tag.
+const findAlphaBandIndex = (fileDirectory: Record<string, unknown>, bandCount: number): number | null => {
+  const extraSamples = fileDirectory.ExtraSamples
+  if (Array.isArray(extraSamples) && extraSamples.length > 0) {
+    const alphaOffset = extraSamples.findIndex((sample) => sample === 1 || sample === 2)
+    if (alphaOffset >= 0) return bandCount - extraSamples.length + alphaOffset
+  }
+  if (bandCount === 4 || bandCount === 2) return bandCount - 1
+  return null
+}
+
+/**
+ * Per-band minimums and maximums of a raster.
+ */
+interface BandStats {
+  /**
+   * Minimum value per band.
+   */
+  mins: number[]
+  /**
+   * Maximum value per band.
+   */
+  maxs: number[]
+}
+
+// Per-band min/max over the (already downsampled) bands, skipping nodata/NaN. Only computed for non-8-bit
+// rasters, where it's needed to contrast-stretch into the 8-bit display range.
+const computeBandStats = (bands: ArrayLike<number>[], noData: number | null): BandStats => {
+  const mins: number[] = []
+  const maxs: number[] = []
+  for (const band of bands) {
+    let min = Infinity
+    let max = -Infinity
+    for (let i = 0; i < band.length; i++) {
+      const value = band[i]
+      if (Number.isNaN(value) || (noData !== null && value === noData)) continue
+      if (value < min) min = value
+      if (value > max) max = value
+    }
+    mins.push(min)
+    maxs.push(max)
+  }
+  return { mins, maxs }
+}
+
+const renderBandsToDataUrl = (
+  bands: ArrayLike<number>[],
+  width: number,
+  height: number,
+  colorFn: RasterColorFn
+): string => {
+  const canvas = document.createElement('canvas')
+  canvas.width = width
+  canvas.height = height
+  const ctx = canvas.getContext('2d')
+  if (!ctx) throw new Error('Could not get a 2D canvas context to render the GeoTIFF')
+
+  const image = ctx.createImageData(width, height)
+  const buffer = image.data
+  const bandCount = bands.length
+  const pixel = new Array<number>(bandCount)
+
+  const pixelCount = width * height
+  let offset = 0
+  for (let p = 0; p < pixelCount; p++) {
+    for (let band = 0; band < bandCount; band++) pixel[band] = bands[band][p]
+    const color = colorFn(pixel)
+    if (color !== null) {
+      buffer[offset] = color[0]
+      buffer[offset + 1] = color[1]
+      buffer[offset + 2] = color[2]
+      buffer[offset + 3] = 255
+    }
+    offset += 4
+  }
+
+  ctx.putImageData(image, 0, 0)
+  return canvas.toDataURL('image/png')
+}
+
+// geotiff.js reads byte ranges from the Blob on demand, so for a Cloud-Optimized GeoTIFF only the chosen
+// overview's bytes are fetched/decoded — never the whole file. Falls back to the full image for plain GeoTIFFs.
+const pickOverviewIndex = async (
+  tiff: Awaited<ReturnType<typeof import('geotiff')['fromBlob']>>,
+  imageCount: number
+): Promise<number> => {
+  let chosenIndex = 0
+  let chosenLongEdge = Infinity
+  for (let i = 0; i < imageCount; i++) {
+    const img = await tiff.getImage(i)
+    const longEdge = Math.max(img.getWidth(), img.getHeight())
+    // Smallest IFD that still covers our display cap, so we decode as few pixels as possible without losing
+    // detail. If none reaches the cap (all overviews are smaller), keep the full-resolution image (index 0).
+    if (longEdge >= MAX_OVERLAY_IMAGE_DIM && longEdge < chosenLongEdge) {
+      chosenLongEdge = longEdge
+      chosenIndex = i
+    }
+  }
+  return chosenIndex
+}
+
+/**
+ * Parses a GeoTIFF blob and rasterizes it once to a static PNG image (the expensive step). Reads from an internal
+ * overview when the file is a COG, so large COGs load quickly; the result can be cached and reused to build cheap
+ * per-map Leaflet image overlays.
+ * @param {Blob} blob - The GeoTIFF file/blob.
+ * @param {MapOverlayRenderMode} [renderMode] - Color mapping for the raster values. Defaults to `grayscale`.
+ * @returns {Promise<GeoTiffImage>} The rendered image data URL and its WGS84 bounds.
+ */
+export const renderGeoTiffImage = async (
+  blob: Blob,
+  renderMode: MapOverlayRenderMode = 'grayscale'
+): Promise<GeoTiffImage> => {
+  const [geotiff, epsgModule, geoExtentModule] = await Promise.all([
+    import('geotiff'),
+    import('geotiff-epsg-code'),
+    import('geo-extent'),
+  ])
+  const getEPSGCode = epsgModule.default
+  const { GeoExtent } = geoExtentModule
+
+  const tiff = await geotiff.fromBlob(blob)
+  const imageCount = await tiff.getImageCount()
+  const fullImage = await tiff.getImage(0)
+  const overviewIndex = await pickOverviewIndex(tiff, imageCount)
+  const image = overviewIndex === 0 ? fullImage : await tiff.getImage(overviewIndex)
+
+  const sourceWidth = image.getWidth()
+  const sourceHeight = image.getHeight()
+  const noData = image.getGDALNoData()
+  const scale = Math.min(1, MAX_OVERLAY_IMAGE_DIM / Math.max(sourceWidth, sourceHeight))
+  const outWidth = Math.max(1, Math.round(sourceWidth * scale))
+  const outHeight = Math.max(1, Math.round(sourceHeight * scale))
+
+  const bands = (await image.readRasters({
+    width: outWidth,
+    height: outHeight,
+    resampleMethod: 'nearest',
+    interleave: false,
+  })) as unknown as ArrayLike<number>[]
+
+  const fileDirectory = image.fileDirectory as Record<string, unknown>
+  const bitsPerSample = fileDirectory.BitsPerSample
+  const is8bit = Array.isArray(bitsPerSample) && bitsPerSample.every((bits) => bits === 8)
+  const alphaIndex = findAlphaBandIndex(fileDirectory, bands.length)
+  const stats = is8bit ? undefined : computeBandStats(bands, noData)
+  const colorFn = buildColorFn(renderMode, noData, stats?.mins, stats?.maxs, is8bit, alphaIndex)
+  const dataUrl = renderBandsToDataUrl(bands, outWidth, outHeight, colorFn)
+
+  const epsg = await getEPSGCode(tiff)
+  if (epsg === undefined) {
+    throw new Error('GeoTIFF has no recognizable CRS (EPSG code); cannot place it on the map.')
+  }
+  const [xmin, ymin, xmax, ymax] = fullImage.getBoundingBox()
+  const bounds: MapOverlayBounds =
+    epsg === 4326
+      ? [
+          [ymin, xmin],
+          [ymax, xmax],
+        ]
+      : (new GeoExtent([xmin, ymin, xmax, ymax], { srs: epsg }).reproj(4326).leafletBounds as MapOverlayBounds)
+
+  return { dataUrl, bounds }
+}

--- a/src/libs/map/overlay-import.ts
+++ b/src/libs/map/overlay-import.ts
@@ -1,0 +1,124 @@
+import { v4 as uuid } from 'uuid'
+
+import type { MapOverlayMeta, MapOverlayRenderMode } from '@/types/mission'
+
+import { OVERLAY_RENDER_VERSION, renderGeoTiffImage } from './geotiff-overlay'
+import {
+  getOverlayStorageBytesAvailable,
+  mapOverlayStorage,
+  removeCachedOverlayRender,
+  requestPersistentOverlayStorage,
+  setCachedOverlayRender,
+} from './overlay-storage'
+
+const GEOTIFF_EXTENSIONS = ['tif', 'tiff', 'gtiff']
+
+/**
+ * Error thrown when a GeoTIFF cannot be stored because the browser's IndexedDB quota would be exceeded.
+ * More likely in the Lite (Web) build; Standalone (Electron) has a much larger IndexedDB quota.
+ */
+export class OverlayStorageQuotaError extends Error {
+  /**
+   * @param {string} message - Human-readable description of the quota problem.
+   */
+  constructor(message: string) {
+    super(message)
+    this.name = 'OverlayStorageQuotaError'
+  }
+}
+
+/**
+ * Opens a file picker for the user to choose one or more GeoTIFF files. Uses a hidden file input so it works
+ * identically in Standalone (Electron) and Lite (Web), where the bytes are read in-renderer.
+ * @returns {Promise<File[]>} The selected files, or an empty array if the dialog was dismissed.
+ */
+export const pickGeoTiffFiles = (): Promise<File[]> => {
+  return new Promise((resolve) => {
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.accept = '.tif,.tiff,.gtiff,image/tiff'
+    input.multiple = true
+    input.onchange = (event: Event): void => {
+      const files = Array.from((event.target as HTMLInputElement).files ?? [])
+      resolve(files)
+    }
+    // A cancelled dialog never fires `change`; resolve empty so callers don't hang.
+    input.oncancel = (): void => resolve([])
+    input.click()
+  })
+}
+
+const overlayNameFromFile = (file: File): string => file.name.replace(/\.(tif|tiff|gtiff)$/i, '')
+
+/**
+ * Whether a file looks like a GeoTIFF based on its extension.
+ * @param {File} file - The file to check.
+ * @returns {boolean} True if the extension matches a known GeoTIFF extension.
+ */
+export const isGeoTiffFile = (file: File): boolean => {
+  const extension = file.name.split('.').pop()?.toLowerCase() ?? ''
+  return GEOTIFF_EXTENSIONS.includes(extension)
+}
+
+/**
+ * Parses, validates and persists a GeoTIFF file, returning its overlay metadata. The raster bytes are written
+ * to the overlay storage (IndexedDB); the caller is responsible for adding the returned metadata to the
+ * mission store.
+ * @param {File} file - The GeoTIFF file to import.
+ * @returns {Promise<MapOverlayMeta>} The metadata describing the stored overlay.
+ * @throws {OverlayStorageQuotaError} When the file would exceed the available IndexedDB quota (Lite only).
+ */
+export const importGeoTiffFile = async (file: File): Promise<MapOverlayMeta> => {
+  const renderMode: MapOverlayRenderMode = 'grayscale'
+
+  // Render once here (read + colorize) — this both validates the GeoTIFF before we consume storage and produces
+  // the image we cache, so the first display and later reloads reuse it instead of parsing the raster again.
+  const { dataUrl, bounds } = await renderGeoTiffImage(file, renderMode)
+
+  const available = await getOverlayStorageBytesAvailable()
+  if (available !== undefined && file.size > available) {
+    throw new OverlayStorageQuotaError(
+      `Not enough browser storage to save "${file.name}". Free up space or use the Standalone (desktop) app.`
+    )
+  }
+
+  await requestPersistentOverlayStorage()
+
+  const id = uuid()
+  try {
+    await mapOverlayStorage.setItem(id, file)
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'QuotaExceededError') {
+      throw new OverlayStorageQuotaError(
+        `Browser storage is full, so "${file.name}" could not be saved. Free up space or use the Standalone app.`
+      )
+    }
+    throw error
+  }
+  await setCachedOverlayRender(id, { version: OVERLAY_RENDER_VERSION, renderMode, dataUrl, bounds })
+
+  return {
+    id,
+    name: overlayNameFromFile(file),
+    bounds,
+    opacity: 1,
+    visible: true,
+    renderMode,
+    fileSize: file.size,
+    createdAt: Date.now(),
+  }
+}
+
+/**
+ * Removes a stored overlay's raster bytes from persistent storage. Safe to call even if the bytes are gone.
+ * @param {string} id - The overlay id (also the storage key).
+ * @returns {Promise<void>}
+ */
+export const deleteStoredOverlay = async (id: string): Promise<void> => {
+  try {
+    await mapOverlayStorage.removeItem(id)
+  } catch (error) {
+    console.error(`Failed to remove stored map overlay ${id}:`, error)
+  }
+  await removeCachedOverlayRender(id)
+}

--- a/src/libs/map/overlay-storage.ts
+++ b/src/libs/map/overlay-storage.ts
@@ -1,0 +1,124 @@
+import localforage from 'localforage'
+
+import { LocalForageStorage } from '@/libs/videoStorage'
+import type { StorageDB } from '@/types/general'
+import type { MapOverlayBounds, MapOverlayRenderMode } from '@/types/mission'
+
+/**
+ * Persistent storage for GeoTIFF overlay raster bytes, in IndexedDB for both builds. Overlays are imported
+ * input data (not generated output like videos/snapshots), so they are not written to the user's filesystem.
+ * In Lite (browser) IndexedDB is origin-quota-limited and evictable; in Standalone (Electron) it has a much
+ * larger quota and is effectively durable.
+ */
+export const mapOverlayStorage: StorageDB = new LocalForageStorage(
+  'Cockpit - Map Overlays',
+  'cockpit-map-overlays-db',
+  1.0,
+  'User-loaded GeoTIFF map overlays (e.g. sonar mosaics, bathymetry, photogrammetry surveys).'
+)
+
+/**
+ * A cached rendered overlay image, persisted so a GeoTIFF reloads instantly on the next app launch without
+ * re-parsing the (potentially huge) raster. The rendered image is size-capped, so this stays small regardless
+ * of the source file size.
+ */
+export interface CachedOverlayRender {
+  /**
+   * Render-algorithm version that produced this image; a mismatch invalidates the cache.
+   */
+  version: number
+  /**
+   * Render mode the cached image was produced with; a mode change invalidates it.
+   */
+  renderMode: MapOverlayRenderMode
+  /**
+   * PNG data URL of the colorized raster.
+   */
+  dataUrl: string
+  /**
+   * WGS84 bounds of the raster.
+   */
+  bounds: MapOverlayBounds
+}
+
+// Keyed by overlay id; holds one rendered image per overlay (the latest render mode used).
+const mapOverlayRenderCacheDB = localforage.createInstance({
+  driver: localforage.INDEXEDDB,
+  name: 'Cockpit - Map Overlay Renders',
+  storeName: 'cockpit-map-overlay-renders-db',
+  version: 1.0,
+  description: 'Cached rendered images of GeoTIFF overlays, so they reload without re-parsing the raster.',
+})
+
+/**
+ * Reads a previously cached rendered overlay image.
+ * @param {string} id - The overlay id.
+ * @returns {Promise<CachedOverlayRender | null>} The cached render, or `null` if absent or unreadable.
+ */
+export const getCachedOverlayRender = async (id: string): Promise<CachedOverlayRender | null> => {
+  try {
+    return await mapOverlayRenderCacheDB.getItem<CachedOverlayRender>(id)
+  } catch (error) {
+    console.error(`Failed to read cached render for map overlay ${id}:`, error)
+    return null
+  }
+}
+
+/**
+ * Persists a rendered overlay image. Best-effort: a failed write (e.g. quota exceeded) is swallowed so it never
+ * breaks rendering — the overlay still works for the session via the in-memory cache.
+ * @param {string} id - The overlay id.
+ * @param {CachedOverlayRender} render - The rendered image to cache.
+ * @returns {Promise<void>}
+ */
+export const setCachedOverlayRender = async (id: string, render: CachedOverlayRender): Promise<void> => {
+  try {
+    await mapOverlayRenderCacheDB.setItem(id, render)
+  } catch (error) {
+    console.warn(`Could not cache rendered map overlay ${id}:`, error)
+  }
+}
+
+/**
+ * Removes a cached rendered overlay image.
+ * @param {string} id - The overlay id.
+ * @returns {Promise<void>}
+ */
+export const removeCachedOverlayRender = async (id: string): Promise<void> => {
+  try {
+    await mapOverlayRenderCacheDB.removeItem(id)
+  } catch (error) {
+    console.error(`Failed to remove cached render for map overlay ${id}:`, error)
+  }
+}
+
+/**
+ * Asks the browser to keep IndexedDB durable so large overlays are less likely to be evicted under storage
+ * pressure. No-op where unsupported.
+ * @returns {Promise<boolean>} True if storage is persisted, false otherwise.
+ */
+export const requestPersistentOverlayStorage = async (): Promise<boolean> => {
+  if (!navigator.storage?.persist) return false
+  try {
+    if (await navigator.storage.persisted()) return true
+    return await navigator.storage.persist()
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Estimated remaining IndexedDB bytes for the current origin, used to warn before storing a large overlay.
+ * Returns `undefined` where the Storage API is unavailable, meaning "no quota concern".
+ * @returns {Promise<number | undefined>} The remaining bytes, or `undefined` when not applicable.
+ */
+export const getOverlayStorageBytesAvailable = async (): Promise<number | undefined> => {
+  if (!navigator.storage?.estimate) return undefined
+  try {
+    const { quota, usage } = await navigator.storage.estimate()
+    if (quota === undefined || usage === undefined) return undefined
+    return Math.max(0, quota - usage)
+  } catch {
+    return undefined
+  }
+}

--- a/src/libs/videoStorage.ts
+++ b/src/libs/videoStorage.ts
@@ -65,7 +65,7 @@ class ElectronStorage implements ElectronStorageDB {
  * LocalForage storage implementation.
  * Uses the localforage library to store and retrieve data in the IndexedDB.
  */
-class LocalForageStorage implements StorageDB {
+export class LocalForageStorage implements StorageDB {
   localForage: LocalForage
 
   /**

--- a/src/stores/mission.ts
+++ b/src/stores/mission.ts
@@ -11,6 +11,7 @@ import { generateSessionSeed } from '@/libs/map/map-tile-fallback'
 import { eventCategoriesDefaultMapping } from '@/libs/slide-to-confirm'
 import {
   AltitudeReferenceType,
+  MapOverlayMeta,
   MapTileProvider,
   MapTileProviderPreference,
   MissionCommand,
@@ -92,6 +93,38 @@ export const useMissionStore = defineStore('mission', () => {
   const mainVehicleStore = useMainVehicleStore()
 
   const pointsOfInterest = useBlueOsStorage<PointOfInterest[]>('cockpit-points-of-interest', [])
+
+  // Metadata for user-loaded GeoTIFF overlays. The raster bytes live in the overlay storage
+  // (IndexedDB), keyed by each entry's `id`.
+  const mapOverlays = useBlueOsStorage<MapOverlayMeta[]>('cockpit-map-overlays-v1', [])
+
+  const addMapOverlay = (overlay: MapOverlayMeta): void => {
+    mapOverlays.value.push(overlay)
+  }
+
+  const removeMapOverlay = (id: string): void => {
+    const index = mapOverlays.value.findIndex((overlay) => overlay.id === id)
+    if (index !== -1) {
+      mapOverlays.value.splice(index, 1)
+    }
+  }
+
+  // Cross-component request to frame the active map on a given overlay. The bumped revision lets the map views
+  // react even when the same overlay is requested twice in a row.
+  const mapOverlayFocusRequest = ref<{
+    /**
+     * Id of the overlay to frame.
+     */
+    id: string
+    /**
+     * Bumped on each request so repeated focus requests still trigger the map views.
+     */
+    revision: number
+  }>({ id: '', revision: 0 })
+
+  const requestMapOverlayFocus = (id: string): void => {
+    mapOverlayFocusRequest.value = { id, revision: mapOverlayFocusRequest.value.revision + 1 }
+  }
 
   watch(missionName, () => (lastMissionName.value = missionName.value))
 
@@ -652,6 +685,11 @@ export const useMissionStore = defineStore('mission', () => {
     updatePointOfInterest,
     removePointOfInterest,
     movePointOfInterest,
+    mapOverlays,
+    addMapOverlay,
+    removeMapOverlay,
+    mapOverlayFocusRequest,
+    requestMapOverlayFocus,
     persistDraft,
     clearDraft,
     bumpVehicleMissionRevision,

--- a/src/types/mission.ts
+++ b/src/types/mission.ts
@@ -486,6 +486,58 @@ export type MapTileProvider = 'Esri World Imagery' | 'OpenStreetMap'
  */
 export type MapTileProviderPreference = MapTileProvider | 'Use last selected'
 
+/**
+ * How a GeoTIFF map overlay's raster values are mapped to colors.
+ * - `grayscale`: render RGB(A) rasters directly, or a single band as grey (sidescan mosaics, orthophotos).
+ * - `intensity`: stretch a single band between its min/max as greyscale (backscatter).
+ * - `bathymetry`: stretch a single band between its min/max onto a depth color ramp.
+ */
+export type MapOverlayRenderMode = 'grayscale' | 'intensity' | 'bathymetry'
+
+/**
+ * Geographic bounds of a map overlay in WGS84, as `[[south, west], [north, east]]`.
+ */
+export type MapOverlayBounds = [[number, number], [number, number]]
+
+/**
+ * Persisted metadata for a user-loaded GeoTIFF map overlay. The raster bytes are stored
+ * separately (in IndexedDB) keyed by {@link MapOverlayMeta.id}.
+ */
+export interface MapOverlayMeta {
+  /**
+   * Unique id, also used as the storage key for the overlay's raster bytes.
+   */
+  id: string
+  /**
+   * User-facing name, derived from the original file name.
+   */
+  name: string
+  /**
+   * WGS84 bounds used to frame the overlay (e.g. "zoom to survey").
+   */
+  bounds: MapOverlayBounds
+  /**
+   * Layer opacity in the range [0, 1].
+   */
+  opacity: number
+  /**
+   * Whether the overlay is shown on the map by default.
+   */
+  visible: boolean
+  /**
+   * Color mapping applied to the raster values.
+   */
+  renderMode: MapOverlayRenderMode
+  /**
+   * Size of the stored raster in bytes.
+   */
+  fileSize: number
+  /**
+   * Creation timestamp (epoch milliseconds).
+   */
+  createdAt: number
+}
+
 export type IconDimensions = {
   /**
    * The size of the icon in pixels

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -671,6 +671,7 @@ import { format } from 'date-fns'
 import { saveAs } from 'file-saver'
 import L, { type LatLngTuple, LayersControlEvent, LeafletMouseEvent, Map, Marker, Polygon } from 'leaflet'
 import { tileLayerOffline } from 'leaflet.offline'
+import { SaveStatus, savetiles } from 'leaflet.offline'
 import { v4 as uuid } from 'uuid'
 import { type InstanceType, computed, nextTick, onMounted, onUnmounted, ref, shallowRef, toRaw, watch } from 'vue'
 
@@ -690,6 +691,7 @@ import RadialMenu, { type RadialMenuItem } from '@/components/RadialMenu.vue'
 import SideConfigPanel from '@/components/SideConfigPanel.vue'
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { provideMapContext } from '@/composables/map/useMapContext'
+import { useMapTileLayers } from '@/composables/map/useMapTileLayers'
 import { useSnackbar } from '@/composables/snackbar'
 import {
   clearAllSurveyAreas,
@@ -3715,38 +3717,8 @@ let stopUnFollowOnUserDrag: (() => void) | undefined
 let fallbackLayers: L.TileLayer[] = []
 
 onMounted(async () => {
-  const tileBufferOptions = { edgeBufferTiles: 2, keepBuffer: 8, updateWhenIdle: false } as const
-
-  const osm = tileLayerOffline('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
-    maxZoom: 23,
-    maxNativeZoom: 19,
-    attribution: '© OpenStreetMap',
-    // Required by the OSM tile usage policy: tiles requested without a Referer are blocked (403R).
-    // See https://wiki.openstreetmap.org/wiki/Referer
-    referrerPolicy: 'strict-origin-when-cross-origin',
-    // CORS is required so the noise-fallback utility can read tile pixels via canvas
-    // to detect placeholder tiles that return HTTP 200.
-    crossOrigin: 'anonymous',
-    ...tileBufferOptions,
-  })
-  const esri = tileLayerOffline(
-    // `blankTile=false` makes ArcGIS return HTTP 404 for missing tiles instead of a
-    // "Map data not yet available" placeholder image. This lets the standard `tileerror`
-    // path drive our procedural-noise fallback.
-    'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}?blankTile=false',
-    {
-      maxZoom: 23,
-      maxNativeZoom: 19,
-      attribution: '© Esri World Imagery',
-      crossOrigin: 'anonymous',
-      ...tileBufferOptions,
-    }
-  )
-
-  const baseMaps = {
-    'OpenStreetMap': osm,
-    'Esri World Imagery': esri,
-  }
+  // Build the shared base maps and extra OSM overlay (tile-provider definitions live in useMapTileLayers)
+  const { osm, esri, extraOsm, baseMaps } = useMapTileLayers({ extraOsm: true })
 
   const preferredProvider =
     missionStore.defaultMapTileProvider === 'Use last selected'
@@ -3763,15 +3735,7 @@ onMounted(async () => {
   mapContext.map.value = planningMap.value
   mapContext.mapReady.value = true
 
-  const extraOsm = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
-    maxZoom: 19,
-    attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
-    // Required by the OSM tile usage policy: tiles requested without a Referer are blocked (403R).
-    // See https://wiki.openstreetmap.org/wiki/Referer
-    referrerPolicy: 'strict-origin-when-cross-origin',
-    crossOrigin: 'anonymous',
-    ...tileBufferOptions,
-  }).addTo(planningMap.value)
+  extraOsm?.addTo(planningMap.value)
   planningMap.value.zoomControl.setPosition('bottomright')
 
   // Replace failed tiles with a procedural noise background sampled by lat/lon, so
@@ -3781,7 +3745,7 @@ onMounted(async () => {
     seed: missionStore.mapFallbackSeed,
     intensity: missionStore.mapFallbackNoiseIntensity,
   })
-  fallbackLayers = [osm, esri, extraOsm]
+  fallbackLayers = [osm, esri, extraOsm].filter((layer): layer is L.TileLayer => layer !== undefined)
   detachTileFallbacks = fallbackLayers.map((layer) => attachTileNoiseFallback(layer, getTileFallbackOptions))
   stopTileFallbackWatcher = watch(
     () => [missionStore.mapFallbackBaseColor, missionStore.mapFallbackSeed, missionStore.mapFallbackNoiseIntensity],

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -585,7 +585,9 @@
     @place-point-of-interest="openPoiDialog"
     @add-waypoint-at-cursor="addWaypointFromContextMenu"
     @clear-vehicle-path-history="clearVehiclePathHistory"
+    @open-map-overlays="overlaysDialogOpen = true"
   />
+  <MapOverlaysDialog v-model="overlaysDialogOpen" :loading-ids="overlayLoadingIds" />
   <Teleport to="#planningMap">
     <RadialMenu
       :visible="segmentRadialMenuVisible"
@@ -677,6 +679,7 @@ import blueboatMarkerImage from '@/assets/blueboat-marker.avif'
 import brov2MarkerImage from '@/assets/brov2-marker.avif'
 import genericVehicleMarkerImage from '@/assets/generic-vehicle-marker.avif'
 import MapNorthIndicator from '@/components/map/MapNorthIndicator.vue'
+import MapOverlaysDialog from '@/components/map/MapOverlaysDialog.vue'
 import ContextMenu from '@/components/mission-planning/ContextMenu.vue'
 import HomePositionSettingHelp from '@/components/mission-planning/HomePositionSettingHelp.vue'
 import MissionEstimatesPanel from '@/components/mission-planning/MissionEstimates.vue'
@@ -931,6 +934,8 @@ const { mapReady } = mapContext
 
 // Syncs user-loaded GeoTIFF overlays (sonar/bathymetry surveys) onto the planning map
 const mapOverlays = useMapOverlays()
+const overlayLoadingIds = mapOverlays.loadingIds
+const overlaysDialogOpen = ref(false)
 
 // Frame the map on a GeoTIFF overlay when requested from the configuration panel
 watch(

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -670,8 +670,6 @@ import { formatDistanceToNow } from 'date-fns'
 import { format } from 'date-fns'
 import { saveAs } from 'file-saver'
 import L, { type LatLngTuple, LayersControlEvent, LeafletMouseEvent, Map, Marker, Polygon } from 'leaflet'
-import { tileLayerOffline } from 'leaflet.offline'
-import { SaveStatus, savetiles } from 'leaflet.offline'
 import { v4 as uuid } from 'uuid'
 import { type InstanceType, computed, nextTick, onMounted, onUnmounted, ref, shallowRef, toRaw, watch } from 'vue'
 
@@ -691,6 +689,7 @@ import RadialMenu, { type RadialMenuItem } from '@/components/RadialMenu.vue'
 import SideConfigPanel from '@/components/SideConfigPanel.vue'
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { provideMapContext } from '@/composables/map/useMapContext'
+import { useMapOverlays } from '@/composables/map/useMapOverlays'
 import { useMapTileLayers } from '@/composables/map/useMapTileLayers'
 import { useSnackbar } from '@/composables/snackbar'
 import {
@@ -929,6 +928,15 @@ const downloadMissionFromVehicle = async (): Promise<void> => {
 const planningMap = shallowRef<Map | undefined>()
 const mapContext = provideMapContext()
 const { mapReady } = mapContext
+
+// Syncs user-loaded GeoTIFF overlays (sonar/bathymetry surveys) onto the planning map
+const mapOverlays = useMapOverlays()
+
+// Frame the map on a GeoTIFF overlay when requested from the configuration panel
+watch(
+  () => missionStore.mapOverlayFocusRequest.revision,
+  () => mapOverlays.zoomToOverlay(missionStore.mapOverlayFocusRequest.id)
+)
 
 const mapCenter = ref<WaypointCoordinates>(missionStore.userLastMapCenter ?? missionStore.defaultMapCenter)
 const zoom = ref(missionStore.userLastMapZoom ?? missionStore.defaultMapZoom)
@@ -3855,6 +3863,9 @@ onMounted(async () => {
   const layerControl = L.control.layers(baseMaps)
   planningMap.value.addControl(layerControl)
 
+  // Render any user-loaded GeoTIFF overlays and keep them in sync with the stored metadata
+  await mapOverlays.initOverlays(planningMap.value, layerControl)
+
   // Initialize scale control (always show)
   createScaleControl()
 
@@ -3920,6 +3931,7 @@ onUnmounted(() => {
   fallbackLayers = []
   stopTileFallbackWatcher?.()
   stopTileFallbackWatcher = undefined
+  mapOverlays.destroyOverlays()
 
   // Reset the map context so descendants stop reacting to the destroyed instance
   mapContext.mapReady.value = false

--- a/yarn.lock
+++ b/yarn.lock
@@ -1407,6 +1407,11 @@
   dependencies:
     uuid "8.3.2"
 
+"@petamoriken/float16@^3.9.3":
+  version "3.9.3"
+  resolved "https://registry.yarnpkg.com/@petamoriken/float16/-/float16-3.9.3.tgz#84acef4816db7e4c2fe1c4e8cf902bcbc0440ac3"
+  integrity sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==
+
 "@pinia/testing@^0.0.12":
   version "0.0.12"
   resolved "https://registry.yarnpkg.com/@pinia/testing/-/testing-0.0.12.tgz#1692568b4b55347429556ab43e354e81519f73e0"
@@ -4059,6 +4064,11 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
+b64ab@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/b64ab/-/b64ab-0.0.1.tgz#b86b1cf6d14324406d4fb0ec5b79298302948846"
+  integrity sha512-ZJsfScQB2vf7nKx/FQ8FyHQb8huQQcJ3lljak04DVReEMoGSg4zXyRLCsFEKcRKc6HGIgJ3tHsJiE4tcm7/HJA==
+
 babel-plugin-polyfill-corejs2@^0.4.10:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.13.tgz#7d445f0e0607ebc8fb6b01d7e8fb02069b91dd8b"
@@ -4092,6 +4102,18 @@ base64-js@^1.3.1, base64-js@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
+bbox-fns@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/bbox-fns/-/bbox-fns-0.20.2.tgz#8b40794d749d10f7d57878b7d93a30d8f7f4db18"
+  integrity sha512-6DyKO3B6suAEducHcELF1cqdmlYj57zMTJim0X4RunclXOXE3wuTB8efm+I9dt2kXl+zPhFxAYSrRU6AUkHlwA==
+  dependencies:
+    preciso "^0.12.2"
+
+bbox-fns@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/bbox-fns/-/bbox-fns-0.6.0.tgz#8be0185800c2777c55e518fab5f7af242e8b6645"
+  integrity sha512-GwAMFzAQQgmbmHaFZQdP8dp2F0L0hby+ssdaQQFws0U8v211993zzlZByrupwucuNIbPwDbVp24ZUcTF/eaKtw==
 
 big.js@^5.2.2:
   version "5.2.2"
@@ -5913,6 +5935,26 @@ gensync@^1.0.0-beta.2:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
+geo-extent@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/geo-extent/-/geo-extent-1.5.0.tgz#c5a06ca8a6eb3ca29f4254ad7fc11f6bea4d07a9"
+  integrity sha512-huWD0E69zeUgC40s5ubZaMseontk07nDT3051+e4CGR7ojqK9v129hB94lMTCJalGeeAphEI3BIX4ufnOyBKbg==
+  dependencies:
+    bbox-fns "^0.20.2"
+    geography-markup-language "^0.2.0"
+    get-epsg-code "1.2.0"
+    preciso "^0.12.2"
+    reproject-bbox "^0.13.1"
+    reproject-geojson "^0.5.0"
+
+geography-markup-language@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/geography-markup-language/-/geography-markup-language-0.2.0.tgz#25c06ef0ae5852d311c76e41ed8638711fa9450d"
+  integrity sha512-AwDEo4UHWACyOnc4IQzGhQHFlPn8HgYJdCTmtN6vRfyAIKdcjL7YlqS20r6Zn/Zo5XMiRajOEH12YRIc1OOkmg==
+  dependencies:
+    bbox-fns "^0.6.0"
+    xml-utils "^1.3.0"
+
 geojson-equality-ts@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/geojson-equality-ts/-/geojson-equality-ts-1.0.2.tgz#2aed0b9aca1fedb17212fecbfc42f73020410480"
@@ -5927,10 +5969,48 @@ geojson-polygon-self-intersections@^1.2.1:
   dependencies:
     rbush "^2.0.1"
 
+geotiff-epsg-code@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/geotiff-epsg-code/-/geotiff-epsg-code-0.3.1.tgz#b83cd55c4b530b72ed8d11a82793b222bb7ace49"
+  integrity sha512-VzzFNfeCG5eTtc14J24Anr8lPFmn3bSYED/JL5JEEZbioYkDrTf6f1eHSkJ6w6dboXygXCe2Zq3314FmYuEYyg==
+  dependencies:
+    get-epsg-code "^1.1.0"
+
+geotiff@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/geotiff/-/geotiff-3.0.5.tgz#2a15e8a9b8355ba0a311bdffca789f7a6853b445"
+  integrity sha512-OWcL9S9+yDZ6iAlXMt32T1iwUApJM8UiD47xbm6ZP1h33d10fqkPs14EG/ttT5EnefpZSx3G15iDFC5FxUNUwA==
+  dependencies:
+    "@petamoriken/float16" "^3.9.3"
+    lerc "^3.0.0"
+    pako "^2.0.4"
+    parse-headers "^2.0.2"
+    quick-lru "^6.1.1"
+    web-worker "^1.5.0"
+    xml-utils "^1.10.2"
+    zstddec "^0.2.0"
+
 get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
+get-depth@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/get-depth/-/get-depth-0.0.3.tgz#42aa24f109a057b1a74cbd18d707e64f9da81ee3"
+  integrity sha512-A0yWzxfqobOgDC/hGNwUYKfNlV8+WnU0EoHazVaXvLyp/I8e8f/Fx/HFS0r2i0RJ5mXj3YmyM8KSN4trtAdHvA==
+
+get-epsg-code@1.2.0, get-epsg-code@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/get-epsg-code/-/get-epsg-code-1.2.0.tgz#9423ad8d9156127453d3f1dfcd691f4d163f763e"
+  integrity sha512-H97flgddOm1i7y8mXIU26WOLRuC9aihgFHXpll/Jbpl3B4IU9YO4AvPi/EwP6xQ8YrEUO1Ny++amxNTqNv9J1Q==
+  dependencies:
+    b64ab "^0.0.1"
+    is-wkt "^0.2.0"
+    utm-utils "^0.6.1"
+    wkt-crs "^0.2.0"
+    wkt-parser "^1.3.3"
+    xml-utils "^1.7.0"
 
 get-func-name@^2.0.1, get-func-name@^2.0.2:
   version "2.0.2"
@@ -6596,6 +6676,11 @@ is-weakset@^2.0.3:
     call-bound "^1.0.3"
     get-intrinsic "^1.2.6"
 
+is-wkt@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/is-wkt/-/is-wkt-0.2.0.tgz#617dfcc1569e7540d80c0f11dfd2902ee9fc4f7d"
+  integrity sha512-qq2UXJbGWS/4zZh5gPqWvTYoRkrX4d5/Z2GgCG3N44BKccELAemP0CNpEQjvDGNdLqLceul45LGW5PxSc9GqSQ==
+
 isarray@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
@@ -6874,6 +6959,11 @@ leaflet@^1.6.0:
   resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.9.4.tgz#23fae724e282fa25745aff82ca4d394748db7d8d"
   integrity sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==
 
+lerc@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/lerc/-/lerc-3.0.0.tgz#36f36fbd4ba46f0abf4833799fff2e7d6865f5cb"
+  integrity sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==
+
 leven@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
@@ -7113,6 +7203,11 @@ merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
+mgrs@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mgrs/-/mgrs-1.0.0.tgz#fb91588e78c90025672395cb40b25f7cd6ad1829"
+  integrity sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA==
 
 micromatch@^4.0.5, micromatch@^4.0.8:
   version "4.0.8"
@@ -7581,12 +7676,22 @@ package-json-from-dist@^1.0.0:
   resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
   integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
 
+pako@^2.0.4:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-2.1.0.tgz#266cc37f98c7d883545d11335c00fbd4062c9a86"
+  integrity sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
   integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   dependencies:
     callsites "^3.0.0"
+
+parse-headers@^2.0.2:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/parse-headers/-/parse-headers-2.0.6.tgz#7940f0abe5fe65df2dd25d4ce8800cb35b49d01c"
+  integrity sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==
 
 parse5@6.0.1:
   version "6.0.1"
@@ -7793,6 +7898,11 @@ preact@^10.19.3:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.26.9.tgz#b3898d1b65140640799062ad73b89846c293b6a7"
   integrity sha512-SSjF9vcnF27mJK1XyFMNJzFd5u3pQiATFqoaDy03XuN00u4ziveVVEGt5RKJrDR8MHE/wJo9Nnad56RLzS2RMA==
 
+preciso@^0.12.2:
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/preciso/-/preciso-0.12.2.tgz#3c802b694a47f1550209dd24fdfc0ed187482cab"
+  integrity sha512-or/2I6/6VDMwJjJdFdyzVc/L1JT29DrlfA096iXBQWryL+ytEAfDgChI/tTnDXb58l5E/kIEa4Omg6AHFLmywA==
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -7833,6 +7943,32 @@ progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
+proj4-fully-loaded@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/proj4-fully-loaded/-/proj4-fully-loaded-0.2.0.tgz#2871046cb21b0d7d44ccab70b233d620b9809057"
+  integrity sha512-9rlkLe9+l8iFpviYiQjdHbw9d3iOmUAF1UlbaVkofvbI26/0/EOWtYku9ln+dJuAovrqHyoJ984G5/edQxvHng==
+  dependencies:
+    proj4 "^2.8.0"
+    proj4js-definitions "^0.1.0"
+
+proj4-merge@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/proj4-merge/-/proj4-merge-0.1.1.tgz#435d5c78e5aa73aec206453d2021e2f91e2534f5"
+  integrity sha512-Ac9W5jgOAqPRspA9fMuRuLs0weDuOCHK7nnd6yOAySzLaxrmq1ZxbCTKVt6pIEOPB3RpgcupBOU3KXmQM0m8rg==
+
+proj4@^2.8.0:
+  version "2.20.9"
+  resolved "https://registry.yarnpkg.com/proj4/-/proj4-2.20.9.tgz#73a00460772cdb5d1c931cf6009cb28fb7495a36"
+  integrity sha512-GLBGqXaTcdWnppre3o1sMmy4DcMGSGq/ng+9k2MTNddarRK6SveINqlqYzi3xEXuy06ljY1TTrC6H9C4f360IQ==
+  dependencies:
+    mgrs "1.0.0"
+    wkt-parser "^1.5.5"
+
+proj4js-definitions@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/proj4js-definitions/-/proj4js-definitions-0.1.0.tgz#4cb6fffc12c19984040c1370e30d39743e66d18c"
+  integrity sha512-qmyhkWihIa3E3ZiFsNxvap6oS5+zEH85felbe/YVFuCr1E2j5yUrNQUOU9UEbvKkRJW9kk0MhENtbW3+9Nnr3g==
 
 promise-inflight@^1.0.1:
   version "1.0.1"
@@ -7891,6 +8027,11 @@ quick-lru@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
+
+quick-lru@^6.1.1:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-6.1.2.tgz#e9a90524108629be35287d0b864e7ad6ceb3659e"
+  integrity sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==
 
 quick-lru@^7.3.0:
   version "7.3.0"
@@ -8036,6 +8177,29 @@ regjsparser@^0.12.0:
   integrity sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==
   dependencies:
     jsesc "~3.0.2"
+
+reproject-bbox@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/reproject-bbox/-/reproject-bbox-0.13.1.tgz#3ddcca73c38bdaecd8aa25f5cc599236e5f1c856"
+  integrity sha512-1DT2QQGxsnUCDU/ndbwbbd/7EoKJejmEDZIJyOWPaYbKZP8dbu65npf1ogOGU54VDL4+u1pboYFQarA5NT+OTQ==
+  dependencies:
+    bbox-fns "^0.20.2"
+    proj4-fully-loaded "^0.2.0"
+    proj4-merge "^0.1.1"
+
+reproject-geojson@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/reproject-geojson/-/reproject-geojson-0.5.0.tgz#b9093b530ca0362e8b089290ee8a07319d74a018"
+  integrity sha512-xEP90OAGHbemceH9cMSc0Wuhzg4/EetEbjk9v+5KY+VRdLoR7ZIg7y+SFc/0ztcrdb37SBnqfBDxVd5TQDY95Q==
+  dependencies:
+    get-depth "^0.0.3"
+    proj4-fully-loaded "^0.2.0"
+    reproject-line "^0.0.1"
+
+reproject-line@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/reproject-line/-/reproject-line-0.0.1.tgz#2d4c058205d2f8158d32f29f18bc733cbe48639a"
+  integrity sha512-1Fyq4wN2zA4k77Wh1A6QM71ijVUbe88RW94Cj/guU+Q0e4LhSuYvJXlHBeUbBjzgEWfuDEx86AP1E2jYPVqS6g==
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -9199,6 +9363,11 @@ util-deprecate@^1.0.1, util-deprecate@^1.0.2:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
+utm-utils@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/utm-utils/-/utm-utils-0.6.1.tgz#41ad4c34ef79f6e622ddd79951c5b884bac46119"
+  integrity sha512-OqSVTkvVFfQaxX8WraDhP6PGECbz8YTDrYAeo74TMmZnzfGkE0wA797/5nFGuCzFVR9e6fnrO42gbqySS4kAxw==
+
 uuid@8.3.2, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
@@ -9431,6 +9600,11 @@ web-vitals@^4.2.4:
   resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-4.2.4.tgz#1d20bc8590a37769bd0902b289550936069184b7"
   integrity sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==
 
+web-worker@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/web-worker/-/web-worker-1.5.0.tgz#71b2b0fbcc4293e8f0aa4f6b8a3ffebff733dcc5"
+  integrity sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==
+
 webfontloader@^1.0.0:
   version "1.6.28"
   resolved "https://registry.yarnpkg.com/webfontloader/-/webfontloader-1.6.28.tgz#db786129253cb6e8eae54c2fb05f870af6675bae"
@@ -9561,6 +9735,16 @@ wide-align@^1.1.5:
   integrity sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==
   dependencies:
     string-width "^1.0.2 || 2 || 3 || 4"
+
+wkt-crs@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/wkt-crs/-/wkt-crs-0.2.0.tgz#7a5555d364d38bc9411928c37329deee7414eeab"
+  integrity sha512-rYheR2V2lyPmTrtxuo9nyFBlTuB4VJ1tlrTpUX88GZleRqLLUazVWihwv7BjGqpmoMd91IaLbG8mURqids9H9w==
+
+wkt-parser@^1.3.3, wkt-parser@^1.5.5:
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/wkt-parser/-/wkt-parser-1.5.5.tgz#251a5b0ba289842a2e8d5b25049c57fb49fb9183"
+  integrity sha512-/zMYi94/7D7fxcOSlVmWn6vnOMj3Gq5d1xvVjaYOS9n6h0qOJ4I7YYVxBWYcH1vq9+suhqzXkn05Yx47zQNUIA==
 
 word-wrap@^1.2.5:
   version "1.2.5"
@@ -9767,6 +9951,11 @@ xml-name-validator@^4.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-4.0.0.tgz#79a006e2e63149a8600f15430f0a4725d1524835"
   integrity sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==
 
+xml-utils@^1.10.2, xml-utils@^1.3.0, xml-utils@^1.7.0:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/xml-utils/-/xml-utils-1.10.2.tgz#436b39ccc25a663ce367ea21abb717afdea5d6b1"
+  integrity sha512-RqM+2o1RYs6T8+3DzDSoTRAUfrvaejbVHcp3+thnAtDKo8LskR+HomLajEy5UjTz24rpka7AxVBRR3g2wTUkJA==
+
 xmlbuilder@>=11.0.1, xmlbuilder@^15.1.1:
   version "15.1.1"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-15.1.1.tgz#9dcdce49eea66d8d10b42cae94a79c3c8d0c2ec5"
@@ -9870,3 +10059,8 @@ zod@^4.1.12:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/zod/-/zod-4.3.6.tgz#89c56e0aa7d2b05107d894412227087885ab112a"
   integrity sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==
+
+zstddec@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/zstddec/-/zstddec-0.2.0.tgz#91c8cde8f351ef5fe0bdfca66bb14a5fa0d16d71"
+  integrity sha512-oyPnDa1X5c13+Y7mA/FDMNJrn4S8UNBe0KCqtDmor40Re7ALrPN6npFwyYVRRh+PqozZQdeg23QtbcamZnG5rA==


### PR DESCRIPTION
# Add support for GeoTIFF map overlays

Load georeferenced GeoTIFF surveys (sidescan/backscatter mosaics, bathymetry, photogrammetry) as background overlays on the dashboard Map widget and the Mission Planning view, so the vehicle can be seen against your own survey data instead of just satellite imagery. Requested [on the forum](https://discuss.bluerobotics.com/t/cockpit-background-map/23134).

<img width="3420" height="2088" alt="image" src="https://github.com/user-attachments/assets/c3afe1c5-54a7-45ec-bf76-a2780e059833" />


## What you can do
- Load one or more GeoTIFF overlays (right click on the map → "Add overlay (GeoTIFF)" / "Manage overlays").
- Per overlay: pick a render mode (Grayscale/RGB, Intensity, Bathymetry), adjust opacity, toggle visibility, center the map on it, or remove it.
- Overlays show up in each map's layer control and persist across reloads. The rendered image is cached (in memory and in IndexedDB) and shared between the Map widget and Mission Planning view, so the overlay isn't re-rendered on every map mount.

## Performance
- Smooth pan/zoom at any survey size — the raster is rendered once to a static image rather than re-computed on every zoom.
- Cloud Optimized GeoTIFFs (COGs) load fast even when large: only the smallest suitable internal overview is read via byte-range reads instead of decoding the full-resolution raster.

## Limitations
- Placed on a reprojected bounding box (not per-pixel warped), so very large surveys (tens of km) may show slight skew; fine for typical local surveys.

## Technical solution (brief)
Decode with `geotiff` (reading internal COG overviews via byte-range reads), rasterize once to a canvas with per-band contrast stretch so non-8-bit data (e.g. 16-bit bathymetry) isn't all white, and display via Leaflet `ImageOverlay`. `geo-extent` reprojects the raster's bounding box to WGS84 and `geotiff-epsg-code` reads its EPSG/CRS code. Heavy libs are lazy-loaded; raster bytes and the rendered image live in IndexedDB (overlays are imported input data, not generated output, so they aren't written to the filesystem), with metadata in `cockpit-map-overlays-v1`. Shared logic is factored into `useMapTileLayers` and `useMapOverlays`.

Contributes to #84.