### PR TITLE
Mission Planning: Add mission library with save, load and import/export

### DIFF
--- a/src/components/MissionLibraryModal.vue
+++ b/src/components/MissionLibraryModal.vue
@@ -1,0 +1,642 @@
+<template>
+  <v-dialog v-model="isVisible" class="dialog">
+    <div class="flex">
+      <div class="mission-modal" :style="interfaceStore.globalGlassMenuStyles">
+        <div class="modal-content">
+          <!-- Left Vertical Menu -->
+          <div class="flex flex-col justify-between h-full px-5 py-3 align-center">
+            <div class="flex flex-col justify-between pt-2 align-center gap-y-8">
+              <button class="flex flex-col justify-center align-center">
+                <div class="mb-1 text-2xl rounded-full frosted-button w-[46px] h-[46px]">
+                  <v-icon size="30">mdi-map-marker-path</v-icon>
+                </div>
+                <div class="text-sm">Missions</div>
+              </button>
+            </div>
+            <div>
+              <v-divider class="opacity-[0.03] ml-[-5px] w-[120%]"></v-divider>
+              <button class="flex flex-col justify-center py-2 mt-4 align-center" @click="closeModal">
+                <div
+                  class="frosted-button flex flex-col justify-center align-center w-[28px] h-[28px] rounded-full mb-1"
+                >
+                  <v-icon class="text-[18px]">mdi-close</v-icon>
+                </div>
+                <div class="text-sm">Close</div>
+              </button>
+            </div>
+          </div>
+
+          <v-divider vertical class="h-[92%] mt-4 opacity-[0.03]"></v-divider>
+
+          <!-- Right Content -->
+          <div class="flex flex-col flex-1 min-h-0 min-w-0 h-full">
+            <!-- Header -->
+            <div class="flex justify-between items-center px-6 pt-4 pb-2 shrink-0">
+              <h3 class="text-lg font-medium">Mission Library</h3>
+            </div>
+
+            <!-- Cards Grid -->
+            <div
+              v-if="missionStore.savedMissions.length > 0"
+              class="grid gap-4 flex-1 min-h-0 overflow-y-auto w-full pt-4 px-6 pb-4 content-start"
+              style="grid-template-columns: repeat(auto-fill, minmax(180px, 1fr))"
+            >
+              <div
+                v-for="mission in missionStore.savedMissions"
+                :key="mission.id"
+                class="relative cursor-pointer group"
+                @click="openDetail(mission)"
+              >
+                <div
+                  class="relative w-full aspect-square overflow-hidden border-4 border-white rounded-md transition duration-75 ease-in border-opacity-10 group-hover:border-opacity-30"
+                >
+                  <img
+                    v-if="thumbnailFor(mission)"
+                    :src="thumbnailFor(mission)"
+                    class="w-full h-full object-cover bg-[#1f2a37]"
+                    alt="Mission thumbnail"
+                  />
+                  <div v-else class="w-full h-full flex justify-center items-center bg-[#1f2a37]">
+                    <v-icon size="48" class="text-white/30">mdi-map-marker-path</v-icon>
+                  </div>
+                  <div class="absolute top-1 right-1 flex flex-col gap-1">
+                    <div class="card-action-button" @click.stop="onLoadClick(mission)">
+                      <v-tooltip activator="parent" location="left" open-delay="500">Place mission on map</v-tooltip>
+                      <v-icon size="16" class="text-white">mdi-map-plus</v-icon>
+                    </div>
+                    <div class="card-action-button" @click.stop="onDeleteClick(mission)">
+                      <v-tooltip activator="parent" location="left" open-delay="500">Delete mission</v-tooltip>
+                      <v-icon size="16" class="text-white">mdi-delete</v-icon>
+                    </div>
+                  </div>
+                  <div class="absolute bottom-1 left-1 right-1 flex flex-wrap gap-1">
+                    <span class="info-pill">
+                      <v-icon size="12" class="mr-1">mdi-map-marker</v-icon>
+                      {{ mission.waypoints.length }}
+                    </span>
+                    <span v-if="mission.surveys?.length" class="info-pill">
+                      <v-icon size="12" class="mr-1">mdi-grid</v-icon>
+                      {{ mission.surveys.length }}
+                    </span>
+                    <span
+                      v-if="mission.estimates?.pathLength && mission.estimates.pathLength !== '—'"
+                      class="info-pill"
+                    >
+                      <v-icon size="12" class="mr-1">mdi-map-marker-distance</v-icon>
+                      {{ mission.estimates.pathLength }}
+                    </span>
+                    <span v-if="mission.estimates?.duration && mission.estimates.duration !== '—'" class="info-pill">
+                      <v-icon size="12" class="mr-1">mdi-clock-outline</v-icon>
+                      {{ mission.estimates.duration }}
+                    </span>
+                    <span v-if="mission.vehicleType" class="info-pill">
+                      {{ vehicleTypeLabel(mission.vehicleType) }}
+                    </span>
+                  </div>
+                </div>
+                <div class="flex flex-col justify-center mt-1 text-xs text-white/80">
+                  <p class="truncate text-center font-medium">{{ mission.name }}</p>
+                  <p class="truncate text-center text-[10px] text-white/50">
+                    {{ formatDate(new Date(mission.updatedAt)) }}
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <div v-else class="flex flex-1 min-h-0 pt-6 items-center justify-center text-center px-6">
+              <div class="max-w-md mx-auto">
+                <v-icon size="60" class="text-white/30 mb-4">mdi-map-marker-path</v-icon>
+                <h4 class="text-lg font-medium text-white mb-2">No missions saved</h4>
+                <p class="text-white/70 text-sm">
+                  Plan a mission and use “Save current mission” to add it to your library.
+                </p>
+              </div>
+            </div>
+
+            <!-- Footer -->
+            <div class="shrink-0 h-14 flex justify-between items-center px-4" style="border-top: 1px solid #ffffff0d">
+              <span class="text-sm text-white/70">
+                {{ missionStore.savedMissions.length }}
+                {{ missionStore.savedMissions.length === 1 ? 'item' : 'items' }} total
+              </span>
+              <div class="flex items-center gap-2">
+                <v-btn
+                  variant="text"
+                  size="small"
+                  prepend-icon="mdi-content-save-plus"
+                  :disabled="!canSaveCurrent"
+                  @click="openSaveDialog"
+                >
+                  Save current mission
+                </v-btn>
+                <v-btn variant="text" size="small" prepend-icon="mdi-upload" @click="triggerImportFile">
+                  Import file
+                </v-btn>
+                <input
+                  ref="importInput"
+                  type="file"
+                  accept=".cmp,application/json"
+                  class="hidden"
+                  @change="onImportFileSelected"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </v-dialog>
+
+  <!-- Mission detail dialog -->
+  <v-dialog v-if="detailMission" v-model="showDetail" max-width="640px">
+    <v-card :style="interfaceStore.globalGlassMenuStyles" class="text-white">
+      <v-icon icon="mdi-close" class="absolute top-3 right-3 cursor-pointer z-10" @click="showDetail = false" />
+      <div class="flex flex-col md:flex-row">
+        <div class="md:w-1/2 w-full p-4 flex items-center justify-center bg-[#1f2a37]">
+          <img
+            v-if="thumbnailFor(detailMission)"
+            :src="thumbnailFor(detailMission)"
+            class="rounded-md w-full max-h-[300px] object-contain"
+            alt="Mission thumbnail"
+          />
+          <div v-else class="flex items-center justify-center h-[200px]">
+            <v-icon size="80" class="text-white/30">mdi-map-marker-path</v-icon>
+          </div>
+        </div>
+        <div class="md:w-1/2 w-full py-4 px-[21px] flex flex-col gap-2 shadow-[inset_0_5px_7px_-5px_rgba(0,0,0,0.5)]">
+          <div class="flex justify-between items-start gap-2">
+            <h2 class="text-xl font-semibold break-words">{{ detailMission.name }}</h2>
+            <span v-if="detailMission.vehicleType" class="info-pill shrink-0 text-[11px] py-1 px-3">
+              {{ vehicleTypeLabel(detailMission.vehicleType) }}
+            </span>
+          </div>
+          <div class="flex items-center gap-2">
+            <p v-if="detailMission.description" class="text-sm text-white/80 break-words flex-1">
+              {{ detailMission.description }}
+            </p>
+            <div class="flex shrink-0 gap-1 ml-auto">
+              <v-btn
+                variant="text"
+                prepend-icon="mdi-export"
+                color="white"
+                size="small"
+                @click="onExportClick(detailMission)"
+              >
+                Export
+              </v-btn>
+              <v-btn
+                variant="text"
+                prepend-icon="mdi-delete"
+                color="white"
+                size="small"
+                @click="onDeleteClick(detailMission)"
+              >
+                Delete
+              </v-btn>
+            </div>
+          </div>
+          <v-divider class="my-0 opacity-[0.09]" />
+          <div class="text-sm flex flex-col gap-1">
+            <div class="flex justify-between">
+              <span class="text-white/60">Waypoints</span>
+              <span>{{ detailMission.waypoints.length }}</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-white/60">Surveys</span>
+              <span>{{ detailMission.surveys?.length ?? 0 }}</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-white/60">Vehicle type</span>
+              <span>{{ vehicleTypeLabel(detailMission.vehicleType) }}</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-white/60">Cruise speed</span>
+              <span>{{ detailMission.settings.defaultCruiseSpeed }} m/s</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-white/60">Created</span>
+              <span>{{ formatDate(new Date(detailMission.createdAt)) }}</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-white/60">Updated</span>
+              <span>{{ formatDate(new Date(detailMission.updatedAt)) }}</span>
+            </div>
+            <div class="flex justify-between items-center">
+              <span class="text-white/60">Location</span>
+              <div class="flex items-center gap-2">
+                <a
+                  :href="googleEarthUrl(detailLocation)"
+                  target="_blank"
+                  rel="noopener"
+                  class="text-blue-300 hover:text-blue-200 inline-flex mr-2"
+                >
+                  <v-tooltip activator="parent" location="top" open-delay="500">Open in Google Earth</v-tooltip>
+                  <v-icon size="18">mdi-google-earth</v-icon>
+                </a>
+                <span>{{ detailLocation[0]?.toFixed(6) ?? '—' }}, {{ detailLocation[1]?.toFixed(6) ?? '—' }}</span>
+              </div>
+            </div>
+          </div>
+          <v-divider v-if="detailMission.estimates" class="my-2 opacity-[0.09]" />
+          <div v-if="detailMission.estimates" class="text-sm">
+            <p class="text-white/60 mb-1">Mission estimates</p>
+            <div class="flex flex-col gap-1">
+              <div class="flex justify-between">
+                <span class="text-white/60">Length</span>
+                <span>{{ detailMission.estimates.pathLength }}</span>
+              </div>
+              <div class="flex justify-between">
+                <span class="text-white/60">ETA</span>
+                <span>{{ detailMission.estimates.duration }}</span>
+              </div>
+              <div class="flex justify-between">
+                <span class="text-white/60">Energy</span>
+                <span>{{ detailMission.estimates.energy }}</span>
+              </div>
+              <div v-if="detailMission.estimates.totalSurveyCoverage !== '—'" class="flex justify-between">
+                <span class="text-white/60">Total survey coverage</span>
+                <span>{{ detailMission.estimates.totalSurveyCoverage }}</span>
+              </div>
+              <div v-if="detailMission.estimates.missionCoverageArea !== '—'" class="flex justify-between">
+                <span class="text-white/60">Mission area (≈)</span>
+                <span>{{ detailMission.estimates.missionCoverageArea }}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <v-divider class="opacity-[0.09]" />
+      <v-card-actions>
+        <div class="flex justify-between w-full pa-1">
+          <v-btn variant="text" color="white" @click="showDetail = false">Close</v-btn>
+          <v-btn color="white" prepend-icon="mdi-map-plus" @click="onLoadClick(detailMission)">
+            Place mission on map
+          </v-btn>
+        </div>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+
+  <!-- Save current mission dialog -->
+  <v-dialog v-model="showSaveDialog" max-width="500px" persistent>
+    <v-card :style="interfaceStore.globalGlassMenuStyles" class="text-white">
+      <v-card-title class="text-lg font-semibold text-center">Save mission to library</v-card-title>
+      <v-icon icon="mdi-close" class="absolute top-3 right-3 cursor-pointer" @click="showSaveDialog = false" />
+      <form @submit.prevent="confirmSaveMission">
+        <v-card-text>
+          <div class="flex flex-col gap-y-5">
+            <div class="flex flex-col gap-y-1">
+              <label for="save-mission-name" class="text-sm text-white/80">Mission name</label>
+              <input
+                id="save-mission-name"
+                v-model="saveForm.name"
+                type="text"
+                class="rounded-md bg-[#FFFFFF11] border border-[#FFFFFF33] text-white text-sm px-3 py-2 focus:outline-none focus:border-[#FFFFFF77]"
+              />
+            </div>
+            <div class="flex flex-col gap-y-1">
+              <label for="save-mission-description" class="text-sm text-white/80">Description (optional)</label>
+              <textarea
+                id="save-mission-description"
+                v-model="saveForm.description"
+                rows="3"
+                class="rounded-md bg-[#FFFFFF11] border border-[#FFFFFF33] text-white text-sm px-3 py-2 resize-y focus:outline-none focus:border-[#FFFFFF77]"
+              />
+            </div>
+          </div>
+        </v-card-text>
+        <v-card-actions>
+          <div class="flex justify-between gap-2 w-full pa-1 pt-2" style="border-top: 1px solid #ffffff0d">
+            <v-btn type="button" variant="text" color="white" @click="showSaveDialog = false">Cancel</v-btn>
+            <v-btn type="submit" color="white" :disabled="!saveForm.name.trim()">Save</v-btn>
+          </div>
+        </v-card-actions>
+      </form>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+import { format } from 'date-fns'
+import { saveAs } from 'file-saver'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+
+import { useInteractionDialog } from '@/composables/interactionDialog'
+import { useSnackbar } from '@/composables/snackbar'
+import { MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
+import { computeMissionLocation, isSavedMission, vehicleTypeLabel } from '@/libs/mission/library'
+import { useAppInterfaceStore } from '@/stores/appInterface'
+import { useMissionStore } from '@/stores/mission'
+import {
+  CockpitMission,
+  instanceOfCockpitMission,
+  MissionEstimatesSnapshot,
+  SavedMission,
+  WaypointCoordinates,
+} from '@/types/mission'
+
+const props = defineProps<{
+  /**
+   * Snapshot of the mission currently being edited in the planner.
+   */
+  currentMissionSnapshot: CockpitMission | null
+  /**
+   * Live mission estimates captured at save time alongside the mission.
+   */
+  currentMissionEstimates?: MissionEstimatesSnapshot
+  /**
+   * Vehicle type to associate with newly saved missions (connected or planned fallback).
+   */
+  effectiveVehicleType?: MavType
+  /**
+   * When true, the "Save current mission" dialog is opened automatically on mount.
+   */
+  openSaveOnMount?: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'load-mission', mission: SavedMission): void
+}>()
+
+const interfaceStore = useAppInterfaceStore()
+const missionStore = useMissionStore()
+const { showDialog, closeDialog } = useInteractionDialog()
+const { openSnackbar } = useSnackbar()
+
+const isVisible = ref(true)
+const showDetail = ref(false)
+const detailMission = ref<SavedMission | null>(null)
+const showSaveDialog = ref(false)
+const importInput = ref<HTMLInputElement | null>(null)
+
+const saveForm = ref({
+  name: '',
+  description: '',
+  id: undefined as string | undefined,
+})
+
+const canSaveCurrent = computed(() =>
+  Boolean(
+    props.currentMissionSnapshot &&
+      ((props.currentMissionSnapshot.waypoints?.length ?? 0) > 0 ||
+        (props.currentMissionSnapshot.surveys?.length ?? 0) > 0)
+  )
+)
+
+const detailLocation = ref<WaypointCoordinates>([0, 0])
+
+const closeModal = (): void => {
+  isVisible.value = false
+  interfaceStore.missionLibraryVisibility = false
+}
+
+watch(isVisible, (visible) => {
+  if (!visible) interfaceStore.missionLibraryVisibility = false
+})
+
+const formatDate = (date: Date): string => format(date, 'LLL dd, yyyy HH:mm')
+
+const googleEarthUrl = (coords: WaypointCoordinates): string =>
+  `https://earth.google.com/web/@${coords[0]},${coords[1]},500a,1000d`
+
+const thumbnailFor = (mission: SavedMission): string | undefined => missionStore.savedMissionThumbnails[mission.id]
+
+const openDetail = (mission: SavedMission): void => {
+  logUserAction(`Opened details for saved mission "${mission.name}"`)
+  detailMission.value = mission
+  detailLocation.value = computeMissionLocation(mission)
+  showDetail.value = true
+}
+
+// Delay clearing detailMission until after the v-dialog close transition to avoid flashing the
+// previous entry when reopening the modal with a different mission.
+let detailClearTimer: ReturnType<typeof setTimeout> | null = null
+watch(showDetail, (visible) => {
+  if (visible) {
+    if (detailClearTimer) {
+      clearTimeout(detailClearTimer)
+      detailClearTimer = null
+    }
+    return
+  }
+  if (detailClearTimer) clearTimeout(detailClearTimer)
+  detailClearTimer = setTimeout(() => {
+    detailMission.value = null
+    detailClearTimer = null
+  }, 250)
+})
+
+const openSaveDialog = (): void => {
+  if (!props.currentMissionSnapshot) return
+  saveForm.value = {
+    name: missionStore.missionName || `Mission ${format(new Date(), 'LLL dd, yyyy HH:mm')}`,
+    description: '',
+    id: undefined,
+  }
+  showSaveDialog.value = true
+}
+
+onMounted(() => {
+  if (props.openSaveOnMount && canSaveCurrent.value) openSaveDialog()
+})
+
+onBeforeUnmount(() => {
+  if (detailClearTimer) {
+    clearTimeout(detailClearTimer)
+    detailClearTimer = null
+  }
+})
+
+const confirmSaveMission = (): void => {
+  if (!props.currentMissionSnapshot) return
+  const trimmedName = saveForm.value.name.trim()
+  if (!trimmedName) return
+  missionStore.saveMissionToLibrary({
+    name: trimmedName,
+    description: saveForm.value.description.trim(),
+    mission: props.currentMissionSnapshot,
+    vehicleType: props.effectiveVehicleType,
+    estimates: props.currentMissionEstimates ? { ...props.currentMissionEstimates } : undefined,
+    id: saveForm.value.id,
+  })
+  showSaveDialog.value = false
+  logUserAction(`Saved mission "${trimmedName}" to the library`)
+  openSnackbar({ variant: 'success', message: 'Mission saved to library.', duration: 2500 })
+}
+
+const onLoadClick = (mission: SavedMission): void => {
+  logUserAction(`Chose to place saved mission "${mission.name}" on the map`)
+  emit('load-mission', mission)
+  showDetail.value = false
+  closeModal()
+}
+
+const onDeleteClick = (mission: SavedMission): void => {
+  showDialog({
+    variant: 'warning',
+    title: 'Delete mission',
+    message: `Delete "${mission.name}" from your library? This cannot be undone.`,
+    actions: [
+      { text: 'Cancel', action: closeDialog },
+      {
+        text: 'Delete',
+        action: () => {
+          missionStore.deleteSavedMission(mission.id)
+          if (detailMission.value?.id === mission.id) {
+            detailMission.value = null
+            showDetail.value = false
+          }
+          closeDialog()
+          logUserAction(`Deleted mission "${mission.name}" from the library`)
+          openSnackbar({ variant: 'info', message: 'Mission deleted from library.', duration: 2500 })
+        },
+      },
+    ],
+  })
+}
+
+const onExportClick = (mission: SavedMission): void => {
+  // Strip the runtime-only `id` from the exported file; it's regenerated on import, and an `id`
+  // collision across machines would silently overwrite an unrelated local entry.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { id: _id, ...exportable } = mission
+  const blob = new Blob([JSON.stringify(exportable, null, 2)], { type: 'application/json' })
+  const sanitizedName = mission.name.replace(/[\\/:*?"<>|]/g, '_').trim() || 'mission'
+  const date = format(new Date(), 'yyyy-MM-dd_HH-mm-ss')
+  saveAs(blob, `${sanitizedName}_${date}.cmp`)
+  logUserAction(`Exported mission "${mission.name}" from the library`)
+  openSnackbar({ variant: 'success', message: 'Mission exported.', duration: 2000 })
+}
+
+const triggerImportFile = (): void => {
+  importInput.value?.click()
+}
+
+const onImportFileSelected = (event: Event): void => {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  if (!file) return
+  const reader = new FileReader()
+  reader.onload = (loadEvent: ProgressEvent<FileReader>) => {
+    try {
+      const contents = String(loadEvent.target?.result ?? '')
+      const parsed = JSON.parse(contents)
+      if (isSavedMission(parsed)) {
+        missionStore.saveMissionToLibrary({
+          name: parsed.name,
+          description: parsed.description ?? '',
+          mission: {
+            version: parsed.version,
+            settings: parsed.settings,
+            waypoints: parsed.waypoints,
+            surveys: parsed.surveys,
+          },
+          vehicleType: parsed.vehicleType,
+          estimates: parsed.estimates,
+        })
+      } else if (instanceOfCockpitMission(parsed)) {
+        const fallbackName = file.name.replace(/\.[^.]+$/, '') || 'Imported mission'
+        missionStore.saveMissionToLibrary({
+          name: fallbackName,
+          description: '',
+          mission: parsed,
+          vehicleType: props.effectiveVehicleType,
+        })
+      } else {
+        openSnackbar({ variant: 'error', message: 'Invalid mission file.', duration: 3000 })
+        return
+      }
+      logUserAction('Imported a mission into the library')
+      openSnackbar({ variant: 'success', message: 'Mission imported into library.', duration: 2500 })
+    } catch (err) {
+      openSnackbar({ variant: 'error', message: `Failed to import mission: ${err}`, duration: 3500 })
+    } finally {
+      if (input) input.value = ''
+    }
+  }
+  reader.readAsText(file)
+}
+</script>
+
+<style scoped>
+.dialog {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  --v-overlay-opacity: 0.1;
+  z-index: 100;
+}
+
+.mission-modal {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 860px;
+  height: 650px;
+  min-width: 600px;
+  max-width: 90%;
+  max-height: 90vh;
+  border: 1px solid #cbcbcb33;
+  border-radius: 12px;
+  box-shadow: 0px 4px 4px 0px #0000004c, 0px 8px 12px 6px #00000026;
+  z-index: 100;
+}
+
+.modal-content {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  height: 100%;
+  color: #ffffff;
+  z-index: 200;
+}
+
+.frosted-button {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: rgba(203, 203, 203, 0.3);
+  box-shadow: -1px -1px 1px rgba(255, 255, 255, 0.3), 1px 1px 2px rgba(0, 0, 0, 0.15);
+  transition: background-color 0.2s ease;
+}
+
+.frosted-button:hover {
+  background: rgba(203, 203, 203, 0.5);
+}
+
+.card-action-button {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  background: #00000055;
+  cursor: pointer;
+  opacity: 0.85;
+  transition: background-color 0.2s ease, opacity 0.2s ease;
+}
+
+.card-action-button:hover {
+  background: #000000aa;
+  opacity: 1;
+}
+
+.info-pill {
+  display: inline-flex;
+  align-items: center;
+  background: #00000066;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  color: #fff;
+  font-size: 10px;
+  border-radius: 999px;
+  padding: 2px 8px;
+}
+</style>

--- a/src/components/mission-planning/MissionEstimates.vue
+++ b/src/components/mission-planning/MissionEstimates.vue
@@ -159,6 +159,7 @@ import { useMissionEstimates } from '@/composables/useMissionEstimates'
 import { MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
+import { useMissionStore } from '@/stores/mission'
 
 defineProps<{
   /**
@@ -171,6 +172,7 @@ const emit = defineEmits<{ (e: 'update:modelValue', v: boolean): void }>()
 
 const interfaceStore = useAppInterfaceStore()
 const vehicleStore = useMainVehicleStore()
+const missionStore = useMissionStore()
 
 const {
   totalMissionLength,
@@ -182,7 +184,9 @@ const {
   missionCoverageAreaSquareMeters,
 } = useMissionEstimates()
 
-const isOptionsIconVisible = computed(() => vehicleStore.vehicleType === MavType.MAV_TYPE_SURFACE_BOAT)
+const isOptionsIconVisible = computed(
+  () => vehicleStore.isVehicleOnline && missionStore.effectiveVehicleType === MavType.MAV_TYPE_SURFACE_BOAT
+)
 
 const maxDistance = computed(() => totalMaxDistance.value)
 const missionDuration = computed(() => totalMissionDuration.value)

--- a/src/composables/useMissionEstimates.ts
+++ b/src/composables/useMissionEstimates.ts
@@ -54,7 +54,7 @@ export const useMissionEstimates = (): {
   const vehicleStore = useMainVehicleStore()
 
   const normalizedVehicleType = computed<MavType>(() => {
-    const raw = vehicleStore.vehicleType as unknown
+    const raw = missionStore.effectiveVehicleType as unknown
     if (typeof raw === 'number') return (raw as unknown as MavType) ?? MavType.MAV_TYPE_GENERIC
     if (typeof raw === 'string') return (MavType as any)[raw] ?? MavType.MAV_TYPE_GENERIC
     return MavType.MAV_TYPE_GENERIC
@@ -65,7 +65,10 @@ export const useMissionEstimates = (): {
     [MavType.MAV_TYPE_SURFACE_BOAT]: blueBoatMissionEstimate,
   }
 
+  // Vehicle-specific estimators need payload data (battery, drag sensor, extra payload) that is
+  // only available when a real vehicle is connected; fall back to the generic estimator otherwise.
   const currentEstimator = computed<VehicleMissionEstimate | null>(() => {
+    if (!vehicleStore.isVehicleOnline) return null
     return estimatorsByType[normalizedVehicleType.value] ?? null
   })
 

--- a/src/libs/mission/library.ts
+++ b/src/libs/mission/library.ts
@@ -1,0 +1,40 @@
+import { MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
+
+/**
+ * Vehicle types the mission planner can plan against, with their user-facing labels.
+ * Single source for both the planner's "Planning for" selector and the library modal's
+ * vehicle-type label rendering, so the two stay in sync.
+ */
+export const PLANNABLE_VEHICLE_TYPES: ReadonlyArray<{
+  /** Human-readable label shown in the UI. */
+  label: string
+  /** Underlying MavType value persisted with the mission. */
+  value: MavType
+}> = [
+  { label: 'Surface Boat', value: MavType.MAV_TYPE_SURFACE_BOAT },
+  { label: 'Submarine', value: MavType.MAV_TYPE_SUBMARINE },
+  { label: 'UAV', value: MavType.MAV_TYPE_QUADROTOR },
+  { label: 'Ground Rover', value: MavType.MAV_TYPE_GROUND_ROVER },
+]
+
+const PLANNABLE_VEHICLE_TYPE_LABELS: Partial<Record<MavType, string>> = Object.fromEntries(
+  PLANNABLE_VEHICLE_TYPES.map(({ label, value }) => [value, label])
+)
+
+/**
+ * Resolves a user-facing label for a stored mission's vehicle type.
+ * Falls through to a humanised MavType name so legacy missions still display something readable.
+ * @param {MavType | undefined} type - The MavType value persisted with the mission.
+ * @returns {string} The label to render, or 'Any' when no type was captured.
+ */
+export const vehicleTypeLabel = (type?: MavType): string => {
+  if (!type) return 'Any'
+  return (
+    PLANNABLE_VEHICLE_TYPE_LABELS[type] ??
+    String(type)
+      .replace('MAV_TYPE_', '')
+      .toLowerCase()
+      .replace(/(^|_)([a-z])/g, (_m, _p1, c) => ` ${c.toUpperCase()}`)
+      .trim()
+  )
+}

--- a/src/libs/mission/library.ts
+++ b/src/libs/mission/library.ts
@@ -1,4 +1,11 @@
 import { MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
+import { CockpitMission, SavedMission, Waypoint, WaypointCoordinates } from '@/types/mission'
+
+// Square so it matches the mission library card's `aspect-square` thumbnail, avoiding
+// the `object-cover` crop that a non-square canvas would suffer inside a square container.
+const THUMBNAIL_WIDTH = 320
+const THUMBNAIL_HEIGHT = 320
+const THUMBNAIL_PADDING = 26
 
 /**
  * Vehicle types the mission planner can plan against, with their user-facing labels.
@@ -37,4 +44,174 @@ export const vehicleTypeLabel = (type?: MavType): string => {
       .replace(/(^|_)([a-z])/g, (_m, _p1, c) => ` ${c.toUpperCase()}`)
       .trim()
   )
+}
+
+const utf8ToBase64 = (input: string): string => {
+  const bytes = new TextEncoder().encode(input)
+  let binary = ''
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return btoa(binary)
+}
+
+type LatLngBounds = {
+  /**
+   * Minimum latitude.
+   */
+  minLat: number
+  /**
+   * Maximum latitude.
+   */
+  maxLat: number
+  /**
+   * Minimum longitude.
+   */
+  minLng: number
+  /**
+   * Maximum longitude.
+   */
+  maxLng: number
+}
+
+const computeBounds = (coordinates: WaypointCoordinates[]): LatLngBounds | null => {
+  if (coordinates.length === 0) return null
+  let minLat = coordinates[0][0]
+  let maxLat = coordinates[0][0]
+  let minLng = coordinates[0][1]
+  let maxLng = coordinates[0][1]
+  for (const [lat, lng] of coordinates) {
+    if (lat < minLat) minLat = lat
+    if (lat > maxLat) maxLat = lat
+    if (lng < minLng) minLng = lng
+    if (lng > maxLng) maxLng = lng
+  }
+  return { minLat, maxLat, minLng, maxLng }
+}
+
+/**
+ * Generates a lightweight SVG thumbnail (base64 data URL) of a mission's geometry.
+ * @param {CockpitMission} mission - The mission to render.
+ * @returns {string} A base64 `data:image/svg+xml` URL.
+ */
+export const generateMissionThumbnail = (mission: CockpitMission): string => {
+  const waypointCoords: WaypointCoordinates[] = (mission.waypoints ?? []).map((w) => w.coordinates)
+  const surveyCoords: WaypointCoordinates[] = (mission.surveys ?? []).flatMap((s) => s.polygonCoordinates ?? [])
+  const allCoords = [...waypointCoords, ...surveyCoords]
+
+  if (allCoords.length === 0) {
+    const emptySvg =
+      `<svg xmlns="http://www.w3.org/2000/svg" width="${THUMBNAIL_WIDTH}" height="${THUMBNAIL_HEIGHT}" viewBox="0 0 ${THUMBNAIL_WIDTH} ${THUMBNAIL_HEIGHT}">` +
+      `<rect width="100%" height="100%" fill="#1f2a37"/>` +
+      `<text x="50%" y="50%" fill="#ffffff66" font-family="sans-serif" font-size="16" text-anchor="middle" dominant-baseline="middle">No path</text>` +
+      `</svg>`
+    return `data:image/svg+xml;base64,${utf8ToBase64(emptySvg)}`
+  }
+
+  const bounds = computeBounds(allCoords)!
+  const latSpan = Math.max(bounds.maxLat - bounds.minLat, 1e-7)
+  const lngSpan = Math.max(bounds.maxLng - bounds.minLng, 1e-7)
+  const usableWidth = THUMBNAIL_WIDTH - THUMBNAIL_PADDING * 2
+  const usableHeight = THUMBNAIL_HEIGHT - THUMBNAIL_PADDING * 2
+  const scale = Math.min(usableWidth / lngSpan, usableHeight / latSpan)
+
+  const offsetX = (THUMBNAIL_WIDTH - lngSpan * scale) / 2
+  const offsetY = (THUMBNAIL_HEIGHT - latSpan * scale) / 2
+
+  const project = ([lat, lng]: WaypointCoordinates): [number, number] => [
+    offsetX + (lng - bounds.minLng) * scale,
+    offsetY + (bounds.maxLat - lat) * scale,
+  ]
+
+  const surveyPolygons = (mission.surveys ?? [])
+    .map((s) => {
+      if (!s.polygonCoordinates?.length) return ''
+      const points = s.polygonCoordinates
+        .map((c) => project(c))
+        .map(([x, y]) => `${x.toFixed(2)},${y.toFixed(2)}`)
+        .join(' ')
+      return `<polygon points="${points}" fill="#3B78A833" stroke="#3B78A8" stroke-width="1.5"/>`
+    })
+    .join('')
+
+  const pathPoints = waypointCoords
+    .map((c) => project(c))
+    .map(([x, y], i) => `${i === 0 ? 'M' : 'L'}${x.toFixed(2)},${y.toFixed(2)}`)
+    .join(' ')
+  const pathElement = pathPoints ? `<path d="${pathPoints}" stroke="#ffd54f" stroke-width="2.5" fill="none"/>` : ''
+
+  const baseRadius = 3
+  const endpointRadius = baseRadius * 1.25
+  const waypointMarkers = waypointCoords
+    .map((c) => project(c))
+    .map(([x, y], i) => {
+      const isEndpoint = i === 0 || i === waypointCoords.length - 1
+      const fill = isEndpoint ? '#ff9800' : '#ffffff'
+      const radius = isEndpoint ? endpointRadius : baseRadius
+      return `<circle cx="${x.toFixed(2)}" cy="${y.toFixed(
+        2
+      )}" r="${radius}" fill="${fill}" stroke="#000000aa" stroke-width="0.5"/>`
+    })
+    .join('')
+
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${THUMBNAIL_WIDTH}" height="${THUMBNAIL_HEIGHT}" viewBox="0 0 ${THUMBNAIL_WIDTH} ${THUMBNAIL_HEIGHT}">` +
+    `<rect width="100%" height="100%" fill="#1f2a37"/>` +
+    surveyPolygons +
+    pathElement +
+    waypointMarkers +
+    `</svg>`
+
+  return `data:image/svg+xml;base64,${utf8ToBase64(svg)}`
+}
+
+/**
+ * Centroid (average lat/lng) of the mission features. Falls back to the saved map center
+ * when the mission has no waypoints or surveys.
+ * @param {CockpitMission} mission - The mission whose location should be computed.
+ * @returns {WaypointCoordinates} The centroid coordinates of the mission.
+ */
+export const computeMissionLocation = (mission: CockpitMission): WaypointCoordinates => {
+  const waypointCoords: WaypointCoordinates[] = (mission.waypoints ?? []).map((w: Waypoint) => w.coordinates)
+  const surveyCoords: WaypointCoordinates[] = (mission.surveys ?? []).flatMap((s) => s.polygonCoordinates ?? [])
+  const allCoords = [...waypointCoords, ...surveyCoords]
+  if (allCoords.length === 0) return mission.settings.mapCenter
+  let sumLat = 0
+  let sumLng = 0
+  for (const [lat, lng] of allCoords) {
+    sumLat += lat
+    sumLng += lng
+  }
+  return [sumLat / allCoords.length, sumLng / allCoords.length]
+}
+
+/**
+ * Type guard for SavedMission.
+ * @param {unknown} value - The value to check.
+ * @returns {boolean} True if the value matches the SavedMission shape.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const isSavedMission = (value: any): value is SavedMission => {
+  if (!value || typeof value !== 'object') return false
+  // `id` is intentionally not required here: exported `.cmp` files have it stripped (the importer
+  // assigns a fresh uuid), so requiring it would force every round-tripped export through the
+  // bare-CockpitMission fallback and lose `name`, `description`, `vehicleType`, `estimates`, and
+  // the timestamps. Discriminate on the saved-mission-specific metadata instead.
+  if (
+    typeof value.name !== 'string' ||
+    typeof value.createdAt !== 'number' ||
+    typeof value.updatedAt !== 'number' ||
+    !Array.isArray(value.waypoints) ||
+    !value.settings ||
+    !Array.isArray(value.settings.mapCenter)
+  ) {
+    return false
+  }
+  // Spot-check the first waypoint so an adversarial .cmp file with a malformed waypoints array
+  // is rejected up-front instead of crashing later when we read coordinates/id off entries.
+  if (value.waypoints.length > 0) {
+    const wp = value.waypoints[0]
+    if (!wp || typeof wp.id !== 'string' || !Array.isArray(wp.coordinates) || wp.coordinates.length < 2) {
+      return false
+    }
+  }
+  return true
 }

--- a/src/stores/appInterface.ts
+++ b/src/stores/appInterface.ts
@@ -45,6 +45,7 @@ export const useAppInterfaceStore = defineStore('responsive', {
     configModalVisibility: false,
     videoLibraryVisibility: false,
     videoLibraryMode: 'videos',
+    missionLibraryVisibility: false,
     UIGlassEffect: useBlueOsStorage('cockpit-ui-glass-effect', {
       opacity: 0.9,
       bgColor: '#63636354',
@@ -129,6 +130,7 @@ export const useAppInterfaceStore = defineStore('responsive', {
     },
     isConfigModalVisible: (state) => state.configModalVisibility,
     isVideoLibraryVisible: (state) => state.videoLibraryVisibility,
+    isMissionLibraryVisible: (state) => state.missionLibraryVisibility,
     getUIGlassEffect: (state) => {
       state.UIGlassEffect
     },

--- a/src/stores/mission.ts
+++ b/src/stores/mission.ts
@@ -1,6 +1,7 @@
 import * as turf from '@turf/turf'
 import { useStorage } from '@vueuse/core'
 import { defineStore } from 'pinia'
+import { v4 as uuid } from 'uuid'
 import { computed, reactive, ref, watch } from 'vue'
 
 import { defaultMapFallbackBaseColor, defaultMapFallbackNoiseIntensity } from '@/assets/defaults'
@@ -9,15 +10,19 @@ import { useBlueOsStorage } from '@/composables/settingsSyncer'
 import { askForUsername } from '@/composables/usernamePrompDialog'
 import { MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import { generateSessionSeed } from '@/libs/map/map-tile-fallback'
+import { generateMissionThumbnail } from '@/libs/mission/library'
 import { eventCategoriesDefaultMapping } from '@/libs/slide-to-confirm'
 import {
   AltitudeReferenceType,
+  CockpitMission,
   MapOverlayMeta,
   MapTileProvider,
   MapTileProviderPreference,
   MissionCommand,
+  MissionEstimatesSnapshot,
   PointOfInterest,
   PointOfInterestCoordinates,
+  SavedMission,
   Survey,
   Waypoint,
   WaypointCoordinates,
@@ -93,6 +98,10 @@ export const useMissionStore = defineStore('mission', () => {
 
   // Fallback vehicle type used by vehicle-specific planning features when no vehicle is connected.
   const plannedVehicleType = useBlueOsStorage<MavType | undefined>('cockpit-planned-vehicle-type', undefined)
+  // Thumbnails are stored separately from the saved missions so that adding many entries doesn't
+  // bloat the main library payload (each thumbnail is ~1-2 KB of base64 SVG).
+  const savedMissions = useBlueOsStorage<SavedMission[]>('cockpit-mission-library', [])
+  const savedMissionThumbnails = useBlueOsStorage<Record<string, string>>('cockpit-mission-library-thumbnails', {})
 
   const { showDialog } = useInteractionDialog()
 
@@ -675,6 +684,80 @@ export const useMissionStore = defineStore('mission', () => {
       : plannedVehicleType.value
   })
 
+  // When `payload.id` matches an existing entry that entry is updated in-place; otherwise a new
+  // entry is prepended.
+  const saveMissionToLibrary = (payload: {
+    /**
+     * Display name for the mission.
+     */
+    name: string
+    /**
+     * Optional description for the mission.
+     */
+    description: string
+    /**
+     * The mission data to persist.
+     */
+    mission: CockpitMission
+    /**
+     * Vehicle type the mission was planned for.
+     */
+    vehicleType?: MavType
+    /**
+     * Mission estimates captured at save time.
+     */
+    estimates?: MissionEstimatesSnapshot
+    /**
+     * Existing entry id to update, or undefined to create a new one.
+     */
+    id?: string
+  }): SavedMission => {
+    const now = Date.now()
+    const thumbnail = generateMissionThumbnail(payload.mission)
+    const existingIndex = payload.id ? savedMissions.value.findIndex((m) => m.id === payload.id) : -1
+
+    if (existingIndex !== -1) {
+      const existing = savedMissions.value[existingIndex]
+      const updated: SavedMission = {
+        ...payload.mission,
+        id: existing.id,
+        name: payload.name,
+        description: payload.description,
+        vehicleType: payload.vehicleType,
+        createdAt: existing.createdAt,
+        updatedAt: now,
+        estimates: payload.estimates,
+      }
+      savedMissions.value.splice(existingIndex, 1, updated)
+      savedMissionThumbnails.value = { ...savedMissionThumbnails.value, [updated.id]: thumbnail }
+      return updated
+    }
+
+    const created: SavedMission = {
+      ...payload.mission,
+      id: uuid(),
+      name: payload.name,
+      description: payload.description,
+      vehicleType: payload.vehicleType,
+      createdAt: now,
+      updatedAt: now,
+      estimates: payload.estimates,
+    }
+    savedMissions.value.unshift(created)
+    savedMissionThumbnails.value = { ...savedMissionThumbnails.value, [created.id]: thumbnail }
+    return created
+  }
+
+  const deleteSavedMission = (id: string): void => {
+    const index = savedMissions.value.findIndex((m) => m.id === id)
+    if (index !== -1) savedMissions.value.splice(index, 1)
+    if (savedMissionThumbnails.value[id]) {
+      const next = { ...savedMissionThumbnails.value }
+      delete next[id]
+      savedMissionThumbnails.value = next
+    }
+  }
+
   return {
     username,
     lastConnectedUser,
@@ -758,5 +841,9 @@ export const useMissionStore = defineStore('mission', () => {
     homeMarkerPosition,
     plannedVehicleType,
     effectiveVehicleType,
+    savedMissions,
+    savedMissionThumbnails,
+    saveMissionToLibrary,
+    deleteSavedMission,
   }
 })

--- a/src/stores/mission.ts
+++ b/src/stores/mission.ts
@@ -7,6 +7,7 @@ import { defaultMapFallbackBaseColor, defaultMapFallbackNoiseIntensity } from '@
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { useBlueOsStorage } from '@/composables/settingsSyncer'
 import { askForUsername } from '@/composables/usernamePrompDialog'
+import { MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import { generateSessionSeed } from '@/libs/map/map-tile-fallback'
 import { eventCategoriesDefaultMapping } from '@/libs/slide-to-confirm'
 import {
@@ -89,6 +90,9 @@ export const useMissionStore = defineStore('mission', () => {
   const mapClearRequestRevision = ref(0)
   const mapDownloadRequestRevision = ref(0)
   const homeMarkerPosition = ref<WaypointCoordinates | undefined>(undefined)
+
+  // Fallback vehicle type used by vehicle-specific planning features when no vehicle is connected.
+  const plannedVehicleType = useBlueOsStorage<MavType | undefined>('cockpit-planned-vehicle-type', undefined)
 
   const { showDialog } = useInteractionDialog()
 
@@ -661,6 +665,16 @@ export const useMissionStore = defineStore('mission', () => {
 
   watch(username, () => window.dispatchEvent(new CustomEvent('user-changed', { detail: { username: username.value } })))
 
+  // Prefers the connected vehicle's type and falls back to the planned type for offline planning.
+  // The fallback is gated on `isVehicleOnline` because `mainVehicleStore.vehicleType` is set on
+  // heartbeat but never cleared on disconnect, so a plain `??` would keep returning the stale
+  // last-connected type after the user goes offline.
+  const effectiveVehicleType = computed<MavType | undefined>(() => {
+    return mainVehicleStore.isVehicleOnline
+      ? (mainVehicleStore.vehicleType as MavType | undefined)
+      : plannedVehicleType.value
+  })
+
   return {
     username,
     lastConnectedUser,
@@ -742,5 +756,7 @@ export const useMissionStore = defineStore('mission', () => {
     canRedo,
     clearUndoStack,
     homeMarkerPosition,
+    plannedVehicleType,
+    effectiveVehicleType,
   }
 })

--- a/src/types/mission.ts
+++ b/src/types/mission.ts
@@ -154,6 +154,67 @@ export type CockpitMission = {
 }
 
 /**
+ * Snapshot of the mission estimates panel values at the time the mission was saved.
+ * All values are pre-formatted strings (matching the Mission Estimates UI).
+ */
+export type MissionEstimatesSnapshot = {
+  /**
+   * Total path length.
+   */
+  pathLength: string
+  /**
+   * Estimated time to complete the mission.
+   */
+  duration: string
+  /**
+   * Estimated energy consumption.
+   */
+  energy: string
+  /**
+   * Total area covered by surveys.
+   */
+  totalSurveyCoverage: string
+  /**
+   * Approximate area enclosed by the mission path when closed.
+   */
+  missionCoverageArea: string
+}
+
+/**
+ * A mission saved into the local Mission Library.
+ */
+export type SavedMission = CockpitMission & {
+  /**
+   * Stable identifier for the saved mission entry.
+   */
+  id: string
+  /**
+   * User-facing mission name.
+   */
+  name: string
+  /**
+   * Optional user description for the mission.
+   */
+  description: string
+  /**
+   * Vehicle type the mission was planned for.
+   */
+  vehicleType?: MavType
+  /**
+   * Epoch milliseconds when the mission was first saved to the library.
+   */
+  createdAt: number
+  /**
+   * Epoch milliseconds when the mission was last updated in the library.
+   */
+  updatedAt: number
+  /**
+   * Mission estimates captured when the mission was saved.
+   */
+  estimates?: MissionEstimatesSnapshot
+}
+
+/**
  * Survey object that contains the information about the survey to be performed.
  */
 export interface Survey {

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -150,6 +150,34 @@
           {{ missionStore.currentPlanningWaypoints.length > 0 ? 'ADD SIMPLE PATH' : 'CREATE SIMPLE PATH' }}
         </button>
         <div
+          v-if="!isCreatingSurvey && !isCreatingSimplePath && !vehicleStore.isVehicleOnline"
+          class="flex flex-col mx-4 my-2 gap-y-1"
+        >
+          <div class="flex flex-row justify-between items-center">
+            <p class="text-sm">Planning for</p>
+            <v-tooltip
+              location="top"
+              text="No vehicle connected. Pick the vehicle type so vehicle-specific planning features show up."
+            >
+              <template #activator="{ props: tooltipProps }">
+                <v-icon v-bind="tooltipProps" size="14" class="opacity-70">mdi-information-outline</v-icon>
+              </template>
+            </v-tooltip>
+          </div>
+          <v-select
+            v-model="missionStore.plannedVehicleType"
+            :items="plannedVehicleTypeItems"
+            item-title="label"
+            item-value="value"
+            hide-details
+            density="compact"
+            theme="dark"
+            variant="outlined"
+            class="text-sm"
+            @update:model-value="onPlannedVehicleTypeChange"
+          />
+        </div>
+        <div
           v-if="!isCreatingSurvey && !isCreatingSimplePath"
           class="flex flex-row justify-center items-center gap-x-2 mx-4 my-1"
         >
@@ -759,6 +787,7 @@ import {
   formatMetersShort,
   polygonAreaSquareMeters,
 } from '@/libs/mission/general-estimates'
+import { PLANNABLE_VEHICLE_TYPES, vehicleTypeLabel } from '@/libs/mission/library'
 import { degrees } from '@/libs/utils'
 import router from '@/router'
 import { SubMenuComponentName, SubMenuName, useAppInterfaceStore } from '@/stores/appInterface'
@@ -1000,6 +1029,11 @@ const availableFrames = Object.values(AltitudeReferenceType).map((value: Altitud
   name: value,
   value,
 }))
+const plannedVehicleTypeItems = PLANNABLE_VEHICLE_TYPES
+
+const onPlannedVehicleTypeChange = (value?: MavType): void => {
+  logUserAction(`Selected "${vehicleTypeLabel(value)}" as the planning vehicle type`)
+}
 const waypointMarkers = shallowRef<{ [id: string]: Marker }>({})
 const isCreatingSimplePath = ref(false)
 const contextMenuVisible = ref(false)

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -415,29 +415,15 @@
               </template>
             </v-tooltip>
             <v-divider vertical />
-            <v-tooltip location="top" text="Save mission to file">
+            <v-tooltip location="top" text="Mission library">
               <template #activator="{ props }">
                 <v-btn
                   v-bind="props"
-                  icon="mdi-content-save"
-                  variant="text"
-                  :disabled="missionStore.currentPlanningWaypoints.length === 0"
-                  size="24"
-                  class="text-[12px]"
-                  @click="saveMissionToFile"
-                />
-              </template>
-            </v-tooltip>
-            <v-divider vertical />
-            <v-tooltip location="top" text="Load mission from file">
-              <template #activator="{ props }">
-                <v-btn
-                  v-bind="props"
-                  icon="mdi-upload"
+                  icon="mdi-bookshelf"
                   variant="text"
                   size="24"
                   class="text-[12px]"
-                  @click="loadMissionFromFile"
+                  @click="openMissionLibrary"
                 />
               </template>
             </v-tooltip>
@@ -725,15 +711,20 @@
     </p>
   </div>
   <MissionEstimatesPanel v-if="!speedDialOpen" v-model="missionStore.showMissionEstimates" />
+  <MissionLibraryModal
+    v-if="interfaceStore.isMissionLibraryVisible"
+    :current-mission-snapshot="currentMissionSnapshot"
+    :current-mission-estimates="currentMissionEstimatesSnapshot"
+    :effective-vehicle-type="missionStore.effectiveVehicleType"
+    @load-mission="handleLoadMissionFromLibrary"
+  />
 </template>
 <script setup lang="ts">
 import 'leaflet/dist/leaflet.css'
 import 'leaflet-edgebuffer'
 
-import { useDebounceFn, useWindowSize } from '@vueuse/core'
+import { useDebounceFn, useWindowSize, watchDebounced } from '@vueuse/core'
 import { formatDistanceToNow } from 'date-fns'
-import { format } from 'date-fns'
-import { saveAs } from 'file-saver'
 import L, { type LatLngTuple, LeafletMouseEvent, Map, Marker, Polygon } from 'leaflet'
 import { v4 as uuid } from 'uuid'
 import { type InstanceType, computed, nextTick, onMounted, onUnmounted, ref, shallowRef, toRaw, watch } from 'vue'
@@ -749,6 +740,7 @@ import MissionEstimatesPanel from '@/components/mission-planning/MissionEstimate
 import ScanDirectionDial from '@/components/mission-planning/ScanDirectionDial.vue'
 import SurveyVertexList from '@/components/mission-planning/SurveyVertexList.vue'
 import WaypointConfigPanel from '@/components/mission-planning/WaypointConfigPanel.vue'
+import MissionLibraryModal from '@/components/MissionLibraryModal.vue'
 import PoiManager from '@/components/poi/PoiManager.vue'
 import PoiMapArrows from '@/components/poi/PoiMapArrows.vue'
 import RadialMenu, { type RadialMenuItem } from '@/components/RadialMenu.vue'
@@ -797,6 +789,8 @@ import { useWidgetManagerStore } from '@/stores/widgetManager'
 import { Point2D } from '@/types/general'
 import {
   type CockpitMission,
+  type MissionEstimatesSnapshot,
+  type SavedMission,
   type Waypoint,
   type WaypointCoordinates,
   AltitudeReferenceType,
@@ -2855,30 +2849,6 @@ const handleShouldUpdateWaypoints = (): void => {
   updateWaypointMarkers()
 }
 
-const saveMissionToFile = async (): Promise<void> => {
-  logUserAction('Saved mission to file')
-  // Commit the local cruise speed back to the store so the chosen value persists across sessions.
-  missionStore.defaultCruiseSpeed = localCruiseSpeed.value
-
-  const cockpitMissionFile: CockpitMission = {
-    version: 0,
-    settings: {
-      mapCenter: mapCenter.value,
-      zoom: zoom.value,
-      currentWaypointAltitude: currentWaypointAltitude.value,
-      currentWaypointAltitudeRefType: currentWaypointAltitudeRefType.value,
-      defaultCruiseSpeed: localCruiseSpeed.value,
-    },
-    waypoints: missionStore.currentPlanningWaypoints,
-    surveys: [...missionStore.currentPlanningSurveys],
-  }
-  const blob = new Blob([JSON.stringify(cockpitMissionFile, null, 2)], {
-    type: 'application/json',
-  })
-  const date = format(new Date(), 'LLL_dd_yyyy_HH_mm_ss')
-  saveAs(blob, `cockpit_mission_plan_${date}.cmp`)
-}
-
 const drawMissionOnTheMap = (waypoints: Waypoint[]): void => {
   waypoints
     .map((wp) => ({
@@ -2892,45 +2862,6 @@ const drawMissionOnTheMap = (waypoints: Waypoint[]): void => {
     })
 
   updateWaypointMarkers()
-}
-
-const loadMissionFromFile = (): void => {
-  logUserAction('Loaded mission from file')
-  const input = document.createElement('input')
-  input.type = 'file'
-  input.accept = '.cmp,application/json'
-  input.onchange = (event: Event): void => {
-    const file = (event.target as HTMLInputElement).files?.[0]
-    if (!file) return
-    const reader = new FileReader()
-    reader.onload = (e: ProgressEvent<FileReader>): void => {
-      try {
-        const contents = e.target?.result
-        if (typeof contents !== 'string') {
-          showDialog({ variant: 'error', message: 'File does not appear to be in the correct format.', timer: 3000 })
-          return
-        }
-        const maybeMission = JSON.parse(contents)
-        if (!instanceOfCockpitMission(maybeMission)) {
-          showDialog({ variant: 'error', message: 'Invalid mission file.', timer: 3000 })
-          return
-        }
-        mapCenter.value = maybeMission['settings']['mapCenter']
-        zoom.value = maybeMission['settings']['zoom']
-        currentWaypointAltitude.value = maybeMission['settings']['currentWaypointAltitude']
-        currentWaypointAltitudeRefType.value = maybeMission['settings']['currentWaypointAltitudeRefType']
-        missionStore.defaultCruiseSpeed = maybeMission['settings']['defaultCruiseSpeed']
-        drawMissionOnTheMap(maybeMission['waypoints'])
-        if (maybeMission['surveys']?.length) {
-          missionStore.currentPlanningSurveys.push(...maybeMission['surveys'])
-        }
-      } catch (error) {
-        showDialog({ variant: 'error', message: `Failed to load mission file: ${error}`, timer: 5000 })
-      }
-    }
-    reader.readAsText(file)
-  }
-  input.click()
 }
 
 const surveyPolygonVertexesMarkers = shallowRef<L.Marker[]>([])
@@ -3890,6 +3821,82 @@ const loadDraftMission = async (mission: CockpitMission): Promise<void> => {
   } catch (error) {
     openSnackbar({ variant: 'error', message: `Failed to load draft mission: ${error}`, duration: 3000 })
   }
+}
+
+// Backed by a debounced watcher so the deep clone runs at most once per change burst, instead of
+// firing on every reactive read of the prop while the library modal is open.
+const buildCurrentMissionSnapshot = (): CockpitMission => ({
+  version: 0,
+  settings: {
+    mapCenter: mapCenter.value,
+    zoom: zoom.value,
+    currentWaypointAltitude: currentWaypointAltitude.value,
+    currentWaypointAltitudeRefType: currentWaypointAltitudeRefType.value,
+    // Use the local (in-input) cruise speed so library saves capture pending changes the user
+    // typed but hasn't committed back to the store yet (e.g. by uploading the mission).
+    defaultCruiseSpeed: localCruiseSpeed.value,
+  },
+  waypoints: structuredClone(toRaw(missionStore.currentPlanningWaypoints)),
+  surveys: structuredClone(toRaw(missionStore.currentPlanningSurveys)),
+})
+
+const currentMissionSnapshot = ref<CockpitMission>(buildCurrentMissionSnapshot())
+
+watchDebounced(
+  [
+    () => missionStore.currentPlanningWaypoints,
+    () => missionStore.currentPlanningSurveys,
+    mapCenter,
+    zoom,
+    currentWaypointAltitude,
+    currentWaypointAltitudeRefType,
+    localCruiseSpeed,
+  ],
+  () => {
+    currentMissionSnapshot.value = buildCurrentMissionSnapshot()
+  },
+  { debounce: 100, deep: true }
+)
+
+const currentMissionEstimatesSnapshot = computed<MissionEstimatesSnapshot>(() => ({
+  pathLength: missionEstimates.totalMissionLength.value,
+  duration: missionEstimates.totalMissionDuration.value,
+  energy: missionEstimates.totalMissionEnergy.value,
+  totalSurveyCoverage: missionEstimates.totalSurveyCoverage.value,
+  missionCoverageArea: missionEstimates.missionCoverageAreaSquareMeters.value,
+}))
+
+const openMissionLibrary = (): void => {
+  logUserAction('Opened the mission library')
+  interfaceStore.missionLibraryVisibility = true
+}
+
+const handleLoadMissionFromLibrary = (mission: SavedMission): void => {
+  if (mission.vehicleType && !vehicleStore.isVehicleOnline) {
+    missionStore.plannedVehicleType = mission.vehicleType
+  }
+
+  showDialog({
+    variant: 'info',
+    title: 'Load mission',
+    message: `Where should "${mission.name}" be placed?`,
+    persistent: false,
+    maxWidth: 620,
+    actions: [
+      { text: 'Cancel', color: 'white', action: closeDialog },
+      {
+        text: 'Keep original location',
+        color: 'white',
+        action: () => {
+          closeDialog()
+          logUserAction(`Loaded mission "${mission.name}" at its original location`)
+          loadDraftMission(mission).catch((err) => {
+            openSnackbar({ variant: 'error', message: `Failed to load mission: ${err}`, duration: 3500 })
+          })
+        },
+      },
+    ],
+  })
 }
 
 onMounted(() => {


### PR DESCRIPTION
- Add a Mission Library modal listing saved missions with thumbnails, name, date, vehicle type, length, ETA and waypoint/survey counts.
- Replace the toolbar's separate save/load buttons with a single "Mission library" entry that opens the modal.
- Save the currently planned mission (waypoints, surveys, settings, estimates) into the library, with name and description.
- Load a saved mission back into the planner at its original location.
- Import and export missions as `.cmp` files.
- Add a "Planning for" vehicle-type selector, used while no vehicle is connected, so vehicle-specific planning surfaces follow the planned type.
- Hide vehicle-specific mission-estimate options when no vehicle is online so the offline planner uses the generic estimator.
- Persist the library and thumbnails under `cockpit-mission-library` and `cockpit-mission-library-thumbnails`, keyed by stable mission id.

First of two sequential PRs splitting #2654 — the follow-up lands on top of this one:

- `mission-library-free-placement` — free-placement workflow to drop, drag/scale/rotate and append a library mission before commit, plus a context-menu library submenu, endpoint-biased inserts for waypoint/survey/path/library actions, and orange highlight of the mission's first and last waypoints.

<img width="1914" height="1060" alt="image" src="https://github.com/user-attachments/assets/f3e1c123-a761-4be3-a72a-41241ef1daf8" />

<img width="1914" height="1059" alt="image" src="https://github.com/user-attachments/assets/76541904-769c-4582-b707-2bb050e92d95" />

<img width="1914" height="1056" alt="image" src="https://github.com/user-attachments/assets/94942c03-790d-4159-8407-22920cd481f1" />

<img width="1913" height="1059" alt="image" src="https://github.com/user-attachments/assets/04a9b849-ba5b-4cd0-8464-266bdf4cdd5b" />
