### PR TITLE
Fix "video file not growing" dialog not being dismissable

### DIFF
--- a/src/composables/interactionDialog.ts
+++ b/src/composables/interactionDialog.ts
@@ -97,11 +97,26 @@ export function useInteractionDialog(): {
   })
 
   let dialogApp: App<Element> | null = null
-  let resolveFn: (value: DialogResult | PromiseLike<DialogResult>) => void
-  let rejectFn: (reason?: DialogResult) => void
+  let mountPoint: HTMLElement | null = null
+  let resolveFn: ((value: DialogResult | PromiseLike<DialogResult>) => void) | undefined
+  let rejectFn: ((reason?: DialogResult) => void) | undefined
+
+  const unmountDialog = (): void => {
+    if (dialogApp) {
+      dialogApp.unmount()
+      dialogApp = null
+    }
+    if (mountPoint) {
+      mountPoint.remove()
+      mountPoint = null
+    }
+  }
 
   const mountDialog = (): void => {
-    const mountPoint = document.createElement('div')
+    // Unmount any previously mounted dialog first, otherwise repeated calls stack orphaned dialog
+    // instances that can never be dismissed and end up blocking the whole screen.
+    unmountDialog()
+    mountPoint = document.createElement('div')
     document.body.appendChild(mountPoint)
     dialogApp = createApp(InteractionDialogComponent, {
       ...dialogProps,
@@ -118,6 +133,9 @@ export function useInteractionDialog(): {
   }
 
   const showDialog = (options: DialogOptions): Promise<DialogResult> => {
+    // Settle any still-pending dialog before replacing it so a caller awaiting a superseded dialog doesn't hang
+    // forever. Resolve (rather than reject) to avoid unhandled rejections for the many callers that don't await.
+    resolveFn?.({ isConfirmed: false })
     return new Promise((resolve, reject) => {
       Object.assign(dialogProps, options, { showDialog: true })
       resolveFn = resolve
@@ -128,16 +146,11 @@ export function useInteractionDialog(): {
 
   const closeDialog = (): void => {
     dialogProps.showDialog = false
-    if (dialogApp) {
-      dialogApp.unmount()
-      dialogApp = null
-    }
+    unmountDialog()
   }
 
   onUnmounted(() => {
-    if (dialogApp) {
-      dialogApp.unmount()
-    }
+    unmountDialog()
   })
 
   return { showDialog, closeDialog }

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -660,16 +660,30 @@ export const useVideoStore = defineStore('video', () => {
     unprocessedVideos.value = { ...unprocessedVideos.value, ...{ [recordingHash]: videoInfo } }
 
     // Common configuration for the not growing dialogs
+    let notGrowingDialogOpen = false
+    const closeNotGrowingDialog = (): void => {
+      notGrowingDialogOpen = false
+      closeDialog()
+    }
     const suppressNotGrowingDialog = (): void => {
       suppressNotGrowingDialogs.value = true
-      closeDialog()
+      closeNotGrowingDialog()
     }
     const notGrowingDialogConfig = {
       variant: 'error',
+      // Persistent so it can only be closed via the actions below, which reset notGrowingDialogOpen. A
+      // backdrop/Escape dismissal would otherwise leave the flag stuck and stop the dialog from ever reappearing.
+      persistent: true,
       actions: [
         { text: "Don't show again during this session", size: 'small', action: suppressNotGrowingDialog },
-        { text: 'Close', size: 'small', action: closeDialog },
+        { text: 'Close', size: 'small', action: closeNotGrowingDialog },
       ],
+    }
+    // Only show the dialog once at a time, otherwise the timed monitor would re-open it on every tick.
+    const showNotGrowingDialog = (message: string): void => {
+      if (suppressNotGrowingDialogs.value || notGrowingDialogOpen) return
+      notGrowingDialogOpen = true
+      showDialog({ ...notGrowingDialogConfig, message })
     }
 
     // On Electron, we can get the size of the video output file in real time
@@ -698,10 +712,7 @@ export const useVideoStore = defineStore('video', () => {
         }
         const lastKnownFileSize = unprocessedVideos.value[recordingHash].lastKnownFileSize
         if (fileStats.size! <= lastKnownFileSize!) {
-          if (!suppressNotGrowingDialogs.value) {
-            const msg = 'The video output file is not growing. This can indicate a problem with the recording.'
-            showDialog({ ...notGrowingDialogConfig, message: msg })
-          }
+          showNotGrowingDialog('The video output file is not growing. This can indicate a problem with the recording.')
           return
         }
         unprocessedVideos.value[recordingHash].lastKnownFileSize = fileStats.size
@@ -722,10 +733,9 @@ export const useVideoStore = defineStore('video', () => {
         const numberOfChunks = await tempVideoStorage.localForage.length()
         const lastKnownNumberOfChunks = unprocessedVideos.value[recordingHash].lastKnownNumberOfChunks
         if (numberOfChunks <= lastKnownNumberOfChunks!) {
-          if (!suppressNotGrowingDialogs.value) {
-            const msg = 'The number of video chunks is not growing. This can indicate a problem with the recording.'
-            showDialog({ ...notGrowingDialogConfig, message: msg })
-          }
+          showNotGrowingDialog(
+            'The number of video chunks is not growing. This can indicate a problem with the recording.'
+          )
           return
         }
         unprocessedVideos.value[recordingHash].lastKnownNumberOfChunks = numberOfChunks


### PR DESCRIPTION
## Summary

A user reported that the "Video file not growing" popup spawned infinitely while recording, "Don't show again" did nothing, and eventually nothing on screen was clickable — the only way out was killing Cockpit from the task manager.

Two compounding bugs caused this:

- **`src/composables/interactionDialog.ts`** — `mountDialog()` created a brand-new Vue app on a new DOM node on every `showDialog` call, overwriting the single `dialogApp` reference. Earlier dialogs were left mounted forever, so any timed caller (like the recording health monitor) stacked dialogs that could never be dismissed and blocked the whole screen. `closeDialog()` / "Don't show again" only ever unmounted the latest one.
- **`src/stores/video.ts`** — the 15s recording health monitor called `showDialog` on every tick with no guard, so the "video file not growing" / "chunks not growing" dialog re-opened indefinitely (violating the AGENTS.md rule about re-opening dialogs in timed loops).

## Changes

- Interaction dialog now unmounts the previous instance (and removes its mount point) before mounting a new one, so at most one dialog exists at a time and it stays dismissible. This protects every caller, not just the video monitor.
- The not-growing dialog is wrapped in a `showNotGrowingDialog()` helper guarded by an open-state flag, so it shows once at a time and resets when closed instead of spamming every 15s.

## Test plan

- [ ] On master, start a recording and force the output file to stop growing (easiest way to do that is changing `fileStats.size!` to `0` on `src/stores/video.ts`).
- [ ] Wait 30s, so two dialogs appear, one on top of the other.
- [ ] Click the "dismiss" button. The last dialog will close, but the first one will still be there.
- [ ] Try to click the "dismiss" button in the second dialog as well. It won't close. You're now stuck because you can't close Cockpit since it will present the "a record is happening" dialog on close.
- [ ] Kill Cockpit with your activity monitor/task manager.
- [ ] Try the same in this branch. Only one dialog will appear and it will close without problems.

Fixes #2797.
