### PR TITLE
Fix startup fallback confirmation buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,20 +139,19 @@
                 nonAppMain.appendChild(fallbackContent);
 
                 document.getElementById('backup-settings-btn').addEventListener('click', function() {
-                    utils.backupSettings().then(function(r) { if (!r.success) alert(r.message); });
+                    utils.backupSettings().then(function(r) { if (!r.success) utils.showFallbackAlert(r.message); });
                 });
                 document.getElementById('import-settings-btn').addEventListener('click', function() {
                     utils.importSettings().then(function(r) {
-                        if (!r.success && !r.message.includes('cancelled')) alert(r.message);
-                        location.reload();
+                        if (!r.success && !r.message.includes('cancelled')) utils.showFallbackAlert(r.message);
                     });
                 });
                 document.getElementById('download-logs-btn').addEventListener('click', function() {
-                    utils.downloadLogs().then(function(r) { alert(r.message); });
+                    utils.downloadLogs().then(function(r) { utils.showFallbackAlert(r.message); });
                 });
                 document.getElementById('clear-settings-btn').addEventListener('click', function() {
                     utils.resetSettings().then(function(r) {
-                        if (!r.success && !r.message.includes('cancelled')) alert(r.message);
+                        if (!r.success && !r.message.includes('cancelled')) utils.showFallbackAlert(r.message);
                     });
                 });
             });

--- a/src/libs/index-utils.js
+++ b/src/libs/index-utils.js
@@ -112,6 +112,87 @@ export function getCapturedLogs() {
 }
 
 /**
+ * Builds a DOM-based modal used by the pre-Vue fallback screen.
+ * Native alert/confirm dialogs don't respond to mouse clicks in our Electron/webview shell,
+ * so we render real buttons that handle clicks (plus Enter/Esc) ourselves.
+ * @param {string} message - The message to display
+ * @param {boolean} withCancel - Whether to render a Cancel button alongside OK
+ * @returns {Promise<boolean>} Resolves true when confirmed, false when cancelled
+ */
+function showFallbackModal(message, withCancel) {
+  return new Promise((resolve) => {
+    const overlay = document.createElement('div')
+    overlay.style.cssText =
+      'position:fixed;inset:0;z-index:2147483647;display:flex;justify-content:center;align-items:center;background:rgba(0,0,0,0.6);'
+
+    const card = document.createElement('div')
+    card.style.cssText =
+      'display:flex;flex-direction:column;align-items:center;background:#333;color:#fff;' +
+      'border:#fff solid 1px;border-radius:5px;padding:2rem;margin:1.5rem;max-width:65%;text-align:center;font-size:16px;'
+
+    const text = document.createElement('p')
+    text.style.cssText = 'white-space:pre-line;margin:0 0 0.5rem 0;'
+    text.textContent = message
+    card.appendChild(text)
+
+    const buttonsRow = document.createElement('div')
+    buttonsRow.style.cssText = 'display:flex;gap:1rem;flex-wrap:wrap;justify-content:center;'
+
+    const baseButtonStyle =
+      'border:none;color:white;padding:15px 32px;font-size:16px;margin-top:1.5rem;cursor:pointer;border-radius:5px;'
+
+    const finish = (result) => {
+      document.removeEventListener('keydown', onKeyDown)
+      if (overlay.parentNode) overlay.parentNode.removeChild(overlay)
+      resolve(result)
+    }
+
+    const onKeyDown = (event) => {
+      if (event.key === 'Enter') finish(true)
+      if (event.key === 'Escape' && withCancel) finish(false)
+    }
+
+    if (withCancel) {
+      const cancelButton = document.createElement('button')
+      cancelButton.textContent = 'Cancel'
+      cancelButton.style.cssText = baseButtonStyle + 'background-color:#a12626;'
+      cancelButton.addEventListener('click', () => finish(false))
+      buttonsRow.appendChild(cancelButton)
+    }
+
+    const okButton = document.createElement('button')
+    okButton.textContent = 'OK'
+    okButton.style.cssText = baseButtonStyle + 'background-color:#0486aa;'
+    okButton.addEventListener('click', () => finish(true))
+    buttonsRow.appendChild(okButton)
+
+    card.appendChild(buttonsRow)
+    overlay.appendChild(card)
+    document.body.appendChild(overlay)
+    document.addEventListener('keydown', onKeyDown)
+    okButton.focus()
+  })
+}
+
+/**
+ * Shows a fallback alert dialog with a single OK button.
+ * @param {string} message - The message to display
+ * @returns {Promise<void>} Resolves when the user dismisses the dialog
+ */
+export async function showFallbackAlert(message) {
+  await showFallbackModal(message, false)
+}
+
+/**
+ * Shows a fallback confirmation dialog with Cancel and OK buttons.
+ * @param {string} message - The message to display
+ * @returns {Promise<boolean>} Resolves true when confirmed, false when cancelled
+ */
+export function showFallbackConfirm(message) {
+  return showFallbackModal(message, true)
+}
+
+/**
  * Backup localStorage settings to JSON file
  * @returns {Promise<{success: boolean, message: string}>} Result of backup operation
  */
@@ -196,7 +277,7 @@ This will:
 
 Found ${Object.keys(backupData).length} setting(s) to import.`
 
-        if (!confirm(confirmMessage)) {
+        if (!(await showFallbackConfirm(confirmMessage))) {
           resolve({ success: false, message: 'Import cancelled by user' })
           return
         }
@@ -217,7 +298,7 @@ Found ${Object.keys(backupData).length} setting(s) to import.`
           await Promise.allSettled(keys.map((key) => caches.delete(key)))
         }
 
-        alert('Settings imported successfully! The page will now reload.')
+        await showFallbackAlert('Settings imported successfully! The page will now reload.')
         location.reload()
       } catch (error) {
         resolve({
@@ -325,7 +406,7 @@ Please try again or contact support.`,
  */
 export async function resetSettings() {
   try {
-    if (!confirm('Are you sure you want to reset Cockpit settings?')) {
+    if (!(await showFallbackConfirm('Are you sure you want to reset Cockpit settings?'))) {
       return { success: false, message: 'Reset cancelled by user' }
     }
 

--- a/src/libs/index-utils.js
+++ b/src/libs/index-utils.js
@@ -193,6 +193,34 @@ export function showFallbackConfirm(message) {
 }
 
 /**
+ * Shows a full-screen "Reloading..." overlay so the user can't interact while Cockpit restarts.
+ * @returns {void}
+ */
+export function showFallbackReloadingOverlay() {
+  const overlay = document.createElement('div')
+  overlay.style.cssText =
+    'position:fixed;inset:0;z-index:2147483647;display:flex;flex-direction:column;justify-content:center;' +
+    'align-items:center;gap:2rem;background:#333;color:#fff;font-size:20px;'
+
+  const spinner = document.createElement('div')
+  spinner.style.cssText =
+    'width:36px;height:36px;border:3px solid rgba(255,255,255,0.15);border-top-color:rgba(255,255,255,0.8);' +
+    'border-radius:50%;'
+  spinner.animate([{ transform: 'rotate(0deg)' }, { transform: 'rotate(360deg)' }], {
+    duration: 800,
+    iterations: Infinity,
+  })
+
+  const text = document.createElement('p')
+  text.textContent = 'Reloading...'
+  text.style.cssText = 'margin:0;'
+
+  overlay.appendChild(spinner)
+  overlay.appendChild(text)
+  document.body.appendChild(overlay)
+}
+
+/**
  * Backup localStorage settings to JSON file
  * @returns {Promise<{success: boolean, message: string}>} Result of backup operation
  */
@@ -408,6 +436,8 @@ export async function resetSettings() {
   if (!(await showFallbackConfirm('Are you sure you want to reset Cockpit settings?'))) {
     return { success: false, message: 'Reset cancelled by user' }
   }
+
+  showFallbackReloadingOverlay()
 
   try {
     localStorage.clear()

--- a/src/libs/index-utils.js
+++ b/src/libs/index-utils.js
@@ -293,7 +293,7 @@ Found ${Object.keys(backupData).length} setting(s) to import.`
         }
 
         // Clear cache and reload page
-        if (caches) {
+        if (typeof caches !== 'undefined') {
           const keys = await caches.keys()
           await Promise.allSettled(keys.map((key) => caches.delete(key)))
         }
@@ -405,23 +405,24 @@ Please try again or contact support.`,
  * @returns {Promise<{success: boolean, message: string}>} Result of reset operation
  */
 export async function resetSettings() {
-  try {
-    if (!(await showFallbackConfirm('Are you sure you want to reset Cockpit settings?'))) {
-      return { success: false, message: 'Reset cancelled by user' }
-    }
+  if (!(await showFallbackConfirm('Are you sure you want to reset Cockpit settings?'))) {
+    return { success: false, message: 'Reset cancelled by user' }
+  }
 
+  try {
     localStorage.clear()
 
-    // Clear cache to ensure a fresh access to all files
-    if (caches) {
-      const keys = await caches.keys()
-      await Promise.allSettled(keys.map((key) => caches.delete(key)))
+    // Clear cache to ensure a fresh access to all files.
+    // Capped with a timeout so a slow/hanging cache API can never block the restart below.
+    if (typeof caches !== 'undefined') {
+      const clearCaches = caches.keys().then((keys) => Promise.allSettled(keys.map((key) => caches.delete(key))))
+      await Promise.race([clearCaches, new Promise((resolve) => setTimeout(resolve, 2000))])
     }
-
-    location.reload()
-
-    return { success: true, message: 'Settings reset successfully' }
   } catch (error) {
-    return { success: false, message: `Error resetting settings: ${error.message}` }
+    // Even if clearing the cache fails, we still want to restart so the cleared settings take effect
+    console.error('Error while resetting settings:', error)
   }
+
+  window.location.reload()
+  return { success: true, message: 'Settings reset successfully' }
 }


### PR DESCRIPTION
The startup fallback screen relied on native `alert()`/`confirm()`, whose buttons don't respond to mouse clicks in our Electron/webview shell (only Enter worked), making the confirmations unusable.

- Replace native `alert`/`confirm` with a custom DOM modal that has real clickable buttons (Enter/Esc still work).
- Make "Reset settings" reliably restart Cockpit: cap cache-clearing with a timeout so it can't hang before the reload.
- Show a full-screen "Reloading..." spinner once reset is confirmed, blocking interaction during the brief delay before reload.

To test it, just add a `throw new Error()` in the first line of `src/main.ts`.

Fix #2801 