### PR TITLE
Map: Stop following the vehicle when the user drags the map

### DIFF
--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -624,6 +624,7 @@ const detachTileFallbacks: (() => void)[] = [
   attachTileNoiseFallback(osm, getTileFallbackOptions),
   attachTileNoiseFallback(esri, getTileFallbackOptions),
 ]
+let stopUnFollowOnUserDrag: (() => void) | undefined
 
 watch(
   () => [missionStore.mapFallbackBaseColor, missionStore.mapFallbackSeed, missionStore.mapFallbackNoiseIntensity],
@@ -886,6 +887,7 @@ onMounted(async () => {
   })
   // Enable auto update for target follower
   targetFollower.enableAutoUpdate()
+  stopUnFollowOnUserDrag = targetFollower.unFollowOnUserDrag(map.value)
 
   window.addEventListener('keydown', onKeydown)
 
@@ -1191,6 +1193,7 @@ watch(
 // - remove event listeners
 onBeforeUnmount(() => {
   targetFollower.disableAutoUpdate()
+  stopUnFollowOnUserDrag?.()
   window.removeEventListener('keydown', onKeydown)
 
   detachTileFallbacks.forEach((detach) => detach())

--- a/src/libs/map/utils-map.ts
+++ b/src/libs/map/utils-map.ts
@@ -10,6 +10,9 @@ import type { SurveyPath, WaypointCoordinates } from '@/types/mission'
  */
 const defaultUpdateIntervalMs = 500
 
+// Minimum distance, in pixels, the user must drag the map before tracking stops, so small or accidental drags don't disable following.
+const defaultUnfollowDragThresholdPx = 150
+
 /**
  * Enum for the different types of targets that can be followed.
  * @enum {string}
@@ -52,6 +55,9 @@ export class TargetFollower {
    * @type {ReturnType<typeof setInterval> | undefined}
    */
   private updateInterval: ReturnType<typeof setInterval> | undefined
+
+  // Whether the user is currently dragging the map, used to pause re-centering so the periodic update doesn't fight the drag.
+  private isUserDragging = false
 
   /**
    * Constructor for the TargetFollower class.
@@ -118,6 +124,7 @@ export class TargetFollower {
    * @returns {void}
    */
   public update(): void {
+    if (this.isUserDragging) return
     this.setCenter(this.target)
   }
 
@@ -160,6 +167,43 @@ export class TargetFollower {
   public unFollow(): void {
     this.target = undefined
     this.onTargetChange(this.target)
+  }
+
+  /**
+   * Stops following once the user pans the map past a pixel threshold. Leaflet drag events
+   * fire only for real user gestures, never for the follower's own panning, so there is no
+   * feedback loop.
+   * @param {L.Map} map - The leaflet map whose user drags should break the follow.
+   * @param {number} thresholdPixels - Minimum drag distance, in pixels, that stops following.
+   * @returns {() => void} Disposer that removes the drag listeners; call it on teardown.
+   */
+  public unFollowOnUserDrag(map: L.Map, thresholdPixels = defaultUnfollowDragThresholdPx): () => void {
+    let dragStartCenter: L.LatLng | undefined
+
+    const onDragStart = (): void => {
+      this.isUserDragging = true
+      dragStartCenter = this.target ? map.getCenter() : undefined
+    }
+
+    const onDragEnd = (): void => {
+      this.isUserDragging = false
+      if (!dragStartCenter || !this.target) return
+      const startPx = map.latLngToContainerPoint(dragStartCenter)
+      const endPx = map.latLngToContainerPoint(map.getCenter())
+      const draggedPixels = startPx.distanceTo(endPx)
+      dragStartCenter = undefined
+      if (draggedPixels >= thresholdPixels) {
+        this.unFollow()
+      }
+    }
+
+    map.on('dragstart', onDragStart)
+    map.on('dragend', onDragEnd)
+
+    return () => {
+      map.off('dragstart', onDragStart)
+      map.off('dragend', onDragEnd)
+    }
   }
 
   /**

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -3770,6 +3770,7 @@ const attachOfflineProgress = (layer: any, layerName: string): void => {
 
 let detachTileFallbacks: (() => void)[] = []
 let stopTileFallbackWatcher: (() => void) | undefined
+let stopUnFollowOnUserDrag: (() => void) | undefined
 let fallbackLayers: L.TileLayer[] = []
 
 onMounted(async () => {
@@ -3958,6 +3959,7 @@ onMounted(async () => {
   }
 
   targetFollower.enableAutoUpdate()
+  stopUnFollowOnUserDrag = targetFollower.unFollowOnUserDrag(planningMap.value)
   missionStore.clearMission()
   clearAllSurveyAreas()
 
@@ -3997,6 +3999,7 @@ watch(
 
 onUnmounted(() => {
   targetFollower.disableAutoUpdate()
+  stopUnFollowOnUserDrag?.()
   if (planningMap.value) {
     planningMap.value.off('mousemove', handleMapMouseMoveNearMissionPath)
     window.removeEventListener('keydown', onGlobalKeyDown)


### PR DESCRIPTION
- Dragging the map past a ~150px threshold now stops tracking the followed target (vehicle/home), so small or accidental drags are ignored.
- Pause the follower's periodic re-centering while a user drag is in progress so the 500ms update no longer fights the gesture.
- Add `unFollowOnUserDrag` to the shared `TargetFollower` and wire it into both the map widget and the mission-planning view, returning a disposer that removes the drag listeners on teardown.

Closes #2359