### PR TITLE
Mission Planning: Add free map placement to mission library items

### DIFF
--- a/src/components/mission-planning/ContextMenu.vue
+++ b/src/components/mission-planning/ContextMenu.vue
@@ -132,7 +132,7 @@
         class="flex flex-col rounded-md"
         :style="[interfaceStore.globalGlassMenuStyles, { background: '#333333EE', border: '1px solid #FFFFFF44' }]"
       >
-        <v-list-item v-if="!isCreatingSurvey" class="flex items-center gap-x-2 pb-2" @click="handleAddWaypointAtCursor">
+        <v-list-item v-if="!isCreatingSurvey" class="flex items-center gap-x-2 pb-2" @click="handleAddHereClick">
           <v-icon
             variant="text"
             icon="mdi-plus-circle-outline"
@@ -141,7 +141,9 @@
             color="white"
             class="text-[18px]"
           ></v-icon>
-          <span class="text-white text-sm ml-4">Add waypoint here</span>
+          <span class="text-white text-sm ml-4">{{
+            nearestSegmentIndex !== null ? 'Add element here' : 'Add waypoint here'
+          }}</span>
         </v-list-item>
         <v-divider />
         <v-list-item class="flex items-center gap-x-2 pb-2" @click="handleToggleSurvey">
@@ -433,12 +435,14 @@ const props = defineProps<{
   selectedWaypoint: Waypoint | undefined
   menuType: ContextMenuTypes
   canSaveCurrent: boolean
+  nearestSegmentIndex: number | null
 }>()
 /* eslint-enable jsdoc/require-jsdoc */
 
 const emit = defineEmits<{
   (event: 'close'): void
   (event: 'add-waypoint-at-cursor'): void
+  (event: 'open-segment-radial-menu', segmentIndex: number): void
   (event: 'toggleSurvey'): void
   (event: 'toggleSimplePath'): void
   (event: 'deleteSelectedSurvey'): void
@@ -511,8 +515,12 @@ const surveyCreationButtonText = computed(() => {
   return 'Add survey'
 })
 
-const handleAddWaypointAtCursor = (): void => {
-  emit('add-waypoint-at-cursor')
+const handleAddHereClick = (): void => {
+  if (props.nearestSegmentIndex !== null) {
+    emit('open-segment-radial-menu', props.nearestSegmentIndex)
+  } else {
+    emit('add-waypoint-at-cursor')
+  }
   emit('close')
 }
 

--- a/src/components/mission-planning/ContextMenu.vue
+++ b/src/components/mission-planning/ContextMenu.vue
@@ -168,6 +168,59 @@
           <span class="text-white text-sm ml-4">{{ pathCreationButtonText }}</span>
         </v-list-item>
         <v-divider />
+        <v-menu open-on-hover location="end" :close-on-content-click="false" :open-delay="50" :close-delay="120">
+          <template #activator="{ props: libraryActivator }">
+            <v-list-item v-bind="libraryActivator" class="flex items-center gap-x-2 pb-2 cursor-pointer">
+              <v-icon
+                variant="text"
+                icon="mdi-bookshelf"
+                rounded="full"
+                size="x-small"
+                color="white"
+                class="text-[16px]"
+              ></v-icon>
+              <span class="text-white text-sm ml-4">Mission library</span>
+              <template #append>
+                <v-icon color="white" class="absolute right-1 text-[21px] self-center -mb-[2px]"
+                  >mdi-chevron-right</v-icon
+                >
+              </template>
+            </v-list-item>
+          </template>
+          <div
+            class="flex flex-col rounded-md ml-1"
+            :style="[interfaceStore.globalGlassMenuStyles, { background: '#333333EE', border: '1px solid #FFFFFF44' }]"
+          >
+            <v-list-item class="flex items-center gap-x-2 pb-2" @click="handleAddMissionFromLibrary">
+              <v-icon
+                variant="text"
+                icon="mdi-map-plus"
+                rounded="full"
+                size="x-small"
+                color="white"
+                class="text-[16px]"
+              ></v-icon>
+              <span class="text-white text-sm ml-4">Add mission from library</span>
+            </v-list-item>
+            <v-divider />
+            <v-list-item
+              class="flex items-center gap-x-2 pb-2"
+              :disabled="!canSaveCurrent"
+              @click="handleSaveMissionToLibrary"
+            >
+              <v-icon
+                variant="text"
+                icon="mdi-content-save-plus"
+                rounded="full"
+                size="x-small"
+                color="white"
+                class="text-[16px]"
+              ></v-icon>
+              <span class="text-white text-sm ml-4">Save mission to library</span>
+            </v-list-item>
+          </div>
+        </v-menu>
+        <v-divider />
         <v-list-item class="flex items-center gap-x-2 pb-2" @click="handlePlacePointOfInterest">
           <v-icon
             variant="text"
@@ -379,6 +432,7 @@ const props = defineProps<{
   enableUndo: boolean
   selectedWaypoint: Waypoint | undefined
   menuType: ContextMenuTypes
+  canSaveCurrent: boolean
 }>()
 /* eslint-enable jsdoc/require-jsdoc */
 
@@ -402,6 +456,8 @@ const emit = defineEmits<{
   (event: 'configureBaseStation'): void
   (event: 'removeBaseStation'): void
   (event: 'toggleBaseStationSignalVisibility'): void
+  (event: 'addMissionFromLibrary'): void
+  (event: 'saveMissionToLibrary'): void
 }>()
 
 const menuType = computed(() => props.menuType)
@@ -541,6 +597,17 @@ const handleToggleBaseStationSignalVisibility = (): void => {
 
 const handleRemoveBaseStation = (): void => {
   emit('removeBaseStation')
+  emit('close')
+}
+
+const handleAddMissionFromLibrary = (): void => {
+  emit('addMissionFromLibrary')
+  emit('close')
+}
+
+const handleSaveMissionToLibrary = (): void => {
+  if (!props.canSaveCurrent) return
+  emit('saveMissionToLibrary')
   emit('close')
 }
 

--- a/src/components/mission-planning/MissionPlacementToolbar.vue
+++ b/src/components/mission-planning/MissionPlacementToolbar.vue
@@ -1,0 +1,183 @@
+<template>
+  <v-tooltip location="top" text="Place mission here">
+    <template #activator="{ props: tooltipProps }">
+      <button
+        v-bind="tooltipProps"
+        type="button"
+        aria-label="Place mission here"
+        :style="positionStyle"
+        class="absolute text-[22px] -ml-[10px] -mt-[10px] bg-transparent rounded-full cursor-pointer elevation-4 z-[650]"
+        @click="emit('confirm')"
+      >
+        <v-icon color="green" class="border-2 rounded-full bg-white">mdi-check-circle</v-icon>
+      </button>
+    </template>
+  </v-tooltip>
+  <v-tooltip location="top" text="Width scale (%) — drag corners to resize, hold Shift for uniform">
+    <template #activator="{ props: tooltipProps }">
+      <div
+        v-bind="tooltipProps"
+        :style="positionStyle"
+        class="absolute mt-[46px] ml-[10px] rounded-lg elevation-4 z-[650] flex items-center bg-[#333333EE] pr-1"
+      >
+        <v-icon color="white" size="14" class="ml-1">mdi-arrow-expand-horizontal</v-icon>
+        <input
+          v-model.number="scaleXModel"
+          class="rounded-lg bg-transparent text-white w-12 pl-1 pa-0"
+          type="number"
+          aria-label="Width scale percent"
+          :min="limits.scaleMinPercent"
+          :max="limits.scaleMaxPercent"
+          step="5"
+          @blur="emit('clamp-scale-x')"
+          @change="emit('clamp-scale-x')"
+        />
+      </div>
+    </template>
+  </v-tooltip>
+  <v-tooltip location="top" text="Height scale (%) — drag corners to resize, hold Shift for uniform">
+    <template #activator="{ props: tooltipProps }">
+      <div
+        v-bind="tooltipProps"
+        :style="positionStyle"
+        class="absolute mt-[76px] ml-[10px] rounded-lg elevation-4 z-[650] flex items-center bg-[#333333EE] pr-1"
+      >
+        <v-icon color="white" size="14" class="ml-1">mdi-arrow-expand-vertical</v-icon>
+        <input
+          v-model.number="scaleYModel"
+          class="rounded-lg bg-transparent text-white w-12 pl-1 pa-0"
+          type="number"
+          aria-label="Height scale percent"
+          :min="limits.scaleMinPercent"
+          :max="limits.scaleMaxPercent"
+          step="5"
+          @blur="emit('clamp-scale-y')"
+          @change="emit('clamp-scale-y')"
+        />
+      </div>
+    </template>
+  </v-tooltip>
+  <v-tooltip location="top" text="Rotation (°)">
+    <template #activator="{ props: tooltipProps }">
+      <div
+        v-bind="tooltipProps"
+        :style="positionStyle"
+        class="absolute mt-[106px] ml-[10px] rounded-lg elevation-4 z-[650] flex items-center bg-[#333333EE] pr-1"
+      >
+        <v-icon color="white" size="14" class="ml-1">mdi-rotate-right</v-icon>
+        <input
+          v-model.number="rotationModel"
+          class="rounded-lg bg-transparent text-white w-12 pl-1 pa-0"
+          type="number"
+          aria-label="Rotation degrees"
+          :min="limits.rotationMinDeg"
+          :max="limits.rotationMaxDeg"
+          step="5"
+          @blur="emit('clamp-rotation')"
+          @change="emit('clamp-rotation')"
+        />
+      </div>
+    </template>
+  </v-tooltip>
+  <v-tooltip location="top" text="Reset scale & rotation">
+    <template #activator="{ props: tooltipProps }">
+      <button
+        v-bind="tooltipProps"
+        type="button"
+        aria-label="Reset scale and rotation"
+        :style="positionStyle"
+        class="absolute mt-[136px] ml-[56px] flex items-center justify-center w-6 h-6 rounded-full cursor-pointer elevation-4 z-[650] bg-[#333333EE]"
+        @click="emit('reset')"
+      >
+        <v-icon color="white" size="16">mdi-restore</v-icon>
+      </button>
+    </template>
+  </v-tooltip>
+  <v-tooltip location="top" text="Cancel placement">
+    <template #activator="{ props: tooltipProps }">
+      <button
+        v-bind="tooltipProps"
+        type="button"
+        aria-label="Cancel placement"
+        :style="positionStyle"
+        class="absolute text-[14px] -mt-[5px] ml-[52px] bg-transparent rounded-full cursor-pointer elevation-4 z-[650]"
+        @click="emit('cancel')"
+      >
+        <div color="white" class="border-2 rounded-full bg-red text-[18px] flex items-center justify-center w-7 h-7">
+          <v-icon size="16" color="white">mdi-delete</v-icon>
+        </div>
+      </button>
+    </template>
+  </v-tooltip>
+</template>
+
+<script lang="ts">
+import type { ScreenPanelFootprint } from '@/libs/map/screen-placement'
+
+/**
+ * Extents of this toolbar's controls around the anchor point `positionStyle` sets, so whoever
+ * positions it does not have to re-derive them from the margins below.
+ */
+export const PLACEMENT_TOOLBAR_FOOTPRINT: ScreenPanelFootprint = {
+  anchorLeftPx: 100,
+  anchorRightPx: 60,
+  anchorTopPx: 10,
+  anchorBottomPx: 215,
+  gapPx: 20,
+  marginPx: 8,
+}
+</script>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import type { PLACEMENT_LIMITS } from '@/libs/mission/library'
+
+const props = defineProps<{
+  /**
+   * Absolute-position style (left/top or display:none) applied to every toolbar control.
+   */
+  positionStyle: Record<string, string>
+  /**
+   * Current width-scale percentage bound to the width input.
+   */
+  scaleXPercent: number
+  /**
+   * Current height-scale percentage bound to the height input.
+   */
+  scaleYPercent: number
+  /**
+   * Current rotation in degrees bound to the rotation input.
+   */
+  rotationDeg: number
+  /**
+   * Min/max bounds for the scale and rotation inputs.
+   */
+  limits: typeof PLACEMENT_LIMITS
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:scaleXPercent', value: number): void
+  (e: 'update:scaleYPercent', value: number): void
+  (e: 'update:rotationDeg', value: number): void
+  (e: 'clamp-scale-x'): void
+  (e: 'clamp-scale-y'): void
+  (e: 'clamp-rotation'): void
+  (e: 'confirm'): void
+  (e: 'reset'): void
+  (e: 'cancel'): void
+}>()
+
+const scaleXModel = computed({
+  get: () => props.scaleXPercent,
+  set: (value: number) => emit('update:scaleXPercent', value),
+})
+const scaleYModel = computed({
+  get: () => props.scaleYPercent,
+  set: (value: number) => emit('update:scaleYPercent', value),
+})
+const rotationModel = computed({
+  get: () => props.rotationDeg,
+  set: (value: number) => emit('update:rotationDeg', value),
+})
+</script>

--- a/src/composables/map/useMissionInsertion.ts
+++ b/src/composables/map/useMissionInsertion.ts
@@ -1,0 +1,192 @@
+import { v4 as uuid } from 'uuid'
+import { type Ref, ref } from 'vue'
+
+import { openSnackbar } from '@/composables/snackbar'
+import { useMissionStore } from '@/stores/mission'
+import type { CockpitMission, MissionCommand, Survey, Waypoint, WaypointCoordinates } from '@/types/mission'
+
+/**
+ * View-side hooks {@link useMissionInsertion} needs to render and load the merged mission. Kept as
+ * callbacks so the composable stays free of leaflet and of the host view's rendering internals.
+ */
+export type UseMissionInsertionOptions = {
+  /**
+   * Clones a waypoint's commands (falling back to the planner's default nav commands when empty).
+   */
+  cloneCommands: (commands?: MissionCommand[]) => MissionCommand[]
+  /**
+   * Draws a single waypoint marker on the host map.
+   */
+  addWaypointMarker: (waypoint: Waypoint) => void
+  /**
+   * Refreshes all waypoint markers (endpoint visuals, indices) after a batch change.
+   */
+  updateWaypointMarkers: () => void
+  /**
+   * Loads a mission as a fresh draft, optionally preserving the current map view.
+   */
+  loadDraftMission: (
+    mission: CockpitMission,
+    options?: {
+      /** Keep the host map's current center/zoom instead of restoring the saved-mission settings. */
+      preserveMapView?: boolean
+    }
+  ) => Promise<void>
+}
+
+/**
+ * How the mission handed to {@link useMissionInsertion}'s finalizer got its coordinates.
+ */
+export type FinalizeMissionPlacementOptions = {
+  /**
+   * True when the user just dragged the mission to a spot on the current map view, so a fresh load
+   * must keep that view instead of jumping to the coordinates the mission was saved at.
+   */
+  wasRepositioned?: boolean
+}
+
+/**
+ * Owns merging a chosen library mission into the current planning: append at the end, insert into a
+ * specific segment, or load fresh when the planning is empty. Undo snapshots, marker refreshes and
+ * user feedback are handled here so the host view only wires rendering callbacks and the confirm hook.
+ * @param {UseMissionInsertionOptions} options - View-side rendering and loading callbacks.
+ * @returns {object} The insert-segment intent ref and the placement finalizer.
+ */
+export const useMissionInsertion = (
+  options: UseMissionInsertionOptions
+): {
+  /**
+   * Segment index a placed mission should be spliced into, or null for append/fresh-load. Set by the
+   * host before placement so either placement outcome routes to the requested segment.
+   */
+  insertSegmentIndex: Ref<number | null>
+  /**
+   * Routes a placed mission to the right outcome: segment insert, append, or fresh load.
+   */
+  finalizeMissionPlacement: (mission: CockpitMission, options?: FinalizeMissionPlacementOptions) => void
+} => {
+  const missionStore = useMissionStore()
+
+  const insertSegmentIndex = ref<number | null>(null)
+
+  // Reuses the same fresh id for matching per-survey waypoint copies — survey edit mode relies
+  // on those ids matching the top-level waypoints, otherwise an orphan survey path is rendered.
+  // (A plain record is used because `Map` is shadowed by Leaflet's `L.Map` import in the host.)
+  const cloneMissionForPlanning = (
+    mission: CockpitMission
+  ): {
+    /**
+     * Top-level waypoints with fresh ids.
+     */
+    newWaypoints: Waypoint[]
+    /**
+     * Surveys with fresh ids; their internal waypoints reuse the top-level fresh ids.
+     */
+    newSurveys: Survey[]
+  } => {
+    const oldToNewWaypointId: Record<string, string> = {}
+    const newWaypoints: Waypoint[] = (mission.waypoints ?? []).map((wp) => {
+      const newId = uuid()
+      oldToNewWaypointId[wp.id] = newId
+      return {
+        id: newId,
+        coordinates: [wp.coordinates[0], wp.coordinates[1]],
+        altitude: wp.altitude,
+        altitudeReferenceType: wp.altitudeReferenceType,
+        commands: options.cloneCommands(wp.commands),
+      }
+    })
+    const newSurveys: Survey[] = (mission.surveys ?? []).map((survey) => ({
+      ...survey,
+      id: uuid(),
+      polygonCoordinates: survey.polygonCoordinates.map((c) => [c[0], c[1]] as WaypointCoordinates),
+      waypoints: survey.waypoints.map((wp) => ({
+        ...wp,
+        id: oldToNewWaypointId[wp.id] ?? uuid(),
+        coordinates: [wp.coordinates[0], wp.coordinates[1]],
+        commands: options.cloneCommands(wp.commands),
+      })),
+    }))
+    return { newWaypoints, newSurveys }
+  }
+
+  const appendMissionToPlanning = (mission: CockpitMission): void => {
+    if (!mission.waypoints?.length && !mission.surveys?.length) {
+      openSnackbar({ variant: 'error', message: 'Mission has nothing to add.', duration: 2500 })
+      return
+    }
+
+    missionStore.pushUndoSnapshot()
+
+    const { newWaypoints, newSurveys } = cloneMissionForPlanning(mission)
+
+    if (newWaypoints.length) {
+      missionStore.currentPlanningWaypoints.push(...newWaypoints)
+      newWaypoints.forEach((wp) => options.addWaypointMarker(wp))
+      options.updateWaypointMarkers()
+    }
+    newSurveys.forEach((survey) => missionStore.currentPlanningSurveys.push(survey))
+
+    openSnackbar({ variant: 'success', message: 'Mission added to current planning.', duration: 2000 })
+  }
+
+  // Splices the mission at `segmentIndex + 1` so it sits between waypoint `segmentIndex` and
+  // waypoint `segmentIndex + 1`. Use `-1` to insert at the very start of the planning.
+  // Appending after the last waypoint uses appendMissionToPlanning, so the upper bound is exclusive.
+  const insertMissionIntoSegment = (mission: CockpitMission, segmentIndex: number): void => {
+    const planning = missionStore.currentPlanningWaypoints
+    if (segmentIndex < -1 || segmentIndex >= planning.length - 1) {
+      openSnackbar({ variant: 'error', message: 'Cannot insert mission: invalid segment.', duration: 2500 })
+      return
+    }
+    if (!mission.waypoints?.length) {
+      openSnackbar({ variant: 'error', message: 'Mission has no waypoints to insert.', duration: 2500 })
+      return
+    }
+
+    missionStore.pushUndoSnapshot()
+
+    const { newWaypoints, newSurveys } = cloneMissionForPlanning(mission)
+
+    const spliceIndex = segmentIndex + 1
+    missionStore.currentPlanningWaypoints.splice(spliceIndex, 0, ...newWaypoints)
+    newWaypoints.forEach((wp) => options.addWaypointMarker(wp))
+    options.updateWaypointMarkers()
+
+    newSurveys.forEach((survey) => missionStore.currentPlanningSurveys.push(survey))
+
+    const message =
+      segmentIndex === -1
+        ? 'Mission inserted at the start of the planning.'
+        : `Mission inserted between waypoints ${segmentIndex + 1} and ${segmentIndex + 2}.`
+    openSnackbar({ variant: 'success', message, duration: 2500 })
+  }
+
+  // Routes a placed library mission to the right outcome: segment insert when triggered from a
+  // segment radial menu, append when the planner already has content, or fresh load when empty.
+  const finalizeMissionPlacement = (mission: CockpitMission, placement?: FinalizeMissionPlacementOptions): void => {
+    const segmentIndex = insertSegmentIndex.value
+    insertSegmentIndex.value = null
+    if (segmentIndex !== null) {
+      insertMissionIntoSegment(mission, segmentIndex)
+      return
+    }
+
+    const hasExistingPlanning =
+      missionStore.currentPlanningWaypoints.length > 0 || missionStore.currentPlanningSurveys.length > 0
+    if (hasExistingPlanning) {
+      appendMissionToPlanning(mission)
+    } else {
+      // A repositioned mission was just dropped on the visible map, so restoring the saved
+      // center/zoom would yank the camera away; one kept at its original location needs it.
+      options.loadDraftMission(mission, { preserveMapView: placement?.wasRepositioned === true }).catch((err) => {
+        openSnackbar({ variant: 'error', message: `Failed to load mission: ${err}`, duration: 3500 })
+      })
+    }
+  }
+
+  return {
+    insertSegmentIndex,
+    finalizeMissionPlacement,
+  }
+}

--- a/src/composables/map/useMissionPlacement.ts
+++ b/src/composables/map/useMissionPlacement.ts
@@ -1,0 +1,828 @@
+import L from 'leaflet'
+import { type Ref, type ShallowRef, onScopeDispose, ref, shallowRef, toRaw, watch } from 'vue'
+
+import { openSnackbar } from '@/composables/snackbar'
+import { type ScreenPanelFootprint, positionPanelNearBounds, screenBounds } from '@/libs/map/screen-placement'
+import {
+  type GeoAnchor,
+  type LocalMetersBounds,
+  type LocalMetersPoint,
+  computeMissionLocation,
+  computeOriginalLocalBounds,
+  METERS_PER_DEGREE_LAT,
+  PLACEMENT_LIMITS,
+  safeRotationRad,
+  safeScalePercent,
+  transformLocalMeters,
+  transformPlacementCoord,
+  unrotateToOriginalLocal,
+} from '@/libs/mission/library'
+import type { CockpitMission, WaypointCoordinates } from '@/types/mission'
+
+const PREVIEW = {
+  rotationHandleOffsetPx: 36,
+  boundsPaddingRatio: 0.08,
+} as const
+
+/**
+ * Every placed coordinate the preview draws, recomputed on each frame of a drag. The layer set it
+ * feeds is fixed for the whole placement session, so the layers are created once and then only
+ * have their geometry reassigned from this.
+ */
+type PreviewGeometry = {
+  /**
+   * Placed polygon rings, one per survey that has a polygon.
+   */
+  surveyPolygons: WaypointCoordinates[][]
+  /**
+   * Placed survey waypoints, flattened in survey order.
+   */
+  surveyWaypoints: WaypointCoordinates[]
+  /**
+   * Placed top-level waypoints, in route order.
+   */
+  waypoints: WaypointCoordinates[]
+  /**
+   * Bounding-box corners (NW, NE, SE, SW), or null when the mission has no measurable extent.
+   */
+  corners: WaypointCoordinates[] | null
+  /**
+   * Midpoint of the bounding box's rotated top edge, or null alongside {@link corners}.
+   */
+  topCenter: WaypointCoordinates | null
+  /**
+   * Position of the rotation handle, offset off {@link topCenter} in screen space.
+   */
+  rotationHandle: WaypointCoordinates | null
+}
+
+/**
+ * Leaflet layers backing the placement preview, held so each frame can reassign their geometry
+ * instead of removing and re-adding them.
+ */
+type PreviewLayers = {
+  /**
+   * One polygon per survey, matching {@link PreviewGeometry.surveyPolygons}.
+   */
+  surveyPolygons: L.Polygon[]
+  /**
+   * One marker per survey waypoint, matching {@link PreviewGeometry.surveyWaypoints}.
+   */
+  surveyWaypoints: L.CircleMarker[]
+  /**
+   * Dashed line through the top-level waypoints, absent for single-waypoint missions.
+   */
+  route: L.Polyline | null
+  /**
+   * One marker per top-level waypoint, matching {@link PreviewGeometry.waypoints}.
+   */
+  waypoints: L.CircleMarker[]
+  /**
+   * Draggable bounding box; also the source of {@link getPlacementBounds}.
+   */
+  boundsPolygon: L.Polygon | null
+  /**
+   * The four corner scale handles, matching {@link PreviewGeometry.corners}.
+   */
+  scaleHandles: L.Marker[]
+  /**
+   * Dashed line joining the rotation handle to the top edge.
+   */
+  rotationStem: L.Polyline | null
+  /**
+   * The rotation handle itself.
+   */
+  rotationHandle: L.Marker | null
+}
+
+// Corner order matches PreviewGeometry.corners: NW, NE, SE, SW.
+const CORNER_CURSORS = ['nwse-resize', 'nesw-resize', 'nwse-resize', 'nesw-resize'] as const
+
+/**
+ * Configuration for {@link useMissionPlacement}.
+ */
+export type UseMissionPlacementOptions = {
+  /**
+   * Invoked when the user confirms placement, with the mission already transformed into its
+   * placed coordinates. The composable resets its own state before calling the callback.
+   */
+  onConfirm: (placedMission: CockpitMission) => void
+  /**
+   * Extents of the host's placement toolbar, used to keep it beside the preview without covering
+   * it. Declared by the toolbar component itself, since its size comes from its own margins.
+   */
+  toolbarFootprint: ScreenPanelFootprint
+}
+
+type ScaleDragInitial = {
+  /**
+   * Corner the user grabbed, in the original mission local frame (east/north meters).
+   */
+  cornerLocal: LocalMetersPoint
+  /**
+   * Scale-X percentage at the moment the drag started.
+   */
+  initialScaleX: number
+  /**
+   * Scale-Y percentage at the moment the drag started.
+   */
+  initialScaleY: number
+}
+
+type RotationDragInitial = {
+  /**
+   * Rotation (degrees) at the moment the drag started.
+   */
+  initialRotation: number
+  /**
+   * Mouse angle (radians, clockwise from screen-north) at the moment the drag started.
+   */
+  initialAngleRad: number
+}
+
+/**
+ * Owns the interactive "free placement" mode for a saved mission on a leaflet map: drag to move,
+ * corner handles to scale, top handle to rotate, then confirm or cancel. The composable manages
+ * its own preview layers, mouse listeners, and animation-frame coalescing; the host view only
+ * provides the map ref, a confirm callback, and an optional click-suppression hook.
+ * @param {Ref<L.Map | null | undefined> | ShallowRef<L.Map | undefined>} mapRef - Reactive reference to the leaflet map the placement runs on.
+ * @param {UseMissionPlacementOptions} options - Confirm callback and view-side hooks.
+ * @returns {object} State refs and actions used by the host view's template and event wiring.
+ */
+export const useMissionPlacement = (
+  mapRef: Ref<L.Map | null | undefined> | ShallowRef<L.Map | undefined>,
+  options: UseMissionPlacementOptions
+): {
+  /**
+   * True while the user is interactively positioning a mission on the map.
+   */
+  isPlacingMission: Ref<boolean>
+  /**
+   * Reactive scale-X percentage bound to the toolbar input.
+   */
+  placementScaleXPercent: Ref<number>
+  /**
+   * Reactive scale-Y percentage bound to the toolbar input.
+   */
+  placementScaleYPercent: Ref<number>
+  /**
+   * Reactive rotation in degrees bound to the toolbar input.
+   */
+  placementRotationDeg: Ref<number>
+  /**
+   * Limits applied to the scale/rotation inputs; mirrors the lib export for template binding.
+   */
+  PLACEMENT_LIMITS: typeof PLACEMENT_LIMITS
+  /**
+   * Clamps {@link placementScaleXPercent} into the configured range.
+   */
+  clampPlacementScaleX: () => void
+  /**
+   * Clamps {@link placementScaleYPercent} into the configured range.
+   */
+  clampPlacementScaleY: () => void
+  /**
+   * Clamps {@link placementRotationDeg} into the configured range.
+   */
+  clampPlacementRotation: () => void
+  /**
+   * Resets scale and rotation inputs to their identity values.
+   */
+  resetPlacementTransform: () => void
+  /**
+   * Starts free placement for the given mission.
+   */
+  startFreePlacement: (mission: CockpitMission) => void
+  /**
+   * Tears down placement state and removes the preview layers.
+   */
+  cancelFreePlacement: () => void
+  /**
+   * Builds the placed mission, invokes the configured confirm callback, then cancels.
+   */
+  confirmFreePlacement: () => void
+  /**
+   * Absolute-position style for the host's placement toolbar, kept beside the live preview.
+   */
+  placementToolbarStyle: Ref<Record<string, string>>
+} => {
+  const isPlacingMission = ref(false)
+  const placementMission = ref<CockpitMission | null>(null)
+  const placementAnchorOriginal = ref<L.LatLng>(L.latLng(0, 0))
+  const placementAnchorCurrent = ref<L.LatLng>(L.latLng(0, 0))
+  const placementScaleXPercent = ref(100)
+  const placementScaleYPercent = ref(100)
+  const placementRotationDeg = ref(0)
+  // Captured once at the start of placement so the preview box rotates and scales with the
+  // mission instead of staying axis-aligned (in meters around `placementAnchorOriginal`).
+  const placementOriginalLocalBounds = ref<LocalMetersBounds | null>(null)
+  const placementToolbarStyle = ref<Record<string, string>>({ display: 'none' })
+  const previewLayers = shallowRef<PreviewLayers | null>(null)
+
+  let placementDragStartLatLng: L.LatLng | null = null
+  let placementRebuildRafHandle: number | null = null
+  let scaleDragInitial: ScaleDragInitial | null = null
+  let rotationDragInitial: RotationDragInitial | null = null
+
+  const originalAnchorAsGeo = (): GeoAnchor => ({
+    lat: placementAnchorOriginal.value.lat,
+    lng: placementAnchorOriginal.value.lng,
+  })
+  const currentAnchorAsGeo = (): GeoAnchor => ({
+    lat: placementAnchorCurrent.value.lat,
+    lng: placementAnchorCurrent.value.lng,
+  })
+  const transformCoord = (c: WaypointCoordinates): WaypointCoordinates =>
+    transformPlacementCoord(
+      c,
+      originalAnchorAsGeo(),
+      currentAnchorAsGeo(),
+      placementScaleXPercent.value,
+      placementScaleYPercent.value,
+      placementRotationDeg.value
+    )
+  const transformLocal = (east: number, north: number): WaypointCoordinates =>
+    transformLocalMeters(
+      east,
+      north,
+      currentAnchorAsGeo(),
+      placementScaleXPercent.value,
+      placementScaleYPercent.value,
+      placementRotationDeg.value
+    )
+
+  const clampPlacementScaleX = (): void => {
+    const raw = Number(placementScaleXPercent.value)
+    placementScaleXPercent.value = Number.isFinite(raw)
+      ? Math.max(PLACEMENT_LIMITS.scaleMinPercent, Math.min(PLACEMENT_LIMITS.scaleMaxPercent, raw))
+      : 100
+  }
+  const clampPlacementScaleY = (): void => {
+    const raw = Number(placementScaleYPercent.value)
+    placementScaleYPercent.value = Number.isFinite(raw)
+      ? Math.max(PLACEMENT_LIMITS.scaleMinPercent, Math.min(PLACEMENT_LIMITS.scaleMaxPercent, raw))
+      : 100
+  }
+  const clampPlacementRotation = (): void => {
+    const raw = Number(placementRotationDeg.value)
+    placementRotationDeg.value = Number.isFinite(raw)
+      ? Math.max(PLACEMENT_LIMITS.rotationMinDeg, Math.min(PLACEMENT_LIMITS.rotationMaxDeg, raw))
+      : 0
+  }
+
+  // Reuses the bounding polygon's lat/lng bounds (already kept in sync with the transform) to
+  // avoid re-projecting every coordinate on each map move/zoom.
+  const getPlacementBounds = (): L.LatLngBounds | null => {
+    const polygonBounds = previewLayers.value?.boundsPolygon?.getBounds()
+    if (polygonBounds) return polygonBounds
+    if (!placementMission.value) return null
+    const wpCoords = placementMission.value.waypoints.map((w) => transformCoord(w.coordinates))
+    const surveyCoords =
+      placementMission.value.surveys?.flatMap((s) => s.polygonCoordinates.map((c) => transformCoord(c))) ?? []
+    const allCoords = [...wpCoords, ...surveyCoords]
+    if (allCoords.length === 0) return null
+    return L.latLngBounds(allCoords.map((c) => L.latLng(c[0], c[1])))
+  }
+
+  const onPlacementMouseDown = (event: L.LeafletMouseEvent): void => {
+    if (!isPlacingMission.value) return
+    placementDragStartLatLng = event.latlng
+    mapRef.value?.dragging.disable()
+    mapRef.value?.on('mousemove', onPlacementMouseMove)
+    mapRef.value?.on('mouseup', onPlacementMouseUp)
+    L.DomEvent.stopPropagation(event.originalEvent)
+    L.DomEvent.preventDefault(event.originalEvent)
+  }
+
+  const onPlacementMouseMove = (event: L.LeafletMouseEvent): void => {
+    if (!placementDragStartLatLng) return
+    const dLat = event.latlng.lat - placementDragStartLatLng.lat
+    const dLng = event.latlng.lng - placementDragStartLatLng.lng
+    placementAnchorCurrent.value = L.latLng(
+      placementAnchorCurrent.value.lat + dLat,
+      placementAnchorCurrent.value.lng + dLng
+    )
+    placementDragStartLatLng = event.latlng
+    schedulePlacementPreviewRebuild()
+    L.DomEvent.stopPropagation(event.originalEvent)
+  }
+
+  const onPlacementMouseUp = (event: L.LeafletMouseEvent): void => {
+    placementDragStartLatLng = null
+    mapRef.value?.dragging.enable()
+    mapRef.value?.off('mousemove', onPlacementMouseMove)
+    mapRef.value?.off('mouseup', onPlacementMouseUp)
+    L.DomEvent.stopPropagation(event.originalEvent)
+    L.DomEvent.preventDefault(event.originalEvent)
+  }
+
+  const onScaleHandleMouseDown = (event: L.LeafletMouseEvent, cornerLocal: LocalMetersPoint): void => {
+    if (!isPlacingMission.value || !mapRef.value) return
+    scaleDragInitial = {
+      cornerLocal: { ...cornerLocal },
+      initialScaleX: placementScaleXPercent.value || 100,
+      initialScaleY: placementScaleYPercent.value || 100,
+    }
+    mapRef.value.dragging.disable()
+    mapRef.value.on('mousemove', onScaleHandleMouseMove)
+    mapRef.value.on('mouseup', onScaleHandleMouseUp)
+    L.DomEvent.stopPropagation(event.originalEvent)
+    L.DomEvent.preventDefault(event.originalEvent)
+  }
+
+  const onScaleHandleMouseMove = (event: L.LeafletMouseEvent): void => {
+    if (!scaleDragInitial || !mapRef.value) return
+    const target = placementAnchorCurrent.value
+    const metersPerDegLngTarget = METERS_PER_DEGREE_LAT * Math.cos((target.lat * Math.PI) / 180)
+
+    // Mouse position in the rotated current frame (meters relative to the current anchor).
+    const mouseEastRot = (event.latlng.lng - target.lng) * metersPerDegLngTarget
+    const mouseNorthRot = (event.latlng.lat - target.lat) * METERS_PER_DEGREE_LAT
+
+    // Express the mouse in the original mission local frame so it lines up with the captured corner.
+    const mouseLocal = unrotateToOriginalLocal(mouseEastRot, mouseNorthRot, placementRotationDeg.value)
+    const { cornerLocal, initialScaleX, initialScaleY } = scaleDragInitial
+    const isShift = (event.originalEvent as MouseEvent).shiftKey
+
+    if (isShift) {
+      // Proportional: project the mouse onto the line from the centroid through the captured corner;
+      // the projection length divided by the corner length gives the uniform scale factor.
+      const cornerLenSq = cornerLocal.east * cornerLocal.east + cornerLocal.north * cornerLocal.north
+      if (cornerLenSq < 1e-9) return
+      const projection = (mouseLocal.east * cornerLocal.east + mouseLocal.north * cornerLocal.north) / cornerLenSq
+      const newScale = Math.max(
+        PLACEMENT_LIMITS.scaleMinPercent,
+        Math.min(PLACEMENT_LIMITS.scaleMaxPercent, Math.round(projection * 100))
+      )
+      placementScaleXPercent.value = newScale
+      placementScaleYPercent.value = newScale
+    } else {
+      if (Math.abs(cornerLocal.east) > 1e-6) {
+        const newScaleX = (mouseLocal.east / cornerLocal.east) * 100
+        placementScaleXPercent.value = Math.max(
+          PLACEMENT_LIMITS.scaleMinPercent,
+          Math.min(PLACEMENT_LIMITS.scaleMaxPercent, Math.round(newScaleX))
+        )
+      } else {
+        placementScaleXPercent.value = initialScaleX
+      }
+      if (Math.abs(cornerLocal.north) > 1e-6) {
+        const newScaleY = (mouseLocal.north / cornerLocal.north) * 100
+        placementScaleYPercent.value = Math.max(
+          PLACEMENT_LIMITS.scaleMinPercent,
+          Math.min(PLACEMENT_LIMITS.scaleMaxPercent, Math.round(newScaleY))
+        )
+      } else {
+        placementScaleYPercent.value = initialScaleY
+      }
+    }
+    L.DomEvent.stopPropagation(event.originalEvent)
+  }
+
+  const onScaleHandleMouseUp = (event: L.LeafletMouseEvent): void => {
+    scaleDragInitial = null
+    mapRef.value?.dragging.enable()
+    mapRef.value?.off('mousemove', onScaleHandleMouseMove)
+    mapRef.value?.off('mouseup', onScaleHandleMouseUp)
+    L.DomEvent.stopPropagation(event.originalEvent)
+    L.DomEvent.preventDefault(event.originalEvent)
+  }
+
+  const onRotationHandleMouseDown = (event: L.LeafletMouseEvent): void => {
+    if (!isPlacingMission.value || !mapRef.value) return
+    const map = mapRef.value
+    const anchorPt = map.latLngToContainerPoint(placementAnchorCurrent.value)
+    const mousePt = map.latLngToContainerPoint(event.latlng)
+    const dx = mousePt.x - anchorPt.x
+    const dy = mousePt.y - anchorPt.y
+    // Angle clockwise from screen-north (negative y direction).
+    const initialAngleRad = Math.atan2(dx, -dy)
+    rotationDragInitial = { initialRotation: placementRotationDeg.value || 0, initialAngleRad }
+    map.dragging.disable()
+    map.on('mousemove', onRotationHandleMouseMove)
+    map.on('mouseup', onRotationHandleMouseUp)
+    L.DomEvent.stopPropagation(event.originalEvent)
+    L.DomEvent.preventDefault(event.originalEvent)
+  }
+
+  const onRotationHandleMouseMove = (event: L.LeafletMouseEvent): void => {
+    if (!rotationDragInitial || !mapRef.value) return
+    const map = mapRef.value
+    const anchorPt = map.latLngToContainerPoint(placementAnchorCurrent.value)
+    const mousePt = map.latLngToContainerPoint(event.latlng)
+    const dx = mousePt.x - anchorPt.x
+    const dy = mousePt.y - anchorPt.y
+    const currentAngleRad = Math.atan2(dx, -dy)
+    const deltaDeg = ((currentAngleRad - rotationDragInitial.initialAngleRad) * 180) / Math.PI
+    let newRotation = rotationDragInitial.initialRotation + deltaDeg
+    while (newRotation > 180) newRotation -= 360
+    while (newRotation <= -180) newRotation += 360
+    placementRotationDeg.value = Math.round(newRotation)
+    L.DomEvent.stopPropagation(event.originalEvent)
+  }
+
+  const onRotationHandleMouseUp = (event: L.LeafletMouseEvent): void => {
+    rotationDragInitial = null
+    mapRef.value?.dragging.enable()
+    mapRef.value?.off('mousemove', onRotationHandleMouseMove)
+    mapRef.value?.off('mouseup', onRotationHandleMouseUp)
+    L.DomEvent.stopPropagation(event.originalEvent)
+    L.DomEvent.preventDefault(event.originalEvent)
+  }
+
+  const clearPlacementLayers = (): void => {
+    const layers = previewLayers.value
+    if (!layers) return
+    layers.boundsPolygon?.off('mousedown', onPlacementMouseDown)
+    layers.rotationHandle?.off('mousedown', onRotationHandleMouseDown)
+    layers.scaleHandles.forEach((handle) => handle.off('mousedown'))
+    const all: (L.Layer | null)[] = [
+      ...layers.surveyPolygons,
+      ...layers.surveyWaypoints,
+      layers.route,
+      ...layers.waypoints,
+      layers.boundsPolygon,
+      ...layers.scaleHandles,
+      layers.rotationStem,
+      layers.rotationHandle,
+    ]
+    all.forEach((layer) => layer && mapRef.value?.removeLayer(layer))
+    previewLayers.value = null
+  }
+
+  // Coalesces rapid placement updates so the preview rebuilds at most once per animation frame.
+  const schedulePlacementPreviewRebuild = (): void => {
+    if (placementRebuildRafHandle !== null) return
+    placementRebuildRafHandle = requestAnimationFrame(() => {
+      placementRebuildRafHandle = null
+      rebuildPlacementPreview()
+    })
+  }
+
+  // Corners in the original local frame, ordered NW, NE, SE, SW. Constant for the whole placement
+  // session, so the scale handles can capture their corner once when they are created.
+  const cornersInOriginalLocalFrame = (): LocalMetersPoint[] | null => {
+    const localBounds = placementOriginalLocalBounds.value
+    if (!localBounds) return null
+    const padE = (localBounds.maxE - localBounds.minE) * PREVIEW.boundsPaddingRatio || 1
+    const padN = (localBounds.maxN - localBounds.minN) * PREVIEW.boundsPaddingRatio || 1
+    const minE = localBounds.minE - padE
+    const maxE = localBounds.maxE + padE
+    const minN = localBounds.minN - padN
+    const maxN = localBounds.maxN + padN
+    return [
+      { east: minE, north: maxN },
+      { east: maxE, north: maxN },
+      { east: maxE, north: minN },
+      { east: minE, north: minN },
+    ]
+  }
+
+  const computePreviewGeometry = (): PreviewGeometry | null => {
+    const map = mapRef.value
+    const mission = placementMission.value
+    if (!map || !mission) return null
+
+    const surveyPolygons: WaypointCoordinates[][] = []
+    const surveyWaypoints: WaypointCoordinates[] = []
+    mission.surveys?.forEach((survey) => {
+      if (!survey.polygonCoordinates?.length) return
+      surveyPolygons.push(survey.polygonCoordinates.map((c) => transformCoord(c)))
+      survey.waypoints.forEach((wp) => surveyWaypoints.push(transformCoord(wp.coordinates)))
+    })
+
+    const geometry: PreviewGeometry = {
+      surveyPolygons,
+      surveyWaypoints,
+      waypoints: mission.waypoints.map((w) => transformCoord(w.coordinates)),
+      corners: null,
+      topCenter: null,
+      rotationHandle: null,
+    }
+
+    const cornersLocal = cornersInOriginalLocalFrame()
+    if (!cornersLocal) return geometry
+
+    geometry.corners = cornersLocal.map((c) => transformLocal(c.east, c.north))
+
+    // Rotation handle: offset from the rotated top-edge centre along the mission's current "up"
+    // so it always sits perpendicular to the top edge.
+    const topCenterE = (cornersLocal[0].east + cornersLocal[1].east) / 2
+    const topCenter = transformLocal(topCenterE, cornersLocal[0].north)
+    const topCenterPt = map.latLngToContainerPoint(L.latLng(topCenter))
+    const theta = safeRotationRad(placementRotationDeg.value)
+    // Local "north" (0, +1) becomes (sin θ, -cos θ) in screen space.
+    const rotHandlePt = L.point(
+      topCenterPt.x + PREVIEW.rotationHandleOffsetPx * Math.sin(theta),
+      topCenterPt.y - PREVIEW.rotationHandleOffsetPx * Math.cos(theta)
+    )
+    const rotHandleLatLng = map.containerPointToLatLng(rotHandlePt)
+
+    geometry.topCenter = topCenter
+    geometry.rotationHandle = [rotHandleLatLng.lat, rotHandleLatLng.lng]
+    return geometry
+  }
+
+  const createPreviewLayers = (geometry: PreviewGeometry): void => {
+    const map = mapRef.value
+    if (!map) return
+
+    const layers: PreviewLayers = {
+      surveyPolygons: geometry.surveyPolygons.map((ring) =>
+        L.polygon(ring, {
+          color: '#FFD54F',
+          fillColor: '#FFD54F',
+          fillOpacity: 0.18,
+          weight: 2,
+          dashArray: '6 4',
+          interactive: false,
+        }).addTo(map)
+      ),
+      surveyWaypoints: geometry.surveyWaypoints.map((coord) =>
+        L.circleMarker(coord, {
+          radius: 3,
+          color: '#000000',
+          weight: 1,
+          fillColor: '#FFFFFF',
+          fillOpacity: 0.85,
+          interactive: false,
+        }).addTo(map)
+      ),
+      route:
+        geometry.waypoints.length > 1
+          ? L.polyline(geometry.waypoints, {
+              color: '#FFD54F',
+              weight: 3,
+              opacity: 0.9,
+              dashArray: '8 6',
+              interactive: false,
+            }).addTo(map)
+          : null,
+      waypoints: geometry.waypoints.map((coord, index) =>
+        L.circleMarker(coord, {
+          radius: 6,
+          color: '#000000',
+          weight: 1,
+          fillColor: index === 0 ? '#4CAF50' : index === geometry.waypoints.length - 1 ? '#F44336' : '#FFFFFF',
+          fillOpacity: 0.95,
+          interactive: false,
+        }).addTo(map)
+      ),
+      boundsPolygon: null,
+      scaleHandles: [],
+      rotationStem: null,
+      rotationHandle: null,
+    }
+
+    const cornersLocal = cornersInOriginalLocalFrame()
+    if (geometry.corners && geometry.topCenter && geometry.rotationHandle && cornersLocal) {
+      const boundsPolygon = L.polygon(geometry.corners, {
+        color: '#FFFFFF',
+        weight: 1,
+        opacity: 0.6,
+        fillOpacity: 0.04,
+        dashArray: '4 4',
+        interactive: true,
+        bubblingMouseEvents: false,
+      }).addTo(map)
+      boundsPolygon.on('mousedown', onPlacementMouseDown)
+      const polyEl = boundsPolygon.getElement() as SVGElement | null
+      if (polyEl) polyEl.style.cursor = 'grab'
+      layers.boundsPolygon = boundsPolygon
+
+      layers.scaleHandles = cornersLocal.map((cornerLocal, idx) => {
+        const handle = L.marker(geometry.corners![idx], {
+          icon: L.divIcon({
+            html:
+              `<div style="width: 12px; height: 12px; background: transparent; border: 2px solid #ffffff; ` +
+              `box-shadow: 0 0 4px rgba(0,0,0,0.7); cursor: ${CORNER_CURSORS[idx]};"></div>`,
+            className: '',
+            iconSize: [12, 12],
+            iconAnchor: [6, 6],
+          }),
+          interactive: true,
+          bubblingMouseEvents: false,
+          keyboard: false,
+        }).addTo(map)
+        handle.on('mousedown', (event: L.LeafletMouseEvent) => onScaleHandleMouseDown(event, cornerLocal))
+        return handle
+      })
+
+      layers.rotationStem = L.polyline([geometry.rotationHandle, geometry.topCenter], {
+        color: '#FFFFFF',
+        weight: 2,
+        opacity: 0.7,
+        dashArray: '2 4',
+        interactive: false,
+      }).addTo(map)
+
+      const rotationHandle = L.marker(geometry.rotationHandle, {
+        icon: L.divIcon({
+          html:
+            `<div style="width: 16px; height: 16px; background: transparent; border: 2px solid #ffffff; ` +
+            `border-radius: 50%; box-shadow: 0 0 4px rgba(0,0,0,0.7); cursor: grab;"></div>`,
+          className: '',
+          iconSize: [16, 16],
+          iconAnchor: [8, 8],
+        }),
+        interactive: true,
+        bubblingMouseEvents: false,
+        keyboard: false,
+      }).addTo(map)
+      rotationHandle.on('mousedown', onRotationHandleMouseDown)
+      layers.rotationHandle = rotationHandle
+    }
+
+    previewLayers.value = layers
+  }
+
+  const applyPreviewGeometry = (geometry: PreviewGeometry, layers: PreviewLayers): void => {
+    geometry.surveyPolygons.forEach((ring, idx) => layers.surveyPolygons[idx]?.setLatLngs(ring))
+    geometry.surveyWaypoints.forEach((coord, idx) => layers.surveyWaypoints[idx]?.setLatLng(coord))
+    layers.route?.setLatLngs(geometry.waypoints)
+    geometry.waypoints.forEach((coord, idx) => layers.waypoints[idx]?.setLatLng(coord))
+
+    if (!geometry.corners || !geometry.topCenter || !geometry.rotationHandle) return
+    layers.boundsPolygon?.setLatLngs(geometry.corners)
+    geometry.corners.forEach((coord, idx) => layers.scaleHandles[idx]?.setLatLng(coord))
+    layers.rotationStem?.setLatLngs([geometry.rotationHandle, geometry.topCenter])
+    layers.rotationHandle?.setLatLng(geometry.rotationHandle)
+  }
+
+  // Keeps the host's toolbar beside the preview without covering it.
+  const updateToolbarPosition = (): void => {
+    const map = mapRef.value
+    const bounds = isPlacingMission.value ? getPlacementBounds() : null
+    if (!map || !bounds) {
+      placementToolbarStyle.value = { display: 'none' }
+      return
+    }
+    const container = map.getContainer()
+    const ne = map.latLngToContainerPoint(bounds.getNorthEast())
+    const sw = map.latLngToContainerPoint(bounds.getSouthWest())
+    const pos = positionPanelNearBounds(
+      screenBounds([
+        { x: ne.x, y: ne.y },
+        { x: sw.x, y: sw.y },
+      ]),
+      options.toolbarFootprint,
+      container.clientWidth,
+      container.clientHeight
+    )
+    placementToolbarStyle.value = {
+      left: `${pos.x + options.toolbarFootprint.anchorLeftPx}px`,
+      top: `${pos.y + options.toolbarFootprint.anchorTopPx}px`,
+    }
+  }
+
+  // The layer set is fixed by the mission being placed, so only its geometry changes per frame.
+  const rebuildPlacementPreview = (): void => {
+    const geometry = computePreviewGeometry()
+    if (!geometry) return
+    const layers = previewLayers.value
+    if (layers) applyPreviewGeometry(geometry, layers)
+    else createPreviewLayers(geometry)
+    updateToolbarPosition()
+  }
+
+  const startFreePlacement = (mission: CockpitMission): void => {
+    if (!mapRef.value) return
+    cancelFreePlacement()
+    // Proxy-safe deep clone matching the `safeClone` pattern in default-profile-importer.ts:
+    // `toRaw` unwraps the Pinia-store reactivity wrappers so the JSON round-trip can't trip over them.
+    placementMission.value = JSON.parse(JSON.stringify(toRaw(mission))) as CockpitMission
+
+    // Anchor the centroid to the current map center so the preview lands inside the viewport.
+    const centroid = computeMissionLocation(placementMission.value)
+    placementAnchorOriginal.value = L.latLng(centroid[0], centroid[1])
+    placementAnchorCurrent.value = mapRef.value.getCenter()
+    placementScaleXPercent.value = 100
+    placementScaleYPercent.value = 100
+    placementRotationDeg.value = 0
+    placementOriginalLocalBounds.value = computeOriginalLocalBounds(placementMission.value, originalAnchorAsGeo())
+
+    isPlacingMission.value = true
+    rebuildPlacementPreview()
+    openSnackbar({
+      variant: 'info',
+      message: 'Drag to reposition. Drag corners to scale (Shift = uniform), drag the top circle to rotate.',
+      duration: 4500,
+    })
+  }
+
+  const cancelFreePlacement = (): void => {
+    clearPlacementLayers()
+    isPlacingMission.value = false
+    placementMission.value = null
+    placementAnchorOriginal.value = L.latLng(0, 0)
+    placementAnchorCurrent.value = L.latLng(0, 0)
+    placementScaleXPercent.value = 100
+    placementScaleYPercent.value = 100
+    placementRotationDeg.value = 0
+    placementOriginalLocalBounds.value = null
+    placementToolbarStyle.value = { display: 'none' }
+    placementDragStartLatLng = null
+    scaleDragInitial = null
+    rotationDragInitial = null
+    if (placementRebuildRafHandle !== null) {
+      cancelAnimationFrame(placementRebuildRafHandle)
+      placementRebuildRafHandle = null
+    }
+    mapRef.value?.dragging.enable()
+    mapRef.value?.off('mousemove', onPlacementMouseMove)
+    mapRef.value?.off('mouseup', onPlacementMouseUp)
+    mapRef.value?.off('mousemove', onScaleHandleMouseMove)
+    mapRef.value?.off('mouseup', onScaleHandleMouseUp)
+    mapRef.value?.off('mousemove', onRotationHandleMouseMove)
+    mapRef.value?.off('mouseup', onRotationHandleMouseUp)
+  }
+
+  const resetPlacementTransform = (): void => {
+    placementScaleXPercent.value = 100
+    placementScaleYPercent.value = 100
+    placementRotationDeg.value = 0
+  }
+
+  const confirmFreePlacement = (): void => {
+    if (!placementMission.value) return
+    const scaleX = safeScalePercent(placementScaleXPercent.value)
+    const scaleY = safeScalePercent(placementScaleYPercent.value)
+    // Surveys store a single scan-line spacing/turnaround in meters; the geometric mean keeps
+    // the density close to the preview when the user picks non-uniform scale factors.
+    const surveyScalarFactor = Math.sqrt(scaleX * scaleY)
+    const rotRaw = placementRotationDeg.value
+    const rotationDeg = Number.isFinite(rotRaw) ? rotRaw : 0
+    const placedMission: CockpitMission = {
+      ...placementMission.value,
+      waypoints: placementMission.value.waypoints.map((wp) => ({
+        ...wp,
+        coordinates: transformCoord(wp.coordinates),
+      })),
+      surveys: placementMission.value.surveys?.map((survey) => ({
+        ...survey,
+        polygonCoordinates: survey.polygonCoordinates.map((c) => transformCoord(c)),
+        waypoints: survey.waypoints.map((wp) => ({
+          ...wp,
+          coordinates: transformCoord(wp.coordinates),
+        })),
+        distanceBetweenLines: survey.distanceBetweenLines * surveyScalarFactor,
+        turnaroundDistance: survey.turnaroundDistance * surveyScalarFactor,
+        surveyLinesAngle: (((survey.surveyLinesAngle + rotationDeg) % 360) + 360) % 360,
+      })),
+    }
+    cancelFreePlacement()
+    options.onConfirm(placedMission)
+  }
+
+  // Re-render the preview when the user types into the scale/rotation inputs.
+  watch([placementScaleXPercent, placementScaleYPercent, placementRotationDeg], () => {
+    if (isPlacingMission.value) schedulePlacementPreviewRebuild()
+  })
+
+  const onZoomEnd = (): void => {
+    if (isPlacingMission.value) rebuildPlacementPreview()
+  }
+
+  const onMapMove = (): void => {
+    if (isPlacingMission.value) updateToolbarPosition()
+  }
+
+  // Also rebuild the preview when the host map reaches a new zoom level so handle screen
+  // offsets recompute correctly. The host's template ref briefly holds the underlying DOM
+  // element before Leaflet replaces it with the L.Map instance, so guard every call.
+  const hookMap = (map: L.Map): void => {
+    map.on('zoomend', onZoomEnd)
+    map.on('drag zoom move', onMapMove)
+  }
+  const unhookMap = (map: L.Map): void => {
+    map.off('zoomend', onZoomEnd)
+    map.off('drag zoom move', onMapMove)
+  }
+
+  watch(mapRef, (map, prevMap) => {
+    if (prevMap instanceof L.Map) unhookMap(prevMap)
+    if (map instanceof L.Map) hookMap(map)
+  })
+  if (mapRef.value instanceof L.Map) hookMap(mapRef.value)
+
+  onScopeDispose(() => {
+    if (mapRef.value instanceof L.Map) unhookMap(mapRef.value)
+    cancelFreePlacement()
+  })
+
+  return {
+    isPlacingMission,
+    placementScaleXPercent,
+    placementScaleYPercent,
+    placementRotationDeg,
+    PLACEMENT_LIMITS,
+    clampPlacementScaleX,
+    clampPlacementScaleY,
+    clampPlacementRotation,
+    resetPlacementTransform,
+    startFreePlacement,
+    cancelFreePlacement,
+    confirmFreePlacement,
+    placementToolbarStyle,
+  }
+}

--- a/src/libs/map/screen-placement.ts
+++ b/src/libs/map/screen-placement.ts
@@ -1,0 +1,144 @@
+import type { Point2D } from '@/types/general'
+import type { ScreenBounds } from '@/types/user-interface'
+
+/**
+ * Screen-space extents of a floating panel, measured outward from the anchor point its CSS
+ * `left`/`top` is applied to. Panels built out of absolutely-positioned children (rather than one
+ * sized box) have no measurable width, so the caller declares it here.
+ */
+export type ScreenPanelFootprint = {
+  /**
+   * Pixels between the anchor point and the panel's left edge.
+   */
+  anchorLeftPx: number
+  /**
+   * Pixels between the anchor point and the panel's right edge.
+   */
+  anchorRightPx: number
+  /**
+   * Pixels between the anchor point and the panel's top edge.
+   */
+  anchorTopPx: number
+  /**
+   * Pixels between the anchor point and the panel's bottom edge.
+   */
+  anchorBottomPx: number
+  /**
+   * Gap kept between the panel and the target bounds.
+   */
+  gapPx: number
+  /**
+   * Minimum distance kept from the viewport edges.
+   */
+  marginPx: number
+}
+
+/**
+ * Computes a screen-space axis-aligned bounding box from an array of 2D points.
+ * @param {Point2D[]} pts - Screen-space points.
+ * @returns {ScreenBounds} The bounding box.
+ */
+export const screenBounds = (pts: Point2D[]): ScreenBounds => {
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+  for (const p of pts) {
+    if (p.x < minX) minX = p.x
+    if (p.y < minY) minY = p.y
+    if (p.x > maxX) maxX = p.x
+    if (p.y > maxY) maxY = p.y
+  }
+  return { minX, minY, maxX, maxY }
+}
+
+/**
+ * Picks the best candidate position by maximising viewport visibility and minimising
+ * overlap with a polygon bounding box, then clamps the result inside the viewport.
+ * @param {Point2D[]} candidates - Top-left positions to evaluate.
+ * @param {number} elW - Element width in pixels.
+ * @param {number} elH - Element height in pixels.
+ * @param {ScreenBounds} polyBounds - Polygon screen bounds.
+ * @param {number} vpW - Viewport width.
+ * @param {number} vpH - Viewport height.
+ * @param {number} margin - Minimum distance from viewport edge.
+ * @returns {Point2D} Clamped top-left position.
+ */
+export const pickBestPosition = (
+  candidates: Point2D[],
+  elW: number,
+  elH: number,
+  polyBounds: ScreenBounds,
+  vpW: number,
+  vpH: number,
+  margin: number
+): Point2D => {
+  const area = elW * elH
+  let best = candidates[0]
+  let bestScore = -Infinity
+
+  for (const c of candidates) {
+    const l = c.x
+    const r = c.x + elW
+    const t = c.y
+    const b = c.y + elH
+
+    const visW = Math.max(0, Math.min(r, vpW - margin) - Math.max(l, margin))
+    const visH = Math.max(0, Math.min(b, vpH - margin) - Math.max(t, margin))
+    const visibility = (visW * visH) / area
+
+    const oW = Math.max(0, Math.min(r, polyBounds.maxX) - Math.max(l, polyBounds.minX))
+    const oH = Math.max(0, Math.min(b, polyBounds.maxY) - Math.max(t, polyBounds.minY))
+    const overlapPenalty = (oW * oH) / area
+
+    const score = visibility - overlapPenalty * 0.5
+    if (score > bestScore) {
+      bestScore = score
+      best = c
+    }
+  }
+
+  return {
+    x: Math.max(margin, Math.min(best.x, vpW - elW - margin)),
+    y: Math.max(margin, Math.min(best.y, vpH - elH - margin)),
+  }
+}
+
+/**
+ * Places a floating panel beside a target's screen bounds, trying right, left, below and above in
+ * that order and clamping the winner into the viewport.
+ * @param {ScreenBounds} target - Screen bounds the panel should sit next to.
+ * @param {ScreenPanelFootprint} footprint - Extents of the panel around its anchor point.
+ * @param {number} viewportWidth - Width of the container the panel is clamped into.
+ * @param {number} viewportHeight - Height of the container the panel is clamped into.
+ * @param {number} rightCandidateExtraGapPx - Additional gap applied only to the right-hand candidate.
+ * @returns {Point2D} Top-left position for the panel, before its own anchor offsets are added.
+ */
+export const positionPanelNearBounds = (
+  target: ScreenBounds,
+  footprint: ScreenPanelFootprint,
+  viewportWidth: number,
+  viewportHeight: number,
+  rightCandidateExtraGapPx = 0
+): Point2D => {
+  const visualW = footprint.anchorLeftPx + footprint.anchorRightPx
+  const visualH = footprint.anchorTopPx + footprint.anchorBottomPx
+
+  const cx = (target.minX + target.maxX) / 2
+  const cy = (target.minY + target.maxY) / 2
+
+  return pickBestPosition(
+    [
+      { x: target.maxX + footprint.gapPx + rightCandidateExtraGapPx, y: cy - visualH / 2 },
+      { x: target.minX - footprint.gapPx - visualW, y: cy - visualH / 2 },
+      { x: cx - visualW / 2, y: target.maxY + footprint.gapPx },
+      { x: cx - visualW / 2, y: target.minY - footprint.gapPx - visualH },
+    ],
+    visualW,
+    visualH,
+    target,
+    viewportWidth,
+    viewportHeight,
+    footprint.marginPx
+  )
+}

--- a/src/libs/map/utils-map.ts
+++ b/src/libs/map/utils-map.ts
@@ -36,6 +36,34 @@ export const distanceInMeters = (from: WaypointCoordinates, to: WaypointCoordina
   L.latLng(from[0], from[1]).distanceTo(L.latLng(to[0], to[1]))
 
 /**
+ * A pointer position expressed both in a map container's pixel space and as a geographic coordinate.
+ */
+export type MapPointerPosition = {
+  /**
+   * Position relative to the map container's top-left corner, in pixels.
+   */
+  containerPoint: L.Point
+  /**
+   * Geographic coordinate under that position.
+   */
+  latlng: L.LatLng
+}
+
+/**
+ * Resolves a viewport-space (client) pixel position against a map, which is what a pointer position
+ * cached outside a leaflet mouse handler needs before it can be treated as a coordinate.
+ * @param {L.Map} map - Map whose container the client position is measured against.
+ * @param {number} clientX - Viewport-space horizontal position, in pixels.
+ * @param {number} clientY - Viewport-space vertical position, in pixels.
+ * @returns {MapPointerPosition} The position in container space and the coordinate under it.
+ */
+export const mapPointerPositionFromClient = (map: L.Map, clientX: number, clientY: number): MapPointerPosition => {
+  const rect = map.getContainer().getBoundingClientRect()
+  const containerPoint = L.point(clientX - rect.left, clientY - rect.top)
+  return { containerPoint, latlng: map.containerPointToLatLng(containerPoint) }
+}
+
+/**
  * Enum for the different types of targets that can be followed.
  * @enum {string}
  */

--- a/src/libs/mission/library.ts
+++ b/src/libs/mission/library.ts
@@ -176,6 +176,207 @@ export const computeMissionLocation = (mission: CockpitMission): WaypointCoordin
 }
 
 /**
+ * Limits applied to the placement transform inputs (scale and rotation).
+ * Shared between the composable that owns the state and the template that binds the inputs.
+ */
+export const PLACEMENT_LIMITS = {
+  /**
+   * Minimum allowed scale percentage (per axis).
+   */
+  scaleMinPercent: 10,
+  /**
+   * Maximum allowed scale percentage (per axis).
+   */
+  scaleMaxPercent: 2000,
+  /**
+   * Minimum allowed rotation in degrees.
+   */
+  rotationMinDeg: -180,
+  /**
+   * Maximum allowed rotation in degrees.
+   */
+  rotationMaxDeg: 180,
+} as const
+
+/**
+ * A 2D point in a local east/north meters frame anchored at some lat/lng origin.
+ */
+export type LocalMetersPoint = {
+  /**
+   * East offset in meters from the local-frame origin.
+   */
+  east: number
+  /**
+   * North offset in meters from the local-frame origin.
+   */
+  north: number
+}
+
+/**
+ * Axis-aligned bounding box in a local east/north meters frame.
+ */
+export type LocalMetersBounds = {
+  /**
+   * Minimum east offset (meters).
+   */
+  minE: number
+  /**
+   * Maximum east offset (meters).
+   */
+  maxE: number
+  /**
+   * Minimum north offset (meters).
+   */
+  minN: number
+  /**
+   * Maximum north offset (meters).
+   */
+  maxN: number
+}
+
+/**
+ * A geographic anchor as a plain `{ lat, lng }` pair so callers don't need a leaflet dependency.
+ */
+export type GeoAnchor = {
+  /**
+   * Latitude in degrees.
+   */
+  lat: number
+  /**
+   * Longitude in degrees.
+   */
+  lng: number
+}
+
+export const METERS_PER_DEGREE_LAT = 111320
+const metersPerDegreeLng = (lat: number): number => METERS_PER_DEGREE_LAT * Math.cos((lat * Math.PI) / 180)
+
+/**
+ * Sanitises a user-entered scale percentage, falling back to 1.0 when the input is invalid.
+ * @param {number} raw - Raw percentage value (e.g. 100 means no scaling).
+ * @returns {number} The corresponding multiplier as a positive finite number.
+ */
+export const safeScalePercent = (raw: number): number => (Number.isFinite(raw) && raw > 0 ? raw / 100 : 1)
+
+/**
+ * Sanitises a user-entered rotation in degrees and converts it to radians.
+ * @param {number} raw - Raw rotation in degrees.
+ * @returns {number} The rotation in radians, or 0 when the input is non-finite.
+ */
+export const safeRotationRad = (raw: number): number => ((Number.isFinite(raw) ? raw : 0) * Math.PI) / 180
+
+/**
+ * Maps a point in the original mission local frame to a geographic coordinate, applying the
+ * configured scale and rotation around `currentAnchor`.
+ * @param {number} east - East offset (meters) from the original anchor.
+ * @param {number} north - North offset (meters) from the original anchor.
+ * @param {GeoAnchor} currentAnchor - Lat/lng anchor where the transformed point is centred.
+ * @param {number} scaleXPercent - Scale-X percentage (100 = no scaling).
+ * @param {number} scaleYPercent - Scale-Y percentage (100 = no scaling).
+ * @param {number} rotationDeg - Clockwise rotation in degrees applied around the anchor.
+ * @returns {WaypointCoordinates} The transformed coordinate as `[lat, lng]`.
+ */
+export const transformLocalMeters = (
+  east: number,
+  north: number,
+  currentAnchor: GeoAnchor,
+  scaleXPercent: number,
+  scaleYPercent: number,
+  rotationDeg: number
+): WaypointCoordinates => {
+  const scaleX = safeScalePercent(scaleXPercent)
+  const scaleY = safeScalePercent(scaleYPercent)
+  const theta = safeRotationRad(rotationDeg)
+  const cos = Math.cos(theta)
+  const sin = Math.sin(theta)
+
+  const sx = east * scaleX
+  const sy = north * scaleY
+  // Clockwise rotation on screen (north = +y on map).
+  const rotatedEast = sx * cos + sy * sin
+  const rotatedNorth = -sx * sin + sy * cos
+
+  return [
+    currentAnchor.lat + rotatedNorth / METERS_PER_DEGREE_LAT,
+    currentAnchor.lng + rotatedEast / metersPerDegreeLng(currentAnchor.lat),
+  ]
+}
+
+/**
+ * Projects a geographic coordinate into the original mission local frame anchored at `origin`.
+ * @param {WaypointCoordinates} coord - Coordinate as `[lat, lng]`.
+ * @param {GeoAnchor} origin - Lat/lng origin of the local frame.
+ * @returns {LocalMetersPoint} The east/north offset in meters from the origin.
+ */
+const projectCoordToOriginalLocal = (coord: WaypointCoordinates, origin: GeoAnchor): LocalMetersPoint => ({
+  east: (coord[1] - origin.lng) * metersPerDegreeLng(origin.lat),
+  north: (coord[0] - origin.lat) * METERS_PER_DEGREE_LAT,
+})
+
+/**
+ * Applies the placement transform to an original mission coordinate, returning the placed coordinate.
+ * @param {WaypointCoordinates} coord - Original coordinate as `[lat, lng]`.
+ * @param {GeoAnchor} originalAnchor - Lat/lng origin of the mission's local frame.
+ * @param {GeoAnchor} currentAnchor - Lat/lng anchor where the placed mission is centred.
+ * @param {number} scaleXPercent - Scale-X percentage (100 = no scaling).
+ * @param {number} scaleYPercent - Scale-Y percentage (100 = no scaling).
+ * @param {number} rotationDeg - Clockwise rotation in degrees.
+ * @returns {WaypointCoordinates} The placed coordinate as `[lat, lng]`.
+ */
+export const transformPlacementCoord = (
+  coord: WaypointCoordinates,
+  originalAnchor: GeoAnchor,
+  currentAnchor: GeoAnchor,
+  scaleXPercent: number,
+  scaleYPercent: number,
+  rotationDeg: number
+): WaypointCoordinates => {
+  const local = projectCoordToOriginalLocal(coord, originalAnchor)
+  return transformLocalMeters(local.east, local.north, currentAnchor, scaleXPercent, scaleYPercent, rotationDeg)
+}
+
+/**
+ * Inverse of the rotation half of {@link transformLocalMeters}: takes a vector expressed in the
+ * rotated current frame back into the original local frame, where captured corner positions live.
+ * @param {number} eastRot - East offset (meters) in the rotated current frame.
+ * @param {number} northRot - North offset (meters) in the rotated current frame.
+ * @param {number} rotationDeg - Clockwise rotation in degrees that was applied to reach the current frame.
+ * @returns {LocalMetersPoint} The same vector expressed in the original local frame.
+ */
+export const unrotateToOriginalLocal = (eastRot: number, northRot: number, rotationDeg: number): LocalMetersPoint => {
+  const theta = safeRotationRad(rotationDeg)
+  const cos = Math.cos(theta)
+  const sin = Math.sin(theta)
+  return { east: eastRot * cos - northRot * sin, north: eastRot * sin + northRot * cos }
+}
+
+/**
+ * Computes the local-frame bounding box of a mission's waypoints and survey polygons.
+ * @param {CockpitMission} mission - The mission whose features should be bounded.
+ * @param {GeoAnchor} origin - Lat/lng origin of the local frame.
+ * @returns {LocalMetersBounds | null} The bounds, or null when the mission has no features.
+ */
+export const computeOriginalLocalBounds = (mission: CockpitMission, origin: GeoAnchor): LocalMetersBounds | null => {
+  const waypointCoords = (mission.waypoints ?? []).map((w) => w.coordinates)
+  const surveyCoords = (mission.surveys ?? []).flatMap((s) => s.polygonCoordinates ?? [])
+  if (waypointCoords.length === 0 && surveyCoords.length === 0) return null
+  let minE = Infinity
+  let maxE = -Infinity
+  let minN = Infinity
+  let maxN = -Infinity
+  const accumulate = (c: WaypointCoordinates): void => {
+    const { east, north } = projectCoordToOriginalLocal(c, origin)
+    if (east < minE) minE = east
+    if (east > maxE) maxE = east
+    if (north < minN) minN = north
+    if (north > maxN) maxN = north
+  }
+  for (const c of waypointCoords) accumulate(c)
+  for (const c of surveyCoords) accumulate(c)
+  return { minE, maxE, minN, maxN }
+}
+
+/**
  * Type guard for SavedMission.
  * @param {unknown} value - The value to check.
  * @returns {boolean} True if the value matches the SavedMission shape.

--- a/src/libs/mission/planning-endpoints.ts
+++ b/src/libs/mission/planning-endpoints.ts
@@ -1,0 +1,16 @@
+import { distanceInMeters } from '@/libs/map/utils-map'
+import type { Waypoint, WaypointCoordinates } from '@/types/mission'
+
+/**
+ * Decides which end of an existing planning a new element clicked at `coordinates` belongs to, so
+ * right-click additions attach to the nearest endpoint instead of always extending the route's end.
+ * @param {WaypointCoordinates} coordinates - Position the new element was requested at.
+ * @param {Waypoint[]} waypoints - Current planning waypoints, in route order.
+ * @returns {number | null} `0` to splice at the start of the planning, or `null` to append at the end.
+ */
+export const endpointSplicePosition = (coordinates: WaypointCoordinates, waypoints: Waypoint[]): number | null => {
+  if (waypoints.length < 2) return null
+  const first = waypoints[0].coordinates
+  const last = waypoints[waypoints.length - 1].coordinates
+  return distanceInMeters(coordinates, first) < distanceInMeters(coordinates, last) ? 0 : null
+}

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -734,6 +734,7 @@
     :enable-undo="enableUndoForCurrentSurvey"
     :selected-waypoint="selectedWaypoint"
     :menu-type="contextMenuType"
+    :can-save-current="canSaveCurrentMissionToLibrary"
     @set-home-position="setHomePositionFromContextMenu"
     @close="hideContextMenu"
     @delete-selected-survey="deleteSelectedSurvey"
@@ -753,6 +754,8 @@
     @configure-base-station="baseStationStore.configPanelOpen = true"
     @remove-base-station="confirmRemoveBaseStation(showDialog, closeDialog)"
     @toggle-base-station-signal-visibility="baseStationStore.toggleSignalVisibility()"
+    @add-mission-from-library="openMissionLibrary"
+    @save-mission-to-library="openMissionLibraryWithSaveDialog"
   />
   <MapOverlaysDialog v-model="overlaysDialogOpen" :loading-ids="overlayLoadingIds" />
   <Teleport to="#planningMap">
@@ -839,6 +842,7 @@
     :current-mission-snapshot="currentMissionSnapshot"
     :current-mission-estimates="currentMissionEstimatesSnapshot"
     :effective-vehicle-type="missionStore.effectiveVehicleType"
+    :open-save-on-mount="missionLibraryOpenSaveOnMount"
     @load-mission="handleLoadMissionFromLibrary"
   />
 </template>
@@ -2986,6 +2990,18 @@ const drawMissionOnTheMap = (waypoints: Waypoint[]): void => {
   updateWaypointMarkers()
 }
 
+// When true, the next mount of `MissionLibraryModal` opens its "Save current mission" dialog.
+const missionLibraryOpenSaveOnMount = ref(false)
+
+const canSaveCurrentMissionToLibrary = computed(
+  () => missionStore.currentPlanningWaypoints.length > 0 || missionStore.currentPlanningSurveys.length > 0
+)
+
+const openMissionLibraryWithSaveDialog = (): void => {
+  if (!canSaveCurrentMissionToLibrary.value) return
+  openMissionLibrary({ openSaveDialog: true })
+}
+
 // Merges a placed/loaded library mission into the current planning (append, segment-insert, or
 // fresh load). The insert-segment intent is carried on `placementInsertSegmentIndex` so both
 // placement outcomes ("Reposition" and "Keep original") route to the requested segment.
@@ -4093,13 +4109,18 @@ const openMissionLibrary = (
   options: {
     /** Segment index to splice the loaded mission into; omit for a normal placement. */
     segmentInsertIndex?: number | null
+    /** Open the library straight into the "save current mission" form. */
+    openSaveDialog?: boolean
   } = {}
 ): void => {
-  // Set the segment-insert intent in the same call that opens the library, so callers never have
-  // to poke `pendingSegmentInsertIndex` around the open; a plain toolbar open clears it.
+  // Set the segment-insert / save intent in the same call that opens the library, so callers never
+  // have to poke `pendingSegmentInsertIndex` around the open; a plain toolbar open clears it.
   pendingSegmentInsertIndex.value = options.segmentInsertIndex ?? null
+  missionLibraryOpenSaveOnMount.value = options.openSaveDialog ?? false
   logUserAction(
-    options.segmentInsertIndex != null
+    options.openSaveDialog
+      ? 'Opened the mission library to save the current mission'
+      : options.segmentInsertIndex != null
       ? 'Opened the mission library to insert a mission into a segment'
       : 'Opened the mission library'
   )

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -735,12 +735,13 @@
     :selected-waypoint="selectedWaypoint"
     :menu-type="contextMenuType"
     :can-save-current="canSaveCurrentMissionToLibrary"
+    :nearest-segment-index="contextMenuNearestSegmentIndex"
     @set-home-position="setHomePositionFromContextMenu"
     @close="hideContextMenu"
     @delete-selected-survey="deleteSelectedSurvey"
     @rotate-survey-entry-point="rotateSurveyEntryPoint"
-    @toggle-survey="toggleSurvey"
-    @toggle-simple-path="toggleSimplePath"
+    @toggle-survey="addSurveyFromContextMenu"
+    @toggle-simple-path="addSimplePathFromContextMenu"
     @undo-generated-waypoints="undoGenerateWaypoints"
     @regenerate-survey-waypoints="regenerateSurveyWaypoints"
     @toggle-crosshatch="toggleSurveyCrosshatch"
@@ -748,13 +749,14 @@
     @remove-waypoint="removeSelectedWaypoint"
     @place-point-of-interest="openPoiDialog"
     @add-waypoint-at-cursor="addWaypointFromContextMenu"
+    @open-segment-radial-menu="openSegmentRadialMenuFromContextMenu"
     @clear-vehicle-path-history="clearVehiclePathHistory"
     @open-map-overlays="overlaysDialogOpen = true"
     @place-base-station="placeBaseStationFromContextMenu"
     @configure-base-station="baseStationStore.configPanelOpen = true"
     @remove-base-station="confirmRemoveBaseStation(showDialog, closeDialog)"
     @toggle-base-station-signal-visibility="baseStationStore.toggleSignalVisibility()"
-    @add-mission-from-library="openMissionLibrary"
+    @add-mission-from-library="addMissionFromLibraryContextMenu"
     @save-mission-to-library="openMissionLibraryWithSaveDialog"
   />
   <MapOverlaysDialog v-model="overlaysDialogOpen" :loading-ids="overlayLoadingIds" />
@@ -910,6 +912,7 @@ import { applyLiveWaypointCoordinates } from '@/libs/map/survey-arrows'
 import {
   createGridOverlay,
   fitMapToWaypoints,
+  mapPointerPositionFromClient,
   persistLiveMapView,
   singleStepZoomMapOptions,
   TargetFollower,
@@ -924,6 +927,7 @@ import {
   polygonAreaSquareMeters,
 } from '@/libs/mission/general-estimates'
 import { PLANNABLE_VEHICLE_TYPES, vehicleTypeLabel } from '@/libs/mission/library'
+import { endpointSplicePosition } from '@/libs/mission/planning-endpoints'
 import { degrees, messageFromError, toPlain } from '@/libs/utils'
 import router from '@/router'
 import { SubMenuComponentName, SubMenuName, useAppInterfaceStore } from '@/stores/appInterface'
@@ -1186,6 +1190,7 @@ const waypointMarkers = shallowRef<{ [id: string]: Marker }>({})
 const isCreatingSimplePath = ref(false)
 const contextMenuVisible = ref(false)
 const contextMenuPosition = ref({ x: 0, y: 0 })
+const contextMenuNearestSegmentIndex = ref<number | null>(null)
 const currentCursorGeoCoordinates = ref<[number, number] | null>(null)
 const confirmButtonStyle = ref<Record<string, string>>({})
 const surveyPolygonVertexesPositions = ref<L.LatLng[]>([])
@@ -1308,8 +1313,12 @@ const clearLiveMeasure = (): void => {
 const currentMeasureAnchor = (): L.LatLng | null => {
   if (!planningMap.value) return null
   if (isCreatingSimplePath.value && missionStore.currentPlanningWaypoints.length > 0) {
-    const last = missionStore.currentPlanningWaypoints[missionStore.currentPlanningWaypoints.length - 1]
-    return L.latLng(last.coordinates[0], last.coordinates[1])
+    // Anchor at index 0 when the session was started near the start endpoint, so subsequent
+    // inserts extend the path outward from whichever waypoint sits at the start of the array.
+    const wps = missionStore.currentPlanningWaypoints
+    const anchor = pendingSimplePathInsertIndex.value !== null ? wps[0] : wps[wps.length - 1]
+    if (!anchor) return null
+    return L.latLng(anchor.coordinates[0], anchor.coordinates[1])
   }
   if (isCreatingSurvey.value && surveyPolygonVertexesPositions.value.length > 0) {
     const last = surveyPolygonVertexesPositions.value[surveyPolygonVertexesPositions.value.length - 1]
@@ -1391,10 +1400,13 @@ const isOverSurveyHandle = (evt: L.LeafletMouseEvent): boolean => {
   return !!el.closest('.custom-div-icon, .edge-marker, .delete-popup, .delete-button')
 }
 
-const handleMapMouseMove = (e: L.LeafletMouseEvent): void => {
+// `evt` is optional so callers triggered without a mousemove (e.g. right after a context-menu
+// action) can still draw the line; hover hit-testing (against survey handles or the last
+// waypoint) is skipped in that case.
+const renderMeasureOverlay = (cursorLatLng: L.LatLng, evt: L.LeafletMouseEvent | null): void => {
   if (!planningMap.value) return
 
-  lastMeasureCursor = e
+  if (evt) lastMeasureCursor = evt
 
   const anchor = currentMeasureAnchor()
   const draggingExistingNode = isDraggingMarker.value || isDraggingPolygon.value
@@ -1411,13 +1423,12 @@ const handleMapMouseMove = (e: L.LeafletMouseEvent): void => {
   const map = planningMap.value
   ensureMeasureOverlay(map)
 
-  // NEW: hide/show the live pill when hovering survey nodes/add/delete UI
   if (measureTextEl) {
-    measureTextEl.style.display = isOverSurveyHandle(e) ? 'none' : 'block'
+    measureTextEl.style.display = evt && isOverSurveyHandle(evt) ? 'none' : 'block'
   }
 
   const a = map.latLngToContainerPoint(anchor!)
-  const b = map.latLngToContainerPoint(e.latlng)
+  const b = map.latLngToContainerPoint(cursorLatLng)
 
   if (measureLineEl) {
     measureLineEl.setAttribute('x1', String(a.x))
@@ -1428,11 +1439,11 @@ const handleMapMouseMove = (e: L.LeafletMouseEvent): void => {
 
   const midX = (a.x + b.x) / 2
   const midY = (a.y + b.y) / 2
-  const dist = anchor!.distanceTo(e.latlng)
+  const dist = anchor!.distanceTo(cursorLatLng)
 
-  const hidePill = isOverSurveyHandle(e) || isOverLastWaypointMarker(e) || dist < 1 // hide if closer than 1 meter to last wp on the array
+  const hidePill = (evt && (isOverSurveyHandle(evt) || isOverLastWaypointMarker(evt))) || dist < 1 // hide if closer than 1 meter to last wp on the array
 
-  const bearing = bearingBetween([anchor!.lat, anchor!.lng], [e.latlng.lat, e.latlng.lng])
+  const bearing = bearingBetween([anchor!.lat, anchor!.lng], [cursorLatLng.lat, cursorLatLng.lng])
   const text = `${formatMetersShort(dist)} · ${formatBearing(bearing)}`
   if (measureTextEl) {
     measureTextEl.textContent = text
@@ -1446,7 +1457,7 @@ const handleMapMouseMove = (e: L.LeafletMouseEvent): void => {
     angleOverlay.renderVertexAngle(
       [prevAnchor.lat, prevAnchor.lng],
       [anchor!.lat, anchor!.lng],
-      [e.latlng.lat, e.latlng.lng]
+      [cursorLatLng.lat, cursorLatLng.lng]
     )
   } else {
     angleOverlay.clearVertexAngles()
@@ -1459,12 +1470,17 @@ const refreshLiveMeasureOnMapMove = (): void => {
   measureRefreshRafId = requestAnimationFrame(() => {
     measureRefreshRafId = null
     if (!planningMap.value || !lastMeasureCursor) return
-    const map = planningMap.value
-    const rect = map.getContainer().getBoundingClientRect()
-    const containerPoint = L.point(cursorLivePositionX.value - rect.left, cursorLivePositionY.value - rect.top)
-    const latlng = map.containerPointToLatLng(containerPoint)
+    const { containerPoint, latlng } = mapPointerPositionFromClient(
+      planningMap.value,
+      cursorLivePositionX.value,
+      cursorLivePositionY.value
+    )
     handleMapMouseMove({ ...lastMeasureCursor, latlng, containerPoint })
   })
+}
+
+const handleMapMouseMove = (e: L.LeafletMouseEvent): void => {
+  renderMeasureOverlay(e.latlng, e)
 }
 
 const saveEsri = (): void => {
@@ -1541,6 +1557,10 @@ const segmentRadialMenuItems: RadialMenuItem[] = [
 ]
 const segmentSurveyInsertIndex = ref<number | null>(null)
 const pendingSegmentInsertIndex = ref<number | null>(null)
+// Non-null when simple-path mode was started from the context menu near the start endpoint.
+// While set, every click inserts at this index (typically `0`) so the path extends outward from
+// the start. Reset to null when leaving simple-path mode.
+const pendingSimplePathInsertIndex = ref<number | null>(null)
 
 const isCtrlDown = ref(false)
 const isShiftDown = ref(false)
@@ -1938,6 +1958,20 @@ const showSegmentRadialMenu = (): void => {
   segmentRadialMenuVisible.value = true
 }
 
+const openSegmentRadialMenuFromContextMenu = (segmentIndex: number): void => {
+  const map = planningMap.value
+  const wps = missionStore.currentPlanningWaypoints
+  if (!map || segmentIndex < 0 || segmentIndex + 1 >= wps.length) return
+  logUserAction('Opened mission segment radial menu from the map context menu')
+  const a = wps[segmentIndex].coordinates
+  const b = wps[segmentIndex + 1].coordinates
+  const midpoint = L.latLng((a[0] + b[0]) / 2, (a[1] + b[1]) / 2)
+  const pt = map.latLngToContainerPoint(midpoint)
+  radialMenuSegmentIndex = segmentIndex
+  segmentRadialMenuPosition.value = { x: pt.x, y: pt.y }
+  segmentRadialMenuVisible.value = true
+}
+
 const dismissSegmentRadialMenu = (): void => {
   if (segmentRadialMenuVisible.value) {
     segmentRadialMenuVisible.value = false
@@ -2061,8 +2095,53 @@ const addWaypointFromClick = (latlng: L.LatLng): void => {
 
 const addWaypointFromContextMenu = (): void => {
   if (!currentCursorGeoCoordinates.value) return
-  const ll = L.latLng(currentCursorGeoCoordinates.value[0], currentCursorGeoCoordinates.value[1])
-  addWaypointFromClick(ll)
+  logUserAction('Added a waypoint from the map context menu')
+  const coordinates = currentCursorGeoCoordinates.value
+
+  const insertIndex = endpointSplicePosition(coordinates, missionStore.currentPlanningWaypoints) ?? undefined
+  addWaypoint(coordinates, currentWaypointAltitude.value, currentWaypointAltitudeRefType.value, undefined, insertIndex)
+  updateWaypointMarkers()
+}
+
+const getContextMenuEndpointSplicePosition = (): number | null =>
+  currentCursorGeoCoordinates.value
+    ? endpointSplicePosition(currentCursorGeoCoordinates.value, missionStore.currentPlanningWaypoints)
+    : null
+
+const addSimplePathFromContextMenu = (): void => {
+  // The same menu entry closes the tool while it is active, and toggleSimplePath logs that.
+  if (!isCreatingSimplePath.value) {
+    logUserAction('Started a simple path from the map context menu')
+    const insertIndex = getContextMenuEndpointSplicePosition()
+    if (insertIndex !== null) pendingSimplePathInsertIndex.value = insertIndex
+  }
+  toggleSimplePath()
+  // Draw the live measure line right away using the live cursor position (not the menu-open
+  // coords), so it has visible length even when the menu was opened next to the anchor waypoint.
+  if (isCreatingSimplePath.value && planningMap.value) {
+    const { latlng } = mapPointerPositionFromClient(
+      planningMap.value,
+      cursorLivePositionX.value,
+      cursorLivePositionY.value
+    )
+    nextTick(() => renderMeasureOverlay(latlng, null))
+  }
+}
+
+const addSurveyFromContextMenu = (): void => {
+  if (!isCreatingSurvey.value) {
+    logUserAction('Started a survey from the map context menu')
+    const insertIndex = getContextMenuEndpointSplicePosition()
+    if (insertIndex !== null) segmentSurveyInsertIndex.value = insertIndex
+  }
+  toggleSurvey()
+}
+
+const addMissionFromLibraryContextMenu = (): void => {
+  // Prepend (segment -1) when the click sits closer to the mission's start endpoint; otherwise let
+  // the placement flow append. The intent is passed in the same call that opens the library.
+  const insertIndex = getContextMenuEndpointSplicePosition()
+  openMissionLibrary({ segmentInsertIndex: insertIndex === 0 ? -1 : undefined })
 }
 
 const makeAreaMarker = (at: L.LatLng, text: string): L.Marker => {
@@ -2203,6 +2282,15 @@ const showContextMenu = (event: L.LeafletMouseEvent): void => {
   cursorCoordinates.value = [event.latlng.lat, event.latlng.lng]
   event.originalEvent.preventDefault()
 
+  contextMenuNearestSegmentIndex.value = null
+  if (contextMenuType.value === 'map' && missionStore.currentPlanningWaypoints.length >= 2) {
+    const latlngs = missionStore.currentPlanningWaypoints.map((w) => L.latLng(w.coordinates[0], w.coordinates[1]))
+    const { segmentIndex, distanceInPixels } = getClosestMissionPathSegmentInfo(latlngs, event.latlng)
+    if (segmentIndex >= 0 && distanceInPixels <= nearMissionPathTolerance) {
+      contextMenuNearestSegmentIndex.value = segmentIndex
+    }
+  }
+
   let x = event.originalEvent.clientX
   let y = event.originalEvent.clientY
 
@@ -2255,6 +2343,7 @@ const showContextMenu = (event: L.LeafletMouseEvent): void => {
 
 const hideContextMenu = (): void => {
   contextMenuVisible.value = false
+  contextMenuNearestSegmentIndex.value = null
   selectedSurveyId.value = ''
 }
 
@@ -2305,6 +2394,7 @@ const toggleSimplePath = (): void => {
   if (isCreatingSimplePath.value) {
     logUserAction('Disabled mission simple-path tool')
     isCreatingSimplePath.value = false
+    pendingSimplePathInsertIndex.value = null
     return
   }
   logUserAction('Enabled mission simple-path tool')
@@ -2314,6 +2404,7 @@ const toggleSimplePath = (): void => {
 const toggleSurvey = (): void => {
   if (isCreatingSimplePath.value) {
     isCreatingSimplePath.value = false
+    pendingSimplePathInsertIndex.value = null
   }
   if (isCreatingSurvey.value) {
     logUserAction('Disabled mission survey tool')
@@ -2658,6 +2749,7 @@ const handleKeyDown = (event: KeyboardEvent): void => {
     }
     if (isCreatingSimplePath.value) {
       isCreatingSimplePath.value = false
+      pendingSimplePathInsertIndex.value = null
     }
   }
   if (event.key === 'Enter' && isCreatingSurvey.value) {
@@ -2865,7 +2957,8 @@ const addWaypoint = (
   coordinates: WaypointCoordinates,
   altitude: number,
   altitudeReferenceType: AltitudeReferenceType,
-  commands?: MissionCommand[]
+  commands?: MissionCommand[],
+  insertIndex?: number
 ): void => {
   if (planningMap.value === undefined) throw new Error('Map not yet defined')
 
@@ -2881,7 +2974,11 @@ const addWaypoint = (
   }
 
   logUserAction(`Added mission waypoint at ${coordinates[0].toFixed(6)}, ${coordinates[1].toFixed(6)}`)
-  missionStore.currentPlanningWaypoints.push(waypoint)
+  if (insertIndex !== undefined) {
+    missionStore.currentPlanningWaypoints.splice(insertIndex, 0, waypoint)
+  } else {
+    missionStore.currentPlanningWaypoints.push(waypoint)
+  }
 
   const newMarker = L.marker(coordinates, { draggable: true })
 
@@ -2911,7 +3008,12 @@ const addWaypoint = (
   const currentMarkerSize = getEffectiveMarkerSize(zoom.value)
   const iconDimensions = getIconDimensionsFromMarkerSize(currentMarkerSize)
   const markerIcon = L.divIcon({
-    html: createWaypointMarkerHtml(waypoint.commands.length, false, surveyEntryExitWaypointIds.value.has(waypoint.id)),
+    html: createWaypointMarkerHtml(
+      waypoint.commands.length,
+      false,
+      surveyEntryExitWaypointIds.value.has(waypoint.id),
+      isEndpointWaypoint(waypointId)
+    ),
     className: 'waypoint-marker-icon',
     iconSize: iconDimensions.iconSize,
     iconAnchor: iconDimensions.iconAnchor,
@@ -3586,21 +3688,33 @@ const generateWaypointsFromSurvey = (): void => {
 }
 
 // Helper function to create waypoint marker HTML with command count indicator
-const createWaypointMarkerHtml = (commandCount: number, isSelected = false, isEntryExit = false): string => {
+const createWaypointMarkerHtml = (
+  commandCount: number,
+  isSelected = false,
+  isEntryExit = false,
+  isEndpoint = false
+): string => {
   const baseClass = isSelected ? 'selected-marker' : 'marker-icon'
   const size = getEffectiveMarkerSize(zoom.value)
   const markerSizeClass = `wp-marker-${size}`
   const showSmallCommandCount = size !== 'md' && commandCount > 1
   const showCommandCount = size === 'md' && commandCount > 1
   const entryExitClass = isEntryExit ? ' green-marker' : ''
+  const endpointClass = isEndpoint ? ' endpoint-marker' : ''
 
   return `
     <div class="${markerSizeClass}">
-      <div class="${baseClass} waypoint-main-marker${entryExitClass}"></div>
+      <div class="${baseClass} waypoint-main-marker${entryExitClass}${endpointClass}"></div>
       ${showCommandCount ? `<div class="command-count-indicator">${commandCount}</div>` : ''}
       ${showSmallCommandCount ? `<div class="command-count-indicator small">${commandCount}</div>` : ''}
     </div>
   `
+}
+
+const isEndpointWaypoint = (waypointId: string): boolean => {
+  const wps = missionStore.currentPlanningWaypoints
+  if (wps.length === 0) return false
+  return waypointId === wps[0].id || waypointId === wps[wps.length - 1].id
 }
 
 const updateWaypointMarkers = (): void => {
@@ -3610,16 +3724,23 @@ const updateWaypointMarkers = (): void => {
   const currentZoom = zoom.value
   const markerSize = getEffectiveMarkerSize(currentZoom)
 
-  missionStore.currentPlanningWaypoints.forEach((wp) => {
+  const wps = missionStore.currentPlanningWaypoints
+  wps.forEach((wp, idx) => {
     const marker = waypointMarkers.value[wp.id]
     if (marker) {
       // Update marker icon to show command count
       const isSelected = selectedWaypoint.value?.id === wp.id
+      const isEndpoint = idx === 0 || idx === wps.length - 1
       const dimensions = getIconDimensionsFromMarkerSize(markerSize)
 
       marker.setIcon(
         L.divIcon({
-          html: createWaypointMarkerHtml(wp.commands.length, isSelected, surveyEntryExitWaypointIds.value.has(wp.id)),
+          html: createWaypointMarkerHtml(
+            wp.commands.length,
+            isSelected,
+            surveyEntryExitWaypointIds.value.has(wp.id),
+            isEndpoint
+          ),
           className: 'waypoint-marker-icon',
           iconSize: dimensions.iconSize,
           iconAnchor: dimensions.iconAnchor,
@@ -3868,6 +3989,7 @@ const undoGenerateWaypoints = (): void => {
 
   rebuildSurveyPolygonFromPositions()
   clearSurveyPolygonUndoStack()
+  updateWaypointMarkers()
   openSnackbar({ variant: 'success', message: 'Undo successful.', duration: 1000 })
   undoIsInProgress.value = false
   removeSurveyAreaSquareMeters(surveyId)
@@ -3929,7 +4051,12 @@ const addWaypointMarker = (waypoint: Waypoint): void => {
   const currentMarkerSize = getEffectiveMarkerSize(zoom.value)
   const dimensions = getIconDimensionsFromMarkerSize(currentMarkerSize)
   const markerIcon = L.divIcon({
-    html: createWaypointMarkerHtml(waypoint.commands.length, false, surveyEntryExitWaypointIds.value.has(waypoint.id)),
+    html: createWaypointMarkerHtml(
+      waypoint.commands.length,
+      false,
+      surveyEntryExitWaypointIds.value.has(waypoint.id),
+      isEndpointWaypoint(waypoint.id)
+    ),
     className: 'waypoint-marker-icon',
     iconSize: dimensions.iconSize,
     iconAnchor: dimensions.iconAnchor,
@@ -3978,7 +4105,8 @@ const applySelectedWaypointMarkerVisual = (newWaypointId?: string, oldWaypointId
           html: createWaypointMarkerHtml(
             oldWp?.commands.length ?? 0,
             false,
-            surveyEntryExitWaypointIds.value.has(oldWaypointId)
+            surveyEntryExitWaypointIds.value.has(oldWaypointId),
+            isEndpointWaypoint(oldWaypointId)
           ),
           className: 'waypoint-marker-icon',
           iconSize: dimensions.iconSize,
@@ -3998,7 +4126,8 @@ const applySelectedWaypointMarkerVisual = (newWaypointId?: string, oldWaypointId
           html: createWaypointMarkerHtml(
             newWp?.commands.length ?? 0,
             true,
-            surveyEntryExitWaypointIds.value.has(newWaypointId)
+            surveyEntryExitWaypointIds.value.has(newWaypointId),
+            isEndpointWaypoint(newWaypointId)
           ),
           className: 'waypoint-marker-icon',
           iconSize: dimensions.iconSize,
@@ -4117,12 +4246,15 @@ const openMissionLibrary = (
   // have to poke `pendingSegmentInsertIndex` around the open; a plain toolbar open clears it.
   pendingSegmentInsertIndex.value = options.segmentInsertIndex ?? null
   missionLibraryOpenSaveOnMount.value = options.openSaveDialog ?? false
+  const insertIndex = options.segmentInsertIndex
   logUserAction(
     options.openSaveDialog
       ? 'Opened the mission library to save the current mission'
-      : options.segmentInsertIndex != null
-      ? 'Opened the mission library to insert a mission into a segment'
-      : 'Opened the mission library'
+      : insertIndex == null
+      ? 'Opened the mission library'
+      : insertIndex < 0
+      ? 'Opened the mission library to prepend a mission before the first waypoint'
+      : 'Opened the mission library to insert a mission into a segment'
   )
   interfaceStore.missionLibraryVisibility = true
 }
@@ -4245,7 +4377,8 @@ const onMapClick = (e: L.LeafletMouseEvent): void => {
           html: createWaypointMarkerHtml(
             oldWaypoint.commands.length,
             false,
-            surveyEntryExitWaypointIds.value.has(oldWaypoint.id)
+            surveyEntryExitWaypointIds.value.has(oldWaypoint.id),
+            isEndpointWaypoint(oldWaypoint.id)
           ),
           className: 'waypoint-marker-icon',
           iconSize: dimensions.iconSize,
@@ -4321,7 +4454,17 @@ const onMapClick = (e: L.LeafletMouseEvent): void => {
       !interfaceStore.configPanelVisible &&
       isCreatingSimplePath.value
     ) {
-      addWaypoint([e.latlng.lat, e.latlng.lng], currentWaypointAltitude.value, currentWaypointAltitudeRefType.value)
+      const insertIndex = pendingSimplePathInsertIndex.value
+      addWaypoint(
+        [e.latlng.lat, e.latlng.lng],
+        currentWaypointAltitude.value,
+        currentWaypointAltitudeRefType.value,
+        undefined,
+        insertIndex ?? undefined
+      )
+      // Refresh so the previous start waypoint loses its endpoint visual and the live measure
+      // line anchors to the just-added waypoint (now at index 0).
+      updateWaypointMarkers()
     }
     clearLiveMeasure()
   }
@@ -4780,6 +4923,7 @@ watch(
   (step) => {
     if (step > 1) {
       isCreatingSimplePath.value = false
+      pendingSimplePathInsertIndex.value = null
       isCreatingSurvey.value = false
       return
     }
@@ -4936,6 +5080,14 @@ watch(
   border-radius: 50%;
   border: 2px solid #ffffff99;
   background-color: #034103;
+}
+
+/* Carried on the ring rather than the fill so a waypoint that is both an endpoint and a survey
+   entry/exit keeps the green of `.green-marker` underneath it. */
+.endpoint-marker {
+  border: 2px solid #ff9800;
+  transform: scale(1.25);
+  transform-origin: center;
 }
 
 .command-count-indicator {

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -882,6 +882,7 @@ import { MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import { MavCmd } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import type { NoiseTileOptions } from '@/libs/map/map-tile-fallback'
 import { attachTileNoiseFallback, refreshNoiseFallbackTiles } from '@/libs/map/map-tile-fallback'
+import { positionPanelNearBounds, screenBounds } from '@/libs/map/screen-placement'
 import { applyLiveWaypointCoordinates } from '@/libs/map/survey-arrows'
 import {
   createGridOverlay,
@@ -906,7 +907,6 @@ import { SubMenuComponentName, SubMenuName, useAppInterfaceStore } from '@/store
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useMissionStore } from '@/stores/mission'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
-import { Point2D } from '@/types/general'
 import {
   type CockpitMission,
   type MissionEstimatesSnapshot,
@@ -924,7 +924,6 @@ import {
   Survey,
   SurveyPath,
 } from '@/types/mission'
-import { ScreenBounds } from '@/types/user-interface'
 
 const missionStore = useMissionStore()
 const vehicleStore = useMainVehicleStore()
@@ -1671,76 +1670,20 @@ const updateSurvey = (id: string, updatedSurvey: Partial<Survey>): void => {
   }
 }
 
-/**
- * Computes screen-space axis-aligned bounding box from an array of 2D points.
- * @param {Point2D[]} pts - Screen-space points
- * @returns {ScreenBounds} The bounding box
- */
-const screenBounds = (pts: Point2D[]): ScreenBounds => {
-  let minX = Infinity
-  let minY = Infinity
-  let maxX = -Infinity
-  let maxY = -Infinity
-  for (const p of pts) {
-    if (p.x < minX) minX = p.x
-    if (p.y < minY) minY = p.y
-    if (p.x > maxX) maxX = p.x
-    if (p.y > maxY) maxY = p.y
-  }
-  return { minX, minY, maxX, maxY }
-}
-
-/**
- * Picks the best candidate position by maximising viewport visibility and minimising
- * overlap with a polygon bounding box, then clamps the result inside the viewport.
- * @param {Point2D[]} candidates - Top-left positions to evaluate
- * @param {number} elW - Element width in pixels
- * @param {number} elH - Element height in pixels
- * @param {ScreenBounds} polyBounds - Polygon screen bounds
- * @param {number} vpW - Viewport width
- * @param {number} vpH - Viewport height
- * @param {number} margin - Minimum distance from viewport edge
- * @returns {Point2D} Clamped top-left position
- */
-const pickBestPosition = (
-  candidates: Point2D[],
-  elW: number,
-  elH: number,
-  polyBounds: ScreenBounds,
-  vpW: number,
-  vpH: number,
-  margin: number
-): Point2D => {
-  const area = elW * elH
-  let best = candidates[0]
-  let bestScore = -Infinity
-
-  for (const c of candidates) {
-    const l = c.x
-    const r = c.x + elW
-    const t = c.y
-    const b = c.y + elH
-
-    const visW = Math.max(0, Math.min(r, vpW - margin) - Math.max(l, margin))
-    const visH = Math.max(0, Math.min(b, vpH - margin) - Math.max(t, margin))
-    const visibility = (visW * visH) / area
-
-    const oW = Math.max(0, Math.min(r, polyBounds.maxX) - Math.max(l, polyBounds.minX))
-    const oH = Math.max(0, Math.min(b, polyBounds.maxY) - Math.max(t, polyBounds.minY))
-    const overlapPenalty = (oW * oH) / area
-
-    const score = visibility - overlapPenalty * 0.5
-    if (score > bestScore) {
-      bestScore = score
-      best = c
-    }
-  }
-
-  return {
-    x: Math.max(margin, Math.min(best.x, vpW - elW - margin)),
-    y: Math.max(margin, Math.min(best.y, vpH - elH - margin)),
-  }
-}
+// Footprint of the survey-confirm controls strip, plus the two hand-tuned offsets it has always
+// carried on top of the shared placement maths.
+const SURVEY_CONFIRM_LAYOUT = {
+  footprint: {
+    anchorLeftPx: 100,
+    anchorRightPx: 60,
+    anchorTopPx: 10,
+    anchorBottomPx: 185,
+    gapPx: 20,
+    marginPx: 8,
+  },
+  extraRightGapPx: 100,
+  extraLeftOffsetPx: 40,
+} as const
 
 const updateConfirmButtonPosition = (): void => {
   if (!planningMap.value) return
@@ -1748,42 +1691,18 @@ const updateConfirmButtonPosition = (): void => {
   if (isCreatingSurvey.value && surveyPolygonVertexesPositions.value.length >= 3) {
     const map = planningMap.value
     const container = map.getContainer()
-    const cw = container.clientWidth
-    const ch = container.clientHeight
-
     const pts = surveyPolygonVertexesPositions.value.map((ll) => map.latLngToContainerPoint(ll))
-    const bounds = screenBounds(pts)
-
-    const anchorToLeft = 100
-    const anchorToRight = 60
-    const anchorToTop = 10
-    const anchorToBottom = 185
-    const visualW = anchorToLeft + anchorToRight
-    const visualH = anchorToTop + anchorToBottom
-    const gap = 20
-    const margin = 8
-
-    const cx = (bounds.minX + bounds.maxX) / 2
-    const cy = (bounds.minY + bounds.maxY) / 2
-
-    const pos = pickBestPosition(
-      [
-        { x: bounds.maxX + gap + 100, y: cy - visualH / 2 },
-        { x: bounds.minX - gap - visualW, y: cy - visualH / 2 },
-        { x: cx - visualW / 2, y: bounds.maxY + gap },
-        { x: cx - visualW / 2, y: bounds.minY - gap - visualH },
-      ],
-      visualW,
-      visualH,
-      bounds,
-      cw,
-      ch,
-      margin
+    const pos = positionPanelNearBounds(
+      screenBounds(pts),
+      SURVEY_CONFIRM_LAYOUT.footprint,
+      container.clientWidth,
+      container.clientHeight,
+      SURVEY_CONFIRM_LAYOUT.extraRightGapPx
     )
 
     confirmButtonStyle.value = {
-      left: `${pos.x + anchorToLeft + 40}px`,
-      top: `${pos.y + anchorToTop}px`,
+      left: `${pos.x + SURVEY_CONFIRM_LAYOUT.footprint.anchorLeftPx + SURVEY_CONFIRM_LAYOUT.extraLeftOffsetPx}px`,
+      top: `${pos.y + SURVEY_CONFIRM_LAYOUT.footprint.anchorTopPx}px`,
     }
   } else {
     confirmButtonStyle.value = { display: 'none' }

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -161,6 +161,20 @@
         @regenerate-survey-waypoints="regenerateSurveyWaypoints"
       />
     </div>
+    <MissionPlacementToolbar
+      v-if="isPlacingMission"
+      v-model:scale-x-percent="placementScaleXPercent"
+      v-model:scale-y-percent="placementScaleYPercent"
+      v-model:rotation-deg="placementRotationDeg"
+      :position-style="placementToolbarStyle"
+      :limits="PLACEMENT_LIMITS"
+      @clamp-scale-x="clampPlacementScaleX"
+      @clamp-scale-y="clampPlacementScaleY"
+      @clamp-rotation="clampPlacementRotation"
+      @confirm="onConfirmPlacement"
+      @reset="onResetPlacement"
+      @cancel="cancelFreePlacement()"
+    />
     <div
       v-show="!interfaceStore.isMainMenuVisible"
       ref="missionToolboxRef"
@@ -494,7 +508,7 @@
                   variant="text"
                   size="24"
                   class="text-[12px]"
-                  @click="openMissionLibrary"
+                  @click="openMissionLibrary()"
                 />
               </template>
             </v-tooltip>
@@ -847,6 +861,9 @@ import MapCenterControl from '@/components/MapCenterControl.vue'
 import ContextMenu from '@/components/mission-planning/ContextMenu.vue'
 import HomePositionSettingHelp from '@/components/mission-planning/HomePositionSettingHelp.vue'
 import MissionEstimatesPanel from '@/components/mission-planning/MissionEstimates.vue'
+import MissionPlacementToolbar, {
+  PLACEMENT_TOOLBAR_FOOTPRINT,
+} from '@/components/mission-planning/MissionPlacementToolbar.vue'
 import ScanDirectionDial from '@/components/mission-planning/ScanDirectionDial.vue'
 import SurveyVertexList from '@/components/mission-planning/SurveyVertexList.vue'
 import WaypointConfigPanel from '@/components/mission-planning/WaypointConfigPanel.vue'
@@ -866,6 +883,8 @@ import { useMapOverlays } from '@/composables/map/useMapOverlays'
 import { useMapPoiMarkers } from '@/composables/map/useMapPoiMarkers'
 import { useMapTileLayers } from '@/composables/map/useMapTileLayers'
 import { useMapTileLayerSelection } from '@/composables/map/useMapTileLayerSelection'
+import { useMissionInsertion } from '@/composables/map/useMissionInsertion'
+import { useMissionPlacement } from '@/composables/map/useMissionPlacement'
 import { type SurveyPreview, useSurveyArrowOverlay } from '@/composables/map/useSurveyArrowOverlay'
 import { useVertexAngleOverlay } from '@/composables/map/useVertexAngleOverlay'
 import { useWaypointMarkerSize } from '@/composables/map/useWaypointMarkerSize'
@@ -1514,8 +1533,10 @@ const segmentRadialMenuPosition = ref({ x: 0, y: 0 })
 const segmentRadialMenuItems: RadialMenuItem[] = [
   { icon: 'mdi-vector-polyline', tooltip: 'Add waypoint' },
   { icon: 'mdi-transit-connection-variant', tooltip: 'Insert survey here' },
+  { icon: 'mdi-bookshelf', tooltip: 'Insert mission from library here' },
 ]
 const segmentSurveyInsertIndex = ref<number | null>(null)
+const pendingSegmentInsertIndex = ref<number | null>(null)
 
 const isCtrlDown = ref(false)
 const isShiftDown = ref(false)
@@ -1930,6 +1951,12 @@ const onSegmentRadialMenuSelect = (index: number): void => {
     }
     dismissSegmentRadialMenu()
     toggleSurvey()
+    return
+  } else if (index === 2) {
+    if (radialMenuSegmentIndex !== null) {
+      openMissionLibrary({ segmentInsertIndex: radialMenuSegmentIndex })
+    }
+    dismissSegmentRadialMenu()
     return
   }
   dismissSegmentRadialMenu()
@@ -2613,6 +2640,12 @@ const performRedo = (): void => {
 }
 
 const handleKeyDown = (event: KeyboardEvent): void => {
+  // Placement owns the whole map while it is live, so Escape backs out of it and the edit
+  // shortcuts below stay off the mission sitting underneath the preview.
+  if (isPlacingMission.value) {
+    if (event.key === 'Escape') cancelFreePlacement()
+    return
+  }
   if (event.key === 'Escape') {
     if (isCreatingSurvey.value) {
       if (isDrawingSurveyPolygon.value) {
@@ -2951,6 +2984,54 @@ const drawMissionOnTheMap = (waypoints: Waypoint[]): void => {
     })
 
   updateWaypointMarkers()
+}
+
+// Merges a placed/loaded library mission into the current planning (append, segment-insert, or
+// fresh load). The insert-segment intent is carried on `placementInsertSegmentIndex` so both
+// placement outcomes ("Reposition" and "Keep original") route to the requested segment.
+const { insertSegmentIndex: placementInsertSegmentIndex, finalizeMissionPlacement } = useMissionInsertion({
+  cloneCommands: (commands) => cloneCommands(commands),
+  addWaypointMarker: (waypoint) => addWaypointMarker(waypoint),
+  updateWaypointMarkers: () => updateWaypointMarkers(),
+  loadDraftMission: (mission, opts) => loadDraftMission(mission, opts),
+})
+
+// --- Mission free placement (drag/scale/rotate before committing) ---
+const {
+  isPlacingMission,
+  placementScaleXPercent,
+  placementScaleYPercent,
+  placementRotationDeg,
+  PLACEMENT_LIMITS,
+  clampPlacementScaleX,
+  clampPlacementScaleY,
+  clampPlacementRotation,
+  resetPlacementTransform,
+  startFreePlacement,
+  cancelFreePlacement: cancelPlacementInternal,
+  confirmFreePlacement,
+  placementToolbarStyle,
+} = useMissionPlacement(planningMap, {
+  onConfirm: (placedMission) => finalizeMissionPlacement(placedMission, { wasRepositioned: true }),
+  toolbarFootprint: PLACEMENT_TOOLBAR_FOOTPRINT,
+})
+
+// Wrap the composable's cancel so the view-owned segment-insert routing intent is also dropped
+// when the user actively cancels via the toolbar button.
+const cancelFreePlacement = (): void => {
+  logUserAction('Cancelled mission placement')
+  cancelPlacementInternal()
+  placementInsertSegmentIndex.value = null
+}
+
+const onConfirmPlacement = (): void => {
+  logUserAction('Confirmed mission placement on the map')
+  confirmFreePlacement()
+}
+
+const onResetPlacement = (): void => {
+  logUserAction('Reset the mission placement scale and rotation')
+  resetPlacementTransform()
 }
 
 const surveyPolygonVertexesMarkers = shallowRef<L.Marker[]>([])
@@ -3930,12 +4011,20 @@ const tryFetchHome = async (): Promise<void> => {
   }
 }
 
-const loadDraftMission = async (mission: CockpitMission): Promise<void> => {
+const loadDraftMission = async (
+  mission: CockpitMission,
+  options?: {
+    /** Keep the host map's current center/zoom instead of restoring the saved-mission settings. */
+    preserveMapView?: boolean
+  }
+): Promise<void> => {
   clearCurrentMission()
 
   try {
-    mapCenter.value = mission.settings.mapCenter
-    zoom.value = mission.settings.zoom
+    if (!options?.preserveMapView) {
+      mapCenter.value = mission.settings.mapCenter
+      zoom.value = mission.settings.zoom
+    }
     currentWaypointAltitude.value = mission.settings.currentWaypointAltitude
     currentWaypointAltitudeRefType.value = mission.settings.currentWaypointAltitudeRefType
     missionStore.defaultCruiseSpeed = mission.settings.defaultCruiseSpeed
@@ -4000,8 +4089,20 @@ const currentMissionEstimatesSnapshot = computed<MissionEstimatesSnapshot>(() =>
   missionCoverageArea: missionEstimates.missionCoverageAreaSquareMeters.value,
 }))
 
-const openMissionLibrary = (): void => {
-  logUserAction('Opened the mission library')
+const openMissionLibrary = (
+  options: {
+    /** Segment index to splice the loaded mission into; omit for a normal placement. */
+    segmentInsertIndex?: number | null
+  } = {}
+): void => {
+  // Set the segment-insert intent in the same call that opens the library, so callers never have
+  // to poke `pendingSegmentInsertIndex` around the open; a plain toolbar open clears it.
+  pendingSegmentInsertIndex.value = options.segmentInsertIndex ?? null
+  logUserAction(
+    options.segmentInsertIndex != null
+      ? 'Opened the mission library to insert a mission into a segment'
+      : 'Opened the mission library'
+  )
   interfaceStore.missionLibraryVisibility = true
 }
 
@@ -4055,23 +4156,45 @@ const handleLoadMissionFromLibrary = (mission: SavedMission): void => {
     missionStore.plannedVehicleType = mission.vehicleType
   }
 
+  // Move the pending intent into a placement-scoped tracker so it survives the dialog/flow.
+  placementInsertSegmentIndex.value = pendingSegmentInsertIndex.value
+  pendingSegmentInsertIndex.value = null
+  const isInserting = placementInsertSegmentIndex.value !== null
+  // Anything already on the planner is merged with rather than replaced, so the labels have to say
+  // "add" instead of "load" and the message has to name what happens to the existing work.
+  const isMerging = isInserting || canSaveCurrentMissionToLibrary.value
+
   showDialog({
     variant: 'info',
-    title: 'Load mission',
-    message: `Where should "${mission.name}" be placed?`,
+    title: isInserting ? 'Insert mission' : isMerging ? 'Add mission' : 'Load mission',
+    message: isMerging
+      ? `"${mission.name}" will be added to the mission you are already planning. Where should it go?`
+      : `Where should "${mission.name}" be placed?`,
     persistent: false,
     maxWidth: 620,
     actions: [
-      { text: 'Cancel', color: 'white', action: closeDialog },
       {
-        text: 'Keep original location',
-        color: 'white',
+        text: 'Cancel',
+        action: () => {
+          placementInsertSegmentIndex.value = null
+          closeDialog()
+        },
+      },
+      {
+        text: isMerging ? 'At its original location' : 'Keep original location',
         action: () => {
           closeDialog()
           logUserAction(`Loaded mission "${mission.name}" at its original location`)
-          loadDraftMission(mission).catch((err) => {
-            openSnackbar({ variant: 'error', message: `Failed to load mission: ${err}`, duration: 3500 })
-          })
+          finalizeMissionPlacement(mission)
+        },
+      },
+      {
+        text: 'Reposition on map',
+        class: 'bg-[#FFFFFF33]',
+        action: () => {
+          closeDialog()
+          logUserAction(`Started repositioning mission "${mission.name}" on the map`)
+          startFreePlacement(mission)
         },
       },
     ],
@@ -4083,6 +4206,8 @@ onMounted(() => {
 })
 
 const onMapClick = (e: L.LeafletMouseEvent): void => {
+  // Swallow map clicks during placement; confirm/cancel happen via the dedicated overlay buttons.
+  if (isPlacingMission.value) return
   hideContextMenu()
 
   // The dedicated home-setting handler owns this click; bail so we don't also drop a survey vertex or waypoint here.
@@ -4287,6 +4412,7 @@ onMounted(async () => {
 
   planningMap.value.on('contextmenu', (e: LeafletMouseEvent) => {
     if (isCreatingSurvey.value) return
+    if (isPlacingMission.value) return
     selectedWaypoint.value = undefined
     contextMenuType.value = selectedSurveyId.value === '' ? 'map' : contextMenuType.value
     currentCursorGeoCoordinates.value = [e.latlng.lat, e.latlng.lng]


### PR DESCRIPTION
- Add a "Reposition on map" option to the library load dialog that drops the saved mission onto the planning map at 1:1 scale with interactive transforms before commit.
- **Drag, scale and rotate** the mission item before merging to map.
- Add an "Insert mission from library here" entry to the segment radial menu so a library mission can be spliced between two existing waypoints.
- Add a "Mission library" submenu to the map context menu, holding "Add mission from library" and "Save mission to library", so a saved mission can be inserted or the current one saved directly from a right-click.
- Bias the context-menu adds (waypoint, survey, simple path, library mission) toward the closer mission endpoint: clicks near the start prepend instead of always appending.
- Highlight the first and last waypoints of the current mission with an orange ring so the endpoints are obvious before inserting near them.
- Move the floating-panel screen-placement maths to `libs/map/screen-placement`, shared by the new placement toolbar and the pre-existing survey-confirm strip.

Diff: $\color{green}\pmb{+2{,}041}$ $\color{red}\pmb{-153}$

https://github.com/user-attachments/assets/abfeb3af-50e2-478c-8305-03584328be2a

Second and final PR splitting #2654.
