### PR TITLE
Cap excessive long log messages and fix hotspots

### DIFF
--- a/src/components/ExpansiblePanel.vue
+++ b/src/components/ExpansiblePanel.vue
@@ -48,12 +48,12 @@
           </div>
         </div>
         <div class="flex justify-between ml-4">
-          <div v-if="hasInfoSlot" class="flex items-center w-[10%]">
+          <div v-if="$slots.info" class="flex items-center w-[10%]">
             <v-btn class="ml-auto rounded-full" size="small" color="transparent" elevation="0" @click.stop="toggleInfo">
               <v-icon :size="interfaceStore.isOnSmallScreen ? 15 : 18" color="white" icon="mdi-information-outline" />
             </v-btn>
           </div>
-          <div v-if="hasWarningSlot" class="flex justify-end items-center w-[10%]">
+          <div v-if="$slots.warning" class="flex justify-end items-center w-[10%]">
             <v-btn
               class="rounded-full relative overflow-hidden"
               size="small"
@@ -116,7 +116,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref, useSlots, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 
 import { useAppInterfaceStore } from '@/stores/appInterface'
 
@@ -160,8 +160,6 @@ const props = defineProps<{
    */
   elevationEffect?: boolean
 }>()
-
-const slots = useSlots()
 
 const isPanelExpanded = ref(props.isExpanded ?? false)
 const noTopDivider = ref(props.noTopDivider ?? false)
@@ -271,21 +269,6 @@ watch(isWarningOpen, (newValue) => {
   }
 })
 
-const hasWarningSlot = ref(false)
-const warningSlotObserver = ref<MutationObserver | null>(null)
-const updateHasWarningSlot = (): void => (hasWarningSlot.value = !!slots.warning?.())
-const hasInfoSlot = ref(false)
-const infoSlotObserver = ref<MutationObserver | null>(null)
-const updateHasInfoSlot = (): void => (hasInfoSlot.value = !!slots.info?.())
-
-const setupSlotObservers = (): void => {
-  warningSlotObserver.value = new MutationObserver(updateHasWarningSlot)
-  warningSlotObserver.value.observe(warningContent.value, { attributes: true, childList: true, subtree: true })
-
-  infoSlotObserver.value = new MutationObserver(updateHasInfoSlot)
-  infoSlotObserver.value.observe(infoContent.value, { attributes: true, childList: true, subtree: true })
-}
-
 onMounted(() => {
   if (content.value && contentInner.value) {
     if (!isPanelExpanded.value) {
@@ -307,15 +290,9 @@ onMounted(() => {
   if (warningContent.value && !isWarningOpen.value) {
     warningContent.value.style.maxHeight = '0px'
   }
-
-  updateHasWarningSlot()
-  updateHasInfoSlot()
-  setupSlotObservers()
 })
 
 onBeforeUnmount(() => {
-  if (warningSlotObserver.value) warningSlotObserver.value.disconnect()
-  if (infoSlotObserver.value) infoSlotObserver.value.disconnect()
   if (contentResizeObserver.value) contentResizeObserver.value.disconnect()
 })
 </script>

--- a/src/libs/system-logging.ts
+++ b/src/libs/system-logging.ts
@@ -114,6 +114,40 @@ export const subscribeToSystemLogEvents = (listener: SystemLogEventListener): ((
   }
 }
 
+// Oversized-message capping. A burst of huge console messages (e.g. [Vue warn] dumps that serialize the
+// whole Vuetify theme inside the component trace) can grow the persisted log to gigabytes and choke the
+// in-app log viewer with entries nobody reads. Observed legit messages stay under 1KB while these dumps
+// reach ~80KB+. Budgets are measured in characters (message.length, i.e. UTF-16 code units) rather than
+// bytes, which is a close-enough approximation for the ASCII-dominated console output. Messages up to
+// `largeLogThresholdChars` always pass untouched; past it, each successive oversized message within
+// `oversizedLogWindowMs` gets a smaller budget, and once the budget is spent every further oversized
+// message is clamped to `oversizedLogFloorChars` until the window resets.
+const largeLogThresholdChars = 1 * 1024
+const oversizedLogWindowMs = 10_000
+const oversizedLogBudgetsChars = [16, 8, 4, 2, 1].map((kb) => kb * 1024)
+const oversizedLogFloorChars = 1 * 1024
+
+let oversizedLogWindowStart = 0
+let oversizedLogCountInWindow = 0
+
+const capLogMessage = (message: string): string => {
+  if (message.length <= largeLogThresholdChars) return message
+
+  const now = Date.now()
+  if (now - oversizedLogWindowStart >= oversizedLogWindowMs) {
+    oversizedLogWindowStart = now
+    oversizedLogCountInWindow = 0
+  }
+
+  const allowance = oversizedLogBudgetsChars[oversizedLogCountInWindow] ?? oversizedLogFloorChars
+  oversizedLogCountInWindow += 1
+
+  if (message.length <= allowance) return message
+
+  const droppedChars = message.length - allowance
+  return `${message.slice(0, allowance)}… [log capped: dropped ${droppedChars} chars to limit oversized-message bursts]`
+}
+
 // Buffer log events and flush them in batches, to avoid one IPC message (Electron) or one IndexedDB write
 // (web) per console call. During logging bursts the per-call overhead is the dominant cost on the renderer.
 const logFlushIntervalMs = 250
@@ -185,12 +219,15 @@ if (enableSystemLogging) {
   `)
 
   const persistLogEvent = (level: string, message: string): void => {
+    // Cap oversized messages once, before the fan-out, so the file, the IndexedDB store and the in-app
+    // viewer are all protected from gigabyte-scale logs and unreadably long entries.
+    const cappedMessage = capLogMessage(message)
     // Feed the in-app console viewer (bounded in-memory buffer), independent of where logs are persisted.
-    recordLogEventForViewer(level, message)
+    recordLogEventForViewer(level, cappedMessage)
     if (isRunningInElectron) {
-      sendLogToElectron(level, message)
+      sendLogToElectron(level, cappedMessage)
     } else {
-      saveLogEventInDB({ epoch: Date.now(), level, msg: message })
+      saveLogEventInDB({ epoch: Date.now(), level, msg: cappedMessage })
     }
   }
 


### PR DESCRIPTION
## Summary

Stops Cockpit dev logs from ballooning to multiple GB, caused by `[Vue warn]` storms whose component traces (with the full serialized Vuetify theme) get written per occurrence.

- **ExpansiblePanel**: stop detecting slot presence by *invoking* the slots (`slots.warning?.()`/`slots.info?.()`) from a MutationObserver — that ran outside render, spammed "Slot invoked outside of the render function" warnings, and self-retriggered. Now reads `$slots` in the template.
- **Log cap**: bound oversized log messages once at the renderer fan-out, so the electron-log file, the Lite IndexedDB store and the in-app viewer are all protected. Messages ≤1 KB pass untouched; successive oversized messages in a 10s window get a decaying budget (16/8/4/2/1 KB) before clamping to 1 KB.

Fixes #2758