### PR TITLE
Map: Refine wheel/pinch zoom to single zoom-level steps

### DIFF
--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -302,7 +302,13 @@ import { useOfflineTiles } from '@/composables/useOfflineTiles'
 import { MavCmd, MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import type { NoiseTileOptions } from '@/libs/map/map-tile-fallback'
 import { attachTileNoiseFallback, refreshNoiseFallbackTiles } from '@/libs/map/map-tile-fallback'
-import { createGridOverlay, fitMapToWaypoints, TargetFollower, WhoToFollow } from '@/libs/map/utils-map'
+import {
+  createGridOverlay,
+  fitMapToWaypoints,
+  singleStepZoomMapOptions,
+  TargetFollower,
+  WhoToFollow,
+} from '@/libs/map/utils-map'
 import { datalogger, DatalogVariable } from '@/libs/sensors-logging'
 import { degrees } from '@/libs/utils'
 import type { MAVLinkVehicle } from '@/libs/vehicle/mavlink/vehicle'
@@ -767,6 +773,7 @@ onMounted(async () => {
   map.value = L.map(mapId.value, {
     layers: [initialBaseLayer, seamarks, marineProfile],
     attributionControl: false,
+    ...singleStepZoomMapOptions,
   }).setView(mapCenter.value as LatLngTuple, zoom.value) as Map
 
   // Expose the Leaflet instance to descendant components via the map context

--- a/src/libs/map/utils-map.ts
+++ b/src/libs/map/utils-map.ts
@@ -13,6 +13,18 @@ const defaultUpdateIntervalMs = 500
 // Minimum distance, in pixels, the user must drag the map before tracking stops, so small or accidental drags don't disable following.
 const defaultUnfollowDragThresholdPx = 150
 
+// Raise wheelPxPerZoomLevel so a single wheel notch/pinch step advances exactly one zoom level
+// (Leaflet's default 60 lets a typical ~100px deltaY round up to 2 levels with zoomSnap: 1).
+export const singleStepZoomMapOptions: Pick<
+  L.MapOptions,
+  'wheelPxPerZoomLevel' | 'wheelDebounceTime' | 'zoomSnap' | 'zoomDelta'
+> = {
+  wheelPxPerZoomLevel: 100,
+  wheelDebounceTime: 100,
+  zoomSnap: 1,
+  zoomDelta: 1,
+}
+
 /**
  * Enum for the different types of targets that can be followed.
  * @enum {string}

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -700,7 +700,13 @@ import { MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import { MavCmd } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import type { NoiseTileOptions } from '@/libs/map/map-tile-fallback'
 import { attachTileNoiseFallback, refreshNoiseFallbackTiles } from '@/libs/map/map-tile-fallback'
-import { createGridOverlay, fitMapToWaypoints, TargetFollower, WhoToFollow } from '@/libs/map/utils-map'
+import {
+  createGridOverlay,
+  fitMapToWaypoints,
+  singleStepZoomMapOptions,
+  TargetFollower,
+  WhoToFollow,
+} from '@/libs/map/utils-map'
 import { generateSurveyPath } from '@/libs/map/utils-map'
 import { centroidLatLng, polygonAreaSquareMeters } from '@/libs/mission/general-estimates'
 import { degrees } from '@/libs/utils'
@@ -3746,10 +3752,10 @@ onMounted(async () => {
       : missionStore.defaultMapTileProvider
   const initialBaseLayer = baseMaps[preferredProvider] || esri
 
-  planningMap.value = L.map('planningMap', { layers: [initialBaseLayer] }).setView(
-    mapCenter.value as LatLngTuple,
-    zoom.value
-  )
+  planningMap.value = L.map('planningMap', {
+    layers: [initialBaseLayer],
+    ...singleStepZoomMapOptions,
+  }).setView(mapCenter.value as LatLngTuple, zoom.value)
 
   // Expose the Leaflet instance to descendant components via the map context
   mapContext.map.value = planningMap.value


### PR DESCRIPTION
- Default Leaflet wheel/pinch zoom advanced two levels per notch on the planning map and the Map widget, which felt jumpy and easy to overshoot.
- Shared `singleStepZoomMapOptions` in `src/libs/map/utils-map.ts` pins one mouse-wheel notch (or pinch step) to exactly one zoom level.
- Map widget and `MissionPlanningView` both consume the shared options so the two maps stay in sync.