### PR TITLE
Mission Planning: Add angle and heading to path segments

### DIFF
--- a/src/composables/map/useDragMeasureOverlay.ts
+++ b/src/composables/map/useDragMeasureOverlay.ts
@@ -1,0 +1,111 @@
+import L, { type Map as LeafletMap } from 'leaflet'
+
+import { affectedAngleTriples } from '@/libs/map/utils-map'
+import { bearingBetween, formatBearing, formatMetersShort } from '@/libs/mission/general-estimates'
+import { useMissionStore } from '@/stores/mission'
+import type { WaypointCoordinates } from '@/types/mission'
+
+import type { UseVertexAngleOverlayReturn } from './useVertexAngleOverlay'
+
+/**
+ * Return type of {@link useDragMeasureOverlay}.
+ */
+export interface UseDragMeasureOverlayReturn {
+  /** Binds the overlay to a Leaflet map. */
+  initDragMeasureOverlay: (map: LeafletMap) => void
+  /** Renders distance/heading pills on the segments touching the dragged waypoint, plus the affected vertex angles. */
+  renderDragMeasurePills: (waypointId: string) => void
+  /** Removes the drag pills and the vertex angles it drew. */
+  destroyDragMeasureOverlay: () => void
+}
+
+/**
+ * While a waypoint is dragged, shows a distance/heading pill on each path segment touching it and, through the
+ * shared angle overlay, the interior angle at the dragged vertex and its immediate neighbors.
+ * @param {UseVertexAngleOverlayReturn} angleOverlay - Shared vertex-angle overlay used to draw the affected angles.
+ * @returns {UseDragMeasureOverlayReturn} Methods to initialize, render, and tear down the drag-measure overlay.
+ */
+export const useDragMeasureOverlay = (angleOverlay: UseVertexAngleOverlayReturn): UseDragMeasureOverlayReturn => {
+  const missionStore = useMissionStore()
+
+  let mapRef: LeafletMap | undefined
+  let overlayEl: HTMLDivElement | null = null
+  let pillEls: HTMLDivElement[] = []
+
+  const initDragMeasureOverlay = (map: LeafletMap): void => {
+    mapRef = map
+  }
+
+  const ensureOverlay = (map: LeafletMap): void => {
+    if (overlayEl) return
+    overlayEl = document.createElement('div')
+    overlayEl.className = 'measure-overlay'
+    overlayEl.style.pointerEvents = 'none'
+    overlayEl.style.position = 'absolute'
+    overlayEl.style.inset = '0'
+    overlayEl.style.zIndex = '640'
+    map.getContainer().appendChild(overlayEl)
+  }
+
+  const destroyDragMeasureOverlay = (): void => {
+    overlayEl?.remove()
+    overlayEl = null
+    pillEls = []
+    angleOverlay.clearVertexAngles()
+  }
+
+  const renderDragMeasurePills = (waypointId: string): void => {
+    if (!mapRef) return
+    const map = mapRef
+    const wps = missionStore.currentPlanningWaypoints
+    const index = wps.findIndex((w) => w.id === waypointId)
+    if (index < 0) {
+      destroyDragMeasureOverlay()
+      return
+    }
+
+    const segments: [WaypointCoordinates, WaypointCoordinates][] = []
+    if (index > 0) segments.push([wps[index - 1].coordinates, wps[index].coordinates])
+    if (index < wps.length - 1) segments.push([wps[index].coordinates, wps[index + 1].coordinates])
+    if (segments.length === 0) {
+      destroyDragMeasureOverlay()
+      return
+    }
+
+    ensureOverlay(map)
+    while (pillEls.length < segments.length) {
+      const pill = document.createElement('div')
+      pill.className = 'live-measure-pill'
+      pill.style.position = 'absolute'
+      pill.style.transform = 'translate(-50%, -50%)'
+      overlayEl!.appendChild(pill)
+      pillEls.push(pill)
+    }
+
+    segments.forEach(([from, to], i) => {
+      const fromLatLng = L.latLng(from[0], from[1])
+      const toLatLng = L.latLng(to[0], to[1])
+      const a = map.latLngToContainerPoint(fromLatLng)
+      const b = map.latLngToContainerPoint(toLatLng)
+      const dist = fromLatLng.distanceTo(toLatLng)
+      const bearing = bearingBetween(from, to)
+      const pill = pillEls[i]
+      pill.textContent = `${formatMetersShort(dist)} · ${formatBearing(bearing)}`
+      pill.style.left = `${(a.x + b.x) / 2}px`
+      pill.style.top = `${(a.y + b.y) / 2}px`
+      pill.style.display = dist < 1 ? 'none' : 'block'
+    })
+    for (let i = segments.length; i < pillEls.length; i++) {
+      pillEls[i].style.display = 'none'
+    }
+
+    const triples = affectedAngleTriples(wps, index)
+    if (triples.length > 0) {
+      angleOverlay.renderVertexAngles(triples)
+    } else {
+      angleOverlay.clearVertexAngles()
+    }
+  }
+
+  return { initDragMeasureOverlay, renderDragMeasurePills, destroyDragMeasureOverlay }
+}

--- a/src/composables/map/useVertexAngleOverlay.ts
+++ b/src/composables/map/useVertexAngleOverlay.ts
@@ -1,0 +1,109 @@
+import L, { type Map as LeafletMap } from 'leaflet'
+
+import { computeVertexAngle } from '@/libs/map/utils-map'
+import type { WaypointCoordinates } from '@/types/mission'
+
+const ANGLE_PANE = 'measureAnglePane'
+
+/** A `[prev, curr, next]` vertex triple whose interior angle at `curr` should be drawn. */
+export type VertexAngleTriple = [WaypointCoordinates, WaypointCoordinates, WaypointCoordinates]
+
+/**
+ * Return type of {@link useVertexAngleOverlay}.
+ */
+export interface UseVertexAngleOverlayReturn {
+  /** Binds the overlay to a Leaflet map and creates the dedicated pane. */
+  initAngleOverlay: (map: LeafletMap) => void
+  /** Draws (or updates) an interior-angle arc and degree tag at each given vertex triple, recycling layers. */
+  renderVertexAngles: (triples: VertexAngleTriple[]) => void
+  /** Draws (or updates) the interior angle at a single `prev`→`curr`→`next` vertex. */
+  renderVertexAngle: (prev: WaypointCoordinates, curr: WaypointCoordinates, next: WaypointCoordinates) => void
+  /** Removes every angle arc and tag currently on the map. */
+  clearVertexAngles: () => void
+  /** Clears the overlay and unbinds the map. */
+  destroyAngleOverlay: () => void
+}
+
+/**
+ * Draws interior-angle arcs with degree labels at path vertices on a Leaflet map, recycling layers across ticks
+ * so it stays cheap on pointer-frequency updates. Shared by the live measure while drawing and by the
+ * drag-measure overlay, and reusable by any map surface that needs to visualize turn angles.
+ * @returns {UseVertexAngleOverlayReturn} Methods to initialize, render, clear, and tear down the angle overlay.
+ */
+export const useVertexAngleOverlay = (): UseVertexAngleOverlayReturn => {
+  let mapRef: LeafletMap | undefined
+  let arcLayers: L.Polyline[] = []
+  let tagLayers: L.Marker[] = []
+  let tagPillEls: (HTMLElement | null)[] = []
+
+  const initAngleOverlay = (map: LeafletMap): void => {
+    mapRef = map
+    if (map.getPane(ANGLE_PANE)) return
+    // Above the tooltip pane (650, where waypoint numbers live) so angle tags always sit on top.
+    const pane = map.createPane(ANGLE_PANE)
+    pane.style.zIndex = '660'
+    pane.style.pointerEvents = 'none'
+  }
+
+  const renderVertexAngles = (triples: VertexAngleTriple[]): void => {
+    if (!mapRef) return
+    const map = mapRef
+    const mapZoom = map.getZoom()
+    const angles = triples
+      .map(([prev, curr, next]) => computeVertexAngle(prev, curr, next, mapZoom))
+      .filter((angle) => angle.labelAt !== null)
+
+    while (arcLayers.length > angles.length) {
+      arcLayers.pop()?.remove()
+      tagLayers.pop()?.remove()
+      tagPillEls.pop()
+    }
+
+    angles.forEach((angle, i) => {
+      const arcLatLngs = angle.arc.map((c) => L.latLng(c[0], c[1]))
+      const labelAt = angle.labelAt!
+      const label = `${angle.angleDeg.toFixed(1)}°`
+      if (arcLayers[i]) {
+        arcLayers[i].setLatLngs(arcLatLngs)
+        tagLayers[i].setLatLng([labelAt[0], labelAt[1]])
+        const pill = tagPillEls[i]
+        if (pill) pill.textContent = label
+      } else {
+        arcLayers[i] = L.polyline(arcLatLngs, {
+          color: '#2563eb',
+          weight: 2,
+          opacity: 0.9,
+          interactive: false,
+        }).addTo(map)
+        const icon = L.divIcon({
+          className: 'measure-angle-tag',
+          html: `<div class="measure-angle-pill">${label}</div>`,
+          iconSize: [0, 0],
+          iconAnchor: [0, 0],
+        })
+        const tag = L.marker([labelAt[0], labelAt[1]], { icon, interactive: false, pane: ANGLE_PANE }).addTo(map)
+        tagLayers[i] = tag
+        tagPillEls[i] = tag.getElement()?.querySelector('.measure-angle-pill') ?? null
+      }
+    })
+  }
+
+  const renderVertexAngle = (prev: WaypointCoordinates, curr: WaypointCoordinates, next: WaypointCoordinates): void => {
+    renderVertexAngles([[prev, curr, next]])
+  }
+
+  const clearVertexAngles = (): void => {
+    arcLayers.forEach((layer) => layer.remove())
+    tagLayers.forEach((layer) => layer.remove())
+    arcLayers = []
+    tagLayers = []
+    tagPillEls = []
+  }
+
+  const destroyAngleOverlay = (): void => {
+    clearVertexAngles()
+    mapRef = undefined
+  }
+
+  return { initAngleOverlay, renderVertexAngles, renderVertexAngle, clearVertexAngles, destroyAngleOverlay }
+}

--- a/src/composables/useMissionEstimates.ts
+++ b/src/composables/useMissionEstimates.ts
@@ -6,6 +6,7 @@ import {
   calculateHaversineDistance,
   computeMissionDurationSecondsFromLegs,
   convexHullSquareMeters,
+  formatMetersShort,
 } from '@/libs/mission/general-estimates'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useMissionStore } from '@/stores/mission'
@@ -45,7 +46,6 @@ export const useMissionEstimates = (): {
   totalMissionDuration: ComputedRef<string>
   totalMissionEnergy: ComputedRef<string>
   missionLegsWithSpeed: ComputedRef<MissionLeg[]>
-  formatMetersShort: (distance: number) => string
   formatArea: (area: number) => string
   formatSeconds: (s: number) => string
   formatWh: (energy: number) => string
@@ -149,12 +149,6 @@ export const useMissionEstimates = (): {
     return Object.values(surveyAreaSquareMetersById.value).reduce((a, b) => a + b, 0)
   })
 
-  const formatMetersShort = (distance: number): string => {
-    if (!isFinite(distance) || distance <= 0) return '—'
-    if (distance < 1000) return `${distance.toFixed(0)} m`
-    return `${(distance / 1000).toFixed(2)} km`
-  }
-
   const formatSeconds = (s: number): string => {
     if (!isFinite(s) || s <= 0) return '—'
     const time = Math.floor(s / 3600)
@@ -201,7 +195,6 @@ export const useMissionEstimates = (): {
     totalMissionDuration,
     totalMissionEnergy,
     missionLegsWithSpeed,
-    formatMetersShort,
     formatArea,
     formatSeconds,
     formatWh,

--- a/src/libs/map/utils-map.ts
+++ b/src/libs/map/utils-map.ts
@@ -604,3 +604,28 @@ export const computeVertexAngle = (
 
   return { angleDeg, arc, labelAt: arc[Math.floor(arc.length / 2)] ?? null }
 }
+
+/**
+ * Vertex triples whose interior angle is reshaped by moving the waypoint at `index`: the moved vertex and each
+ * immediate neighbor that itself has two neighbors (endpoints have no interior angle).
+ * @param {{ coordinates: WaypointCoordinates }[]} waypoints - The ordered path waypoints.
+ * @param {number} index - Index of the waypoint being moved.
+ * @returns {[WaypointCoordinates, WaypointCoordinates, WaypointCoordinates][]} The affected `[prev, curr, next]` triples.
+ */
+export const affectedAngleTriples = (
+  waypoints: {
+    /**
+     * The waypoint coordinates.
+     */
+    coordinates: WaypointCoordinates
+  }[],
+  index: number
+): [WaypointCoordinates, WaypointCoordinates, WaypointCoordinates][] => {
+  const triples: [WaypointCoordinates, WaypointCoordinates, WaypointCoordinates][] = []
+  for (const j of [index - 1, index, index + 1]) {
+    if (j >= 1 && j <= waypoints.length - 2) {
+      triples.push([waypoints[j - 1].coordinates, waypoints[j].coordinates, waypoints[j + 1].coordinates])
+    }
+  }
+  return triples
+}

--- a/src/libs/map/utils-map.ts
+++ b/src/libs/map/utils-map.ts
@@ -2,6 +2,7 @@ import * as turf from '@turf/turf'
 import type { Feature, Polygon } from 'geojson'
 import * as L from 'leaflet'
 
+import { bearingBetween, calculateHaversineDistance, deltaBearing } from '@/libs/mission/general-estimates'
 import type { SurveyPath, WaypointCoordinates } from '@/types/mission'
 
 /**
@@ -550,4 +551,56 @@ export const createGridOverlay = (map: L.Map, gridLayer?: L.LayerGroup): L.Layer
 
   newGridLayer.addTo(map)
   return newGridLayer
+}
+
+/**
+ * Interior angle at a path vertex plus the geometry used to render it.
+ */
+interface VertexAngle {
+  /** Interior angle between the two segments meeting at the vertex, in degrees. */
+  angleDeg: number
+  /** Lat/lng points making up the arc that visualizes the angle. */
+  arc: WaypointCoordinates[]
+  /** Arc midpoint used to anchor the degree label, or null when the arc has no points. */
+  labelAt: WaypointCoordinates | null
+}
+
+/**
+ * Interior angle at `curr` between segments `prev`→`curr` and `curr`→`next`, plus a small arc that visualizes it.
+ * @param {WaypointCoordinates} prev - Vertex before the angle vertex.
+ * @param {WaypointCoordinates} curr - Vertex where the angle is measured.
+ * @param {WaypointCoordinates} next - Vertex after the angle vertex.
+ * @param {number} mapZoom - Current map zoom, used to scale the arc radius.
+ * @returns {VertexAngle} The angle in degrees, the arc points, and the arc midpoint to anchor a label.
+ */
+export const computeVertexAngle = (
+  prev: WaypointCoordinates,
+  curr: WaypointCoordinates,
+  next: WaypointCoordinates,
+  mapZoom: number
+): VertexAngle => {
+  const incomingBearing = bearingBetween(prev, curr)
+  const outgoingBearing = bearingBetween(curr, next)
+  const reverseIncomingBearing = (incomingBearing + 180) % 360
+  const angleDeg = deltaBearing(reverseIncomingBearing, outgoingBearing)
+
+  const radiusMeters = Math.max(15, Math.min(50, 1000 / mapZoom))
+  const longerSegment = Math.max(calculateHaversineDistance(prev, curr), calculateHaversineDistance(curr, next))
+  const arcRadius = Math.min(radiusMeters, longerSegment * 0.3) * 0.5
+
+  const normalizedDiff = ((outgoingBearing - reverseIncomingBearing + 540) % 360) - 180
+  const startBearing = normalizedDiff >= 0 ? reverseIncomingBearing : reverseIncomingBearing - angleDeg
+  const endBearing = normalizedDiff >= 0 ? reverseIncomingBearing + angleDeg : reverseIncomingBearing
+
+  const arc: WaypointCoordinates[] = []
+  const steps = Math.max(8, Math.floor(angleDeg / 2))
+  for (let i = 0; i <= steps; i++) {
+    const bearing = (((startBearing + ((endBearing - startBearing) * i) / steps) % 360) + 360) % 360
+    const rad = (bearing * Math.PI) / 180
+    const latOffset = (arcRadius / 111320) * Math.cos(rad)
+    const lngOffset = (arcRadius / (111320 * Math.cos((curr[0] * Math.PI) / 180))) * Math.sin(rad)
+    arc.push([curr[0] + latOffset, curr[1] + lngOffset])
+  }
+
+  return { angleDeg, arc, labelAt: arc[Math.floor(arc.length / 2)] ?? null }
 }

--- a/src/libs/mission/general-estimates.ts
+++ b/src/libs/mission/general-estimates.ts
@@ -145,6 +145,18 @@ export const deltaBearing = (bearing1: number, bearing2: number): number => {
   return angle
 }
 
+export const formatMetersShort = (distance: number): string => {
+  if (!isFinite(distance) || distance <= 0) return '—'
+  if (distance < 1000) return `${distance.toFixed(0)} m`
+  return `${(distance / 1000).toFixed(2)} km`
+}
+
+export const formatBearing = (bearing: number): string => {
+  if (!isFinite(bearing)) return '—'
+  const normalized = ((bearing % 360) + 360) % 360
+  return `${Math.round(normalized).toString().padStart(3, '0')}°`
+}
+
 // Compute path time from provided legs (speed & distance) -> Still needs turning penalty that depends on vehicle
 export const computeMissionDurationSecondsFromLegs = (legs: MissionLeg[]): number => {
   if (!Array.isArray(legs) || legs.length === 0) return NaN

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -691,9 +691,11 @@ import PoiMapArrows from '@/components/poi/PoiMapArrows.vue'
 import RadialMenu, { type RadialMenuItem } from '@/components/RadialMenu.vue'
 import SideConfigPanel from '@/components/SideConfigPanel.vue'
 import { useInteractionDialog } from '@/composables/interactionDialog'
+import { useDragMeasureOverlay } from '@/composables/map/useDragMeasureOverlay'
 import { provideMapContext } from '@/composables/map/useMapContext'
 import { useMapOverlays } from '@/composables/map/useMapOverlays'
 import { useMapTileLayers } from '@/composables/map/useMapTileLayers'
+import { useVertexAngleOverlay } from '@/composables/map/useVertexAngleOverlay'
 import { useSnackbar } from '@/composables/snackbar'
 import {
   clearAllSurveyAreas,
@@ -714,7 +716,13 @@ import {
   WhoToFollow,
 } from '@/libs/map/utils-map'
 import { generateSurveyPath } from '@/libs/map/utils-map'
-import { centroidLatLng, polygonAreaSquareMeters } from '@/libs/mission/general-estimates'
+import {
+  bearingBetween,
+  centroidLatLng,
+  formatBearing,
+  formatMetersShort,
+  polygonAreaSquareMeters,
+} from '@/libs/mission/general-estimates'
 import { degrees } from '@/libs/utils'
 import router from '@/router'
 import { SubMenuComponentName, SubMenuName, useAppInterfaceStore } from '@/stores/appInterface'
@@ -746,6 +754,8 @@ const vehicleStore = useMainVehicleStore()
 const interfaceStore = useAppInterfaceStore()
 const widgetStore = useWidgetManagerStore()
 const missionEstimates = useMissionEstimates()
+const angleOverlay = useVertexAngleOverlay()
+const dragMeasureOverlay = useDragMeasureOverlay(angleOverlay)
 const { height: windowHeight } = useWindowSize()
 
 const { showDialog, closeDialog } = useInteractionDialog()
@@ -1030,6 +1040,9 @@ let measureOverlayEl: HTMLDivElement | null = null
 let measureSvgEl: SVGSVGElement | null = null
 let measureLineEl: SVGLineElement | null = null
 let measureTextEl: HTMLDivElement | null = null
+// Last cursor event kept so the live measure can be re-rendered while the map pans (no mousemove fires then)
+let lastMeasureCursor: L.LeafletMouseEvent | null = null
+let measureRefreshRafId: number | null = null
 const surveyAreaMarkers = shallowRef<Record<string, L.Marker>>({})
 const liveSurveyAreaMarker = shallowRef<L.Marker | null>(null)
 
@@ -1050,6 +1063,8 @@ const glassMenuCssVars = computed(() => ({
 
 const clearLiveMeasure = (): void => {
   destroyMeasureOverlay(planningMap.value || undefined)
+  angleOverlay.clearVertexAngles()
+  lastMeasureCursor = null
 }
 
 const currentMeasureAnchor = (): L.LatLng | null => {
@@ -1061,6 +1076,21 @@ const currentMeasureAnchor = (): L.LatLng | null => {
   if (isCreatingSurvey.value && surveyPolygonVertexesPositions.value.length > 0) {
     const last = surveyPolygonVertexesPositions.value[surveyPolygonVertexesPositions.value.length - 1]
     return L.latLng(last.lat, last.lng)
+  }
+
+  return null
+}
+
+// Point before the measure anchor, used to measure the angle the segment being drawn makes with the previous one.
+const currentMeasurePrevAnchor = (): L.LatLng | null => {
+  if (!planningMap.value) return null
+  if (isCreatingSimplePath.value && missionStore.currentPlanningWaypoints.length > 1) {
+    const wp = missionStore.currentPlanningWaypoints[missionStore.currentPlanningWaypoints.length - 2]
+    return L.latLng(wp.coordinates[0], wp.coordinates[1])
+  }
+  if (isCreatingSurvey.value && surveyPolygonVertexesPositions.value.length > 1) {
+    const vertex = surveyPolygonVertexesPositions.value[surveyPolygonVertexesPositions.value.length - 2]
+    return L.latLng(vertex.lat, vertex.lng)
   }
 
   return null
@@ -1126,10 +1156,17 @@ const isOverSurveyHandle = (evt: L.LeafletMouseEvent): boolean => {
 const handleMapMouseMove = (e: L.LeafletMouseEvent): void => {
   if (!planningMap.value) return
 
+  lastMeasureCursor = e
+
   const anchor = currentMeasureAnchor()
-  const measuring = !!anchor && (isCreatingSimplePath.value || (isCreatingSurvey.value && isDrawingSurveyPolygon.value))
+  const draggingExistingNode = isDraggingMarker.value || isDraggingPolygon.value
+  const measuring =
+    !!anchor &&
+    !draggingExistingNode &&
+    (isCreatingSimplePath.value || (isCreatingSurvey.value && isDrawingSurveyPolygon.value))
   if (!measuring) {
     destroyMeasureOverlay(planningMap.value)
+    angleOverlay.clearVertexAngles()
     return
   }
 
@@ -1157,13 +1194,39 @@ const handleMapMouseMove = (e: L.LeafletMouseEvent): void => {
 
   const hidePill = isOverSurveyHandle(e) || isOverLastWaypointMarker(e) || dist < 1 // hide if closer than 1 meter to last wp on the array
 
-  const text = missionEstimates.formatMetersShort(dist)
+  const bearing = bearingBetween([anchor!.lat, anchor!.lng], [e.latlng.lat, e.latlng.lng])
+  const text = `${formatMetersShort(dist)} · ${formatBearing(bearing)}`
   if (measureTextEl) {
     measureTextEl.textContent = text
     measureTextEl.style.left = `${midX}px`
     measureTextEl.style.top = `${midY}px`
     measureTextEl.style.display = hidePill ? 'none' : 'block'
   }
+
+  const prevAnchor = currentMeasurePrevAnchor()
+  if (prevAnchor && !hidePill) {
+    angleOverlay.renderVertexAngle(
+      [prevAnchor.lat, prevAnchor.lng],
+      [anchor!.lat, anchor!.lng],
+      [e.latlng.lat, e.latlng.lng]
+    )
+  } else {
+    angleOverlay.clearVertexAngles()
+  }
+}
+
+// Keep the live measure pinned to the cursor while the map pans under it.
+const refreshLiveMeasureOnMapMove = (): void => {
+  if (!planningMap.value || !lastMeasureCursor || measureRefreshRafId !== null) return
+  measureRefreshRafId = requestAnimationFrame(() => {
+    measureRefreshRafId = null
+    if (!planningMap.value || !lastMeasureCursor) return
+    const map = planningMap.value
+    const rect = map.getContainer().getBoundingClientRect()
+    const containerPoint = L.point(cursorLivePositionX.value - rect.left, cursorLivePositionY.value - rect.top)
+    const latlng = map.containerPointToLatLng(containerPoint)
+    handleMapMouseMove({ ...lastMeasureCursor, latlng, containerPoint })
+  })
 }
 
 const saveEsri = (): void => {
@@ -2576,12 +2639,14 @@ const addWaypoint = (
     const latlng = newMarker.getLatLng()
     missionStore.moveWaypoint(waypointId, [latlng.lat, latlng.lng])
     isDraggingMarker.value = true
+    dragMeasureOverlay.renderDragMeasurePills(waypointId)
   })
 
   newMarker.on('dragend', () => {
     const latlng = newMarker.getLatLng()
     missionStore.moveWaypoint(waypointId, [latlng.lat, latlng.lng])
     isDraggingMarker.value = false
+    dragMeasureOverlay.destroyDragMeasureOverlay()
   })
   newMarker.on('contextmenu', (e: L.LeafletMouseEvent) => {
     const oldId = selectedWaypoint.value?.id
@@ -3461,12 +3526,14 @@ const addWaypointMarker = (waypoint: Waypoint): void => {
     const latlng = newMarker.getLatLng()
     missionStore.moveWaypoint(waypoint.id, [latlng.lat, latlng.lng])
     isDraggingMarker.value = true
+    dragMeasureOverlay.renderDragMeasurePills(waypoint.id)
   })
 
   newMarker.on('dragend', () => {
     const latlng = newMarker.getLatLng()
     missionStore.moveWaypoint(waypoint.id, [latlng.lat, latlng.lng])
     isDraggingMarker.value = false
+    dragMeasureOverlay.destroyDragMeasureOverlay()
   })
 
   newMarker.on('contextmenu', (event: LeafletMouseEvent) => {
@@ -3771,6 +3838,8 @@ onMounted(async () => {
   const pane = planningMap.value!.createPane('measurePane')
   pane.style.zIndex = '640'
   pane.style.pointerEvents = 'none'
+  angleOverlay.initAngleOverlay(planningMap.value!)
+  dragMeasureOverlay.initDragMeasureOverlay(planningMap.value!)
   measureLayer.value = L.layerGroup().addTo(planningMap.value!) as L.LayerGroup
 
   // Listen for base layer changes to save user preference
@@ -3860,6 +3929,7 @@ onMounted(async () => {
   })
 
   planningMap.value.on('drag', updateConfirmButtonPosition)
+  planningMap.value.on('drag', refreshLiveMeasureOnMapMove)
   planningMap.value.on('mousemove', handleMapMouseMove)
   planningMap.value.on('click', (e: L.LeafletMouseEvent) => {
     onMapClick(e)
@@ -3929,7 +3999,11 @@ onUnmounted(() => {
     window.removeEventListener('mousemove', onWindowMouseMove)
   }
   planningMap.value?.off('mousemove', handleMapMouseMove)
+  planningMap.value?.off('drag', refreshLiveMeasureOnMapMove)
+  if (measureRefreshRafId !== null) cancelAnimationFrame(measureRefreshRafId)
   clearLiveMeasure()
+  dragMeasureOverlay.destroyDragMeasureOverlay()
+  angleOverlay.destroyAngleOverlay()
 
   detachTileFallbacks.forEach((detach) => detach())
   detachTileFallbacks = []
@@ -4556,6 +4630,23 @@ watch(
 .measure-area-icon {
   transform: translate(-50%, -50%);
   pointer-events: none;
+}
+.measure-angle-tag {
+  background: transparent;
+  border: none;
+}
+.measure-angle-pill {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  padding: 3px 8px;
+  border-radius: 16px;
+  background: #00000022;
+  color: #fff;
+  font-size: 12px;
+  line-height: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  backdrop-filter: blur(10px);
+  white-space: nowrap;
 }
 .measure-area-pill {
   transform: translate(-50%, -50%);


### PR DESCRIPTION
- Live measure pill now shows compass heading alongside distance from the last waypoint to the cursor.
- Dragging a vertex between two waypoints shows distance + heading pills on both adjacent segments.
- Interior turn angle renders as an arc with a degree label at the vertex, both while drawing and while dragging a middle vertex.

https://github.com/user-attachments/assets/158f2c3f-1a6f-494f-9388-c7bb0fe73ad1

Closes #2367