### PR TITLE
Fix download progress bar detatching from top bar

### DIFF
--- a/src/stores/appInterface.ts
+++ b/src/stores/appInterface.ts
@@ -115,6 +115,9 @@ export const useAppInterfaceStore = defineStore('responsive', {
     isOnSmallScreen: (state) => state.width <= 1280,
     isOnPhoneScreen: (state) => state.width < 600,
     isOnVeryLargeScreen: (state) => state.width > 1920,
+    // Mirrors the scale `WidgetBar` actually applies to the top/bottom bars on small screens, so overlays can
+    // align with the rendered bar height (not the logical 48px) from a single source of truth.
+    renderedBarScale: (state) => (state.width <= 1280 ? state.width / 1800 : 1),
     mainMenuWidth: (state) => {
       if (state.width < 720) return 78
       if (state.width >= 720 && state.width < 980) return 95

--- a/src/stores/widgetManager.ts
+++ b/src/stores/widgetManager.ts
@@ -27,6 +27,7 @@ import { settingsManager } from '@/libs/settings-management'
 import { isEqual, sequentialArray } from '@/libs/utils'
 import { isViewsGroupBlank } from '@/migration/default-profile-importer'
 import { legacySavedProfilesKey, migrateLegacyViewsGroup } from '@/migration/profile-migrations'
+import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import type { Point2D, SizeRect2D } from '@/types/general'
 import {
@@ -52,6 +53,7 @@ const { height: windowHeight } = useWindowSize()
 const viewsGroupKey = 'cockpit-views-group-v1'
 
 export const useWidgetManagerStore = defineStore('widget-manager', () => {
+  const interfaceStore = useAppInterfaceStore()
   const editingMode = ref(false)
   const snapToGrid = ref(true)
   const gridInterval = ref(0.01)
@@ -269,6 +271,15 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
     return currentView.value.showBottomBarOnBoot ? desiredBottomBarHeightPixels.value : 0
   })
 
+  // Positioning to overlays that need to hug the visible edge of top or bottom bar.
+  const currentTopBarHeightPixelsScaled = computed(() => {
+    return currentTopBarHeightPixels.value * interfaceStore.renderedBarScale
+  })
+
+  const currentBottomBarHeightPixelsScaled = computed(() => {
+    return currentBottomBarHeightPixels.value * interfaceStore.renderedBarScale
+  })
+
   const currentView = computed<View>({
     get() {
       const idx = Math.min(currentViewIndex.value, currentProfile.value.views.length - 1)
@@ -333,11 +344,11 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
     const clearances = { top: 0, bottom: 0 }
 
     const widgetTopEdgePixels = windowHeight.value * widget.position.y
-    const topBarStartPixels = currentTopBarHeightPixels.value
+    const topBarStartPixels = currentTopBarHeightPixelsScaled.value
     clearances.top = widgetTopEdgePixels - topBarStartPixels
 
     const widgetBottomEdgePixels = windowHeight.value * (widget.position.y + widget.size.height)
-    const bottomBarStartPixels = windowHeight.value - currentBottomBarHeightPixels.value
+    const bottomBarStartPixels = windowHeight.value - currentBottomBarHeightPixelsScaled.value
     clearances.bottom = bottomBarStartPixels - widgetBottomEdgePixels
 
     return clearances
@@ -787,6 +798,8 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
     visibleAreaMinClearancePixels,
     currentTopBarHeightPixels,
     currentBottomBarHeightPixels,
+    currentTopBarHeightPixelsScaled,
+    currentBottomBarHeightPixelsScaled,
     showElementPropsDrawer,
     isElementsPropsDrawerVisible,
     elementToShowOnDrawer,

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -549,11 +549,12 @@
       bottom
       height="10"
       color="white"
-      :style="`top: ${widgetStore.currentTopBarHeightPixels}px`"
+      :style="`top: ${widgetStore.currentTopBarHeightPixelsScaled}px`"
     />
     <p
       v-if="uploadingMission"
-      class="fixed top-[58px] left-[7px] flex text-md font-bold text-white z-30 drop-shadow-md"
+      class="fixed left-[7px] flex text-md font-bold text-white z-30 drop-shadow-md"
+      :style="`top: ${widgetStore.currentTopBarHeightPixelsScaled + 10}px`"
     >
       Uploading mission to vehicle...
     </p>
@@ -635,11 +636,11 @@
     absolute
     bottom
     color="white"
-    :style="{ top: '48px' }"
+    :style="`top: ${widgetStore.currentTopBarHeightPixelsScaled}px`"
   />
   <p
     v-if="fetchingMission"
-    :style="{ top: '48px' }"
+    :style="`top: ${widgetStore.currentTopBarHeightPixelsScaled}px`"
     class="absolute left-[7px] mt-4 flex text-md font-bold text-white z-30 drop-shadow-md"
   >
     Loading mission...


### PR DESCRIPTION
**Problem:**

- The mission download "Loading mission..." bar was anchored to a constant 48px / `currentTopBarHeightPixels`, but `WidgetBar` shrinks the top/bottom bars with `transform: scale(width/1800)` on small screens (`width <= 1280`), so on narrow windows the bar floated in the gap below the real top edge.

**Fix:**

- New `renderedBarScale` getter on `appInterface` mirrors the scale `WidgetBar` actually applies.
- New `currentTop/BottomBarHeightPixelsScaled` computeds in `widgetManager`, and `widgetClearanceForVisibleArea` now uses them, transparently fixing the `Map` widget's loading bar and bottom buttons on small screens.
- `MissionPlanningView` upload+download progress bars and labels are anchored to the scaled top-bar height.

Closes #2678