### PR TITLE
Mission planning: Show max distance on a mission

### DIFF
--- a/src/components/mission-planning/MissionEstimates.vue
+++ b/src/components/mission-planning/MissionEstimates.vue
@@ -2,7 +2,7 @@
   <div
     v-if="modelValue"
     class="absolute right-4 bottom-36 rounded-[10px] px-3 py-2"
-    :style="[interfaceStore.globalGlassMenuStyles, { width: '250px' }]"
+    :style="[interfaceStore.globalGlassMenuStyles, { width: '280px' }]"
   >
     <p class="text-sm font-semibold mb-[6px]">Mission estimates</p>
     <v-divider class="mb-2" />
@@ -23,6 +23,10 @@
     <div class="text-xs leading-6">
       <div class="flex justify-between">
         <span>Length</span><span>{{ totalMissionLength }}</span>
+      </div>
+      <div v-if="maxDistance !== '—'" class="flex justify-between">
+        <span>Max distance from {{ maxDistanceReferenceLabel }}</span
+        ><span>{{ maxDistance }}</span>
       </div>
       <div class="flex justify-between">
         <span>ETA</span><span>{{ missionDuration }}</span>
@@ -170,6 +174,8 @@ const vehicleStore = useMainVehicleStore()
 
 const {
   totalMissionLength,
+  totalMaxDistance,
+  maxDistanceReferenceLabel,
   totalSurveyCoverage,
   totalMissionDuration,
   totalMissionEnergy,
@@ -178,6 +184,7 @@ const {
 
 const isOptionsIconVisible = computed(() => vehicleStore.vehicleType === MavType.MAV_TYPE_SURFACE_BOAT)
 
+const maxDistance = computed(() => totalMaxDistance.value)
 const missionDuration = computed(() => totalMissionDuration.value)
 const missionEnergy = computed(() => totalMissionEnergy.value)
 const missionCoverage = computed(() => missionCoverageAreaSquareMeters.value)

--- a/src/composables/useMissionEstimates.ts
+++ b/src/composables/useMissionEstimates.ts
@@ -9,7 +9,12 @@ import {
 } from '@/libs/mission/general-estimates'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useMissionStore } from '@/stores/mission'
-import { MissionEstimatesByVehicleConfig, MissionLeg, VehicleMissionEstimate } from '@/types/mission'
+import {
+  MissionEstimatesByVehicleConfig,
+  MissionLeg,
+  VehicleMissionEstimate,
+  WaypointCoordinates,
+} from '@/types/mission'
 
 type LatLng = [number, number]
 
@@ -33,6 +38,8 @@ export const clearAllSurveyAreas = (): void => {
 export const useMissionEstimates = (): {
   missionLengthMeters: ComputedRef<number>
   missionCoverageAreaSquareMeters: ComputedRef<string>
+  totalMaxDistance: ComputedRef<string>
+  maxDistanceReferenceLabel: ComputedRef<string>
   totalMissionLength: ComputedRef<string>
   totalSurveyCoverage: ComputedRef<string>
   totalMissionDuration: ComputedRef<string>
@@ -110,6 +117,23 @@ export const useMissionEstimates = (): {
     return total
   })
 
+  // Reference point the max distance is measured from (home or, if available, the base station)
+  const maxDistanceReferencePoint = computed<WaypointCoordinates | undefined>(() => missionStore.homeMarkerPosition)
+  const maxDistanceReferenceLabel = computed<string>(() => 'home')
+
+  // Farthest mission waypoint from the reference point, indicating the maximum telemetry range needed
+  const maxDistanceMeters = computed(() => {
+    const reference = maxDistanceReferencePoint.value
+    const wps = missionStore.currentPlanningWaypoints || []
+    if (!reference || wps.length === 0) return 0
+    let max = 0
+    for (const wp of wps) {
+      const distance = calculateHaversineDistance(reference, wp.coordinates as LatLng)
+      if (distance > max) max = distance
+    }
+    return max
+  })
+
   // Mission total coverage area (consider polygons if first and last points are < than 100 meters apart)
   const missionCoverageAreaSquareMeters = computed(() => {
     const wps = missionStore.currentPlanningWaypoints || []
@@ -160,6 +184,7 @@ export const useMissionEstimates = (): {
 
   // Basic mission stats - no vehicle-specific estimates
   const totalMissionLength = computed(() => formatMetersShort(missionLengthMeters.value))
+  const totalMaxDistance = computed(() => formatMetersShort(maxDistanceMeters.value))
   const totalSurveyCoverage = computed(() => formatArea(totalSurveyCoverageSquareMeters.value))
 
   // Mission duration (s), with vehicle-specific estimates if available
@@ -178,6 +203,8 @@ export const useMissionEstimates = (): {
   return {
     missionLengthMeters,
     missionCoverageAreaSquareMeters,
+    totalMaxDistance,
+    maxDistanceReferenceLabel,
     totalMissionLength,
     totalSurveyCoverage,
     totalMissionDuration,


### PR DESCRIPTION
- Adds a "Max distance from home" row right after Length, showing the farthest mission waypoint from the reference point.
- Reference point resolves through a single computed plus a label, so it switches to the base-station position (and "Max distance from base station" text) once #2694 lands, with no template changes.
- Row hides when no reference point is set.

![Mission estimates max distance row](https://raw.githubusercontent.com/ArturoManzoli/cockpit/pr-assets/mission-estimates-max-distance.png)

Closes #2640