### PR TITLE
Mission Planning: Fix mission area being smaller than survey area

### DIFF
--- a/src/composables/useMissionEstimates.ts
+++ b/src/composables/useMissionEstimates.ts
@@ -5,7 +5,7 @@ import { blueBoatMissionEstimate } from '@/libs/mission/blueboat-estimates'
 import {
   calculateHaversineDistance,
   computeMissionDurationSecondsFromLegs,
-  polygonAreaSquareMeters,
+  convexHullSquareMeters,
 } from '@/libs/mission/general-estimates'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useMissionStore } from '@/stores/mission'
@@ -134,23 +134,14 @@ export const useMissionEstimates = (): {
     return max
   })
 
-  // Mission total coverage area (consider polygons if first and last points are < than 100 meters apart)
+  // Mission footprint as the convex hull of every waypoint plus every survey polygon vertex,
+  // so any contained survey polygon is always a subset of the reported area.
   const missionCoverageAreaSquareMeters = computed(() => {
-    const wps = missionStore.currentPlanningWaypoints || []
-    if (wps.length >= 3) {
-      const first = wps[0].coordinates as [number, number]
-      const last = wps[wps.length - 1].coordinates as [number, number]
-      const closedToleranceInMeters = 100
-      const distanceToClose = calculateHaversineDistance(first, last)
-
-      if (distanceToClose <= closedToleranceInMeters) {
-        const isDuplicate = distanceToClose === 0
-        const ring = (isDuplicate ? wps.slice(0, -1) : wps).map((w) => w.coordinates as [number, number])
-        const area = polygonAreaSquareMeters(ring)
-        return formatArea(area)
-      }
-    }
-    return '—'
+    const waypointCoords = missionStore.currentPlanningWaypoints.map((w) => w.coordinates as LatLng)
+    const surveyVertexCoords = missionStore.currentPlanningSurveys.flatMap((s) => s.polygonCoordinates as LatLng[])
+    const points = [...waypointCoords, ...surveyVertexCoords]
+    const area = convexHullSquareMeters(points)
+    return area > 0 ? formatArea(area) : '—'
   })
 
   // Total survey coverage from survey areas set in the UI

--- a/src/libs/mission/general-estimates.ts
+++ b/src/libs/mission/general-estimates.ts
@@ -1,3 +1,5 @@
+import { convex, featureCollection, point } from '@turf/turf'
+
 import { MissionLeg, WaypointCoordinates } from '@/types/mission'
 
 import { norm360, radians } from '../utils'
@@ -101,6 +103,20 @@ export const polygonAreaSquareMeters = (position: WaypointCoordinates[]): number
     sum += pts[i].x * pts[j].y - pts[j].x * pts[i].y
   }
   return Math.abs(sum) / 2
+}
+
+/**
+ * Area of the convex hull of a set of lat/lng points, in square meters.
+ * @param {WaypointCoordinates[]} points - [lat, lng] pairs to wrap; order does not matter.
+ * @returns {number} Hull area in m²; 0 if fewer than 3 points or the points are collinear.
+ */
+export const convexHullSquareMeters = (points: WaypointCoordinates[]): number => {
+  if (points.length < 3) return 0
+  const fc = featureCollection(points.map(([lat, lon]) => point([lon, lat])))
+  const hull = convex(fc)
+  if (!hull) return 0
+  const ring = hull.geometry.coordinates[0].map(([lon, lat]) => [lat, lon] as WaypointCoordinates)
+  return polygonAreaSquareMeters(ring)
 }
 
 // Energy density estimates (kg/Wh) by battery chemistry


### PR DESCRIPTION
**Problem:**

- `missionCoverageAreaSquareMeters` ran the shoelace formula over `currentPlanningWaypoints` in mission order, so a survey's lawn-mower zigzag self-intersected into a near-zero polygon while the survey's own coverage polygon kept its true area.
- Result: "Mission area" smaller than "Total survey coverage" whenever a survey was present and the mission's first and last waypoints were within 100 m.

**Fix:**

- New `convexHullSquareMeters` helper in `src/libs/mission/general-estimates.ts` using `turf.convex` on top of the existing local-tangent-plane shoelace area.
- `missionCoverageAreaSquareMeters` now feeds every waypoint coordinate and every `survey.polygonCoordinates` vertex into the hull, guaranteeing each survey polygon is contained in the reported footprint.
- Dropped the 100 m closed-loop gating; the area shows whenever the hull has area.

Before:

![Before](https://github.com/user-attachments/assets/6c1d01bb-968d-41fc-bc7c-8a01d671af6e)

After:

![After](https://raw.githubusercontent.com/ArturoManzoli/cockpit/pr-assets/mission-area-convex-hull-after.png)

Closes #2641
