### PR TITLE
Geofence: Add mission-planning geofence editor

### DIFF
--- a/src/components/geofence/GeoFenceDrawingActionButtons.vue
+++ b/src/components/geofence/GeoFenceDrawingActionButtons.vue
@@ -1,0 +1,165 @@
+<template>
+  <v-tooltip location="top" text="Finish polygon fence">
+    <template #activator="{ props: tooltipProps }">
+      <div
+        v-if="fenceDraft.isDrawingPolygon && polygonVertexes.length >= 3"
+        v-bind="tooltipProps"
+        :style="confirmButtonStyle"
+        class="absolute text-[22px] -ml-[10px] -mt-[10px] bg-transparent rounded-full cursor-pointer elevation-4"
+        variant="text"
+        @click="onFinish"
+      >
+        <v-icon color="green" class="border-2 rounded-full bg-white">mdi-check-circle</v-icon>
+      </div>
+    </template>
+  </v-tooltip>
+  <v-tooltip location="top" text="Discard polygon fence">
+    <template #activator="{ props: tooltipProps }">
+      <div
+        v-if="fenceDraft.isDrawingPolygon && polygonVertexes.length >= 1"
+        v-bind="tooltipProps"
+        :style="confirmButtonStyle"
+        class="absolute text-[14px] mt-[40px] -ml-[7px] bg-transparent rounded-full cursor-pointer elevation-4"
+        variant="text"
+        @click="onDiscard"
+      >
+        <div color="white" class="border-2 rounded-full bg-red text-[18px] pa-1">
+          <svg width="16" height="16" viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path
+              d="M2 4h12M4 4v10a2 2 0 002 2h4a2 2 0 002-2V4M6 4V2h4v2"
+              stroke="white"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </div>
+      </div>
+    </template>
+  </v-tooltip>
+</template>
+
+<script setup lang="ts">
+import type L from 'leaflet'
+import { onBeforeUnmount, ref, watch } from 'vue'
+
+import { useMapContext } from '@/composables/map/useMapContext'
+import { useGeoFenceEditorDraft } from '@/composables/useGeoFenceEditorDraft'
+import { pickBestPosition, screenBounds } from '@/libs/mission/confirm-button-placement'
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+const props = defineProps<{
+  /**
+   * Current in-progress polygon vertexes from the fence drawing
+   * composable. Kept as a prop rather than re-instantiating the
+   * composable so the parent stays the single owner of the drawing
+   * state.
+   */
+  polygonVertexes: L.LatLng[]
+}>()
+
+const emit = defineEmits<{
+  /**
+   * Fired when the user commits the drawn polygon by clicking the
+   * check-mark button. The parent should forward this to the fence
+   * drawing composable's `finishPolygonDrawing` action.
+   */
+  (event: 'finish'): void
+}>()
+
+const fenceDraft = useGeoFenceEditorDraft()
+// Read the Leaflet map from the shared map context instead of a prop.
+// The parent's own `planningMap` ref shares its name with a template
+// ref on the map container `<div>`, so Vue's ref-binding transiently
+// writes the DOM element into that ref during re-renders. Consuming
+// the map through the dedicated `mapContext.map` shallowRef — which is
+// only written once from the parent's `onMounted` — sidesteps the
+// collision and keeps this component from seeing a non-map value.
+const { map: mapRef } = useMapContext()
+
+const confirmButtonStyle = ref<Record<string, string>>({})
+
+// Anchor + visual sizing constants tuned so the check-mark and trash
+// buttons sit right of the polygon by default, with the trash button
+// stacked under the check-mark. See `pickBestPosition` for the fallback
+// candidate ordering (right, left, below, above the polygon bounds).
+const ANCHOR_TO_LEFT = 30
+const ANCHOR_TO_RIGHT = 30
+const ANCHOR_TO_TOP = 10
+const ANCHOR_TO_BOTTOM = 80
+const VISUAL_W = ANCHOR_TO_LEFT + ANCHOR_TO_RIGHT
+const VISUAL_H = ANCHOR_TO_TOP + ANCHOR_TO_BOTTOM
+const GAP = 20
+const MARGIN = 8
+
+const updateConfirmButtonPosition = (): void => {
+  const map = mapRef.value
+  if (!map) return
+
+  if (fenceDraft.isDrawingPolygon && props.polygonVertexes.length >= 3) {
+    const container = map.getContainer()
+    const cw = container.clientWidth
+    const ch = container.clientHeight
+
+    const pts = props.polygonVertexes.map((ll) => map.latLngToContainerPoint(ll))
+    const bounds = screenBounds(pts)
+
+    const cx = (bounds.minX + bounds.maxX) / 2
+    const cy = (bounds.minY + bounds.maxY) / 2
+
+    const pos = pickBestPosition(
+      [
+        { x: bounds.maxX + GAP, y: cy - VISUAL_H / 2 },
+        { x: bounds.minX - GAP - VISUAL_W, y: cy - VISUAL_H / 2 },
+        { x: cx - VISUAL_W / 2, y: bounds.maxY + GAP },
+        { x: cx - VISUAL_W / 2, y: bounds.minY - GAP - VISUAL_H },
+      ],
+      VISUAL_W,
+      VISUAL_H,
+      bounds,
+      cw,
+      ch,
+      MARGIN
+    )
+
+    confirmButtonStyle.value = {
+      left: `${pos.x + ANCHOR_TO_LEFT}px`,
+      top: `${pos.y + ANCHOR_TO_TOP}px`,
+    }
+  } else {
+    confirmButtonStyle.value = { display: 'none' }
+  }
+}
+
+watch([() => props.polygonVertexes, () => fenceDraft.isDrawingPolygon], () => updateConfirmButtonPosition(), {
+  immediate: true,
+  deep: true,
+})
+
+watch(
+  mapRef,
+  (map, prevMap) => {
+    prevMap?.off('drag', updateConfirmButtonPosition)
+    prevMap?.off('zoom', updateConfirmButtonPosition)
+    map?.on('drag', updateConfirmButtonPosition)
+    map?.on('zoom', updateConfirmButtonPosition)
+    updateConfirmButtonPosition()
+  },
+  { immediate: true }
+)
+
+onBeforeUnmount(() => {
+  mapRef.value?.off('drag', updateConfirmButtonPosition)
+  mapRef.value?.off('zoom', updateConfirmButtonPosition)
+})
+
+const onFinish = (): void => {
+  logUserAction('Confirmed the in-progress polygon fence drawing')
+  emit('finish')
+}
+
+const onDiscard = (): void => {
+  logUserAction('Discarded the in-progress polygon fence drawing')
+  fenceDraft.cancelDrawingPolygon()
+}
+</script>

--- a/src/components/geofence/GeoFenceEditor.vue
+++ b/src/components/geofence/GeoFenceEditor.vue
@@ -1,0 +1,741 @@
+<template>
+  <div class="flex flex-col w-full">
+    <p v-if="!fenceStore.isFenceSupported" class="px-2 py-1 mx-2 text-xs rounded-md bg-[#FF8800AA] text-white">
+      This vehicle does not advertise the GeoFence MAVLink service. Editing is allowed but uploads may be rejected.
+    </p>
+
+    <div class="flex flex-row items-center justify-end gap-x-2 mb-3 mt-1">
+      <span class="text-sm font-medium mr-2">Add fence:</span>
+      <div class="flex flex-row items-center gap-x-2">
+        <v-tooltip location="top" :text="fenceDraft.isDrawingPolygon ? 'Cancel polygon drawing' : 'Add polygon fence'">
+          <template #activator="{ props: tooltipProps }">
+            <v-btn
+              v-bind="tooltipProps"
+              :icon="fenceDraft.isDrawingPolygon ? 'mdi-close' : 'mdi-vector-polygon'"
+              variant="elevated"
+              :color="fenceDraft.isDrawingPolygon ? '#A8453B' : '#3B78A8'"
+              size="x-small"
+              class="rounded-md"
+              :disabled="fenceDraft.isDrawingCircle"
+              @click="onAddPolygon"
+            />
+          </template>
+        </v-tooltip>
+        <v-tooltip location="top" :text="fenceDraft.isDrawingCircle ? 'Cancel circle drawing' : 'Add circular fence'">
+          <template #activator="{ props: tooltipProps }">
+            <v-btn
+              v-bind="tooltipProps"
+              :icon="fenceDraft.isDrawingCircle ? 'mdi-close' : 'mdi-vector-circle-variant'"
+              variant="elevated"
+              :color="fenceDraft.isDrawingCircle ? '#A8453B' : '#3B78A8'"
+              size="x-small"
+              class="rounded-md"
+              :disabled="fenceDraft.isDrawingPolygon"
+              @click="onAddCircle"
+            />
+          </template>
+        </v-tooltip>
+      </div>
+    </div>
+
+    <div class="fence-expansible-wrapper -mx-2">
+      <ExpansiblePanel
+        compact
+        invert-chevron
+        hover-effect
+        elevation-effect
+        :is-expanded="fenceStore.polygons.length > 0"
+        no-bottom-divider
+        darken-content
+      >
+        <template #title>
+          <div class="flex w-[90%] justify-between items-center text-[14px] -mb-3 font-normal ml-2">
+            Polygons
+            <v-badge
+              :content="fenceStore.polygons.length"
+              color="#3B78A8"
+              rounded="md"
+              class="ml-10 scale-75 opacity-90"
+            />
+          </div>
+        </template>
+        <template #content>
+          <div class="flex flex-col items-center w-full px-1 py-1">
+            <p v-if="fenceStore.polygons.length === 0" class="text-xs opacity-70 my-1">No polygon fences.</p>
+            <div
+              v-for="(polygon, idx) in fenceStore.polygons"
+              :key="polygon.id"
+              class="fence-card flex items-center justify-between w-full border-[1px] border-[#FFFFFF15] rounded-md my-[3px] px-2 py-[3px] pr-3 cursor-pointer elevation-1 transition-colors duration-150"
+              :class="
+                fenceDraft.interactiveShapeId === polygon.id
+                  ? 'bg-[#CBCBCB44] border-[#FFFFFF25]'
+                  : 'bg-[#CBCBCB22] hover:bg-[#CBCBCB33]'
+              "
+              @click="onToggleShapeInteractive(polygon.id)"
+            >
+              <v-icon icon="mdi-vector-polygon" class="mr-2 opacity-70 text-[18px]" />
+              <v-divider vertical class="my-1" />
+              <p class="ml-3 grow overflow-hidden text-xs text-ellipsis whitespace-nowrap">Polygon {{ idx + 1 }}</p>
+              <span
+                class="text-[10px] font-medium uppercase tracking-wide px-2 py-[1px] rounded-md mr-2 text-white cursor-pointer select-none transition-opacity duration-150 hover:opacity-80"
+                :class="polygon.inclusion ? 'bg-[#3B78A8]' : 'bg-[#FF8800]'"
+                @click.stop="onTogglePolygonInclusion(polygon.id)"
+              >
+                {{ polygon.inclusion ? 'Inclusion' : 'Exclusion' }}
+              </span>
+              <div class="flex justify-start items-center w-[65px]">
+                <v-divider vertical class="my-1 mr-2" />
+                <div class="text-[17px] mdi mdi-trash-can cursor-pointer" @click.stop="onDeletePolygon(polygon.id)" />
+                <v-switch
+                  :model-value="polygon.inclusion"
+                  color="#3B78A8"
+                  base-color="#FF8800B3"
+                  density="compact"
+                  hide-details
+                  inset
+                  class="fence-switch origin-right scale-50 -ml-3 elevation-2"
+                  :class="{ 'fence-switch--exclusion': !polygon.inclusion }"
+                  @click.stop
+                  @update:model-value="onSetPolygonInclusion(polygon.id, $event === true)"
+                />
+              </div>
+            </div>
+          </div>
+        </template>
+      </ExpansiblePanel>
+    </div>
+
+    <div class="fence-expansible-wrapper -mx-2">
+      <ExpansiblePanel
+        compact
+        invert-chevron
+        hover-effect
+        elevation-effect
+        :is-expanded="fenceStore.circles.length > 0"
+        darken-content
+      >
+        <template #title>
+          <div class="flex w-[90%] justify-between items-center text-[14px] -mb-3 font-normal ml-2">
+            Circles
+            <v-badge
+              :content="fenceStore.circles.length"
+              color="#3B78A8"
+              rounded="md"
+              class="ml-10 scale-75 opacity-90"
+            />
+          </div>
+        </template>
+        <template #content>
+          <div class="flex flex-col items-center w-full px-1 py-1">
+            <p v-if="fenceStore.circles.length === 0" class="text-xs opacity-70 my-1">No circle fences.</p>
+            <div
+              v-for="(circle, idx) in fenceStore.circles"
+              :key="circle.id"
+              class="fence-card flex items-center justify-between w-full border-[1px] border-[#FFFFFF15] rounded-md my-[3px] px-2 pt-[3px] pb-[3px] pr-3 cursor-pointer elevation-1 transition-colors duration-150"
+              :class="
+                fenceDraft.interactiveShapeId === circle.id
+                  ? 'bg-[#CBCBCB44] border-[#FFFFFF25]'
+                  : 'bg-[#CBCBCB22] hover:bg-[#CBCBCB33]'
+              "
+              @click="onToggleShapeInteractive(circle.id)"
+            >
+              <v-icon icon="mdi-vector-circle-variant" class="mr-2 opacity-70 text-[18px]" />
+              <v-divider vertical class="my-1" />
+              <p class="ml-3 grow overflow-hidden text-xs text-ellipsis whitespace-nowrap">Circle {{ idx + 1 }}</p>
+              <span
+                class="text-[10px] font-medium uppercase tracking-wide px-2 py-[1px] rounded-md mr-2 text-white cursor-pointer select-none transition-opacity duration-150 hover:opacity-80"
+                :class="circle.inclusion ? 'bg-[#3B78A8]' : 'bg-[#FF8800]'"
+                @click.stop="onToggleCircleInclusion(circle.id)"
+              >
+                {{ circle.inclusion ? 'Inclusion' : 'Exclusion' }}
+              </span>
+              <div class="flex justify-start items-center w-[65px]">
+                <v-divider vertical class="my-1 mr-2" />
+                <div class="text-[17px] mdi mdi-trash-can cursor-pointer" @click.stop="onDeleteCircle(circle.id)" />
+                <v-switch
+                  :model-value="circle.inclusion"
+                  color="#3B78A8"
+                  base-color="#FF8800B3"
+                  density="compact"
+                  hide-details
+                  inset
+                  class="fence-switch origin-right scale-50 -ml-3"
+                  :class="{ 'fence-switch--exclusion': !circle.inclusion }"
+                  @click.stop
+                  @update:model-value="onSetCircleInclusion(circle.id, $event === true)"
+                />
+              </div>
+            </div>
+          </div>
+        </template>
+      </ExpansiblePanel>
+    </div>
+
+    <div class="flex flex-col ma-2 py-2 px-4 border-[1px] border-[#FFFFFF22] bg-[#00000022] rounded-md p-2">
+      <div v-if="fenceStore.isArduPilot" class="flex items-center justify-between gap-x-2 fence-autoenable-row">
+        <p class="text-xs">Auto enable fence on takeoff</p>
+        <v-switch
+          :model-value="(fenceStore.fenceAutoEnableMode ?? 1) > 0"
+          color="#3B78A8"
+          density="compact"
+          hide-details
+          inset
+          class="origin-right scale-[0.6] elevation-2 fence-autoenable-switch"
+          :disabled="!vehicleStore.isVehicleOnline || fenceAutoEnableBusy"
+          @update:model-value="onToggleFenceAutoEnable"
+        />
+      </div>
+      <v-divider class="opacity-10 my-1 mx-12" />
+      <div v-if="fenceStore.breachReturn" class="flex items-center justify-between gap-x-2">
+        <p class="text-xs">Breach return altitude</p>
+        <div class="flex items-center gap-x-1">
+          <v-tooltip
+            location="left"
+            max-width="320"
+            :open-on-hover="false"
+            open-on-click
+            :model-value="breachAltTooltipOpen"
+            @update:model-value="(v) => (breachAltTooltipOpen = v)"
+          >
+            <template #activator="{ props: tooltipProps }">
+              <v-icon
+                v-bind="tooltipProps"
+                size="14"
+                class="text-slate-400 cursor-pointer opacity-70 hover:opacity-100"
+              >
+                mdi-information-outline
+              </v-icon>
+            </template>
+            <div class="text-xs whitespace-pre-line pa-1 leading-snug">
+              Altitude in meters (relative to the home position) the vehicle targets when returning to the breach point.
+              On a fence breach the autopilot navigates to the rally location and climbs or descends to this altitude
+              before holding or continuing the configured fence action (FENCE_ACTION on ArduPilot, GF_ACTION on PX4).
+              Set it safely above local terrain and obstacles.
+            </div>
+          </v-tooltip>
+          <input
+            type="number"
+            step="1"
+            class="p-1 bg-[#FFFFFF11] w-[70px] text-xs text-right rounded-sm"
+            :value="fenceStore.breachReturn.altitude"
+            @change="onBreachReturnAltInput(($event.target as HTMLInputElement).value)"
+          />
+          <v-btn icon="mdi-delete" variant="text" size="x-small" class="-mr-2" @click="onClearBreachReturn" />
+        </div>
+      </div>
+      <div v-if="!fenceStore.breachReturn" class="flex flex-row items-center gap-x-2 mt-1">
+        <button
+          class="flex-1 h-auto py-1 px-2 text-xs rounded-md elevation-1 bg-[#FFFFFF22] hover:bg-[#FFFFFF33] transition-colors duration-200"
+          @click="onAddBreachReturn"
+        >
+          ADD BREACH RETURN POINT
+        </button>
+        <v-tooltip location="left" max-width="320">
+          <template #activator="{ props: tooltipProps }">
+            <v-icon v-bind="tooltipProps" class="text-slate-400 text-sm cursor-help">mdi-information-outline</v-icon>
+          </template>
+          <div class="text-sm pa-1">
+            <p class="mb-1 text-center"><strong>Breach return point</strong></p>
+            <p class="mb-[3px]">
+              Optional rally location the autopilot returns to when the vehicle breaches the geofence.
+            </p>
+            <p class="mb-[3px]">
+              Click <em>Add breach return point</em> to seed it at the map center, then drag the orange
+              <strong>B</strong> marker to fine-tune the location and edit the altitude (relative to home) inline.
+            </p>
+            <p>
+              Behavior on breach is governed by the autopilot fence parameters (<code>FENCE_ACTION</code> on ArduPilot,
+              <code>GF_ACTION</code> on PX4) — typically set them to <em>RTL</em> or <em>Land</em> for the rally point
+              to be honored.
+            </p>
+          </div>
+        </v-tooltip>
+      </div>
+    </div>
+
+    <p
+      v-if="fenceStore.isArduPilotPlane && fenceStore.polygons.length === 0"
+      class="px-2 py-1 mx-2 text-[11px] rounded-md bg-[#33333366]"
+    >
+      ArduPilot Plane: a polygon must be drawn for any fence parameter to take effect.
+    </p>
+    <p
+      v-if="fenceStore.isPx4 && fenceStore.inclusionPolygonCount > 1"
+      class="px-2 py-1 mx-2 mt-1 text-[11px] rounded-md bg-[#33333366]"
+    >
+      PX4: multiple inclusion polygons are AND-ed (intersection), not OR-ed.
+    </p>
+
+    <GeoFenceParametersPanel />
+
+    <div class="flex w-full justify-between my-2 px-4 pt-1">
+      <v-tooltip location="top" text="Save fence to file">
+        <template #activator="{ props: tooltipProps }">
+          <v-btn
+            v-bind="tooltipProps"
+            icon="mdi-content-save"
+            variant="text"
+            :disabled="!fenceStore.hasItems"
+            size="24"
+            class="text-[12px]"
+            @click="onSaveCfp"
+          />
+        </template>
+      </v-tooltip>
+      <v-divider vertical />
+      <v-tooltip location="top" text="Load fence from file (.cfp / .plan)">
+        <template #activator="{ props: tooltipProps }">
+          <v-btn
+            v-bind="tooltipProps"
+            icon="mdi-upload"
+            variant="text"
+            size="24"
+            class="text-[12px]"
+            @click="onPickFile"
+          />
+        </template>
+      </v-tooltip>
+      <v-divider vertical />
+      <v-tooltip location="top" text="Export `.plan` (mission + fence)">
+        <template #activator="{ props: tooltipProps }">
+          <v-btn
+            v-bind="tooltipProps"
+            icon="mdi-download-network"
+            variant="text"
+            size="24"
+            class="text-[12px]"
+            @click="onExportMavlinkPlan"
+          />
+        </template>
+      </v-tooltip>
+      <v-divider vertical />
+      <v-tooltip location="top" text="Clear fence on vehicle">
+        <template #activator="{ props: tooltipProps }">
+          <v-btn
+            v-bind="tooltipProps"
+            icon="mdi-delete"
+            :disabled="fenceStore.syncInProgress || !vehicleStore.isVehicleOnline"
+            variant="text"
+            size="24"
+            class="text-[12px]"
+            @click="onClearOnVehicle"
+          />
+        </template>
+      </v-tooltip>
+    </div>
+
+    <button
+      :disabled="!fenceStore.hasItems || !vehicleStore.isVehicleOnline || fenceStore.syncInProgress"
+      :class="{
+        'bg-[#FFFFFF11] hover:bg-[#FFFFFF11] text-[#FFFFFF22] elevation-0':
+          !fenceStore.hasItems || !vehicleStore.isVehicleOnline || fenceStore.syncInProgress,
+      }"
+      class="h-auto py-2 px-2 m-2 mt-2 text-sm rounded-md elevation-1 bg-[#3B78A8] hover:bg-[#3B78A8] transition-colors duration-200"
+      @click="onUpload"
+    >
+      UPLOAD FENCE TO VEHICLE
+    </button>
+    <button
+      v-if="fenceStore.hasItems"
+      class="h-auto py-1 px-1 m-2 text-sm rounded-md elevation-1 bg-[#FFFFFF11] hover:bg-[#FFFFFF22] transition-colors duration-200"
+      @click="onClearLocal"
+    >
+      CLEAR CURRENT FENCE
+    </button>
+    <button
+      :disabled="fenceStore.syncInProgress || !vehicleStore.isVehicleOnline"
+      class="h-auto py-2 px-2 m-2 text-sm rounded-md elevation-1 bg-[#FFFFFF11] hover:bg-[#FFFFFF22] transition-colors duration-200"
+      :class="{ 'cursor-not-allowed opacity-50 text-[#FFFFFF44]': !vehicleStore.isVehicleOnline }"
+      @click="onDownload"
+    >
+      DOWNLOAD FENCE FROM VEHICLE
+    </button>
+
+    <input ref="fileInput" type="file" accept=".cfp,.plan,application/json" class="hidden" @change="onFilePicked" />
+
+    <v-progress-linear v-if="fenceStore.syncInProgress" :model-value="syncProgress" height="4" color="white" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { format } from 'date-fns'
+import { saveAs } from 'file-saver'
+import { ref } from 'vue'
+
+import ExpansiblePanel from '@/components/ExpansiblePanel.vue'
+import GeoFenceParametersPanel from '@/components/geofence/GeoFenceParametersPanel.vue'
+import { useInteractionDialog } from '@/composables/interactionDialog'
+import { useSnackbar } from '@/composables/snackbar'
+import { useGeoFenceEditorDraft } from '@/composables/useGeoFenceEditorDraft'
+import {
+  geoFencePlanToMavlinkPlanFile,
+  mavlinkPlanFileToGeoFencePlan,
+} from '@/libs/vehicle/mavlink/geofence-conversion'
+import { useGeoFenceStore } from '@/stores/geoFence'
+import { useMainVehicleStore } from '@/stores/mainVehicle'
+import { useMissionStore } from '@/stores/mission'
+import {
+  type CockpitFencePlanFile,
+  type MavlinkPlanFile,
+  instanceOfCockpitFencePlanFile,
+  instanceOfMavlinkPlanFile,
+} from '@/types/geofence'
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+const props = defineProps<{
+  /**
+   * Map center used to seed new polygons / circles around the user's view.
+   */
+  mapCenter: [number, number]
+}>()
+
+/**
+ * Events:
+ * - `mission-loaded` — emitted when a fence file load also brings in mission
+ *   waypoints (e.g. the mission section of a `.plan` file) so the host view
+ *   can re-render them.
+ */
+const emit = defineEmits(['mission-loaded'])
+
+const fenceStore = useGeoFenceStore()
+const fenceDraft = useGeoFenceEditorDraft()
+const vehicleStore = useMainVehicleStore()
+const missionStore = useMissionStore()
+const { showDialog, closeDialog } = useInteractionDialog()
+const { openSnackbar } = useSnackbar()
+
+const fileInput = ref<HTMLInputElement | null>(null)
+const syncProgress = ref(0)
+const breachAltTooltipOpen = ref(false)
+
+const onToggleShapeInteractive = (id: string): void => {
+  const willSelect = fenceDraft.interactiveShapeId !== id
+  logUserAction(
+    willSelect ? 'Selected a fence shape for interactive editing' : 'Deselected the interactive fence shape'
+  )
+  fenceDraft.setInteractive(willSelect ? id : undefined)
+}
+
+const onTogglePolygonInclusion = (id: string): void => {
+  logUserAction('Toggled polygon fence inclusion mode via the badge')
+  fenceStore.togglePolygonInclusion(id)
+}
+
+const onSetPolygonInclusion = (id: string, inclusion: boolean): void => {
+  logUserAction('Set polygon fence inclusion mode via the switch')
+  fenceStore.updatePolygon(id, { inclusion })
+}
+
+const onDeletePolygon = (id: string): void => {
+  logUserAction('Deleted a polygon fence')
+  fenceStore.deletePolygon(id)
+}
+
+const onToggleCircleInclusion = (id: string): void => {
+  logUserAction('Toggled circle fence inclusion mode via the badge')
+  fenceStore.toggleCircleInclusion(id)
+}
+
+const onSetCircleInclusion = (id: string, inclusion: boolean): void => {
+  logUserAction('Set circle fence inclusion mode via the switch')
+  fenceStore.updateCircle(id, { inclusion })
+}
+
+const onDeleteCircle = (id: string): void => {
+  logUserAction('Deleted a circle fence')
+  fenceStore.deleteCircle(id)
+}
+
+const onAddPolygon = (): void => {
+  if (fenceDraft.isDrawingPolygon) {
+    logUserAction('Cancelled the in-progress polygon fence drawing')
+    fenceDraft.cancelDrawingPolygon()
+    return
+  }
+  logUserAction('Started drawing a polygon fence')
+  fenceDraft.startDrawingPolygon(true)
+  openSnackbar({
+    variant: 'info',
+    message: 'Click the map to add vertices.',
+    duration: 5000,
+    closeButton: true,
+  })
+}
+
+const onAddCircle = (): void => {
+  if (fenceDraft.isDrawingCircle) {
+    logUserAction('Cancelled the in-progress circle fence drawing')
+    fenceDraft.cancelDrawingCircle()
+    return
+  }
+  logUserAction('Started drawing a circle fence')
+  fenceDraft.startDrawingCircle(true)
+  openSnackbar({
+    variant: 'info',
+    message: 'Click the map to set the circle center, then click again to set the radius.',
+    duration: 5000,
+    closeButton: true,
+  })
+}
+
+const onAddBreachReturn = (): void => {
+  logUserAction('Added a breach return point at the map center')
+  fenceStore.setBreachReturn({ coordinates: [props.mapCenter[0], props.mapCenter[1]], altitude: 50 })
+}
+
+const onClearBreachReturn = (): void => {
+  logUserAction('Cleared the breach return point')
+  fenceStore.setBreachReturn(undefined)
+}
+
+const onBreachReturnAltInput = (value: string): void => {
+  if (!fenceStore.breachReturn) return
+  const altitude = Number(value)
+  if (!Number.isFinite(altitude)) return
+  logUserAction('Edited the breach return point altitude')
+  fenceStore.setBreachReturn({ coordinates: fenceStore.breachReturn.coordinates, altitude })
+}
+
+const fenceAutoEnableBusy = ref(false)
+
+const onToggleFenceAutoEnable = (value: boolean | null): void => {
+  if (fenceAutoEnableBusy.value) return
+  const target = value ? 1 : 0
+  logUserAction(target ? 'Enabled auto-enable fence on takeoff' : 'Disabled auto-enable fence on takeoff')
+  fenceAutoEnableBusy.value = true
+  try {
+    fenceStore.setFenceAutoEnable(target)
+  } catch (error) {
+    showDialog({
+      variant: 'error',
+      title: target ? 'Failed to enable auto fence' : 'Failed to disable auto fence',
+      message: error instanceof Error ? error.message : String(error),
+      timer: 4000,
+    })
+  } finally {
+    fenceAutoEnableBusy.value = false
+  }
+}
+
+const confirmAction = async (title: string, message: string, confirmText: string): Promise<boolean> => {
+  let confirmed = false
+  await new Promise<void>((resolve) => {
+    showDialog({
+      variant: 'warning',
+      title,
+      message,
+      persistent: false,
+      maxWidth: '520px',
+      actions: [
+        {
+          text: 'Cancel',
+          color: 'white',
+          action: () => {
+            closeDialog()
+            resolve()
+          },
+        },
+        {
+          text: confirmText,
+          color: 'white',
+          action: () => {
+            confirmed = true
+            closeDialog()
+            resolve()
+          },
+        },
+      ],
+    })
+  })
+  return confirmed
+}
+
+const confirmPx4MultipleInclusionsIfNeeded = async (): Promise<boolean> => {
+  if (!fenceStore.isPx4) return true
+  if (fenceStore.inclusionPolygonCount <= 1) return true
+  return confirmAction(
+    'PX4 multiple inclusion polygons',
+    'PX4 currently treats multiple inclusion polygons as AND (intersection), not OR. Continue with the upload?',
+    'Upload anyway'
+  )
+}
+
+const onUpload = async (): Promise<void> => {
+  logUserAction('Uploaded the local fence to the vehicle')
+  syncProgress.value = 0
+  if (!(await confirmPx4MultipleInclusionsIfNeeded())) return
+  try {
+    await fenceStore.uploadToVehicle(async (p: number) => {
+      syncProgress.value = p
+    })
+  } catch (error) {
+    showDialog({
+      variant: 'error',
+      title: 'Geofence upload failed',
+      message: error instanceof Error ? error.message : String(error),
+      timer: 5000,
+    })
+  }
+}
+
+const onDownload = async (): Promise<void> => {
+  logUserAction('Downloaded the fence from the vehicle')
+  syncProgress.value = 0
+  try {
+    await fenceStore.downloadFromVehicle(async (p: number) => {
+      syncProgress.value = p
+    })
+  } catch (error) {
+    showDialog({
+      variant: 'error',
+      title: 'Geofence download failed',
+      message: error instanceof Error ? error.message : String(error),
+      timer: 5000,
+    })
+  }
+}
+
+const onClearOnVehicle = async (): Promise<void> => {
+  const confirmed = await confirmAction(
+    'Clear fence on vehicle',
+    'This permanently removes the geofence currently stored on the vehicle. Continue?',
+    'Clear on vehicle'
+  )
+  if (!confirmed) return
+  logUserAction('Cleared the fence stored on the vehicle')
+  try {
+    await fenceStore.clearOnVehicle()
+  } catch (error) {
+    showDialog({
+      variant: 'error',
+      title: 'Geofence clear failed',
+      message: error instanceof Error ? error.message : String(error),
+      timer: 5000,
+    })
+  }
+}
+
+const onClearLocal = async (): Promise<void> => {
+  const confirmed = await confirmAction(
+    'Clear local fence plan',
+    'This removes all polygons, circles and the breach return point from the local fence plan. Continue?',
+    'Clear plan'
+  )
+  if (!confirmed) return
+  logUserAction('Cleared the local fence plan')
+  fenceStore.clearAll()
+}
+
+const onSaveCfp = (): void => {
+  logUserAction('Exported the local fence to a Cockpit fence plan file')
+  const file: CockpitFencePlanFile = { version: 0, fileType: 'CockpitFencePlan', plan: fenceStore.exportPlan() }
+  const blob = new Blob([JSON.stringify(file, null, 2)], { type: 'application/json' })
+  const date = format(new Date(), 'LLL_dd_yyyy_HH_mm_ss')
+  saveAs(blob, `cockpit_fence_plan_${date}.cfp`)
+}
+
+const onExportMavlinkPlan = (): void => {
+  logUserAction('Exported the local fence as a MAVLink `.plan` file')
+  const planFile = geoFencePlanToMavlinkPlanFile(fenceStore.exportPlan(), [props.mapCenter[0], props.mapCenter[1]])
+  const blob = new Blob([JSON.stringify(planFile, null, 2)], { type: 'application/json' })
+  const date = format(new Date(), 'LLL_dd_yyyy_HH_mm_ss')
+  saveAs(blob, `cockpit_fence_${date}.plan`)
+  if (missionStore.currentPlanningWaypoints.length > 0) {
+    openSnackbar({
+      variant: 'warning',
+      message: 'Exported `.plan` contains only the fence; mission waypoints were not included.',
+      duration: 5000,
+    })
+  }
+}
+
+const onPickFile = (): void => {
+  logUserAction('Opened the fence file picker')
+  fileInput.value?.click()
+}
+
+const importMavlinkPlan = (planFile: MavlinkPlanFile): void => {
+  const plan = mavlinkPlanFileToGeoFencePlan(planFile)
+  if (plan === undefined) {
+    openSnackbar({
+      variant: 'warning',
+      message: `Unsupported \`.plan\` geoFence version (${
+        planFile.geoFence?.version ?? 'missing'
+      }). Skipping fence section.`,
+      duration: 4000,
+    })
+  } else {
+    fenceStore.loadFromPlan(plan)
+  }
+
+  // `.plan` files also include a mission section. We don't take ownership of
+  // mission editing here, but we surface a hint so the user can switch back to
+  // the mission layer to inspect it.
+  if (planFile.mission && missionStore.currentPlanningWaypoints.length === 0) {
+    emit('mission-loaded')
+  }
+}
+
+const onFilePicked = async (event: Event): Promise<void> => {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  if (!file) return
+
+  const text = await file.text()
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch (error) {
+    showDialog({ variant: 'error', message: 'Invalid JSON file.', timer: 3000 })
+    input.value = ''
+    return
+  }
+
+  if (instanceOfCockpitFencePlanFile(parsed)) {
+    logUserAction('Loaded a Cockpit fence plan file into the local fence')
+    fenceStore.loadFromPlan(parsed.plan)
+    openSnackbar({ variant: 'success', message: 'Cockpit fence plan loaded.', duration: 3000 })
+  } else if (instanceOfMavlinkPlanFile(parsed)) {
+    logUserAction('Loaded a MAVLink `.plan` file into the local fence')
+    importMavlinkPlan(parsed)
+    openSnackbar({ variant: 'success', message: '`.plan` file loaded.', duration: 3000 })
+  } else {
+    showDialog({ variant: 'error', message: 'Unsupported file format.', timer: 3000 })
+  }
+
+  input.value = ''
+}
+</script>
+
+<style scoped>
+.fence-card :deep(.v-switch) {
+  flex: 0 0 auto;
+}
+.fence-card :deep(.v-switch .v-input__control),
+.fence-card :deep(.v-switch .v-selection-control),
+.fence-card :deep(.v-switch .v-selection-control__wrapper) {
+  min-height: 0;
+  height: 16px;
+}
+.fence-card :deep(.fence-switch--exclusion .v-switch__track) {
+  background-color: #ff8800 !important;
+  opacity: 0.7 !important;
+}
+.fence-card :deep(.fence-switch--exclusion .v-switch__thumb) {
+  background-color: #ffffff !important;
+  color: #ff8800 !important;
+}
+.fence-expansible-wrapper :deep(.content-expand-collapse) {
+  padding-left: 0;
+  padding-right: 0;
+}
+.fence-autoenable-row :deep(.v-switch) {
+  flex: 0 0 auto;
+}
+.fence-autoenable-row :deep(.v-switch .v-input__control),
+.fence-autoenable-row :deep(.v-switch .v-selection-control),
+.fence-autoenable-row :deep(.v-switch .v-selection-control__wrapper) {
+  min-height: 0;
+  height: 24px;
+}
+</style>

--- a/src/components/geofence/GeoFenceMapLayer.vue
+++ b/src/components/geofence/GeoFenceMapLayer.vue
@@ -1,0 +1,94 @@
+<template>
+  <div class="hidden" />
+</template>
+
+<script setup lang="ts">
+import { useFenceRendering } from '@/composables/map/useFenceRendering'
+import type { GeoFencePlan } from '@/types/geofence'
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+const props = withDefaults(
+  defineProps<{
+    /**
+     * When true, fences are rendered without drag/edit affordances.
+     * Used by the live overlay on the flight Map widget.
+     */
+    readonly?: boolean
+    /**
+     * Optional plan to render. When omitted (interactive mode), the layer
+     * subscribes to the live `useGeoFenceStore` editor state instead.
+     */
+    plan?: GeoFencePlan
+  }>(),
+  { readonly: false, plan: undefined }
+)
+
+useFenceRendering({
+  get readonly() {
+    return props.readonly
+  },
+  get plan() {
+    return props.plan
+  },
+})
+</script>
+
+<!--
+  Styling targets DOM that Leaflet injects outside this component's render
+  tree (divIcons attached to the map's overlay pane, owned by the parent Map
+  component). Vue's `scoped` data-v-* attribute can't reach those elements,
+  so the rules below must stay global. The `fence-` prefix is the namespace
+  guard against accidental collisions.
+-->
+<style>
+.fence-breach-return-icon {
+  background: transparent;
+  border: none;
+}
+.fence-breach-return {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: #ff8800;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 12px;
+  border: 2px solid #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+}
+.fence-center-handle-icon {
+  background: transparent;
+  border: none;
+  cursor: move;
+}
+.fence-center-handle {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  color: #1f2937;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  border: 2px solid #3b78a8;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+  cursor: move;
+}
+.fence-center-handle .mdi {
+  pointer-events: none;
+}
+/* `fence-drag-handle` and `fence-add-handle` are passed via Leaflet's
+   `L.CircleMarker({ className })`, which Leaflet merges onto the rendered
+   SVG `<circle>` element on the overlay pane — so these cursor rules apply
+   to the circle node directly, not to a wrapping div. */
+.fence-drag-handle {
+  cursor: move;
+}
+.fence-add-handle {
+  cursor: copy;
+}
+</style>

--- a/src/components/geofence/GeoFenceParametersPanel.vue
+++ b/src/components/geofence/GeoFenceParametersPanel.vue
@@ -1,0 +1,273 @@
+<template>
+  <div class="fence-expansible-wrapper -mx-2 w-auto">
+    <ExpansiblePanel compact invert-chevron hover-effect elevation-effect :is-expanded="false" darken-content>
+      <template #title>
+        <div class="flex w-[90%] justify-between items-center text-[14px] -mb-3 font-normal ml-2">Fence parameters</div>
+      </template>
+      <template #content>
+        <div class="flex flex-col w-full">
+          <p v-if="!isApm && !isPx4" class="text-xs opacity-70 px-3 py-2">
+            Connect a vehicle to view its geofence parameters.
+          </p>
+          <p v-else class="text-[11px] opacity-70 px-3 pt-2 pb-1">
+            These parameters apply to all fences uploaded to the vehicle.
+          </p>
+
+          <div
+            v-for="param in activeParams"
+            :key="param.name"
+            class="flex w-full justify-between items-center border-b-[1px] border-[#FFFFFF22] h-[36px] px-3"
+          >
+            <p class="text-start text-[12px] flex-1 truncate">{{ param.name }}</p>
+            <div class="flex items-center gap-x-2">
+              <v-tooltip
+                location="left"
+                max-width="320"
+                :open-on-hover="false"
+                open-on-click
+                :model-value="openTooltip === param.name"
+                @update:model-value="
+                  (v) => (openTooltip = v ? param.name : openTooltip === param.name ? null : openTooltip)
+                "
+              >
+                <template #activator="{ props }">
+                  <v-icon v-bind="props" size="14" class="text-slate-400 cursor-pointer opacity-70 hover:opacity-100">
+                    mdi-information-outline
+                  </v-icon>
+                </template>
+                <div class="text-xs whitespace-pre-line pa-1 leading-snug">{{ param.description }}</div>
+              </v-tooltip>
+              <input
+                type="number"
+                class="p-1 bg-[#FFFFFF11] w-[90px] text-xs text-right rounded-sm"
+                :value="paramValues[param.name] ?? ''"
+                @change="onWriteParam(param.name, ($event.target as HTMLInputElement).value, param.type)"
+              />
+            </div>
+          </div>
+
+          <div class="flex flex-row justify-end px-3 py-2">
+            <v-tooltip location="top" text="Reload values from vehicle">
+              <template #activator="{ props }">
+                <v-btn v-bind="props" variant="text" size="x-small" icon @click="refreshAllParams">
+                  <v-icon size="14">mdi-refresh</v-icon>
+                </v-btn>
+              </template>
+            </v-tooltip>
+          </div>
+        </div>
+      </template>
+    </ExpansiblePanel>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
+
+import ExpansiblePanel from '@/components/ExpansiblePanel.vue'
+import { useSnackbar } from '@/composables/snackbar'
+import type { MavParamType as DialectMavParamType } from '@/libs/connection/m2r/dialects/ardupilotmega/MavParamType'
+import { MAVLinkType, MavParamType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
+import * as Vehicle from '@/libs/vehicle/vehicle'
+import { useMainVehicleStore } from '@/stores/mainVehicle'
+
+/**
+ * Static metadata for an autopilot parameter exposed in the fence parameters
+ * panel — name, human-readable description, expected MAVLink datatype, and
+ * the firmware family it belongs to. The runtime value lives in `paramValues`.
+ */
+interface ParamDescriptor {
+  /**
+   * Onboard parameter name (max 16 chars).
+   */
+  name: string
+  /**
+   * Short user-facing description.
+   */
+  description: string
+  /**
+   * Underlying parameter encoding type, wrapped in the tagged-union form
+   * expected by the MAVLink parameter API.
+   */
+  type: DialectMavParamType
+}
+
+const apmParams: ParamDescriptor[] = [
+  {
+    name: 'FENCE_ACTION',
+    description: [
+      'Action taken when the fence is breached. Available values vary by vehicle type:',
+      '0 → Report only (no autopilot reaction).',
+      '1 → RTL, falling back to Land if RTL is unavailable.',
+      '2 → Always Land (Copter only).',
+      '3 → SmartRTL, falling back to RTL or Land (Copter only).',
+      '4 → Brake, falling back to Land (Copter only).',
+      '5 → SmartRTL, falling back to Land (Copter only).',
+      '6 → Switch to Guided mode (Plane only).',
+      '7 → Switch to Guided mode while passing pilot throttle (Plane only).',
+    ].join('\n'),
+    type: { type: MavParamType.MAV_PARAM_TYPE_UINT8 } as DialectMavParamType,
+  },
+  {
+    name: 'FENCE_ALT_MAX',
+    description: 'Maximum altitude (meters) before the fence triggers. Numeric value, range 10 to 1000, increment 1.',
+    type: { type: MavParamType.MAV_PARAM_TYPE_REAL32 } as DialectMavParamType,
+  },
+  {
+    name: 'FENCE_ALT_MIN',
+    description: 'Minimum altitude (meters) before the fence triggers. Numeric value, range -100 to 100, increment 1.',
+    type: { type: MavParamType.MAV_PARAM_TYPE_REAL32 } as DialectMavParamType,
+  },
+  {
+    name: 'FENCE_MARGIN',
+    description:
+      'Buffer distance (meters) the autopilot tries to keep from the fence boundary to avoid breaching. Numeric value, range 1 to 10.',
+    type: { type: MavParamType.MAV_PARAM_TYPE_REAL32 } as DialectMavParamType,
+  },
+  {
+    name: 'FENCE_AUTOENABLE',
+    description: [
+      'Controls whether the fence is automatically enabled by the autopilot:',
+      '0 → Off (only enabled manually via FENCE_ENABLE).',
+      '1 → Auto-enable on takeoff once the configured altitude is reached.',
+      '2 → Auto-enable on takeoff; the minimum-altitude floor is disabled during landing.',
+      '3 → Auto-enable as soon as the vehicle is armed.',
+    ].join('\n'),
+    type: { type: MavParamType.MAV_PARAM_TYPE_UINT8 } as DialectMavParamType,
+  },
+]
+
+const px4Params: ParamDescriptor[] = [
+  {
+    name: 'GF_ACTION',
+    description: [
+      'Action taken when the fence is breached:',
+      '0 → None (no autopilot reaction).',
+      '1 → Warning only (notification, no behavior change).',
+      '2 → Hold (switch to Hold mode and stop in place).',
+      '3 → Return (switch to Return mode / RTL).',
+      '4 → Terminate (immediate flight termination, vehicle disarm/crash).',
+      '5 → Land (switch to Land mode at current position).',
+    ].join('\n'),
+    type: { type: MavParamType.MAV_PARAM_TYPE_INT32 } as DialectMavParamType,
+  },
+  {
+    name: 'GF_MAX_HOR_DIST',
+    description:
+      'Maximum horizontal distance (meters) the vehicle may travel from the home position. Numeric value. 0 → no horizontal limit.',
+    type: { type: MavParamType.MAV_PARAM_TYPE_REAL32 } as DialectMavParamType,
+  },
+  {
+    name: 'GF_MAX_VER_DIST',
+    description:
+      'Maximum vertical distance (meters) the vehicle may travel above the home position. Numeric value. 0 → no vertical limit.',
+    type: { type: MavParamType.MAV_PARAM_TYPE_REAL32 } as DialectMavParamType,
+  },
+  {
+    name: 'GF_PREDICT',
+    description: [
+      'Predictive geofence breach detection. The autopilot acts based on the projected position when enabled:',
+      '0 → Disabled (act only after a breach has occurred).',
+      '1 → Enabled (act as soon as a breach is predicted).',
+    ].join('\n'),
+    type: { type: MavParamType.MAV_PARAM_TYPE_INT32 } as DialectMavParamType,
+  },
+]
+
+const vehicleStore = useMainVehicleStore()
+const { openSnackbar } = useSnackbar()
+
+const paramValues = reactive<Record<string, number | undefined>>({})
+const openTooltip = ref<string | null>(null)
+
+const isApm = computed<boolean>(() => vehicleStore.mainVehicle?.firmware() === Vehicle.Firmware.ArduPilot)
+const isPx4 = computed<boolean>(() => vehicleStore.mainVehicle?.firmware() === Vehicle.Firmware.PX4)
+const activeParams = computed<ParamDescriptor[]>(() => (isApm.value ? apmParams : isPx4.value ? px4Params : []))
+
+const refreshAllParams = (): void => {
+  activeParams.value.forEach((p) => vehicleStore.requestParameter(p.name))
+}
+
+const onWriteParam = (name: string, valueStr: string, type: DialectMavParamType): void => {
+  if (!vehicleStore.mainVehicle) return
+  const value = Number(valueStr)
+  if (!Number.isFinite(value)) return
+  try {
+    vehicleStore.mainVehicle.setParameter({ id: name, value, type })
+    paramValues[name] = value
+    // The write may be rejected on the wire (out-of-range, read-only); request
+    // the value back so the PARAM_VALUE reply reconciles the optimistic update.
+    vehicleStore.requestParameter(name)
+  } catch (error) {
+    openSnackbar({
+      variant: 'error',
+      message: `Failed to write ${name}: ${error instanceof Error ? error.message : String(error)}`,
+      duration: 4000,
+    })
+  }
+}
+
+// Captured separately so it can be unsubscribed on unmount; otherwise every
+// remount of this panel adds another listener that lives for the vehicle's
+// lifetime.
+const onParamValueMessage = (pack: {
+  /**
+   * Decoded MAVLink message payload. We narrow it inside the handler to the
+   * subset of `PARAM_VALUE` fields we actually consume.
+   */
+  message: unknown
+}): void => {
+  const message = pack.message as {
+    /**
+     * Parameter id as a 16-byte char array (NUL-padded).
+     */
+    param_id: string[]
+    /**
+     * Current value of the parameter, encoded as a number regardless of
+     * the underlying `param_type`.
+     */
+    param_value: number
+  }
+  const name = message.param_id.join('').replace(/\0/g, '')
+  if (apmParams.some((p) => p.name === name) || px4Params.some((p) => p.name === name)) {
+    paramValues[name] = Number(message.param_value)
+  }
+}
+
+// Track which vehicle the PARAM_VALUE listener is currently attached to so
+// reconnections or vehicle switches detach from the previous instance and
+// (re)attach to the new one — otherwise the panel goes stale on the new link.
+let attachedVehicle: typeof vehicleStore.mainVehicle | undefined
+
+const attachToVehicle = (vehicle: typeof vehicleStore.mainVehicle | undefined): void => {
+  if (attachedVehicle === vehicle) return
+  attachedVehicle?.onIncomingMAVLinkMessage.remove(MAVLinkType.PARAM_VALUE, onParamValueMessage)
+  attachedVehicle = vehicle
+  attachedVehicle?.onIncomingMAVLinkMessage.add(MAVLinkType.PARAM_VALUE, onParamValueMessage)
+}
+
+onMounted(() => {
+  attachToVehicle(vehicleStore.mainVehicle)
+  refreshAllParams()
+})
+
+onBeforeUnmount(() => {
+  attachToVehicle(undefined)
+})
+
+watch(
+  () => vehicleStore.mainVehicle,
+  (vehicle) => {
+    attachToVehicle(vehicle)
+    refreshAllParams()
+  }
+)
+watch(() => vehicleStore.firmwareType, refreshAllParams)
+</script>
+
+<style scoped>
+.fence-expansible-wrapper :deep(.content-expand-collapse) {
+  padding-left: 0;
+  padding-right: 0;
+}
+</style>

--- a/src/components/mission-planning/MissionPlanningSidebar.vue
+++ b/src/components/mission-planning/MissionPlanningSidebar.vue
@@ -1,0 +1,78 @@
+<template>
+  <div
+    v-show="!interfaceStore.isMainMenuVisible"
+    class="absolute flex flex-col left-10 rounded-[10px] max-h-[80vh] overflow-hidden z-[200]"
+    :style="[
+      interfaceStore.globalGlassMenuStyles,
+      { height: 'auto', maxHeight: calculatedHeight, width: '320px', borderBottom: 'none' },
+    ]"
+  >
+    <div class="flex flex-row w-full elevation-2 z-10">
+      <button
+        class="flex-1 h-11 flex items-center justify-center text-base font-medium transition-colors duration-200"
+        :class="planningMode === 'mission' ? 'bg-[#3B78A8] text-white' : 'bg-[#FFFFFF11] hover:bg-[#FFFFFF22]'"
+        @click="onSelectPlanningMode('mission')"
+      >
+        <v-icon size="18" class="mr-1">mdi-map-marker-path</v-icon>
+        Mission
+      </button>
+      <div class="w-px bg-[#FFFFFF22]" />
+      <button
+        class="flex-1 h-11 flex items-center justify-center text-base font-medium transition-colors duration-200"
+        :class="planningMode === 'geofence' ? 'bg-[#3B78A8] text-white' : 'bg-[#FFFFFF11] hover:bg-[#FFFFFF22]'"
+        @click="onSelectPlanningMode('geofence')"
+      >
+        <v-icon size="18" class="mr-1">mdi-shield-outline</v-icon>
+        GeoFence
+      </button>
+    </div>
+    <div class="flex flex-col w-full h-full p-2 overflow-y-auto">
+      <GeoFenceEditor
+        v-if="planningMode === 'geofence'"
+        :map-center="mapCenter"
+        @mission-loaded="emit('missionLoaded')"
+      />
+      <slot v-if="planningMode === 'mission'" name="mission" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { defineModel } from 'vue'
+
+import GeoFenceEditor from '@/components/geofence/GeoFenceEditor.vue'
+import { useAppInterfaceStore } from '@/stores/appInterface'
+
+const planningMode = defineModel<'mission' | 'geofence'>('planningMode', { required: true })
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+defineProps<{
+  /**
+   * Current map center forwarded to the geofence editor so newly
+   * created polygons and circles are seeded near the visible area.
+   */
+  mapCenter: [number, number]
+  /**
+   * Max height in CSS units for the collapsible shell, computed by
+   * the planning view to fit the viewport under the top bar.
+   */
+  calculatedHeight: string | number
+}>()
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+const emit = defineEmits<{
+  /**
+   * Forwarded from the geofence editor when it loads a mission from a
+   * saved plan file. Parent should refresh its waypoint markers.
+   */
+  missionLoaded: []
+}>()
+
+const interfaceStore = useAppInterfaceStore()
+
+const onSelectPlanningMode = (mode: 'mission' | 'geofence'): void => {
+  if (planningMode.value === mode) return
+  logUserAction(`Switched planning mode to ${mode === 'mission' ? 'Mission' : 'GeoFence'}`)
+  planningMode.value = mode
+}
+</script>

--- a/src/composables/map/useFenceDrawing.ts
+++ b/src/composables/map/useFenceDrawing.ts
@@ -1,0 +1,404 @@
+import L from 'leaflet'
+import { type Ref, ref, shallowRef, toRaw } from 'vue'
+
+import { useGeoFenceEditorDraft } from '@/composables/useGeoFenceEditorDraft'
+import { centroidLatLng, polygonAreaSquareMeters } from '@/libs/mission/general-estimates'
+import { useGeoFenceStore } from '@/stores/geoFence'
+import type { WaypointCoordinates } from '@/types/mission'
+
+const FENCE_DRAW_COLOR = '#FF8800'
+
+/**
+ * Dependencies the planning view injects into {@link useFenceDrawing} —
+ * everything that is owned by the view (the Leaflet map instance, the measure
+ * overlay plumbing, area-label formatting) but is needed by the drawing
+ * primitives. Keeping these out of the composable lets the planning view stay
+ * the single owner of the map and measure-pane lifecycle.
+ */
+export interface UseFenceDrawingDeps {
+  /**
+   * Reactive reference to the planning Leaflet map instance. The composable
+   * reads it on demand so it transparently picks up late-mounted maps.
+   */
+  map: Ref<L.Map | undefined>
+  /**
+   * Formats a square-meter area into the human-readable label used inside
+   * the live area pill (delegated so the view can stay the single source of
+   * unit/locale formatting).
+   */
+  formatArea: (squareMeters: number) => string
+  /**
+   * Builds the L.Marker that renders the area pill at the polygon centroid.
+   * The view owns this because it shares the marker with the survey flow and
+   * wants identical styling/pane assignment across both flows.
+   */
+  makeAreaMarker: (at: L.LatLng, text: string) => L.Marker
+  /**
+   * Adds a measure-overlay layer (area pills, distance labels) to the
+   * shared measure layer-group owned by the view.
+   */
+  addAreaToMeasureLayer: (layer: L.Layer) => void
+}
+
+/**
+ * Public surface of the fence drawing composable. The view consumes
+ * `polygonVertexesPositions` for template guards and confirm-button
+ * placement, and calls the action functions from the map click handlers,
+ * the confirm button, and the cleanup paths in the planning lifecycle.
+ */
+export interface UseFenceDrawingApi {
+  /**
+   * Reactive list of vertex coordinates of the polygon currently being
+   * drawn. Mirrors the Leaflet vertex markers and is kept in sync with
+   * the fence editor draft's `pendingPolygonVertices` on every mutation.
+   */
+  polygonVertexesPositions: Ref<L.LatLng[]>
+  /**
+   * Adds a new vertex to the in-progress polygon at the end of the chain
+   * or, when `edgeIndex` is provided, between the vertex at `edgeIndex`
+   * and the next one (used when the user clicks a "+" marker on an edge).
+   */
+  addPolygonPoint: (latlng: L.LatLng, edgeIndex?: number) => void
+  /**
+   * Commits the in-progress polygon to the store, transitioning the editor
+   * out of the drawing state. No-op when fewer than 3 vertexes exist.
+   */
+  finishPolygonDrawing: () => void
+  /**
+   * Removes every Leaflet artifact created during polygon drawing
+   * (vertexes, edge "+" markers, the dashed polygon, the area pill) and
+   * resets the internal state. Used when the user cancels the draw or
+   * switches planning modes mid-draw.
+   */
+  clearPolygonDrawingArtifacts: () => void
+  /**
+   * Sets (or moves) the center marker for the in-progress circle and
+   * stores it on the geofence store so subsequent mouse-moves can compute
+   * the radius preview.
+   */
+  setPendingCircleCenter: (latlng: L.LatLng) => void
+  /**
+   * Refreshes the dashed circle preview from the geofence store's
+   * pending center and radius. Called on each mouse-move while drawing.
+   */
+  updatePendingCircleLayer: () => void
+  /**
+   * Removes both the pending-circle dashed layer and its center marker.
+   * Used when committing the circle or cancelling mid-draw.
+   */
+  clearPendingCircleArtifacts: () => void
+}
+
+/**
+ * Encapsulates the in-progress fence drawing state for the planning map:
+ * polygon vertex markers, edge "+"-markers, the dashed live polygon, the
+ * area pill at the centroid, and the two-click circle drawing primitives.
+ *
+ * Mirrors the survey-polygon UX (crosshair, draggable vertices, hover-delete,
+ * "+"-markers on edges) but in the orange fence palette. The view owns the
+ * Leaflet map, the area-label/measure-layer plumbing, and the confirm-button
+ * positioning logic — all injected through {@link UseFenceDrawingDeps}.
+ *
+ * The composable does not call any view-side UI helper itself; instead, the
+ * exposed `polygonVertexesPositions` ref triggers the view's existing watch
+ * so confirm-button repositioning happens through the same path the survey
+ * flow already uses.
+ * @param {UseFenceDrawingDeps} deps Map and measure-layer plumbing owned by the planning view.
+ * @returns {UseFenceDrawingApi} Fence drawing state and action functions for the view.
+ */
+export const useFenceDrawing = (deps: UseFenceDrawingDeps): UseFenceDrawingApi => {
+  const fenceStore = useGeoFenceStore()
+  const fenceDraft = useGeoFenceEditorDraft()
+
+  const polygonVertexesPositions = ref<L.LatLng[]>([])
+  const polygonVertexesMarkers = ref<L.Marker[]>([])
+  const polygonLayer = shallowRef<L.Polygon | null>(null)
+  const edgeAddMarkers: L.Marker[] = []
+  const livePolygonAreaMarker = shallowRef<L.Marker | null>(null)
+
+  const pendingCircleCenterMarker = shallowRef<L.Marker | null>(null)
+  const pendingCircleLayer = shallowRef<L.Circle | null>(null)
+
+  const syncVerticesToStore = (): void => {
+    fenceDraft.pendingPolygonVertices.splice(
+      0,
+      fenceDraft.pendingPolygonVertices.length,
+      ...polygonVertexesPositions.value.map(({ lat, lng }) => [lat, lng] as [number, number])
+    )
+  }
+
+  const updateLivePolygonAreaLabel = (coords: WaypointCoordinates[]): void => {
+    if (coords.length < 3) {
+      if (livePolygonAreaMarker.value) {
+        deps.map.value?.removeLayer(livePolygonAreaMarker.value)
+        livePolygonAreaMarker.value = null
+      }
+      return
+    }
+
+    const m2 = polygonAreaSquareMeters(coords)
+    const label = deps.formatArea(m2)
+    const centerTuple = centroidLatLng(coords)
+    if (!Number.isFinite(centerTuple[0]) || !Number.isFinite(centerTuple[1])) return
+    const center = L.latLng(centerTuple[0], centerTuple[1])
+
+    if (!livePolygonAreaMarker.value) {
+      livePolygonAreaMarker.value = deps.makeAreaMarker(center, label)
+      deps.addAreaToMeasureLayer(livePolygonAreaMarker.value)
+    } else {
+      livePolygonAreaMarker.value.setLatLng(center)
+      const pill = livePolygonAreaMarker.value.getElement()?.querySelector('.measure-area-pill')
+      if (pill) pill.textContent = label
+    }
+  }
+
+  const updatePolygonLayer = (): void => {
+    polygonVertexesPositions.value = polygonVertexesMarkers.value.map((marker) => marker.getLatLng())
+
+    if (polygonLayer.value) {
+      polygonLayer.value.setLatLngs(polygonVertexesPositions.value)
+    } else if (polygonVertexesPositions.value.length >= 3) {
+      polygonLayer.value = L.polygon(polygonVertexesPositions.value, {
+        color: FENCE_DRAW_COLOR,
+        fillColor: FENCE_DRAW_COLOR,
+        fillOpacity: 0.15,
+        weight: 2,
+        dashArray: '4 4',
+        className: 'fence-polygon-draft',
+      }).addTo(toRaw(deps.map.value)!)
+    }
+
+    if (polygonLayer.value && polygonVertexesPositions.value.length >= 3) {
+      updateLivePolygonAreaLabel(polygonVertexesPositions.value.map((p) => [p.lat, p.lng] as WaypointCoordinates))
+    } else if (polygonVertexesPositions.value.length < 3 && polygonLayer.value) {
+      deps.map.value?.removeLayer(polygonLayer.value as unknown as L.Layer)
+      polygonLayer.value = null
+      updateLivePolygonAreaLabel([])
+    }
+
+    syncVerticesToStore()
+  }
+
+  const updateEdgeAddMarkers = (): void => {
+    edgeAddMarkers.forEach((marker) => marker.remove())
+    edgeAddMarkers.length = 0
+
+    if (polygonVertexesPositions.value.length < 3) return
+
+    for (let i = 0; i < polygonVertexesPositions.value.length; i++) {
+      const start = polygonVertexesPositions.value[i]
+      const end = polygonVertexesPositions.value[(i + 1) % polygonVertexesPositions.value.length]
+      const middle = L.latLng((start.lat + end.lat) / 2, (start.lng + end.lng) / 2)
+
+      const edgeAddMarker = L.marker(middle, {
+        icon: L.divIcon({
+          html: `
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" style="display: block;">
+              <circle cx="10" cy="10" r="9" fill="white" stroke="${FENCE_DRAW_COLOR}" stroke-width="2"/>
+              <path d="M10 5V15M5 10H15" stroke="${FENCE_DRAW_COLOR}" stroke-width="2"/>
+            </svg>
+          `,
+          className: 'fence-edge-marker',
+          iconSize: [24, 24],
+          iconAnchor: [12, 12],
+        }),
+      })
+
+      edgeAddMarker.on('click', (e: L.LeafletMouseEvent) => addPolygonPoint(e.latlng, i))
+      edgeAddMarker.addTo(toRaw(deps.map.value)!)
+      edgeAddMarkers.push(edgeAddMarker)
+    }
+  }
+
+  const createVertexMarker = (
+    latlng: L.LatLng,
+    onClick: (marker: L.Marker, evt: L.LeafletEvent) => void,
+    onDrag: () => void
+  ): L.Marker => {
+    let justCreated = true
+
+    return L.marker(latlng, {
+      icon: L.divIcon({
+        html: `
+          <div class="fence-vertex-icon">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <circle cx="12" cy="12" r="5" fill="${FENCE_DRAW_COLOR}" stroke="white" stroke-width="2"/>
+            </svg>
+            <div class="delete-popup" style="display: none;">
+              <button class="delete-button">
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M2 4h12M4 4v10a2 2 0 002 2h4a2 2 0 002-2V4M6 4V2h4v2"
+                        stroke="white" stroke-width="1.5"
+                        stroke-linecap="round" stroke-linejoin="round"/>
+                  </svg>
+                </button>
+            </div>
+          </div>
+        `,
+        className: 'fence-vertex-div-icon',
+        iconSize: [24, 24],
+        iconAnchor: [12, 12],
+      }),
+      draggable: true,
+    })
+      .on('drag', () => {
+        onDrag()
+      })
+      .on('mouseover', (event: L.LeafletEvent) => {
+        if (justCreated) {
+          justCreated = false
+          return
+        }
+        const target = event.target as L.Marker
+        const popup = target.getElement()?.querySelector('.delete-popup') as HTMLDivElement
+        if (popup) popup.style.display = 'block'
+      })
+      .on('mouseout', (event: L.LeafletEvent) => {
+        const target = event.target as L.Marker
+        const popup = target.getElement()?.querySelector('.delete-popup') as HTMLDivElement
+        if (popup) popup.style.display = 'none'
+      })
+      .on('click', (event: L.LeafletEvent) => {
+        const target = event.target as L.Marker
+        onClick(target, event)
+      })
+  }
+
+  const removePolygonVertex = (index: number): void => {
+    const marker = polygonVertexesMarkers.value[index]
+    if (!marker) return
+    polygonVertexesPositions.value.splice(index, 1)
+    polygonVertexesMarkers.value.splice(index, 1)
+    marker.remove()
+    updatePolygonLayer()
+    updateEdgeAddMarkers()
+  }
+
+  const addPolygonPoint = (latlng: L.LatLng, edgeIndex: number | undefined = undefined): void => {
+    if (!fenceDraft.isDrawingPolygon) return
+
+    if (edgeIndex === undefined) {
+      polygonVertexesPositions.value.push(latlng)
+    } else {
+      polygonVertexesPositions.value.splice(edgeIndex + 1, 0, latlng)
+    }
+
+    const newMarker = createVertexMarker(
+      latlng,
+      (marker) => {
+        const idx = polygonVertexesMarkers.value.indexOf(marker)
+        if (idx !== -1) removePolygonVertex(idx)
+      },
+      () => {
+        updatePolygonLayer()
+        updateEdgeAddMarkers()
+      }
+    ).addTo(toRaw(deps.map.value)!)
+
+    if (edgeIndex === undefined) {
+      polygonVertexesMarkers.value.push(newMarker)
+    } else {
+      polygonVertexesMarkers.value.splice(edgeIndex + 1, 0, newMarker)
+    }
+
+    updatePolygonLayer()
+    updateEdgeAddMarkers()
+  }
+
+  const finishPolygonDrawing = (): void => {
+    if (polygonVertexesPositions.value.length < 3) return
+    syncVerticesToStore()
+    fenceStore.finishDrawingPolygon()
+  }
+
+  const clearPolygonDrawingArtifacts = (): void => {
+    if (polygonLayer.value) {
+      deps.map.value?.removeLayer(polygonLayer.value as unknown as L.Layer)
+      polygonLayer.value = null
+    }
+    if (livePolygonAreaMarker.value) {
+      deps.map.value?.removeLayer(livePolygonAreaMarker.value)
+      livePolygonAreaMarker.value = null
+    }
+    polygonVertexesMarkers.value.forEach((marker) => marker.remove())
+    edgeAddMarkers.forEach((marker) => marker.remove())
+    edgeAddMarkers.length = 0
+    polygonVertexesMarkers.value = []
+    polygonVertexesPositions.value = []
+  }
+
+  const setPendingCircleCenter = (latlng: L.LatLng): void => {
+    if (!fenceDraft.isDrawingCircle) return
+    fenceDraft.setPendingCircleCenter([latlng.lat, latlng.lng])
+
+    if (pendingCircleCenterMarker.value) {
+      pendingCircleCenterMarker.value.setLatLng(latlng)
+    } else {
+      pendingCircleCenterMarker.value = L.marker(latlng, {
+        icon: L.divIcon({
+          html: `
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <circle cx="7" cy="7" r="5" fill="${FENCE_DRAW_COLOR}" stroke="white" stroke-width="2"/>
+            </svg>
+          `,
+          className: 'fence-vertex-div-icon',
+          iconSize: [14, 14],
+          iconAnchor: [7, 7],
+        }),
+        interactive: false,
+        keyboard: false,
+      }).addTo(toRaw(deps.map.value)!)
+    }
+  }
+
+  const updatePendingCircleLayer = (): void => {
+    if (!deps.map.value) return
+    const center = fenceDraft.pendingCircleCenter
+    const radius = fenceDraft.pendingCircleRadius
+    if (!center || radius < 1) {
+      if (pendingCircleLayer.value) {
+        deps.map.value.removeLayer(pendingCircleLayer.value as unknown as L.Layer)
+        pendingCircleLayer.value = null
+      }
+      return
+    }
+
+    const latlng = L.latLng(center[0], center[1])
+    if (pendingCircleLayer.value) {
+      pendingCircleLayer.value.setLatLng(latlng)
+      pendingCircleLayer.value.setRadius(radius)
+    } else {
+      pendingCircleLayer.value = L.circle(latlng, {
+        radius,
+        color: FENCE_DRAW_COLOR,
+        fillColor: FENCE_DRAW_COLOR,
+        fillOpacity: 0.15,
+        weight: 2,
+        dashArray: '4 4',
+        className: 'fence-circle-draft',
+        interactive: false,
+      }).addTo(toRaw(deps.map.value)!)
+    }
+  }
+
+  const clearPendingCircleArtifacts = (): void => {
+    if (pendingCircleLayer.value) {
+      deps.map.value?.removeLayer(pendingCircleLayer.value as unknown as L.Layer)
+      pendingCircleLayer.value = null
+    }
+    if (pendingCircleCenterMarker.value) {
+      deps.map.value?.removeLayer(pendingCircleCenterMarker.value)
+      pendingCircleCenterMarker.value = null
+    }
+  }
+
+  return {
+    polygonVertexesPositions,
+    addPolygonPoint,
+    finishPolygonDrawing,
+    clearPolygonDrawingArtifacts,
+    setPendingCircleCenter,
+    updatePendingCircleLayer,
+    clearPendingCircleArtifacts,
+  }
+}

--- a/src/composables/map/useFenceRendering.ts
+++ b/src/composables/map/useFenceRendering.ts
@@ -1,0 +1,571 @@
+import { useDebounceFn } from '@vueuse/core'
+import L from 'leaflet'
+import { onBeforeUnmount, watch } from 'vue'
+
+import { useMapContext } from '@/composables/map/useMapContext'
+import { useGeoFenceEditorDraft } from '@/composables/useGeoFenceEditorDraft'
+import { centroidLatLng } from '@/libs/mission/general-estimates'
+import { useGeoFenceStore } from '@/stores/geoFence'
+import type { BreachReturnPoint, FenceCircle, FenceLatLng, FencePolygon, GeoFencePlan } from '@/types/geofence'
+
+/**
+ * Props consumed by {@link useFenceRendering}. Mirrors the host
+ * `GeoFenceMapLayer` component's props so its reactive proxy can be passed
+ * through untouched, keeping the reads reactive.
+ */
+export interface FenceRenderingProps {
+  /**
+   * When true, fences are rendered without drag/edit affordances (the
+   * read-only live overlay on the flight Map widget).
+   */
+  readonly: boolean
+  /**
+   * Optional plan to render. When omitted (interactive mode), the renderer
+   * subscribes to the live `useGeoFenceStore` editor state instead.
+   */
+  plan?: GeoFencePlan
+}
+
+/**
+ * Owns the imperative Leaflet rendering of the geofence overlay — polygons,
+ * circles, drag/vertex handles, the breach-return marker and the live radius
+ * measure — so Leaflet stays out of the `.vue` component and the map solution
+ * remains swappable. Reads the reactive `props`, the injected map context and
+ * the fence store/draft, and tears every layer down on unmount.
+ * @param {FenceRenderingProps} props Reactive props proxy from the host component.
+ * @returns {void}
+ */
+export const useFenceRendering = (props: FenceRenderingProps): void => {
+  const fenceStore = useGeoFenceStore()
+  const fenceDraft = useGeoFenceEditorDraft()
+  const { map, mapReady } = useMapContext()
+
+  const INCLUSION_BORDER = '#3B78A8'
+  const INCLUSION_FILL_COLOR = '#3B78A8'
+  const INCLUSION_FILL_OPACITY = 0.2
+  const EXCLUSION_BORDER = '#FF8800'
+  const EXCLUSION_FILL_COLOR = '#FF8800'
+  const EXCLUSION_FILL_OPACITY = 1
+  const EXCLUSION_PATTERN_ID = 'fence-exclusion-stripes'
+  const EXCLUSION_PATTERN_DIM_ID = 'fence-exclusion-stripes-dim'
+  const VERTEX_COLOR = '#FFFFFF'
+  const VERTEX_BORDER = '#FF8800'
+
+  // Read-only renders (e.g. the live overlay on the flight Map widget) get every
+  // fence-related opacity halved so the fences sit further into the background
+  // while staying clearly differentiated as inclusion/exclusion.
+  const READONLY_OPACITY_FACTOR = 0.5
+
+  const polygonLayers = new Map<string, L.Polygon>()
+  const polygonVertexMarkers = new Map<string, L.CircleMarker[]>()
+  const polygonMidpointMarkers = new Map<string, L.CircleMarker[]>()
+  const polygonCenterMarkers = new Map<string, L.Marker>()
+  const circleLayers = new Map<string, L.Circle>()
+  const circleCenterMarkers = new Map<string, L.CircleMarker>()
+  const circleEdgeMarkers = new Map<string, L.CircleMarker>()
+  let breachReturnMarker: L.Marker | null = null
+
+  const polygonStyle = (inclusion: boolean): L.PathOptions => {
+    const dim = props.readonly ? READONLY_OPACITY_FACTOR : 1
+    return {
+      color: inclusion ? INCLUSION_BORDER : EXCLUSION_BORDER,
+      weight: 2,
+      opacity: (inclusion ? 1 : 0.6) * dim,
+      fillColor: inclusion ? INCLUSION_FILL_COLOR : EXCLUSION_FILL_COLOR,
+      fillOpacity: (inclusion ? INCLUSION_FILL_OPACITY : EXCLUSION_FILL_OPACITY) * dim,
+    }
+  }
+
+  /**
+   * Lazily injects a 45° striped orange / transparent SVG `<pattern>` into the
+   * map's overlay SVG so exclusion fences can fill themselves with it. Leaflet
+   * draws all vector layers under a single SVG renderer per map, so a single
+   * pattern definition is enough for the whole layer.
+   *
+   * Two flavors are registered on demand: a "normal" pattern used by the
+   * interactive editor, and a dimmed one (50% less opaque) used by the
+   * read-only live overlay so map context stays readable underneath.
+   * @param { L.Map } targetMap The Leaflet map to inject the pattern into.
+   * @param { boolean } dim When true, registers / reuses the dimmed pattern.
+   */
+  const ensureExclusionPattern = (targetMap: L.Map, dim: boolean): void => {
+    const overlayPane = targetMap.getPanes().overlayPane
+    const svg = overlayPane?.querySelector('svg') as SVGSVGElement | null
+    if (!svg) return
+    const id = dim ? EXCLUSION_PATTERN_DIM_ID : EXCLUSION_PATTERN_ID
+    if (svg.querySelector(`#${id}`)) return
+
+    const svgNs = 'http://www.w3.org/2000/svg'
+    let defs = svg.querySelector('defs') as SVGDefsElement | null
+    if (!defs) {
+      defs = document.createElementNS(svgNs, 'defs')
+      svg.insertBefore(defs, svg.firstChild)
+    }
+
+    const pattern = document.createElementNS(svgNs, 'pattern')
+    pattern.setAttribute('id', id)
+    pattern.setAttribute('patternUnits', 'userSpaceOnUse')
+    pattern.setAttribute('width', '12')
+    pattern.setAttribute('height', '12')
+    pattern.setAttribute('patternTransform', 'rotate(45)')
+
+    const stripe = document.createElementNS(svgNs, 'rect')
+    stripe.setAttribute('x', '0')
+    stripe.setAttribute('y', '0')
+    stripe.setAttribute('width', '6')
+    stripe.setAttribute('height', '12')
+    stripe.setAttribute('fill', EXCLUSION_FILL_COLOR)
+    stripe.setAttribute('fill-opacity', String(0.32 * (dim ? READONLY_OPACITY_FACTOR : 1)))
+    pattern.appendChild(stripe)
+
+    defs.appendChild(pattern)
+  }
+
+  /**
+   * Applies the appropriate `fill` to the SVG path element of a fence layer.
+   * Inclusion fences get the translucent blue color (already set via
+   * `polygonStyle`); exclusion fences are repainted to reference the diagonal
+   * stripe pattern, which Leaflet's `fillColor` can't express directly.
+   * @param { L.Path } layer The Leaflet vector layer whose element should be styled.
+   * @param { boolean } inclusion Whether the underlying fence is an inclusion fence.
+   */
+  const applyFenceFill = (layer: L.Path, inclusion: boolean): void => {
+    const el = layer.getElement() as SVGPathElement | null
+    if (!el) return
+    if (inclusion) {
+      el.setAttribute('fill', INCLUSION_FILL_COLOR)
+    } else if (map.value) {
+      ensureExclusionPattern(map.value, props.readonly)
+      const patternId = props.readonly ? EXCLUSION_PATTERN_DIM_ID : EXCLUSION_PATTERN_ID
+      el.setAttribute('fill', `url(#${patternId})`)
+    }
+  }
+
+  const vertexHandleStyle = (): L.PathOptions => ({
+    color: VERTEX_BORDER,
+    fillColor: VERTEX_COLOR,
+    fillOpacity: 1,
+    weight: 2,
+    opacity: 1,
+  })
+
+  const midpointHandleStyle = (): L.PathOptions => ({
+    color: VERTEX_BORDER,
+    fillColor: VERTEX_COLOR,
+    fillOpacity: 0.6,
+    weight: 1,
+    opacity: 0.6,
+  })
+
+  const midpointBetween = (a: FenceLatLng, b: FenceLatLng): FenceLatLng => [(a[0] + b[0]) / 2, (a[1] + b[1]) / 2]
+
+  const formatRadiusShort = (meters: number): string => {
+    if (!isFinite(meters) || meters <= 0) return '—'
+    if (meters < 1000) return `${meters.toFixed(0)} m`
+    return `${(meters / 1000).toFixed(2)} km`
+  }
+
+  let radiusPillMarker: L.Marker | null = null
+  let radiusLine: L.Polyline | null = null
+
+  const showRadiusMeasure = (center: L.LatLng, cursor: L.LatLng, radius: number): void => {
+    if (!map.value) return
+
+    const latlngs: L.LatLngTuple[] = [
+      [center.lat, center.lng],
+      [cursor.lat, cursor.lng],
+    ]
+    if (radiusLine) {
+      radiusLine.setLatLngs(latlngs)
+    } else {
+      radiusLine = L.polyline(latlngs, {
+        color: '#2563eb',
+        weight: 2,
+        opacity: 0.9,
+        dashArray: '10, 10',
+        interactive: false,
+      }).addTo(map.value)
+    }
+
+    const midpoint = L.latLng((center.lat + cursor.lat) / 2, (center.lng + cursor.lng) / 2)
+    const html = `<div class="live-measure-pill">${formatRadiusShort(radius)}</div>`
+    const icon = L.divIcon({ html, className: 'live-measure-tag', iconSize: [0, 0], iconAnchor: [0, 0] })
+    if (radiusPillMarker) {
+      radiusPillMarker.setLatLng(midpoint)
+      radiusPillMarker.setIcon(icon)
+    } else {
+      radiusPillMarker = L.marker(midpoint, { icon, interactive: false, keyboard: false }).addTo(map.value)
+    }
+  }
+
+  const hideRadiusMeasure = (): void => {
+    if (radiusPillMarker && map.value) map.value.removeLayer(radiusPillMarker)
+    radiusPillMarker = null
+    if (radiusLine && map.value) map.value.removeLayer(radiusLine)
+    radiusLine = null
+  }
+
+  const removePolygonHandles = (id: string): void => {
+    polygonVertexMarkers.get(id)?.forEach((m) => map.value?.removeLayer(m))
+    polygonMidpointMarkers.get(id)?.forEach((m) => map.value?.removeLayer(m))
+    const center = polygonCenterMarkers.get(id)
+    if (center && map.value) map.value.removeLayer(center)
+    polygonVertexMarkers.delete(id)
+    polygonMidpointMarkers.delete(id)
+    polygonCenterMarkers.delete(id)
+  }
+
+  const removePolygonLayer = (id: string): void => {
+    const layer = polygonLayers.get(id)
+    if (layer && map.value) map.value.removeLayer(layer)
+    polygonLayers.delete(id)
+    removePolygonHandles(id)
+  }
+
+  const removeCircleHandles = (id: string): void => {
+    const center = circleCenterMarkers.get(id)
+    if (center && map.value) map.value.removeLayer(center)
+    circleCenterMarkers.delete(id)
+    const edge = circleEdgeMarkers.get(id)
+    if (edge && map.value) map.value.removeLayer(edge)
+    circleEdgeMarkers.delete(id)
+  }
+
+  const removeCircleLayer = (id: string): void => {
+    const layer = circleLayers.get(id)
+    if (layer && map.value) map.value.removeLayer(layer)
+    circleLayers.delete(id)
+    removeCircleHandles(id)
+  }
+
+  const removeBreachReturnMarker = (): void => {
+    if (breachReturnMarker && map.value) map.value.removeLayer(breachReturnMarker)
+    breachReturnMarker = null
+  }
+
+  const clearAllLayers = (): void => {
+    Array.from(polygonLayers.keys()).forEach(removePolygonLayer)
+    Array.from(circleLayers.keys()).forEach(removeCircleLayer)
+    removeBreachReturnMarker()
+    hideRadiusMeasure()
+  }
+
+  const isInteractiveShape = (id: string): boolean => !props.readonly && fenceDraft.interactiveShapeId === id
+
+  const buildVertexMarkers = (polygon: FencePolygon): void => {
+    if (!map.value) return
+    removePolygonHandles(polygon.id)
+
+    if (!isInteractiveShape(polygon.id)) return
+
+    const vertexMarkers: L.CircleMarker[] = polygon.vertices.map((vertex, index) => {
+      const marker = L.circleMarker(vertex as L.LatLngTuple, {
+        ...vertexHandleStyle(),
+        radius: 6,
+        pane: 'markerPane',
+        className: 'fence-drag-handle',
+      })
+      marker.addTo(map.value as L.Map)
+      let dragging = false
+
+      marker.on('mousedown', () => {
+        dragging = true
+        map.value?.dragging.disable()
+        const onMove = (event: L.LeafletMouseEvent): void => {
+          if (!dragging) return
+          const newVertices = polygon.vertices.map(
+            (v, i): FenceLatLng => (i === index ? [event.latlng.lat, event.latlng.lng] : v)
+          )
+          fenceStore.updatePolygon(polygon.id, { vertices: newVertices })
+        }
+        const onUp = (): void => {
+          dragging = false
+          map.value?.off('mousemove', onMove)
+          map.value?.off('mouseup', onUp)
+          map.value?.dragging.enable()
+        }
+        map.value?.on('mousemove', onMove)
+        map.value?.on('mouseup', onUp)
+      })
+
+      marker.on('contextmenu', (event: L.LeafletMouseEvent) => {
+        L.DomEvent.stopPropagation(event)
+        if (polygon.vertices.length <= 3) return
+        const newVertices = polygon.vertices.filter((_, i) => i !== index)
+        fenceStore.updatePolygon(polygon.id, { vertices: newVertices })
+      })
+
+      return marker
+    })
+    polygonVertexMarkers.set(polygon.id, vertexMarkers)
+
+    const midpointMarkers: L.CircleMarker[] = []
+    polygon.vertices.forEach((vertex, index) => {
+      const next = polygon.vertices[(index + 1) % polygon.vertices.length]
+      const mid = midpointBetween(vertex, next)
+      const marker = L.circleMarker(mid as L.LatLngTuple, {
+        ...midpointHandleStyle(),
+        radius: 4,
+        pane: 'markerPane',
+        className: 'fence-add-handle',
+      })
+      marker.addTo(map.value as L.Map)
+      marker.on('click', (event: L.LeafletMouseEvent) => {
+        L.DomEvent.stopPropagation(event)
+        const insertAt = index + 1
+        const newVertices: FenceLatLng[] = [
+          ...polygon.vertices.slice(0, insertAt),
+          [event.latlng.lat, event.latlng.lng],
+          ...polygon.vertices.slice(insertAt),
+        ]
+        fenceStore.updatePolygon(polygon.id, { vertices: newVertices })
+      })
+      midpointMarkers.push(marker)
+    })
+    polygonMidpointMarkers.set(polygon.id, midpointMarkers)
+
+    buildPolygonCenterHandle(polygon)
+  }
+
+  const buildPolygonCenterHandle = (polygon: FencePolygon): void => {
+    if (!map.value) return
+    if (polygon.vertices.length < 3) return
+
+    const center = centroidLatLng(polygon.vertices)
+    const html = `<div class="fence-center-handle"><span class="mdi mdi-cursor-move" /></div>`
+    const icon = L.divIcon({
+      html,
+      className: 'fence-center-handle-icon',
+      iconSize: [18, 18],
+      iconAnchor: [9, 9],
+    })
+    const marker = L.marker(center as L.LatLngTuple, { icon, pane: 'markerPane', interactive: true })
+    marker.addTo(map.value)
+
+    let dragging = false
+    let lastLatLng: L.LatLng | null = null
+    marker.on('mousedown', (event: L.LeafletMouseEvent) => {
+      L.DomEvent.stopPropagation(event)
+      dragging = true
+      lastLatLng = event.latlng
+      map.value?.dragging.disable()
+      const onMove = (moveEvent: L.LeafletMouseEvent): void => {
+        if (!dragging || !lastLatLng) return
+        const dLat = moveEvent.latlng.lat - lastLatLng.lat
+        const dLng = moveEvent.latlng.lng - lastLatLng.lng
+        lastLatLng = moveEvent.latlng
+        const current = fenceStore.polygons.find((p) => p.id === polygon.id)
+        if (!current) return
+        const newVertices: FenceLatLng[] = current.vertices.map(([lat, lng]) => [lat + dLat, lng + dLng])
+        fenceStore.updatePolygon(polygon.id, { vertices: newVertices })
+      }
+      const onUp = (): void => {
+        dragging = false
+        lastLatLng = null
+        map.value?.off('mousemove', onMove)
+        map.value?.off('mouseup', onUp)
+        map.value?.dragging.enable()
+      }
+      map.value?.on('mousemove', onMove)
+      map.value?.on('mouseup', onUp)
+    })
+
+    polygonCenterMarkers.set(polygon.id, marker)
+  }
+
+  const renderPolygon = (polygon: FencePolygon): void => {
+    if (!map.value) return
+    const existing = polygonLayers.get(polygon.id)
+    if (existing) {
+      existing.setLatLngs(polygon.vertices as L.LatLngExpression[])
+      existing.setStyle(polygonStyle(polygon.inclusion))
+      applyFenceFill(existing, polygon.inclusion)
+    } else {
+      const layer = L.polygon(polygon.vertices as L.LatLngExpression[], polygonStyle(polygon.inclusion))
+      layer.addTo(map.value)
+      applyFenceFill(layer, polygon.inclusion)
+      if (!props.readonly) {
+        layer.on('click', (event: L.LeafletMouseEvent) => {
+          L.DomEvent.stopPropagation(event)
+          fenceDraft.setInteractive(polygon.id)
+        })
+      }
+      polygonLayers.set(polygon.id, layer)
+    }
+    buildVertexMarkers(polygon)
+  }
+
+  const buildCircleHandles = (circle: FenceCircle): void => {
+    if (!map.value) return
+    removeCircleHandles(circle.id)
+
+    if (!isInteractiveShape(circle.id)) return
+
+    const centerMarker = L.circleMarker(circle.center as L.LatLngTuple, {
+      ...vertexHandleStyle(),
+      radius: 6,
+      pane: 'markerPane',
+      className: 'fence-drag-handle',
+    })
+    centerMarker.addTo(map.value)
+    let centerDragging = false
+    centerMarker.on('mousedown', () => {
+      centerDragging = true
+      map.value?.dragging.disable()
+      const onMove = (event: L.LeafletMouseEvent): void => {
+        if (!centerDragging) return
+        fenceStore.updateCircle(circle.id, { center: [event.latlng.lat, event.latlng.lng] })
+      }
+      const onUp = (): void => {
+        centerDragging = false
+        map.value?.off('mousemove', onMove)
+        map.value?.off('mouseup', onUp)
+        map.value?.dragging.enable()
+      }
+      map.value?.on('mousemove', onMove)
+      map.value?.on('mouseup', onUp)
+    })
+    circleCenterMarkers.set(circle.id, centerMarker)
+
+    const edgeBounds = L.latLng(circle.center[0], circle.center[1]).toBounds(circle.radius * 2)
+    const edgeLatLng: L.LatLngTuple = [circle.center[0], edgeBounds.getEast()]
+    const edgeMarker = L.circleMarker(edgeLatLng, {
+      ...vertexHandleStyle(),
+      radius: 5,
+      pane: 'markerPane',
+      className: 'fence-drag-handle',
+    })
+    edgeMarker.addTo(map.value)
+    let edgeDragging = false
+    edgeMarker.on('mousedown', () => {
+      edgeDragging = true
+      map.value?.dragging.disable()
+      const onMove = (event: L.LeafletMouseEvent): void => {
+        if (!edgeDragging) return
+        const center = L.latLng(circle.center[0], circle.center[1])
+        const distance = center.distanceTo(event.latlng)
+        fenceStore.updateCircle(circle.id, { radius: distance })
+        showRadiusMeasure(center, event.latlng, distance)
+      }
+      const onUp = (): void => {
+        edgeDragging = false
+        map.value?.off('mousemove', onMove)
+        map.value?.off('mouseup', onUp)
+        map.value?.dragging.enable()
+        hideRadiusMeasure()
+      }
+      map.value?.on('mousemove', onMove)
+      map.value?.on('mouseup', onUp)
+    })
+    circleEdgeMarkers.set(circle.id, edgeMarker)
+  }
+
+  const renderCircle = (circle: FenceCircle): void => {
+    if (!map.value) return
+    const existing = circleLayers.get(circle.id)
+    if (existing) {
+      existing.setLatLng(circle.center as L.LatLngTuple)
+      existing.setRadius(circle.radius)
+      existing.setStyle(polygonStyle(circle.inclusion))
+      applyFenceFill(existing, circle.inclusion)
+    } else {
+      const layer = L.circle(circle.center as L.LatLngTuple, {
+        ...polygonStyle(circle.inclusion),
+        radius: circle.radius,
+      })
+      layer.addTo(map.value)
+      applyFenceFill(layer, circle.inclusion)
+      if (!props.readonly) {
+        layer.on('click', (event: L.LeafletMouseEvent) => {
+          L.DomEvent.stopPropagation(event)
+          fenceDraft.setInteractive(circle.id)
+        })
+      }
+      circleLayers.set(circle.id, layer)
+    }
+    buildCircleHandles(circle)
+  }
+
+  const renderBreachReturn = (point: BreachReturnPoint | undefined): void => {
+    if (!map.value) return
+    if (!point) {
+      removeBreachReturnMarker()
+      return
+    }
+    const html = `<div class="fence-breach-return">B</div>`
+    const icon = L.divIcon({ html, className: 'fence-breach-return-icon', iconSize: [22, 22], iconAnchor: [11, 11] })
+    if (breachReturnMarker) {
+      breachReturnMarker.setLatLng(point.coordinates as L.LatLngTuple)
+      // Refresh the icon so any future visual changes (size, color, inner HTML)
+      // surface on subsequent renders without needing to recreate the marker.
+      breachReturnMarker.setIcon(icon)
+    } else {
+      breachReturnMarker = L.marker(point.coordinates as L.LatLngTuple, { icon, draggable: !props.readonly })
+      breachReturnMarker.addTo(map.value)
+      if (!props.readonly) {
+        // Read latitude/altitude from the store (source of truth) instead of
+        // the captured `point` so altitude edits made after the marker is
+        // created don't get overwritten by the next drag.
+        breachReturnMarker.on('dragend', (event) => {
+          const newCoords = (event.target as L.Marker).getLatLng()
+          const currentAltitude = fenceStore.breachReturn?.altitude ?? point.altitude
+          fenceStore.setBreachReturn({ coordinates: [newCoords.lat, newCoords.lng], altitude: currentAltitude })
+        })
+      }
+    }
+    breachReturnMarker.bindTooltip(`Breach return — ${point.altitude.toFixed(1)} m`, {
+      direction: 'top',
+      offset: [0, -10],
+    })
+  }
+
+  const sourcePolygons = (): FencePolygon[] => (props.plan ? props.plan.polygons : fenceStore.polygons)
+  const sourceCircles = (): FenceCircle[] => (props.plan ? props.plan.circles : fenceStore.circles)
+  const sourceBreach = (): BreachReturnPoint | undefined =>
+    props.plan ? props.plan.breachReturn : fenceStore.breachReturn
+
+  const syncLayers = (): void => {
+    if (!map.value) return
+
+    const polys = sourcePolygons()
+    const polyIds = new Set(polys.map((p) => p.id))
+    Array.from(polygonLayers.keys()).forEach((id) => {
+      if (!polyIds.has(id)) removePolygonLayer(id)
+    })
+    polys.forEach(renderPolygon)
+
+    const circs = sourceCircles()
+    const circleIds = new Set(circs.map((c) => c.id))
+    Array.from(circleLayers.keys()).forEach((id) => {
+      if (!circleIds.has(id)) removeCircleLayer(id)
+    })
+    circs.forEach(renderCircle)
+
+    renderBreachReturn(sourceBreach())
+  }
+
+  // Coalesce change-driven sync into one frame so vertex drags don't rebuild
+  // every Leaflet layer per `mousemove`. The initial sync below stays
+  // synchronous so the overlay paints on the same tick the map becomes ready.
+  const debouncedSyncLayers = useDebounceFn(syncLayers, 16)
+
+  watch(
+    mapReady,
+    (ready) => {
+      if (ready) syncLayers()
+    },
+    { immediate: true }
+  )
+
+  // Deep-watching the raw store/prop sources lets Vue's reactivity track every
+  // nested change without reallocating a normalized snapshot on each tick;
+  // drag-driven mutations no longer build per-vertex strings just to detect that
+  // "something changed".
+  watch(
+    () => [sourcePolygons(), sourceCircles(), sourceBreach(), fenceDraft.interactiveShapeId, props.readonly],
+    () => debouncedSyncLayers(),
+    { deep: true }
+  )
+
+  onBeforeUnmount(() => clearAllLayers())
+}

--- a/src/composables/mission-planning/useFenceMapInteraction.ts
+++ b/src/composables/mission-planning/useFenceMapInteraction.ts
@@ -1,0 +1,110 @@
+import type L from 'leaflet'
+import { type Ref, computed } from 'vue'
+
+import { useGeoFenceEditorDraft } from '@/composables/useGeoFenceEditorDraft'
+import { useGeoFenceStore } from '@/stores/geoFence'
+
+/**
+ * Options for `useFenceMapInteraction`.
+ */
+export interface UseFenceMapInteractionOptions {
+  /**
+   * Reactive planning mode from the planning view. Fence input is
+   * only routed while the view is in `'geofence'` mode; the composable
+   * silently short-circuits otherwise.
+   */
+  planningMode: Ref<'mission' | 'geofence'>
+  /**
+   * Fence-drawing composable action that appends a new latitude/longitude
+   * vertex to the polygon currently being drawn.
+   */
+  addFencePolygonPoint: (latlng: L.LatLng) => void
+  /**
+   * Fence-drawing composable action that seeds the center of a
+   * to-be-drawn circle fence at the given latitude/longitude.
+   */
+  setPendingFenceCircleCenter: (latlng: L.LatLng) => void
+  /**
+   * Planning view callback that clears the ephemeral measure preview
+   * so a fresh vertex or circle center does not leave a stale line
+   * dangling from the previous pointer position.
+   */
+  clearLiveMeasure: () => void
+}
+
+/**
+ * Bridges keyboard shortcuts and map clicks into the geofence drawing
+ * state machine when the planning view is in geofence mode. The
+ * planning view keeps its existing key/click listeners; this composable
+ * only exposes handlers that the view delegates to so the fence code
+ * paths live in one place.
+ */
+export interface UseFenceMapInteractionReturn {
+  /**
+   * Handles the fence-relevant subset of the planning view's global
+   * keydown handler (Escape cancels the current polygon or circle
+   * draw, Enter finishes it when valid). Safe to call for every key
+   * event since it no-ops outside fence mode.
+   */
+  handleFenceKeyDown: (event: KeyboardEvent) => void
+  /**
+   * Handles a Leaflet map click while a fence shape is being drawn.
+   * Returns `true` when the click was consumed by fence handling so
+   * the planning view knows to skip its mission/survey click paths.
+   * @returns `true` if fence handling consumed the click, `false`
+   * otherwise so the caller can fall through to its own logic.
+   */
+  onFenceMapClick: (e: L.LeafletMouseEvent) => boolean
+}
+
+/**
+ * Encapsulate the fence-mode keyboard and map-click branching that
+ * used to live inline in the planning view. Keeps the planning view
+ * agnostic of fence store internals.
+ * @param {UseFenceMapInteractionOptions} options Wiring to the planning
+ * view's planning mode, the fence drawing composable actions and the
+ * planning view's live-measure clearing callback.
+ * @returns {UseFenceMapInteractionReturn} Delegates for keydown and
+ * map-click events.
+ */
+export const useFenceMapInteraction = (options: UseFenceMapInteractionOptions): UseFenceMapInteractionReturn => {
+  const fenceStore = useGeoFenceStore()
+  const fenceDraft = useGeoFenceEditorDraft()
+  const inFenceMode = computed(() => options.planningMode.value === 'geofence')
+
+  const handleFenceKeyDown = (event: KeyboardEvent): void => {
+    if (!inFenceMode.value) return
+    if (event.key === 'Escape') {
+      if (fenceDraft.isDrawingPolygon) fenceDraft.cancelDrawingPolygon()
+      if (fenceDraft.isDrawingCircle) fenceDraft.cancelDrawingCircle()
+      return
+    }
+    if (event.key === 'Enter') {
+      if (fenceDraft.isDrawingPolygon) {
+        fenceStore.finishDrawingPolygon()
+      } else if (fenceDraft.isDrawingCircle && fenceDraft.pendingCircleCenter && fenceDraft.pendingCircleRadius >= 1) {
+        fenceStore.finishDrawingCircle()
+      }
+    }
+  }
+
+  const onFenceMapClick = (e: L.LeafletMouseEvent): boolean => {
+    if (!inFenceMode.value) return false
+    if (fenceDraft.isDrawingPolygon) {
+      options.addFencePolygonPoint(e.latlng)
+      options.clearLiveMeasure()
+      return true
+    }
+    if (fenceDraft.isDrawingCircle) {
+      if (!fenceDraft.pendingCircleCenter) {
+        options.setPendingFenceCircleCenter(e.latlng)
+      } else if (fenceDraft.pendingCircleRadius >= 1) {
+        fenceStore.finishDrawingCircle()
+      }
+      return true
+    }
+    return false
+  }
+
+  return { handleFenceKeyDown, onFenceMapClick }
+}

--- a/src/composables/useGeoFenceEditorDraft.ts
+++ b/src/composables/useGeoFenceEditorDraft.ts
@@ -1,0 +1,148 @@
+import { reactive } from 'vue'
+
+import { CIRCLE_MAX_RADIUS_M } from '@/libs/geo-fence'
+import type { FenceLatLng } from '@/types/geofence'
+
+/**
+ * Transient, non-persisted editor interaction state for the geofence editor:
+ * which shape is currently selected and the in-progress polygon/circle draw
+ * buffers. Kept out of the `geo-fence` store (which owns the persisted plan
+ * and vehicle sync) because this is ephemeral UI state shared between the
+ * editor panel and the map layer, not app data. Exposed as a single module
+ * singleton so every consumer mutates and observes the same draft.
+ */
+export interface GeoFenceEditorDraft {
+  /**
+   * Id of the shape currently in edit mode, or `undefined` when none is selected.
+   */
+  interactiveShapeId: string | undefined
+  /**
+   * True while the click-to-draw polygon flow is active.
+   */
+  isDrawingPolygon: boolean
+  /**
+   * Whether the polygon being drawn is an inclusion fence.
+   */
+  pendingPolygonInclusion: boolean
+  /**
+   * Vertices accumulated for the polygon currently being drawn.
+   */
+  pendingPolygonVertices: FenceLatLng[]
+  /**
+   * True while the click-to-draw circle flow is active.
+   */
+  isDrawingCircle: boolean
+  /**
+   * Whether the circle being drawn is an inclusion fence.
+   */
+  pendingCircleInclusion: boolean
+  /**
+   * Center of the circle currently being drawn, or `undefined` before the first click.
+   */
+  pendingCircleCenter: FenceLatLng | undefined
+  /**
+   * Live radius (meters) of the circle currently being drawn.
+   */
+  pendingCircleRadius: number
+  /**
+   * Selects the shape with the given id as the interactive one.
+   * @param { string | undefined } id Shape id to select, or `undefined` to clear.
+   */
+  setInteractive: (id: string | undefined) => void
+  /**
+   * Enters the click-to-draw polygon flow, clearing any pending vertices.
+   * @param { boolean } inclusion Whether the polygon being drawn is an inclusion fence.
+   */
+  startDrawingPolygon: (inclusion: boolean) => void
+  /**
+   * Appends a vertex to the polygon currently being drawn. No-op outside drawing mode.
+   * @param { FenceLatLng } vertex The vertex to append, in `[lat, lng]`.
+   */
+  addPendingPolygonVertex: (vertex: FenceLatLng) => void
+  /**
+   * Removes the last vertex appended to the polygon currently being drawn.
+   */
+  popPendingPolygonVertex: () => void
+  /**
+   * Aborts the polygon currently being drawn, discarding pending vertices.
+   */
+  cancelDrawingPolygon: () => void
+  /**
+   * Enters the click-to-draw circle flow, clearing any pending center/radius.
+   * @param { boolean } inclusion Whether the circle being drawn is an inclusion fence.
+   */
+  startDrawingCircle: (inclusion: boolean) => void
+  /**
+   * Sets the center of the circle currently being drawn (first click). No-op outside drawing mode.
+   * @param { FenceLatLng } center The center coordinates, in `[lat, lng]`.
+   */
+  setPendingCircleCenter: (center: FenceLatLng) => void
+  /**
+   * Updates the radius (meters) of the circle currently being drawn, clamped to `[1, CIRCLE_MAX_RADIUS_M]`.
+   * @param { number } radius The new radius in meters.
+   */
+  setPendingCircleRadius: (radius: number) => void
+  /**
+   * Aborts the circle currently being drawn, discarding pending data.
+   */
+  cancelDrawingCircle: () => void
+}
+
+const draft = reactive<GeoFenceEditorDraft>({
+  interactiveShapeId: undefined,
+  isDrawingPolygon: false,
+  pendingPolygonInclusion: true,
+  pendingPolygonVertices: [],
+  isDrawingCircle: false,
+  pendingCircleInclusion: true,
+  pendingCircleCenter: undefined,
+  pendingCircleRadius: 0,
+  setInteractive(id) {
+    draft.interactiveShapeId = id
+  },
+  startDrawingPolygon(inclusion) {
+    draft.pendingPolygonInclusion = inclusion
+    draft.pendingPolygonVertices.splice(0)
+    draft.isDrawingPolygon = true
+    draft.interactiveShapeId = undefined
+  },
+  addPendingPolygonVertex(vertex) {
+    if (!draft.isDrawingPolygon) return
+    draft.pendingPolygonVertices.push([vertex[0], vertex[1]])
+  },
+  popPendingPolygonVertex() {
+    if (!draft.isDrawingPolygon) return
+    draft.pendingPolygonVertices.pop()
+  },
+  cancelDrawingPolygon() {
+    draft.pendingPolygonVertices.splice(0)
+    draft.isDrawingPolygon = false
+  },
+  startDrawingCircle(inclusion) {
+    draft.pendingCircleInclusion = inclusion
+    draft.pendingCircleCenter = undefined
+    draft.pendingCircleRadius = 0
+    draft.isDrawingCircle = true
+    draft.interactiveShapeId = undefined
+  },
+  setPendingCircleCenter(center) {
+    if (!draft.isDrawingCircle) return
+    draft.pendingCircleCenter = [center[0], center[1]]
+    draft.pendingCircleRadius = 0
+  },
+  setPendingCircleRadius(radius) {
+    if (!draft.isDrawingCircle || !draft.pendingCircleCenter) return
+    draft.pendingCircleRadius = Math.max(1, Math.min(CIRCLE_MAX_RADIUS_M, radius))
+  },
+  cancelDrawingCircle() {
+    draft.pendingCircleCenter = undefined
+    draft.pendingCircleRadius = 0
+    draft.isDrawingCircle = false
+  },
+})
+
+/**
+ * Access the shared geofence editor draft (interaction + in-progress draw state).
+ * @returns { GeoFenceEditorDraft } The module-singleton draft state and its mutators.
+ */
+export const useGeoFenceEditorDraft = (): GeoFenceEditorDraft => draft

--- a/src/libs/geo-fence.ts
+++ b/src/libs/geo-fence.ts
@@ -1,0 +1,154 @@
+import * as turf from '@turf/turf'
+
+import type { FenceCircle, FenceLatLng, FencePolygon, GeoFencePlan } from '@/types/geofence'
+
+export const POLYGON_DEFAULT_HALF_SIDE_M = 100
+export const POLYGON_MAX_HALF_SIDE_M = 1500
+export const CIRCLE_DEFAULT_RADIUS_M = 100
+export const CIRCLE_MAX_RADIUS_M = 1500
+
+const EARTH_RADIUS_M = 6378137
+
+/**
+ * Minimal shape required by `detectMissionBreaches`. Accepts both Cockpit's
+ * `Waypoint` and any caller-supplied object that exposes `[lat, lng]`
+ * coordinates, so the breach check stays decoupled from the mission types.
+ */
+export type WaypointLike = {
+  /**
+   * Geographic location of the waypoint as `[latitude, longitude]` in degrees.
+   */
+  coordinates: [number, number]
+}
+
+/**
+ * Result of a `detectMissionBreaches` call.
+ */
+export type MissionBreachReport = {
+  /**
+   * True when at least one waypoint breaches the active fence.
+   */
+  hasBreaches: boolean
+  /**
+   * Indices (within the input waypoint list) of every breaching waypoint.
+   */
+  breachedIndices: number[]
+  /**
+   * Total number of waypoints inspected.
+   */
+  totalChecked: number
+  /**
+   * False when no fence plan was available to check against; callers can use
+   * this to differentiate "no breaches" from "no fence to check".
+   */
+  hadPlan: boolean
+}
+
+/**
+ * Deep-copies a vertex ring so mutations on the copy don't alias the source.
+ * @param { FenceLatLng[] } vertices Vertices to clone.
+ * @returns { FenceLatLng[] } A fresh array of fresh `[lat, lng]` tuples.
+ */
+export const cloneVertices = (vertices: FenceLatLng[]): FenceLatLng[] => vertices.map(([lat, lng]) => [lat, lng])
+
+/**
+ * Deep-copies a geofence plan via JSON round-trip.
+ * @param { GeoFencePlan } plan Plan to clone.
+ * @returns { GeoFencePlan } A structurally independent copy.
+ */
+export const clonePlan = (plan: GeoFencePlan): GeoFencePlan => JSON.parse(JSON.stringify(plan)) as GeoFencePlan
+
+/**
+ * Creates an empty geofence plan.
+ * @returns { GeoFencePlan } An empty plan with no polygons, circles, or breach return.
+ */
+export const emptyGeoFencePlan = (): GeoFencePlan => ({ version: 2, polygons: [], circles: [] })
+
+/**
+ * Computes the offset (in degrees) needed to move a point on the WGS84
+ * spheroid by `dxMeters` east and `dyMeters` north. Used to seed default
+ * polygon and circle sizes around a given anchor.
+ * @param { FenceLatLng } anchor The anchor point `[lat, lng]`.
+ * @param { number } dxMeters Offset east in meters.
+ * @param { number } dyMeters Offset north in meters.
+ * @returns { FenceLatLng } The offset coordinates.
+ */
+export const offsetCoordinates = (anchor: FenceLatLng, dxMeters: number, dyMeters: number): FenceLatLng => {
+  const [lat, lng] = anchor
+  const dLat = (dyMeters / EARTH_RADIUS_M) * (180 / Math.PI)
+  const dLng = ((dxMeters / EARTH_RADIUS_M) * (180 / Math.PI)) / Math.cos((lat * Math.PI) / 180)
+  return [lat + dLat, lng + dLng]
+}
+
+/**
+ * Tests whether a `[lat, lng]` point lies inside the polygon defined by the
+ * given vertex ring. Vertices are given in `[lat, lng]` order, the ring is
+ * implicitly closed, and the check uses turf's well-tested
+ * `booleanPointInPolygon` (ray casting).
+ * @param { FenceLatLng } point The `[lat, lng]` point to test.
+ * @param { FenceLatLng[] } vertices Polygon vertices `[lat, lng]`, open ring.
+ * @returns { boolean } True if the point is inside the polygon.
+ */
+export const isPointInsidePolygon = (point: FenceLatLng, vertices: FenceLatLng[]): boolean => {
+  if (vertices.length < 3) return false
+  const closed = [...vertices, vertices[0]]
+  const turfPoly = turf.polygon([closed.map(([lat, lng]) => [lng, lat])])
+  const turfPoint = turf.point([point[1], point[0]])
+  return turf.booleanPointInPolygon(turfPoint, turfPoly)
+}
+
+/**
+ * Great-circle distance in meters between two `[lat, lng]` points using
+ * turf's haversine implementation.
+ * @param { FenceLatLng } a First `[lat, lng]` point.
+ * @param { FenceLatLng } b Second `[lat, lng]` point.
+ * @returns { number } Distance between the two points in meters.
+ */
+export const distanceMeters = (a: FenceLatLng, b: FenceLatLng): number => {
+  return turf.distance(turf.point([a[1], a[0]]), turf.point([b[1], b[0]]), { units: 'meters' })
+}
+
+/**
+ * Checks a list of waypoints against a set of fence shapes. A waypoint is
+ * flagged when it sits outside every inclusion shape (and at least one
+ * inclusion shape exists) or inside any exclusion shape.
+ * @param { WaypointLike[] } waypoints Waypoints to test.
+ * @param { FencePolygon[] } polygons Polygons to test against.
+ * @param { FenceCircle[] } circles Circles to test against.
+ * @returns { MissionBreachReport } Breach summary with offending indices.
+ */
+export const detectMissionBreaches = (
+  waypoints: WaypointLike[],
+  polygons: FencePolygon[],
+  circles: FenceCircle[]
+): MissionBreachReport => {
+  if (polygons.length === 0 && circles.length === 0) {
+    return { hasBreaches: false, breachedIndices: [], totalChecked: waypoints.length, hadPlan: false }
+  }
+
+  const inclusionPolygons = polygons.filter((p) => p.inclusion)
+  const exclusionPolygons = polygons.filter((p) => !p.inclusion)
+  const inclusionCircles = circles.filter((c) => c.inclusion)
+  const exclusionCircles = circles.filter((c) => !c.inclusion)
+  const hasInclusion = inclusionPolygons.length > 0 || inclusionCircles.length > 0
+
+  const breachedIndices: number[] = []
+  waypoints.forEach((wp, index) => {
+    const point: FenceLatLng = [wp.coordinates[0], wp.coordinates[1]]
+    const insideAnyInclusion =
+      !hasInclusion ||
+      inclusionPolygons.some((p) => isPointInsidePolygon(point, p.vertices)) ||
+      inclusionCircles.some((c) => distanceMeters(point, c.center) <= c.radius)
+    const insideAnyExclusion =
+      exclusionPolygons.some((p) => isPointInsidePolygon(point, p.vertices)) ||
+      exclusionCircles.some((c) => distanceMeters(point, c.center) <= c.radius)
+    if (!insideAnyInclusion || insideAnyExclusion) breachedIndices.push(index)
+  })
+
+  return {
+    hasBreaches: breachedIndices.length > 0,
+    breachedIndices,
+    totalChecked: waypoints.length,
+    hadPlan: true,
+  }
+}

--- a/src/libs/mission/confirm-button-placement.ts
+++ b/src/libs/mission/confirm-button-placement.ts
@@ -1,0 +1,76 @@
+import type { Point2D } from '@/types/general'
+import type { ScreenBounds } from '@/types/user-interface'
+
+/**
+ * Computes a screen-space axis-aligned bounding box from an array of 2D points.
+ * @param {Point2D[]} pts Screen-space points.
+ * @returns {ScreenBounds} The bounding box that tightly contains every point.
+ */
+export const screenBounds = (pts: Point2D[]): ScreenBounds => {
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+  for (const p of pts) {
+    if (p.x < minX) minX = p.x
+    if (p.y < minY) minY = p.y
+    if (p.x > maxX) maxX = p.x
+    if (p.y > maxY) maxY = p.y
+  }
+  return { minX, minY, maxX, maxY }
+}
+
+/**
+ * Picks the best candidate top-left position for a floating action button by
+ * maximising viewport visibility and minimising overlap with a polygon
+ * bounding box, then clamps the result inside the viewport. Used by both the
+ * survey polygon and the geofence polygon confirm buttons to keep their
+ * floating anchors visible and away from the shape being drawn.
+ * @param {Point2D[]} candidates Top-left positions to evaluate.
+ * @param {number} elW Element width in pixels.
+ * @param {number} elH Element height in pixels.
+ * @param {ScreenBounds} polyBounds Polygon screen bounds.
+ * @param {number} vpW Viewport width.
+ * @param {number} vpH Viewport height.
+ * @param {number} margin Minimum distance from viewport edge.
+ * @returns {Point2D} Clamped top-left position for the floating element.
+ */
+export const pickBestPosition = (
+  candidates: Point2D[],
+  elW: number,
+  elH: number,
+  polyBounds: ScreenBounds,
+  vpW: number,
+  vpH: number,
+  margin: number
+): Point2D => {
+  const area = elW * elH
+  let best = candidates[0]
+  let bestScore = -Infinity
+
+  for (const c of candidates) {
+    const l = c.x
+    const r = c.x + elW
+    const t = c.y
+    const b = c.y + elH
+
+    const visW = Math.max(0, Math.min(r, vpW - margin) - Math.max(l, margin))
+    const visH = Math.max(0, Math.min(b, vpH - margin) - Math.max(t, margin))
+    const visibility = (visW * visH) / area
+
+    const oW = Math.max(0, Math.min(r, polyBounds.maxX) - Math.max(l, polyBounds.minX))
+    const oH = Math.max(0, Math.min(b, polyBounds.maxY) - Math.max(t, polyBounds.minY))
+    const overlapPenalty = (oW * oH) / area
+
+    const score = visibility - overlapPenalty * 0.5
+    if (score > bestScore) {
+      bestScore = score
+      best = c
+    }
+  }
+
+  return {
+    x: Math.max(margin, Math.min(best.x, vpW - elW - margin)),
+    y: Math.max(margin, Math.min(best.y, vpH - elH - margin)),
+  }
+}

--- a/src/libs/vehicle/mavlink/geofence-conversion.ts
+++ b/src/libs/vehicle/mavlink/geofence-conversion.ts
@@ -4,6 +4,8 @@ import { MavCmd, MavFrame, MAVLinkType, MavMissionType } from '@/libs/connection
 import type { Message } from '@/libs/connection/m2r/messages/mavlink2rest-message'
 import type { BreachReturnPoint, FenceCircle, FenceLatLng, FencePolygon, GeoFencePlan } from '@/types/geofence'
 
+export { emptyGeoFencePlan } from '@/libs/geo-fence'
+
 const COORD_SCALE = 1e7
 
 /**
@@ -209,9 +211,3 @@ export const convertMavlinkToGeoFencePlan = (items: Message.MissionItemInt[]): G
 
   return { version: 2, polygons, circles, breachReturn }
 }
-
-/**
- * Creates an empty geofence plan.
- * @returns { GeoFencePlan } An empty plan with no polygons, circles, or breach return.
- */
-export const emptyGeoFencePlan = (): GeoFencePlan => ({ version: 2, polygons: [], circles: [] })

--- a/src/libs/vehicle/mavlink/geofence-conversion.ts
+++ b/src/libs/vehicle/mavlink/geofence-conversion.ts
@@ -1,0 +1,217 @@
+import { v4 as uuid } from 'uuid'
+
+import { MavCmd, MavFrame, MAVLinkType, MavMissionType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
+import type { Message } from '@/libs/connection/m2r/messages/mavlink2rest-message'
+import type { BreachReturnPoint, FenceCircle, FenceLatLng, FencePolygon, GeoFencePlan } from '@/types/geofence'
+
+const COORD_SCALE = 1e7
+
+/**
+ * Builds a `MISSION_ITEM_INT` for a single fence vertex/circle/return point.
+ * @param { number } seq Sequence index of the item in the upload.
+ * @param { number } system_id Target system ID.
+ * @param { MavCmd } command MAV_CMD to use for this item.
+ * @param { MavFrame } frame Coordinate frame for this item.
+ * @param { number } param1 Item-specific parameter 1 (vertex count or radius).
+ * @param { number } lat Latitude in decimal degrees.
+ * @param { number } lon Longitude in decimal degrees.
+ * @param { number } alt Altitude in meters (used by breach return point only).
+ * @returns { Message.MissionItemInt } The encoded mission item.
+ */
+const buildFenceItem = (
+  seq: number,
+  system_id: number,
+  command: MavCmd,
+  frame: MavFrame,
+  param1: number,
+  lat: number,
+  lon: number,
+  alt: number
+): Message.MissionItemInt => ({
+  target_system: system_id,
+  target_component: 1,
+  type: MAVLinkType.MISSION_ITEM_INT,
+  seq,
+  frame: { type: frame },
+  command: { type: command },
+  current: 0,
+  autocontinue: 1,
+  param1,
+  param2: 0,
+  param3: 0,
+  param4: 0,
+  x: Math.round(lat * COORD_SCALE),
+  y: Math.round(lon * COORD_SCALE),
+  z: alt,
+  mission_type: { type: MavMissionType.MAV_MISSION_TYPE_FENCE },
+})
+
+/**
+ * Encodes a `GeoFencePlan` into a flat `MissionItemInt[]` ready to be uploaded
+ * via the MAVLink mission micro-service with `mission_type = MAV_MISSION_TYPE_FENCE`.
+ *
+ * Polygon vertices belonging to the same polygon are sent sequentially and
+ * carry the same `param1 = vertex_count`. The vehicle uses the change in
+ * `command` or `param1` to detect polygon boundaries.
+ *
+ * The optional breach return point is emitted last with
+ * `MAV_FRAME_GLOBAL_RELATIVE_ALT` so altitude is interpreted relative to home.
+ * @param { GeoFencePlan } plan The plan to encode.
+ * @param { number } system_id Target system ID for the items.
+ * @returns { Message.MissionItemInt[] } The flat sequence of mission items.
+ */
+export const convertGeoFencePlanToMavlink = (plan: GeoFencePlan, system_id: number): Message.MissionItemInt[] => {
+  const items: Message.MissionItemInt[] = []
+
+  plan.polygons.forEach((polygon) => {
+    if (polygon.vertices.length < 3) return
+    const command = polygon.inclusion
+      ? MavCmd.MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION
+      : MavCmd.MAV_CMD_NAV_FENCE_POLYGON_VERTEX_EXCLUSION
+    const vertexCount = polygon.vertices.length
+    polygon.vertices.forEach(([lat, lon]) => {
+      items.push(buildFenceItem(items.length, system_id, command, MavFrame.MAV_FRAME_GLOBAL, vertexCount, lat, lon, 0))
+    })
+  })
+
+  plan.circles.forEach((circle) => {
+    const command = circle.inclusion
+      ? MavCmd.MAV_CMD_NAV_FENCE_CIRCLE_INCLUSION
+      : MavCmd.MAV_CMD_NAV_FENCE_CIRCLE_EXCLUSION
+    const [lat, lon] = circle.center
+    items.push(buildFenceItem(items.length, system_id, command, MavFrame.MAV_FRAME_GLOBAL, circle.radius, lat, lon, 0))
+  })
+
+  if (plan.breachReturn) {
+    const [lat, lon] = plan.breachReturn.coordinates
+    items.push(
+      buildFenceItem(
+        items.length,
+        system_id,
+        MavCmd.MAV_CMD_NAV_FENCE_RETURN_POINT,
+        MavFrame.MAV_FRAME_GLOBAL_RELATIVE_ALT,
+        0,
+        lat,
+        lon,
+        plan.breachReturn.altitude
+      )
+    )
+  }
+
+  return items
+}
+
+const POLYGON_INCLUSION = 'MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION'
+const POLYGON_EXCLUSION = 'MAV_CMD_NAV_FENCE_POLYGON_VERTEX_EXCLUSION'
+const CIRCLE_INCLUSION = 'MAV_CMD_NAV_FENCE_CIRCLE_INCLUSION'
+const CIRCLE_EXCLUSION = 'MAV_CMD_NAV_FENCE_CIRCLE_EXCLUSION'
+const RETURN_POINT = 'MAV_CMD_NAV_FENCE_RETURN_POINT'
+
+const isPolygonCommand = (cmd: string): boolean => cmd === POLYGON_INCLUSION || cmd === POLYGON_EXCLUSION
+
+// `item.x` and `item.y` are 1e7 fixed-point degrees on the wire; dividing by
+// `COORD_SCALE` recovers floating-point degrees. The division can introduce
+// sub-centimeter rounding artifacts (binary doubles can't represent every
+// 1e-7 step exactly), but the residual sits well below GPS noise, so the
+// downstream renderer and re-encoder treat the round-trip as lossless.
+const itemCoordinates = (item: Message.MissionItemInt): FenceLatLng => [item.x / COORD_SCALE, item.y / COORD_SCALE]
+
+/**
+ * Decodes a flat `MissionItemInt[]` (downloaded from the vehicle with
+ * `mission_type = MAV_MISSION_TYPE_FENCE`) back into a `GeoFencePlan`.
+ *
+ * Polygons are reassembled by accumulating consecutive items with the same
+ * polygon command until `param1` (vertex count) vertices have been collected.
+ * Mismatched commands or vertex counts mid-polygon throw a descriptive error
+ * so callers can flag corrupted/partial fence downloads.
+ * @param { Message.MissionItemInt[] } items Items downloaded from the vehicle.
+ * @returns { GeoFencePlan } The decoded geofence plan.
+ */
+export const convertMavlinkToGeoFencePlan = (items: Message.MissionItemInt[]): GeoFencePlan => {
+  const polygons: FencePolygon[] = []
+  const circles: FenceCircle[] = []
+  let breachReturn: BreachReturnPoint | undefined = undefined
+
+  let pendingVertices: FenceLatLng[] = []
+  let pendingCommand: string | undefined = undefined
+  let pendingExpectedCount = 0
+
+  const flushPendingPolygon = (): void => {
+    if (pendingVertices.length === 0) return
+    if (pendingCommand === undefined) return
+    polygons.push({
+      id: uuid(),
+      inclusion: pendingCommand === POLYGON_INCLUSION,
+      vertices: pendingVertices,
+    })
+    pendingVertices = []
+    pendingCommand = undefined
+    pendingExpectedCount = 0
+  }
+
+  for (const item of items) {
+    const command = item.command.type as string
+
+    if (isPolygonCommand(command)) {
+      const vertexCount = Math.round(item.param1)
+      if (pendingCommand === undefined) {
+        pendingCommand = command
+        pendingExpectedCount = vertexCount
+        pendingVertices = [itemCoordinates(item)]
+      } else if (pendingCommand !== command || pendingExpectedCount !== vertexCount) {
+        // Bad polygon item format — vertex count or command changed mid-polygon.
+        throw new Error(
+          `[Fence download] Bad polygon item format at seq ${item.seq}. Polygon vertices have inconsistent command or count.`
+        )
+      } else {
+        pendingVertices.push(itemCoordinates(item))
+      }
+
+      if (pendingVertices.length === pendingExpectedCount) {
+        flushPendingPolygon()
+      }
+      continue
+    }
+
+    if (pendingVertices.length > 0) {
+      // Incomplete polygon — non-vertex command appears before the polygon is closed.
+      throw new Error(
+        `[Fence download] Incomplete polygon at seq ${item.seq}. Expected ${pendingExpectedCount} vertices, got ${pendingVertices.length}.`
+      )
+    }
+
+    if (command === CIRCLE_INCLUSION || command === CIRCLE_EXCLUSION) {
+      circles.push({
+        id: uuid(),
+        inclusion: command === CIRCLE_INCLUSION,
+        center: itemCoordinates(item),
+        radius: item.param1,
+      })
+      continue
+    }
+
+    if (command === RETURN_POINT) {
+      breachReturn = {
+        coordinates: itemCoordinates(item),
+        altitude: item.z,
+      }
+      continue
+    }
+
+    throw new Error(`[Fence download] Unsupported command '${command}' at seq ${item.seq}.`)
+  }
+
+  if (pendingVertices.length > 0) {
+    throw new Error(
+      `[Fence download] Incomplete polygon at end of items. Expected ${pendingExpectedCount} vertices, got ${pendingVertices.length}.`
+    )
+  }
+
+  return { version: 2, polygons, circles, breachReturn }
+}
+
+/**
+ * Creates an empty geofence plan.
+ * @returns { GeoFencePlan } An empty plan with no polygons, circles, or breach return.
+ */
+export const emptyGeoFencePlan = (): GeoFencePlan => ({ version: 2, polygons: [], circles: [] })

--- a/src/libs/vehicle/mavlink/geofence-conversion.ts
+++ b/src/libs/vehicle/mavlink/geofence-conversion.ts
@@ -2,7 +2,14 @@ import { v4 as uuid } from 'uuid'
 
 import { MavCmd, MavFrame, MAVLinkType, MavMissionType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import type { Message } from '@/libs/connection/m2r/messages/mavlink2rest-message'
-import type { BreachReturnPoint, FenceCircle, FenceLatLng, FencePolygon, GeoFencePlan } from '@/types/geofence'
+import type {
+  BreachReturnPoint,
+  FenceCircle,
+  FenceLatLng,
+  FencePolygon,
+  GeoFencePlan,
+  MavlinkPlanFile,
+} from '@/types/geofence'
 
 export { emptyGeoFencePlan } from '@/libs/geo-fence'
 
@@ -210,4 +217,73 @@ export const convertMavlinkToGeoFencePlan = (items: Message.MissionItemInt[]): G
   }
 
   return { version: 2, polygons, circles, breachReturn }
+}
+
+/**
+ * Serializes a `GeoFencePlan` into a MAVLink-ecosystem `.plan` file document so
+ * a Cockpit fence can round-trip with other ground stations. The `mission` and
+ * `rallyPoints` blocks are emitted as empty stubs — Cockpit only owns the
+ * `geoFence` section of the file.
+ * @param { GeoFencePlan } plan The fence plan to serialize.
+ * @param { FenceLatLng } plannedHomePosition `[lat, lon]` written as the planned home position.
+ * @returns { MavlinkPlanFile } The `.plan` file document, ready to be stringified.
+ */
+export const geoFencePlanToMavlinkPlanFile = (
+  plan: GeoFencePlan,
+  plannedHomePosition: FenceLatLng
+): MavlinkPlanFile => ({
+  fileType: 'Plan',
+  version: 1,
+  groundStation: 'Cockpit',
+  mission: { version: 2, items: [], plannedHomePosition: [plannedHomePosition[0], plannedHomePosition[1], 0] },
+  geoFence: {
+    version: 2,
+    polygons: plan.polygons.map((p) => ({
+      version: 1,
+      inclusion: p.inclusion,
+      polygon: p.vertices.map((v): [number, number] => [v[0], v[1]]),
+    })),
+    circles: plan.circles.map((c) => ({
+      version: 1,
+      inclusion: c.inclusion,
+      circle: { center: [c.center[0], c.center[1]], radius: c.radius },
+    })),
+    breachReturn: plan.breachReturn
+      ? [plan.breachReturn.coordinates[0], plan.breachReturn.coordinates[1], plan.breachReturn.altitude]
+      : undefined,
+  },
+  rallyPoints: { version: 2, points: [] },
+})
+
+/**
+ * Parses the `geoFence` section of a MAVLink-ecosystem `.plan` file into a
+ * `GeoFencePlan`. Returns `undefined` when the file carries an unsupported
+ * `geoFence` version (only version 2 is understood) so callers can surface the
+ * mismatch to the user.
+ * @param { MavlinkPlanFile } planFile The parsed `.plan` file document.
+ * @returns { GeoFencePlan | undefined } The decoded plan, or `undefined` on an unsupported version.
+ */
+export const mavlinkPlanFileToGeoFencePlan = (planFile: MavlinkPlanFile): GeoFencePlan | undefined => {
+  if (planFile.geoFence?.version !== 2) return undefined
+
+  return {
+    version: 2,
+    polygons: (planFile.geoFence.polygons ?? []).map((p) => ({
+      id: uuid(),
+      inclusion: p.inclusion,
+      vertices: p.polygon.map((v): [number, number] => [v[0], v[1]]),
+    })),
+    circles: (planFile.geoFence.circles ?? []).map((c) => ({
+      id: uuid(),
+      inclusion: c.inclusion,
+      center: [c.circle.center[0], c.circle.center[1]],
+      radius: c.circle.radius,
+    })),
+    breachReturn: planFile.geoFence.breachReturn
+      ? {
+          coordinates: [planFile.geoFence.breachReturn[0], planFile.geoFence.breachReturn[1]],
+          altitude: planFile.geoFence.breachReturn[2],
+        }
+      : undefined,
+  }
 }

--- a/src/libs/vehicle/mavlink/vehicle.ts
+++ b/src/libs/vehicle/mavlink/vehicle.ts
@@ -32,6 +32,11 @@ import { Signal, SignalTyped } from '@/libs/signal'
 import { degrees, frequencyHzToIntervalUs, isEqual, round, sleep } from '@/libs/utils'
 import { defaultMessageIntervalsOptions } from '@/libs/vehicle/mavlink/defaults'
 import {
+  convertGeoFencePlanToMavlink,
+  convertMavlinkToGeoFencePlan,
+  emptyGeoFencePlan,
+} from '@/libs/vehicle/mavlink/geofence-conversion'
+import {
   type MAVLinkParameterSetData,
   type MessageIntervalOptions,
   alertLevelFromMavSeverity,
@@ -52,6 +57,7 @@ import {
   StatusText,
   Velocity,
 } from '@/libs/vehicle/types'
+import type { GeoFencePlan } from '@/types/geofence'
 import { type MissionLoadingCallback, type Waypoint, defaultLoadingCallback } from '@/types/mission'
 
 import { flattenData } from '../common/data-flattener'
@@ -1179,9 +1185,35 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
     loadingCallback: MissionLoadingCallback = defaultLoadingCallback,
     timeoutBetweenItems = 10000
   ): Promise<Waypoint[]> {
-    // Only deal with regular mission items for now
-    const missionType = MavMissionType.MAV_MISSION_TYPE_MISSION
+    const missionItems = await this._fetchMissionItems(
+      MavMissionType.MAV_MISSION_TYPE_MISSION,
+      loadingCallback,
+      timeoutBetweenItems
+    )
+    this._currentMavlinkMissionItemsOnVehicle = missionItems
+    return convertMavlinkWaypointsToCockpit(missionItems)
+  }
 
+  /**
+   * Generic mission download. Implements the MAVLink mission micro-service
+   * download handshake (`MISSION_REQUEST_LIST` → `MISSION_COUNT` →
+   * `MISSION_REQUEST_INT` loop → `MISSION_ACK`) for any `MAV_MISSION_TYPE`
+   * (regular mission, geofence, rally points), returning the raw items.
+   *
+   * Reads `MISSION_COUNT` and `MISSION_ITEM_INT` from the shared `_messages`
+   * cache, which is not partitioned by `mission_type`. Concurrent downloads
+   * across mission types would consume each other's replies, so callers must
+   * serialize fetches against uploads/clears within a vehicle session.
+   * @param { MavMissionType } missionType Which mission micro-service to talk to.
+   * @param { MissionLoadingCallback } loadingCallback Callback that returns the state of the loading progress.
+   * @param { number } timeoutBetweenItems Timeout between mission items in milliseconds.
+   * @returns { Promise<Message.MissionItemInt[]> } Raw mission items downloaded from the vehicle.
+   */
+  protected async _fetchMissionItems(
+    missionType: MavMissionType,
+    loadingCallback: MissionLoadingCallback = defaultLoadingCallback,
+    timeoutBetweenItems = 10000
+  ): Promise<Message.MissionItemInt[]> {
     // Get number of mission items to be downloaded
     const initTimeCount = new Date().getTime()
     let timeoutEpoch = new Date().getTime()
@@ -1281,8 +1313,7 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
 
     console.debug('[Mission download] Sending mission acknowledgment to vehicle...')
     this.sendMissionAck(allItemsDownloaded, missionType)
-    this._currentMavlinkMissionItemsOnVehicle = missionItems
-    return convertMavlinkWaypointsToCockpit(missionItems)
+    return missionItems
   }
 
   /**
@@ -1358,6 +1389,95 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
       mission_type: { type: MavMissionType.MAV_MISSION_TYPE_MISSION },
     }
     sendMavlinkMessage(message)
+  }
+
+  /**
+   * Upload a geofence plan to the vehicle using the MAVLink mission
+   * micro-service with `mission_type = MAV_MISSION_TYPE_FENCE`.
+   *
+   * Polygon vertices are emitted sequentially per polygon, each with the
+   * same `param1 = vertex_count`. Circles are emitted with `param1 = radius`.
+   * The optional breach return point is emitted last using
+   * `MAV_FRAME_GLOBAL_RELATIVE_ALT`. See `convertGeoFencePlanToMavlink`.
+   * @param { GeoFencePlan } plan The fence plan to upload.
+   * @param { MissionLoadingCallback } loadingCallback Callback that returns the state of the upload progress.
+   */
+  async uploadFence(
+    plan: GeoFencePlan,
+    loadingCallback: MissionLoadingCallback = defaultLoadingCallback
+  ): Promise<void> {
+    const items = convertGeoFencePlanToMavlink(plan, this.currentSystemId)
+    await this._uploadMissionItems(MavMissionType.MAV_MISSION_TYPE_FENCE, items, loadingCallback)
+    await this._ensureArduPilotPolygonFenceTypeBit(plan)
+  }
+
+  /**
+   * On ArduPilot, makes sure the `Polygon` bit (4) of the `FENCE_TYPE` bitmask
+   * is enabled whenever the uploaded plan contains polygon or circle items —
+   * the autopilot won't enforce uploaded fences otherwise. Other bits of
+   * `FENCE_TYPE` (AltMax, Circle radius, AltMin) are preserved untouched so
+   * users can still drive them from the parameters panel.
+   * @param { GeoFencePlan } plan The plan that was just uploaded.
+   */
+  private async _ensureArduPilotPolygonFenceTypeBit(plan: GeoFencePlan): Promise<void> {
+    if (this.firmware() !== Vehicle.Firmware.ArduPilot) return
+    if (plan.polygons.length === 0 && plan.circles.length === 0) return
+    const POLYGON_BIT = 4
+    const current = await this.requestParameterValue('FENCE_TYPE')
+    // A timeout resolves to `undefined` (a real 0 resolves to 0); bail instead
+    // of assuming 0, which would clobber the user's other FENCE_TYPE bits.
+    if (current === undefined) return
+    const currentMask = Math.round(current)
+    const desired = currentMask | POLYGON_BIT
+    if (desired === currentMask) return
+    this.setParameter({
+      id: 'FENCE_TYPE',
+      value: desired,
+      // @ts-ignore: The correct type is indeed a Type<MavParamType>
+      type: { type: MavParamType.MAV_PARAM_TYPE_UINT8 },
+    })
+  }
+
+  /**
+   * Download the geofence plan currently stored on the vehicle. Returns an
+   * empty plan when the vehicle reports zero items.
+   * @param { MissionLoadingCallback } loadingCallback Callback that returns the state of the download progress.
+   * @returns { Promise<GeoFencePlan> } The decoded fence plan from the vehicle.
+   */
+  async fetchFence(loadingCallback: MissionLoadingCallback = defaultLoadingCallback): Promise<GeoFencePlan> {
+    const items = await this._fetchMissionItems(MavMissionType.MAV_MISSION_TYPE_FENCE, loadingCallback)
+    if (items.length === 0) return emptyGeoFencePlan()
+    return convertMavlinkToGeoFencePlan(items)
+  }
+
+  /**
+   * Clear the geofence currently stored on the vehicle and await the
+   * `MISSION_ACK` reply, mirroring the symmetric handshake of
+   * `uploadFence`/`fetchFence`. Throws if no acknowledgment arrives within
+   * `timeoutMs` or if the autopilot rejects the clear.
+   * @param { number } timeoutMs Timeout in milliseconds before giving up.
+   * @returns { Promise<void> } Resolves once the autopilot acknowledges the clear.
+   */
+  async clearFence(timeoutMs = 3000): Promise<void> {
+    const initTime = new Date().getTime()
+    const message: Message.MissionClearAll = {
+      type: MAVLinkType.MISSION_CLEAR_ALL,
+      target_system: this.currentSystemId,
+      target_component: 1,
+      mission_type: { type: MavMissionType.MAV_MISSION_TYPE_FENCE },
+    }
+    sendMavlinkMessage(message)
+
+    while (new Date().getTime() - initTime < timeoutMs) {
+      await sleep(50)
+      const ack = this._messages.get(MAVLinkType.MISSION_ACK)
+      if (ack === undefined || ack.epoch < initTime) continue
+      if (ack.mavtype.type !== MavMissionResult.MAV_MISSION_ACCEPTED) {
+        throw Error(`Failed clearing fence. Result received: ${ack.mavtype.type}.`)
+      }
+      return
+    }
+    throw Error('Timeout waiting for fence clear acknowledgment.')
   }
 
   /**
@@ -1472,10 +1592,32 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
     const mavlinkWaypoints = convertCockpitWaypointsToMavlink(items, this.currentSystemId)
 
     console.debug(`[Mission upload] Cockpit waypoints: ${JSON.stringify(items, null, 2)}`)
-    console.debug(`[Mission upload] MAVLink waypoints: ${JSON.stringify(mavlinkWaypoints, null, 2)}`)
 
-    // Only deal with regular mission items for now
-    const missionType = MavMissionType.MAV_MISSION_TYPE_MISSION
+    await this._uploadMissionItems(
+      MavMissionType.MAV_MISSION_TYPE_MISSION,
+      mavlinkWaypoints,
+      loadingCallback,
+      timeoutBetweenItems
+    )
+  }
+
+  /**
+   * Generic mission upload. Implements the MAVLink mission micro-service
+   * upload handshake (`MISSION_COUNT` → `MISSION_REQUEST_INT` loop →
+   * `MISSION_ACK`) for any `MAV_MISSION_TYPE`. The provided items must
+   * already have their `mission_type` field set to `missionType`.
+   * @param { MavMissionType } missionType Which mission micro-service to talk to.
+   * @param { Message.MissionItemInt[] } mavlinkWaypoints Mission items that will be sent.
+   * @param { MissionLoadingCallback } loadingCallback Callback that returns the state of the loading progress.
+   * @param { number } timeoutBetweenItems Timeout between mission items in milliseconds.
+   */
+  protected async _uploadMissionItems(
+    missionType: MavMissionType,
+    mavlinkWaypoints: Message.MissionItemInt[],
+    loadingCallback: MissionLoadingCallback = defaultLoadingCallback,
+    timeoutBetweenItems = 3000
+  ): Promise<void> {
+    console.debug(`[Mission upload] MAVLink waypoints: ${JSON.stringify(mavlinkWaypoints, null, 2)}`)
 
     // Say to the vehicle how many mission items we are going to send
     this.sendMissionCount(mavlinkWaypoints.length, missionType)

--- a/src/libs/vehicle/mavlink/vehicle.ts
+++ b/src/libs/vehicle/mavlink/vehicle.ts
@@ -86,10 +86,12 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
   _vehicleSpecificErrors = [0, 0, 0, 0]
   _messages: MAVLinkMessageDictionary = new Map()
   _currentMissionSeq: number | undefined = undefined
+  _capabilities: number | undefined = undefined
 
   onIncomingMAVLinkMessage = new SignalTyped()
   onOutgoingMAVLinkMessage = new SignalTyped()
   onMissionItemReached = new Signal<number>()
+  onCapabilities = new Signal<number>()
   _flying = false
 
   shouldCreateDatalakeVariablesFromOtherSystems = false
@@ -115,6 +117,15 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
       console.error('Failed to request default messages from the vehicle.')
       console.error(error)
     }
+
+    // Request the autopilot capabilities so we know which optional MAVLink
+    // services (geofence, rally points, etc.) the vehicle supports.
+    this.requestAutopilotCapabilities().catch((error) => {
+      console.warn(
+        'Failed to request autopilot capabilities. Capability gating will fall back to optimistic mode.',
+        error
+      )
+    })
 
     // Create data-lake variables for the vehicle
     this.createPredefinedDataLakeVariables()
@@ -487,6 +498,14 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
         break
       }
 
+      case MAVLinkType.AUTOPILOT_VERSION: {
+        const msg = mavlink_message.message as Message.AutopilotVersion
+        const bits = Number(msg.capabilities?.bits ?? 0)
+        this._capabilities = bits
+        this.onCapabilities.emit_value(bits)
+        break
+      }
+
       default:
         break
     }
@@ -851,6 +870,24 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
       target_component: 0,
     }
     sendMavlinkMessage(paramRequestMessage)
+  }
+
+  /**
+   * Request the vehicle to publish its `AUTOPILOT_VERSION` message so the
+   * GCS can read the autopilot capability bitmask.
+   * @returns { Promise<void> } Resolves when the request command is acknowledged.
+   */
+  async requestAutopilotCapabilities(): Promise<void> {
+    await this.sendCommandLong(MavCmd.MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES, 1)
+  }
+
+  /**
+   * Get the cached autopilot capability bitmask from the last received
+   * `AUTOPILOT_VERSION` message.
+   * @returns { number | undefined } The capability bits, or `undefined` if not yet received.
+   */
+  capabilities(): number | undefined {
+    return this._capabilities
   }
 
   /**

--- a/src/libs/vehicle/mavlink/vehicle.ts
+++ b/src/libs/vehicle/mavlink/vehicle.ts
@@ -873,6 +873,60 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
   }
 
   /**
+   * Request a single onboard parameter from the vehicle by name. The vehicle
+   * will reply with a `PARAM_VALUE` message that bubbles up via `onParameter`.
+   * @param { string } paramName Onboard parameter id (max 16 chars).
+   */
+  requestParameter(paramName: string): void {
+    const param_id: string[] = [...paramName]
+    while (param_id.length < 16) {
+      param_id.push('\0')
+    }
+    const paramRequestReadMessage: Message.ParamRequestRead = {
+      type: MAVLinkType.PARAM_REQUEST_READ,
+      target_system: this.currentSystemId,
+      target_component: 0,
+      param_index: -1,
+      // @ts-ignore: The correct type is indeed a char array
+      param_id,
+    }
+    sendMavlinkMessage(paramRequestReadMessage)
+  }
+
+  /**
+   * Request a single onboard parameter and resolve with its value when the
+   * matching `PARAM_VALUE` reply arrives. Resolves with `undefined` if no
+   * matching reply is received within `timeoutMs`.
+   * @param { string } paramName Onboard parameter id (max 16 chars).
+   * @param { number } timeoutMs Timeout in milliseconds before giving up.
+   * @returns { Promise<number | undefined> } The parameter value, or undefined on timeout.
+   */
+  async requestParameterValue(paramName: string, timeoutMs = 1500): Promise<number | undefined> {
+    return new Promise<number | undefined>((resolve) => {
+      let resolved = false
+      // Slot lifetime is bounded by the timeout: either the matching PARAM_VALUE
+      // arrives and the slot removes itself, or `setTimeout` fires after
+      // `timeoutMs` and removes it. The promise always settles, so the slot is
+      // never left registered on `onParameter`.
+      const slot = ([param]: [Parameter, number | undefined]): void => {
+        if (resolved || param?.name !== paramName) return
+        resolved = true
+        this.onParameter.remove(slot)
+        clearTimeout(timeoutHandle)
+        resolve(param.value)
+      }
+      this.onParameter.add(slot)
+      this.requestParameter(paramName)
+      const timeoutHandle = setTimeout(() => {
+        if (resolved) return
+        resolved = true
+        this.onParameter.remove(slot)
+        resolve(undefined)
+      }, timeoutMs)
+    })
+  }
+
+  /**
    * Request the vehicle to publish its `AUTOPILOT_VERSION` message so the
    * GCS can read the autopilot capability bitmask.
    * @returns { Promise<void> } Resolves when the request command is acknowledged.

--- a/src/stores/geoFence.ts
+++ b/src/stores/geoFence.ts
@@ -1,0 +1,596 @@
+import { tryOnScopeDispose, useDebounceFn, useDocumentVisibility } from '@vueuse/core'
+import { defineStore } from 'pinia'
+import { v4 as uuid } from 'uuid'
+import { computed, reactive, ref, watch } from 'vue'
+
+import { useBlueOsStorage } from '@/composables/settingsSyncer'
+import { useSnackbar } from '@/composables/snackbar'
+import { useGeoFenceEditorDraft } from '@/composables/useGeoFenceEditorDraft'
+import { MavParamType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
+import {
+  type MissionBreachReport,
+  type WaypointLike,
+  CIRCLE_DEFAULT_RADIUS_M,
+  CIRCLE_MAX_RADIUS_M,
+  clonePlan,
+  cloneVertices,
+  detectMissionBreaches as detectMissionBreachesInShapes,
+  emptyGeoFencePlan,
+  offsetCoordinates,
+  POLYGON_DEFAULT_HALF_SIDE_M,
+  POLYGON_MAX_HALF_SIDE_M,
+} from '@/libs/geo-fence'
+import type { Parameter } from '@/libs/vehicle/types'
+import * as Vehicle from '@/libs/vehicle/vehicle'
+import type { BreachReturnPoint, FenceCircle, FenceLatLng, FencePolygon, GeoFencePlan } from '@/types/geofence'
+import type { MissionLoadingCallback } from '@/types/mission'
+
+import { useMainVehicleStore } from './mainVehicle'
+
+export const useGeoFenceStore = defineStore('geo-fence', () => {
+  const mainVehicleStore = useMainVehicleStore()
+  const { openSnackbar } = useSnackbar()
+  const draft = useGeoFenceEditorDraft()
+
+  const polygons = reactive<FencePolygon[]>([])
+  const circles = reactive<FenceCircle[]>([])
+  const breachReturn = ref<BreachReturnPoint | undefined>(undefined)
+
+  const dirty = ref(false)
+  const syncInProgress = ref(false)
+  const lastUploadedPlan = ref<GeoFencePlan | undefined>(undefined)
+
+  const draftFence = useBlueOsStorage<GeoFencePlan>('cockpit-draft-fence', emptyGeoFencePlan())
+  const persistedVehicleFence = useBlueOsStorage<GeoFencePlan | null>('cockpit-vehicle-fence', null)
+
+  // Restore previously persisted last-uploaded plan so the live overlay can
+  // appear immediately after a page reload without re-downloading.
+  if (persistedVehicleFence.value) {
+    lastUploadedPlan.value = clonePlan(persistedVehicleFence.value)
+  }
+
+  // Restore the user's draft into the reactive working model.
+  if (draftFence.value) {
+    polygons.push(...(draftFence.value.polygons ?? []))
+    circles.push(...(draftFence.value.circles ?? []))
+    breachReturn.value = draftFence.value.breachReturn
+  }
+
+  const markDirty = (): void => {
+    dirty.value = true
+  }
+
+  const persistDraft = (): void => {
+    draftFence.value = exportPlan()
+  }
+
+  // Debounced variant for high-frequency callers (vertex drag updates fire on
+  // every mousemove). Atomic actions stay on the immediate `persistDraft` so
+  // discrete edits (add/delete/finish-drawing/clear/load/setBreachReturn)
+  // are flushed to storage right away.
+  const persistDraftDebounced = useDebounceFn(persistDraft, 300)
+
+  // MAV_PROTOCOL_CAPABILITY_MISSION_FENCE — bit 14 of AUTOPILOT_VERSION.capabilities.
+  // The dialect generator doesn't expose this enum yet (the field is typed as a
+  // generic BitFlag), so we mirror the single value we need.
+  const MAV_PROTOCOL_CAPABILITY_MISSION_FENCE = 1 << 14
+
+  /**
+   * Whether the connected vehicle advertises the geofence MAVLink service.
+   * Optimistic by default: if no `AUTOPILOT_VERSION` has been received yet,
+   * the editor remains enabled.
+   * @returns { boolean } True when the editor should be enabled for the current vehicle.
+   */
+  const isFenceSupported = computed<boolean>(() => {
+    const bits = mainVehicleStore.capabilities
+    if (bits === undefined) return true
+    return (bits & MAV_PROTOCOL_CAPABILITY_MISSION_FENCE) !== 0
+  })
+
+  /**
+   * True when the connected vehicle is an ArduPilot Plane. ArduPilot Plane
+   * requires a polygon to be present for any fence parameter (incl. ALT_MAX)
+   * to take effect — surfaced as a UI hint.
+   * @returns { boolean } True for ArduPilot Plane vehicles.
+   */
+  const isArduPilotPlane = computed<boolean>(() => {
+    const v = mainVehicleStore.mainVehicle
+    if (!v) return false
+    return v.firmware() === Vehicle.Firmware.ArduPilot && v.type() === Vehicle.Type.Plane
+  })
+
+  /**
+   * True when the connected vehicle is PX4. PX4 ANDs multiple inclusion
+   * polygons (intersection) — surfaced as a UI hint.
+   * @returns { boolean } True for PX4 vehicles.
+   */
+  const isPx4 = computed<boolean>(() => {
+    const v = mainVehicleStore.mainVehicle
+    if (!v) return false
+    return v.firmware() === Vehicle.Firmware.PX4
+  })
+
+  /**
+   * True when the connected vehicle runs ArduPilot firmware. Used to gate
+   * features that exist only on ArduPilot (e.g. the `FENCE_ENABLE` runtime
+   * enforcement toggle, which has no PX4 equivalent).
+   * @returns { boolean } True for any ArduPilot vehicle.
+   */
+  const isArduPilot = computed<boolean>(() => {
+    const v = mainVehicleStore.mainVehicle
+    if (!v) return false
+    return v.firmware() === Vehicle.Firmware.ArduPilot
+  })
+
+  // Tracks the vehicle-side fence enforcement state (ArduPilot's `FENCE_ENABLE`).
+  // `undefined` until the first PARAM_VALUE reply lands, so the UI can render a
+  // neutral state instead of falsely claiming the fence is disabled.
+  const fenceEnabled = ref<boolean | undefined>(undefined)
+
+  // Tracks the current `FENCE_AUTOENABLE` mode (0–4 on ArduPilot). Drives the
+  // "Auto enable fence on takeoff" switch in the editor; non-zero is treated
+  // as ON because every supported mode auto-enables enforcement at some
+  // arming/takeoff point.
+  const fenceAutoEnableMode = ref<number | undefined>(undefined)
+
+  /**
+   * Asks the vehicle for the current `FENCE_ENABLE` value. The reply is
+   * received asynchronously via PARAM_VALUE and updates `fenceEnabled`.
+   * No-op on non-ArduPilot vehicles or when no vehicle is connected.
+   */
+  const refreshFenceEnabled = (): void => {
+    const v = mainVehicleStore.mainVehicle
+    if (!v) return
+    if (!isArduPilot.value) return
+    v.requestParameter('FENCE_ENABLE')
+  }
+
+  /**
+   * Asks the vehicle for the current `FENCE_AUTOENABLE` value. The reply
+   * arrives asynchronously via PARAM_VALUE and updates `fenceAutoEnableMode`.
+   * No-op on non-ArduPilot vehicles or when no vehicle is connected.
+   */
+  const refreshFenceAutoEnable = (): void => {
+    const v = mainVehicleStore.mainVehicle
+    if (!v) return
+    if (!isArduPilot.value) return
+    v.requestParameter('FENCE_AUTOENABLE')
+  }
+
+  /**
+   * Toggles vehicle-side geofence enforcement by writing the `FENCE_ENABLE`
+   * parameter on ArduPilot. Performs an optimistic local update; the real
+   * value is reconfirmed when the resulting PARAM_VALUE reply arrives.
+   * @param { boolean } enabled Whether enforcement should be active on the vehicle.
+   */
+  const setFenceEnabled = (enabled: boolean): void => {
+    const v = mainVehicleStore.mainVehicle
+    if (!v) throw new Error('No vehicle connected.')
+    if (!isArduPilot.value) {
+      throw new Error('Fence enforcement toggle is only supported on ArduPilot vehicles.')
+    }
+    v.setParameter({
+      id: 'FENCE_ENABLE',
+      value: enabled ? 1 : 0,
+      type: { type: MavParamType.MAV_PARAM_TYPE_UINT8 },
+    })
+    fenceEnabled.value = enabled
+  }
+
+  /**
+   * Writes `FENCE_AUTOENABLE` on ArduPilot, controlling whether the autopilot
+   * automatically arms fence enforcement on auto-takeoff. Mode `1` is the
+   * common "enable on takeoff, disable on landing" preset; `0` disables it.
+   * @param { number } mode `FENCE_AUTOENABLE` mode (vendor-defined; typically 0–4).
+   */
+  const setFenceAutoEnable = (mode: number): void => {
+    const v = mainVehicleStore.mainVehicle
+    if (!v) throw new Error('No vehicle connected.')
+    if (!isArduPilot.value) {
+      throw new Error('FENCE_AUTOENABLE is only supported on ArduPilot vehicles.')
+    }
+    v.setParameter({
+      id: 'FENCE_AUTOENABLE',
+      value: mode,
+      type: { type: MavParamType.MAV_PARAM_TYPE_UINT8 },
+    })
+    fenceAutoEnableMode.value = mode
+  }
+
+  // Wire PARAM_VALUE updates from the vehicle into `fenceEnabled` /
+  // `fenceAutoEnableMode` so that any change — whether triggered by us, by
+  // another GCS, or auto-applied by the autopilot itself (e.g.
+  // `FENCE_AUTOENABLE` on takeoff) — is reflected in the UI. Re-binds
+  // whenever the active vehicle instance changes.
+  let attachedVehicle: Vehicle.Abstract | undefined
+  const fenceParamSlot = ([param]: [Parameter, number | undefined]): void => {
+    if (!param) return
+    if (param.name === 'FENCE_ENABLE') {
+      fenceEnabled.value = Math.round(param.value) === 1
+    } else if (param.name === 'FENCE_AUTOENABLE') {
+      fenceAutoEnableMode.value = Math.round(param.value)
+    }
+  }
+  watch(
+    () => mainVehicleStore.mainVehicle,
+    (newVehicle) => {
+      if (attachedVehicle) attachedVehicle.onParameter.remove(fenceParamSlot)
+      attachedVehicle = newVehicle
+      if (newVehicle) newVehicle.onParameter.add(fenceParamSlot)
+    },
+    { immediate: true }
+  )
+
+  // The autopilot does not emit unsolicited PARAM_VALUE messages when its own
+  // logic flips `FENCE_ENABLE` (for example, on `FENCE_AUTOENABLE`-driven
+  // takeoff-time activation). To keep the Map widget toggle in sync with the
+  // real enforcement state we poll `FENCE_ENABLE` while a fence is loaded on
+  // the vehicle. `FENCE_AUTOENABLE` itself never changes autopilot-side, so
+  // we only need to refresh it on the rising edge. Polling pauses whenever
+  // the tab is hidden so we don't generate idle MAVLink traffic in the
+  // background. The interval is intentionally lazy — enforcement state rarely
+  // changes mid-flight, so a 10s cadence is enough to keep the UI honest
+  // without flooding the link.
+  const FENCE_ENABLE_POLL_INTERVAL_MS = 10000
+  let fenceEnablePollHandle: ReturnType<typeof setInterval> | undefined
+  const visibility = useDocumentVisibility()
+  watch(
+    [isArduPilot, lastUploadedPlan, () => mainVehicleStore.isVehicleOnline, visibility],
+    ([isAP, plan, online, vis]) => {
+      if (fenceEnablePollHandle !== undefined) {
+        clearInterval(fenceEnablePollHandle)
+        fenceEnablePollHandle = undefined
+      }
+      const baselineActive = Boolean(isAP && plan && online)
+      if (!baselineActive) {
+        fenceEnabled.value = undefined
+        fenceAutoEnableMode.value = undefined
+        return
+      }
+      if (vis !== 'visible') return
+      refreshFenceEnabled()
+      refreshFenceAutoEnable()
+      fenceEnablePollHandle = setInterval(refreshFenceEnabled, FENCE_ENABLE_POLL_INTERVAL_MS)
+    },
+    { immediate: true }
+  )
+
+  // Pinia stores are app-singletons in production, so this never fires in the
+  // running app. Kept for tests and any future caller that explicitly
+  // `$dispose()`s the store, so the polling timer and parameter listener
+  // don't outlive the store's effect scope.
+  tryOnScopeDispose(() => {
+    if (fenceEnablePollHandle !== undefined) {
+      clearInterval(fenceEnablePollHandle)
+      fenceEnablePollHandle = undefined
+    }
+    if (attachedVehicle) {
+      attachedVehicle.onParameter.remove(fenceParamSlot)
+      attachedVehicle = undefined
+    }
+  })
+
+  const clearAll = (): void => {
+    polygons.splice(0)
+    circles.splice(0)
+    breachReturn.value = undefined
+    draft.setInteractive(undefined)
+    markDirty()
+    persistDraft()
+  }
+
+  const addPolygon = (anchor: FenceLatLng, inclusion: boolean): FencePolygon => {
+    const halfSide = POLYGON_DEFAULT_HALF_SIDE_M
+    const vertices: FenceLatLng[] = [
+      offsetCoordinates(anchor, -halfSide, halfSide),
+      offsetCoordinates(anchor, halfSide, halfSide),
+      offsetCoordinates(anchor, halfSide, -halfSide),
+      offsetCoordinates(anchor, -halfSide, -halfSide),
+    ]
+    const polygon: FencePolygon = { id: uuid(), inclusion, vertices }
+    polygons.push(polygon)
+    draft.setInteractive(polygon.id)
+    markDirty()
+    persistDraft()
+    return polygon
+  }
+
+  const addCircle = (anchor: FenceLatLng, inclusion: boolean): FenceCircle => {
+    const circle: FenceCircle = {
+      id: uuid(),
+      inclusion,
+      center: [anchor[0], anchor[1]],
+      radius: CIRCLE_DEFAULT_RADIUS_M,
+    }
+    circles.push(circle)
+    draft.setInteractive(circle.id)
+    markDirty()
+    persistDraft()
+    return circle
+  }
+
+  const updatePolygon = (id: string, update: Partial<Omit<FencePolygon, 'id'>>): void => {
+    const polygon = polygons.find((p) => p.id === id)
+    if (!polygon) return
+    if (update.inclusion !== undefined) polygon.inclusion = update.inclusion
+    if (update.vertices !== undefined) polygon.vertices = cloneVertices(update.vertices)
+    markDirty()
+    persistDraftDebounced()
+  }
+
+  const updateCircle = (id: string, update: Partial<Omit<FenceCircle, 'id'>>): void => {
+    const circle = circles.find((c) => c.id === id)
+    if (!circle) return
+    if (update.inclusion !== undefined) circle.inclusion = update.inclusion
+    if (update.center !== undefined) circle.center = [update.center[0], update.center[1]]
+    if (update.radius !== undefined) circle.radius = Math.max(1, Math.min(CIRCLE_MAX_RADIUS_M, update.radius))
+    markDirty()
+    persistDraftDebounced()
+  }
+
+  const togglePolygonInclusion = (id: string): void => {
+    const polygon = polygons.find((p) => p.id === id)
+    if (!polygon) return
+    updatePolygon(id, { inclusion: !polygon.inclusion })
+  }
+
+  const toggleCircleInclusion = (id: string): void => {
+    const circle = circles.find((c) => c.id === id)
+    if (!circle) return
+    updateCircle(id, { inclusion: !circle.inclusion })
+  }
+
+  const deletePolygon = (id: string): void => {
+    const idx = polygons.findIndex((p) => p.id === id)
+    if (idx === -1) return
+    polygons.splice(idx, 1)
+    if (draft.interactiveShapeId === id) draft.setInteractive(undefined)
+    markDirty()
+    persistDraft()
+  }
+
+  const deleteCircle = (id: string): void => {
+    const idx = circles.findIndex((c) => c.id === id)
+    if (idx === -1) return
+    circles.splice(idx, 1)
+    if (draft.interactiveShapeId === id) draft.setInteractive(undefined)
+    markDirty()
+    persistDraft()
+  }
+
+  /**
+   * Commits the polygon currently being drawn into the persistent fence
+   * model. Requires at least 3 vertices, otherwise it cancels silently.
+   * @returns { FencePolygon | undefined } The committed polygon, or `undefined` if not enough vertices.
+   */
+  const finishDrawingPolygon = (): FencePolygon | undefined => {
+    if (!draft.isDrawingPolygon || draft.pendingPolygonVertices.length < 3) {
+      draft.cancelDrawingPolygon()
+      return undefined
+    }
+    const polygon: FencePolygon = {
+      id: uuid(),
+      inclusion: draft.pendingPolygonInclusion,
+      vertices: cloneVertices(draft.pendingPolygonVertices),
+    }
+    polygons.push(polygon)
+    draft.cancelDrawingPolygon()
+    draft.setInteractive(polygon.id)
+    markDirty()
+    persistDraft()
+    return polygon
+  }
+
+  /**
+   * Commits the circle currently being drawn into the persistent fence
+   * model. Requires a center and a radius >= 1m, otherwise it cancels
+   * silently.
+   * @returns { FenceCircle | undefined } The committed circle, or `undefined` if not enough data.
+   */
+  const finishDrawingCircle = (): FenceCircle | undefined => {
+    if (!draft.isDrawingCircle || !draft.pendingCircleCenter || draft.pendingCircleRadius < 1) {
+      draft.cancelDrawingCircle()
+      return undefined
+    }
+    const circle: FenceCircle = {
+      id: uuid(),
+      inclusion: draft.pendingCircleInclusion,
+      center: [draft.pendingCircleCenter[0], draft.pendingCircleCenter[1]],
+      radius: draft.pendingCircleRadius,
+    }
+    circles.push(circle)
+    draft.cancelDrawingCircle()
+    draft.setInteractive(circle.id)
+    markDirty()
+    persistDraft()
+    return circle
+  }
+
+  const setBreachReturn = (point: BreachReturnPoint | undefined): void => {
+    breachReturn.value = point ? { coordinates: [...point.coordinates], altitude: point.altitude } : undefined
+    markDirty()
+    persistDraft()
+  }
+
+  /**
+   * Loads a complete fence plan into the editor, replacing the current draft.
+   * @param { GeoFencePlan } plan The plan to load.
+   */
+  const loadFromPlan = (plan: GeoFencePlan): void => {
+    polygons.splice(
+      0,
+      polygons.length,
+      ...plan.polygons.map((p) => ({
+        id: p.id ?? uuid(),
+        inclusion: p.inclusion,
+        vertices: cloneVertices(p.vertices),
+      }))
+    )
+    circles.splice(
+      0,
+      circles.length,
+      ...plan.circles.map((c) => ({
+        id: c.id ?? uuid(),
+        inclusion: c.inclusion,
+        center: [c.center[0], c.center[1]] as FenceLatLng,
+        radius: c.radius,
+      }))
+    )
+    breachReturn.value = plan.breachReturn
+      ? { coordinates: [...plan.breachReturn.coordinates], altitude: plan.breachReturn.altitude }
+      : undefined
+    draft.setInteractive(undefined)
+    markDirty()
+    persistDraft()
+  }
+
+  /**
+   * Snapshots the current editor state into a `GeoFencePlan` (e.g. for upload
+   * or file export). Always returns a fresh deep copy.
+   * @returns { GeoFencePlan } The current plan.
+   */
+  const exportPlan = (): GeoFencePlan => ({
+    version: 2,
+    polygons: polygons.map((p) => ({ id: p.id, inclusion: p.inclusion, vertices: cloneVertices(p.vertices) })),
+    circles: circles.map((c) => ({
+      id: c.id,
+      inclusion: c.inclusion,
+      center: [c.center[0], c.center[1]],
+      radius: c.radius,
+    })),
+    breachReturn: breachReturn.value
+      ? { coordinates: [...breachReturn.value.coordinates], altitude: breachReturn.value.altitude }
+      : undefined,
+  })
+
+  const inclusionPolygonCount = computed<number>(() => polygons.filter((p) => p.inclusion).length)
+  const hasItems = computed<boolean>(
+    () => polygons.length > 0 || circles.length > 0 || breachReturn.value !== undefined
+  )
+
+  /**
+   * Checks the given list of waypoints against the current editor fence
+   * plan, with the uploaded plan as a fallback when the editor is empty.
+   * @param { WaypointLike[] } waypoints Waypoints to test.
+   * @returns { MissionBreachReport } Breach summary with offending indices.
+   */
+  const detectMissionBreaches = (waypoints: WaypointLike[]): MissionBreachReport => {
+    // Read straight from the reactive editor state when it has shapes,
+    // otherwise fall back to the (already plain) `lastUploadedPlan`. Avoids
+    // a deep copy of every fence shape on every upload attempt.
+    const editorHasFences = polygons.length > 0 || circles.length > 0
+    const sourcePolygons: FencePolygon[] = editorHasFences ? polygons : lastUploadedPlan.value?.polygons ?? []
+    const sourceCircles: FenceCircle[] = editorHasFences ? circles : lastUploadedPlan.value?.circles ?? []
+    return detectMissionBreachesInShapes(waypoints, sourcePolygons, sourceCircles)
+  }
+
+  /**
+   * Uploads the current editor state to the vehicle. Caches the uploaded
+   * plan in `lastUploadedPlan` (also persisted to BlueOS) so the live
+   * overlay on the flight Map widget can render it without re-downloading.
+   * @param { MissionLoadingCallback } loadingCallback Callback invoked with progress.
+   */
+  const uploadToVehicle = async (loadingCallback?: MissionLoadingCallback): Promise<void> => {
+    syncInProgress.value = true
+    try {
+      const plan = exportPlan()
+      await mainVehicleStore.uploadFence(plan, loadingCallback ?? (async () => undefined))
+      lastUploadedPlan.value = clonePlan(plan)
+      persistedVehicleFence.value = clonePlan(plan)
+      dirty.value = false
+
+      // Auto-enable enforcement on ArduPilot so users don't need a second click
+      // after upload, and arm `FENCE_AUTOENABLE` so subsequent auto-takeoffs
+      // re-engage the fence even if it was manually disabled in between.
+      // Failures are non-fatal: the user can still flip the dedicated toggle
+      // from the Map widget and tweak the parameter from the parameters panel.
+      if (isArduPilot.value) {
+        try {
+          setFenceEnabled(true)
+          setFenceAutoEnable(1)
+        } catch (error) {
+          console.warn('Auto-enable of vehicle geofence failed:', error)
+        }
+      }
+
+      openSnackbar({ variant: 'success', message: 'Geofence uploaded to vehicle.', duration: 3000 })
+    } finally {
+      syncInProgress.value = false
+    }
+  }
+
+  /**
+   * Downloads the current geofence from the vehicle, replaces the editor
+   * state with it, and updates the cached `lastUploadedPlan`.
+   * @param { MissionLoadingCallback } loadingCallback Callback invoked with progress.
+   */
+  const downloadFromVehicle = async (loadingCallback?: MissionLoadingCallback): Promise<void> => {
+    syncInProgress.value = true
+    try {
+      const plan = await mainVehicleStore.fetchFence(loadingCallback ?? (async () => undefined))
+      loadFromPlan(plan)
+      lastUploadedPlan.value = clonePlan(plan)
+      persistedVehicleFence.value = clonePlan(plan)
+      dirty.value = false
+      openSnackbar({ variant: 'success', message: 'Geofence downloaded from vehicle.', duration: 3000 })
+    } finally {
+      syncInProgress.value = false
+    }
+  }
+
+  /**
+   * Clears the geofence currently stored on the vehicle, and clears the
+   * cached overlay so the live overlay control disappears.
+   */
+  const clearOnVehicle = async (): Promise<void> => {
+    syncInProgress.value = true
+    try {
+      await mainVehicleStore.clearFence()
+      lastUploadedPlan.value = undefined
+      persistedVehicleFence.value = null
+    } finally {
+      syncInProgress.value = false
+    }
+  }
+
+  return {
+    polygons,
+    circles,
+    breachReturn,
+    dirty,
+    syncInProgress,
+    lastUploadedPlan,
+    isFenceSupported,
+    isArduPilotPlane,
+    isPx4,
+    isArduPilot,
+    fenceEnabled,
+    fenceAutoEnableMode,
+    setFenceEnabled,
+    setFenceAutoEnable,
+    refreshFenceEnabled,
+    refreshFenceAutoEnable,
+    inclusionPolygonCount,
+    hasItems,
+    detectMissionBreaches,
+    addPolygon,
+    addCircle,
+    updatePolygon,
+    updateCircle,
+    togglePolygonInclusion,
+    toggleCircleInclusion,
+    deletePolygon,
+    deleteCircle,
+    finishDrawingPolygon,
+    finishDrawingCircle,
+    setBreachReturn,
+    clearAll,
+    loadFromPlan,
+    exportPlan,
+    uploadToVehicle,
+    downloadFromVehicle,
+    clearOnVehicle,
+    polygonDefaults: { defaultHalfSideMeters: POLYGON_DEFAULT_HALF_SIDE_M, maxHalfSideMeters: POLYGON_MAX_HALF_SIDE_M },
+    circleDefaults: { defaultRadiusMeters: CIRCLE_DEFAULT_RADIUS_M, maxRadiusMeters: CIRCLE_MAX_RADIUS_M },
+  }
+})

--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -49,6 +49,7 @@ import type {
 import { Coordinates } from '@/libs/vehicle/types'
 import * as Vehicle from '@/libs/vehicle/vehicle'
 import { VehicleFactory } from '@/libs/vehicle/vehicle-factory'
+import type { GeoFencePlan } from '@/types/geofence'
 import type { MissionLoadingCallback, Waypoint } from '@/types/mission'
 
 import { useControllerStore } from './controller'
@@ -143,6 +144,7 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
   const vehiclePositionMaxSampleRate = useStorage('cockpit-vehicle-position-max-sampling-ms', 200) // Limits the frequency of vehicle position updates
   const reachedMissionItemSequences = ref<number[]>([])
   const currentMissionSeq = ref<number | undefined>(undefined)
+  const capabilities = ref<number | undefined>(undefined)
 
   const markMissionItemAsReached = (sequence: number): void => {
     if (reachedMissionItemSequences.value.includes(sequence)) return
@@ -542,6 +544,47 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
   }
 
   /**
+   * Upload a geofence plan to the vehicle.
+   * @param { GeoFencePlan } plan The plan to upload.
+   * @param { MissionLoadingCallback } loadingCallback Callback invoked with upload progress.
+   * @returns { Promise<void> } Resolves when the vehicle acks the upload.
+   */
+  async function uploadFence(plan: GeoFencePlan, loadingCallback: MissionLoadingCallback): Promise<void> {
+    if (!mainVehicle.value) throw new Error('No vehicle available to upload fence.')
+    return await mainVehicle.value.uploadFence(plan, loadingCallback)
+  }
+
+  /**
+   * Download the geofence plan currently stored on the vehicle.
+   * @param { MissionLoadingCallback } loadingCallback Callback invoked with download progress.
+   * @returns { Promise<GeoFencePlan> } The decoded geofence plan from the vehicle.
+   */
+  async function fetchFence(loadingCallback: MissionLoadingCallback): Promise<GeoFencePlan> {
+    if (!mainVehicle.value) throw new Error('No vehicle available to fetch fence.')
+    return await mainVehicle.value.fetchFence(loadingCallback)
+  }
+
+  /**
+   * Clear the geofence currently stored on the vehicle.
+   * @returns { Promise<void> } Resolves once the vehicle acknowledges the clear.
+   */
+  async function clearFence(): Promise<void> {
+    if (!mainVehicle.value) throw new Error('No vehicle available to clear fence.')
+    await mainVehicle.value.clearFence()
+    openSnackbar({ message: 'Geofence deleted from vehicle', variant: 'info' })
+  }
+
+  /**
+   * Request a single onboard parameter from the vehicle by name.
+   * The reply arrives asynchronously via the standard `PARAM_VALUE` channel.
+   * @param { string } paramName Onboard parameter id (max 16 chars).
+   */
+  function requestParameter(paramName: string): void {
+    if (!mainVehicle.value) return
+    mainVehicle.value.requestParameter(paramName)
+  }
+
+  /**
    * Start mission that is on the vehicle
    */
   async function startMission(): Promise<void> {
@@ -639,6 +682,12 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     // Set callback for mission's current waypoint updates
     mainVehicle.value.onMissionCurrent.add(MAVLinkType.MISSION_CURRENT, (seq: number) => {
       currentMissionSeq.value = seq
+    })
+
+    // Track autopilot capability bitmask so feature gates (e.g. geofence) can react.
+    capabilities.value = mainVehicle.value.capabilities()
+    mainVehicle.value.onCapabilities.add((bits: number) => {
+      capabilities.value = bits
     })
 
     mainVehicle.value.onAltitude.add((newAltitude: Altitude) => {
@@ -1047,6 +1096,11 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     fetchMission,
     uploadMission,
     clearMissions,
+    uploadFence,
+    fetchFence,
+    clearFence,
+    requestParameter,
+    capabilities,
     startMission,
     pauseMission,
     returnHome,

--- a/src/types/geofence.ts
+++ b/src/types/geofence.ts
@@ -94,6 +94,138 @@ export interface GeoFencePlan {
 }
 
 /**
+ * Cockpit-native fence file. Wraps a `GeoFencePlan` in a small envelope so
+ * the file can be unambiguously identified on import (cf. `.cmp` mission
+ * files).
+ */
+export interface CockpitFencePlanFile {
+  /**
+   * Cockpit fence file version. Currently `0`.
+   */
+  version: number
+  /**
+   * Discriminator used by the importer.
+   */
+  fileType: 'CockpitFencePlan'
+  /**
+   * The actual fence plan.
+   */
+  plan: GeoFencePlan
+}
+
+/**
+ * Subset of the MAVLink-ecosystem `.plan` JSON document we need to parse
+ * and emit for round-tripping with other ground stations. We only model
+ * the `geoFence` block exhaustively; the `mission` and `rallyPoints`
+ * blocks are treated as opaque so we can preserve them on round-trip.
+ */
+export interface MavlinkPlanFile {
+  /**
+   * Always `'Plan'` for a `.plan` file.
+   */
+  fileType: 'Plan'
+  /**
+   * Plan-file schema version.
+   */
+  version: number
+  /**
+   * Originating ground station name.
+   */
+  groundStation?: string
+  /**
+   * Mission section (kept opaque for round-trip).
+   */
+  mission?: unknown
+  /**
+   * Rally points section (kept opaque for round-trip).
+   */
+  rallyPoints?: unknown
+  /**
+   * Geofence section.
+   */
+  geoFence?: {
+    /**
+     * Schema version. Cockpit only reads `version === 2`.
+     */
+    version: number
+    /**
+     * Polygons array (`.plan` schema).
+     */
+    polygons?: {
+      /**
+       * Per-polygon schema version.
+       */
+      version: number
+      /**
+       * Whether the polygon is an inclusion fence.
+       */
+      inclusion: boolean
+      /**
+       * Vertex list, each `[lat, lon]`.
+       */
+      polygon: [number, number][]
+    }[]
+    /**
+     * Circles array (`.plan` schema).
+     */
+    circles?: {
+      /**
+       * Per-circle schema version.
+       */
+      version: number
+      /**
+       * Whether the circle is an inclusion fence.
+       */
+      inclusion: boolean
+      /**
+       * Center coordinates and radius.
+       */
+      circle: {
+        /**
+         * Center coordinates `[lat, lon]`.
+         */
+        center: [number, number]
+        /**
+         * Radius in meters.
+         */
+        radius: number
+      }
+    }[]
+    /**
+     * Breach return point as `[lat, lon, alt]`.
+     */
+    breachReturn?: [number, number, number]
+  }
+}
+
+/**
+ * Validates that a parsed JSON object is a `CockpitFencePlanFile`.
+ * @param { unknown } maybeFile The parsed JSON to inspect.
+ * @returns { boolean } True if the object is a valid Cockpit fence file.
+ */
+export const instanceOfCockpitFencePlanFile = (maybeFile: unknown): maybeFile is CockpitFencePlanFile => {
+  if (!maybeFile || typeof maybeFile !== 'object') return false
+  const f = maybeFile as Partial<CockpitFencePlanFile>
+  if (f.fileType !== 'CockpitFencePlan') return false
+  if (typeof f.version !== 'number') return false
+  return instanceOfGeoFencePlan(f.plan)
+}
+
+/**
+ * Lightweight envelope check for a MAVLink-ecosystem `.plan` file.
+ * Validates only the outer `fileType === 'Plan'` discriminator and that
+ * `version` is a number; the inner `mission` / `geoFence` blocks are not
+ * inspected and must be validated by the caller before use.
+ * @param { unknown } maybeFile The parsed JSON to inspect.
+ * @returns { boolean } True if the object looks like a `.plan` envelope.
+ */
+export const instanceOfMavlinkPlanFile = (maybeFile: unknown): maybeFile is MavlinkPlanFile => {
+  if (!maybeFile || typeof maybeFile !== 'object') return false
+  const f = maybeFile as Partial<MavlinkPlanFile>
+  return f.fileType === 'Plan' && typeof f.version === 'number'
+}
+
+/**
  * Validates that a parsed object conforms to the `GeoFencePlan` shape.
  * @param { unknown } maybePlan The parsed JSON to inspect.
  * @returns { boolean } True if the object is a valid `GeoFencePlan`.

--- a/src/types/geofence.ts
+++ b/src/types/geofence.ts
@@ -1,0 +1,108 @@
+import type { WaypointCoordinates } from '@/types/mission'
+
+/**
+ * Geographical coordinates in the format [latitude, longitude].
+ */
+export type FenceLatLng = WaypointCoordinates
+
+/**
+ * A polygon-shaped geofence. May be inclusion (vehicle must stay inside)
+ * or exclusion (vehicle must stay outside).
+ */
+export interface FencePolygon {
+  /**
+   * Unique identification for the polygon.
+   */
+  id: string
+  /**
+   * If true, the vehicle is restricted to the inside of the polygon.
+   * If false, the vehicle is restricted to the outside of the polygon.
+   */
+  inclusion: boolean
+  /**
+   * Ordered list of polygon vertices. Polygons are 2D — altitude limits are
+   * enforced via vehicle parameters (FENCE_ALT_MAX/MIN, GF_MAX_VER_DIST).
+   */
+  vertices: FenceLatLng[]
+}
+
+/**
+ * A circle-shaped geofence. May be inclusion (vehicle must stay inside)
+ * or exclusion (vehicle must stay outside).
+ */
+export interface FenceCircle {
+  /**
+   * Unique identification for the circle.
+   */
+  id: string
+  /**
+   * If true, the vehicle is restricted to the inside of the circle.
+   * If false, the vehicle is restricted to the outside of the circle.
+   */
+  inclusion: boolean
+  /**
+   * Geographical coordinates of the circle center.
+   */
+  center: FenceLatLng
+  /**
+   * Radius of the circle in meters.
+   */
+  radius: number
+}
+
+/**
+ * Optional point the vehicle should return to when the geofence is breached.
+ * Stored separately from polygons/circles. On ArduPilot Plane this can be
+ * overridden by rally points when FENCE_RET_RALLY = 1. Not honored by PX4.
+ */
+export interface BreachReturnPoint {
+  /**
+   * Geographical coordinates of the breach return point.
+   */
+  coordinates: FenceLatLng
+  /**
+   * Altitude (meters, relative to home) the vehicle should fly to.
+   */
+  altitude: number
+}
+
+/**
+ * Complete geofence plan as used at runtime in Cockpit. Schema mirrors the
+ * de-facto MAVLink-ecosystem `.plan` `geoFence` block (version 2) so files
+ * can round-trip with other ground stations. Polygons store vertices as
+ * `[lat, lon]`; circles store `{ center: [lat, lon], radius }`;
+ * `breachReturn` is the structured `BreachReturnPoint` (separate
+ * `coordinates` and `altitude`).
+ */
+export interface GeoFencePlan {
+  /**
+   * Schema version. Matches the `.plan` `geoFence.version` field.
+   */
+  version: 2
+  /**
+   * Inclusion and exclusion polygons.
+   */
+  polygons: FencePolygon[]
+  /**
+   * Inclusion and exclusion circles.
+   */
+  circles: FenceCircle[]
+  /**
+   * Optional breach return point.
+   */
+  breachReturn?: BreachReturnPoint
+}
+
+/**
+ * Validates that a parsed object conforms to the `GeoFencePlan` shape.
+ * @param { unknown } maybePlan The parsed JSON to inspect.
+ * @returns { boolean } True if the object is a valid `GeoFencePlan`.
+ */
+export const instanceOfGeoFencePlan = (maybePlan: unknown): maybePlan is GeoFencePlan => {
+  if (!maybePlan || typeof maybePlan !== 'object') return false
+  const p = maybePlan as Partial<GeoFencePlan>
+  if (p.version !== 2) return false
+  if (!Array.isArray(p.polygons)) return false
+  if (!Array.isArray(p.circles)) return false
+  return true
+}

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -757,6 +757,7 @@ import {
   WhoToFollow,
 } from '@/libs/map/utils-map'
 import { generateSurveyPath } from '@/libs/map/utils-map'
+import { pickBestPosition, screenBounds } from '@/libs/mission/confirm-button-placement'
 import {
   bearingBetween,
   centroidLatLng,
@@ -770,7 +771,6 @@ import { SubMenuComponentName, SubMenuName, useAppInterfaceStore } from '@/store
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useMissionStore } from '@/stores/mission'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
-import { Point2D } from '@/types/general'
 import {
   type CockpitMission,
   type Waypoint,
@@ -787,7 +787,6 @@ import {
   Survey,
   SurveyPath,
 } from '@/types/mission'
-import { ScreenBounds } from '@/types/user-interface'
 
 const missionStore = useMissionStore()
 const vehicleStore = useMainVehicleStore()
@@ -1478,77 +1477,6 @@ const updateSurvey = (id: string, updatedSurvey: Partial<Survey>): void => {
   const index = surveys.value.findIndex((s) => s.id === id)
   if (index !== -1) {
     surveys.value[index] = { ...surveys.value[index], ...updatedSurvey }
-  }
-}
-
-/**
- * Computes screen-space axis-aligned bounding box from an array of 2D points.
- * @param {Point2D[]} pts - Screen-space points
- * @returns {ScreenBounds} The bounding box
- */
-const screenBounds = (pts: Point2D[]): ScreenBounds => {
-  let minX = Infinity
-  let minY = Infinity
-  let maxX = -Infinity
-  let maxY = -Infinity
-  for (const p of pts) {
-    if (p.x < minX) minX = p.x
-    if (p.y < minY) minY = p.y
-    if (p.x > maxX) maxX = p.x
-    if (p.y > maxY) maxY = p.y
-  }
-  return { minX, minY, maxX, maxY }
-}
-
-/**
- * Picks the best candidate position by maximising viewport visibility and minimising
- * overlap with a polygon bounding box, then clamps the result inside the viewport.
- * @param {Point2D[]} candidates - Top-left positions to evaluate
- * @param {number} elW - Element width in pixels
- * @param {number} elH - Element height in pixels
- * @param {ScreenBounds} polyBounds - Polygon screen bounds
- * @param {number} vpW - Viewport width
- * @param {number} vpH - Viewport height
- * @param {number} margin - Minimum distance from viewport edge
- * @returns {Point2D} Clamped top-left position
- */
-const pickBestPosition = (
-  candidates: Point2D[],
-  elW: number,
-  elH: number,
-  polyBounds: ScreenBounds,
-  vpW: number,
-  vpH: number,
-  margin: number
-): Point2D => {
-  const area = elW * elH
-  let best = candidates[0]
-  let bestScore = -Infinity
-
-  for (const c of candidates) {
-    const l = c.x
-    const r = c.x + elW
-    const t = c.y
-    const b = c.y + elH
-
-    const visW = Math.max(0, Math.min(r, vpW - margin) - Math.max(l, margin))
-    const visH = Math.max(0, Math.min(b, vpH - margin) - Math.max(t, margin))
-    const visibility = (visW * visH) / area
-
-    const oW = Math.max(0, Math.min(r, polyBounds.maxX) - Math.max(l, polyBounds.minX))
-    const oH = Math.max(0, Math.min(b, polyBounds.maxY) - Math.max(t, polyBounds.minY))
-    const overlapPenalty = (oW * oH) / area
-
-    const score = visibility - overlapPenalty * 0.5
-    if (score > bestScore) {
-      bestScore = score
-      best = c
-    }
-  }
-
-  return {
-    x: Math.max(margin, Math.min(best.x, vpW - elW - margin)),
-    y: Math.max(margin, Math.min(best.y, vpH - elH - margin)),
   }
 }
 

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -475,107 +475,112 @@
         </button>
       </div>
     </div>
-    <v-tooltip location="top" text="Switch to Flight mode">
-      <template #activator="{ props: tooltipProps }">
-        <v-btn
-          v-bind="tooltipProps"
-          class="absolute right-[135px] w-[140px] m-3 mb-[13px] bottom-12 bg-slate-50 text-[12px] font-bold"
-          elevation="8"
-          text="Flight mode"
-          append-icon="mdi-send"
-          :style="interfaceStore.globalGlassMenuStyles"
-          hide-details
-          size="small"
-          @click.stop="goToFlightView"
-        />
-      </template>
-    </v-tooltip>
-    <v-tooltip location="top center" text="Download map tiles">
-      <template #activator="{ props: tooltipProps }">
-        <v-menu v-model="downloadMenuOpen" :close-on-content-click="false" location="top end">
-          <template #activator="{ props: menuProps }">
-            <v-btn
-              v-bind="{ ...menuProps, ...tooltipProps }"
-              class="absolute m-3 rounded-sm shadow-sm bottom-12 bg-slate-50 right-[88px] text-[14px]"
-              :style="interfaceStore.globalGlassMenuStyles"
-              size="x-small"
-              icon="mdi-download-multiple"
-            />
-          </template>
+    <div
+      class="planning-bottom-buttons absolute right-[52px] mb-3 bottom-12 flex flex-row items-center"
+      style="z-index: 1002; gap: 10px"
+    >
+      <v-tooltip location="top" text="Switch to Flight mode">
+        <template #activator="{ props: tooltipProps }">
+          <v-btn
+            v-bind="tooltipProps"
+            class="w-[140px] bg-slate-50 text-[12px] font-bold"
+            elevation="8"
+            text="Flight mode"
+            append-icon="mdi-send"
+            :style="interfaceStore.globalGlassMenuStyles"
+            hide-details
+            size="small"
+            @click.stop="goToFlightView"
+          />
+        </template>
+      </v-tooltip>
+      <v-tooltip location="top center" text="Download map tiles">
+        <template #activator="{ props: tooltipProps }">
+          <v-menu v-model="downloadMenuOpen" :close-on-content-click="false" location="top end">
+            <template #activator="{ props: menuProps }">
+              <v-btn
+                v-bind="{ ...menuProps, ...tooltipProps }"
+                class="rounded-sm shadow-sm bg-slate-50 text-[14px]"
+                :style="interfaceStore.globalGlassMenuStyles"
+                size="x-small"
+                icon="mdi-download-multiple"
+              />
+            </template>
 
-          <v-list :style="interfaceStore.globalGlassMenuStyles" class="py-0 min-w-[220px] rounded-lg border-[1px]">
-            <v-list-item class="py-0" title="Save visible Esri tiles" @click="saveEsri" />
-            <v-divider />
-            <v-list-item class="py-0" title="Save visible OSM tiles" @click="saveOSM" />
-          </v-list>
-        </v-menu>
-      </template>
-    </v-tooltip>
-    <v-speed-dial v-model="speedDialOpen" location="top center" transition="slide-y-reverse-transition">
-      <template #activator="{ props: activatorProps }">
-        <v-tooltip location="top center" :text="centerActivatorTooltipText" :disabled="speedDialOpen">
+            <v-list :style="interfaceStore.globalGlassMenuStyles" class="py-0 min-w-[220px] rounded-lg border-[1px]">
+              <v-list-item class="py-0" title="Save visible Esri tiles" @click="saveEsri" />
+              <v-divider />
+              <v-list-item class="py-0" title="Save visible OSM tiles" @click="saveOSM" />
+            </v-list>
+          </v-menu>
+        </template>
+      </v-tooltip>
+      <v-speed-dial v-model="speedDialOpen" location="top center" transition="slide-y-reverse-transition">
+        <template #activator="{ props: activatorProps }">
+          <v-tooltip location="top center" :text="centerActivatorTooltipText" :disabled="speedDialOpen">
+            <template #activator="{ props: tooltipProps }">
+              <v-btn
+                v-bind="{ ...activatorProps, ...tooltipProps }"
+                class="rounded-sm shadow-sm bg-slate-50 text-[14px]"
+                :style="interfaceStore.globalGlassMenuStyles"
+                :color="followerTarget !== undefined ? 'red' : ''"
+                icon="mdi-crosshairs-gps"
+                size="x-small"
+              />
+            </template>
+          </v-tooltip>
+        </template>
+        <v-tooltip location="left" :text="centerMissionButtonTooltipText">
           <template #activator="{ props: tooltipProps }">
             <v-btn
-              v-bind="{ ...activatorProps, ...tooltipProps }"
-              class="absolute m-3 rounded-sm shadow-sm bottom-12 right-[44px] bg-slate-50 text-[14px]"
-              :style="interfaceStore.globalGlassMenuStyles"
-              :color="followerTarget !== undefined ? 'red' : ''"
-              icon="mdi-crosshairs-gps"
+              key="mission"
+              v-bind="tooltipProps"
+              class="rounded-sm shadow-sm bg-slate-50 text-[14px]"
+              :style="[interfaceStore.globalGlassMenuStyles, !hasMissionWaypoints ? { color: '#FFFFFF44' } : {}]"
+              :class="[!hasMissionWaypoints ? 'active-events-on-disabled' : '']"
+              icon="mdi-map-marker-path"
               size="x-small"
+              :disabled="!hasMissionWaypoints"
+              @click.stop="centerOnMission"
             />
           </template>
         </v-tooltip>
-      </template>
-      <v-tooltip location="left" :text="centerMissionButtonTooltipText">
-        <template #activator="{ props: tooltipProps }">
-          <v-btn
-            key="mission"
-            v-bind="tooltipProps"
-            class="rounded-sm shadow-sm bg-slate-50 text-[14px]"
-            :style="[interfaceStore.globalGlassMenuStyles, !hasMissionWaypoints ? { color: '#FFFFFF44' } : {}]"
-            :class="[!hasMissionWaypoints ? 'active-events-on-disabled' : '']"
-            icon="mdi-map-marker-path"
-            size="x-small"
-            :disabled="!hasMissionWaypoints"
-            @click.stop="centerOnMission"
-          />
-        </template>
-      </v-tooltip>
-      <v-tooltip location="left" :text="centerHomeButtonTooltipText">
-        <template #activator="{ props: tooltipProps }">
-          <v-btn
-            key="home"
-            v-bind="tooltipProps"
-            class="rounded-sm shadow-sm bg-slate-50 text-[14px]"
-            :style="[interfaceStore.globalGlassMenuStyles, !home ? { color: '#FFFFFF44' } : {}]"
-            :class="[!home ? 'active-events-on-disabled' : '']"
-            :color="followerTarget == WhoToFollow.HOME ? 'red' : ''"
-            icon="mdi-home-search"
-            size="x-small"
-            :disabled="!home"
-            @click.stop="targetFollower.goToTarget(WhoToFollow.HOME, true)"
-            @dblclick.stop="targetFollower.follow(WhoToFollow.HOME)"
-          />
-        </template>
-      </v-tooltip>
-      <v-tooltip location="left" :text="centerVehicleButtonTooltipText">
-        <template #activator="{ props: tooltipProps }">
-          <v-btn
-            key="vehicle"
-            v-bind="tooltipProps"
-            class="rounded-sm shadow-sm bg-slate-50 text-[14px]"
-            :style="[interfaceStore.globalGlassMenuStyles, !vehiclePosition ? { color: '#FFFFFF44' } : {}]"
-            :class="[!vehiclePosition ? 'active-events-on-disabled' : '']"
-            :color="followerTarget == WhoToFollow.VEHICLE ? 'red' : ''"
-            icon="mdi-airplane-marker"
-            size="x-small"
-            :disabled="!vehiclePosition"
-            @click.stop="targetFollower.goToTarget(WhoToFollow.VEHICLE, true)"
-            @dblclick.stop="targetFollower.follow(WhoToFollow.VEHICLE)"
-          />
-        </template>
-      </v-tooltip>
-    </v-speed-dial>
+        <v-tooltip location="left" :text="centerHomeButtonTooltipText">
+          <template #activator="{ props: tooltipProps }">
+            <v-btn
+              key="home"
+              v-bind="tooltipProps"
+              class="rounded-sm shadow-sm bg-slate-50 text-[14px]"
+              :style="[interfaceStore.globalGlassMenuStyles, !home ? { color: '#FFFFFF44' } : {}]"
+              :class="[!home ? 'active-events-on-disabled' : '']"
+              :color="followerTarget == WhoToFollow.HOME ? 'red' : ''"
+              icon="mdi-home-search"
+              size="x-small"
+              :disabled="!home"
+              @click.stop="targetFollower.goToTarget(WhoToFollow.HOME, true)"
+              @dblclick.stop="targetFollower.follow(WhoToFollow.HOME)"
+            />
+          </template>
+        </v-tooltip>
+        <v-tooltip location="left" :text="centerVehicleButtonTooltipText">
+          <template #activator="{ props: tooltipProps }">
+            <v-btn
+              key="vehicle"
+              v-bind="tooltipProps"
+              class="rounded-sm shadow-sm bg-slate-50 text-[14px]"
+              :style="[interfaceStore.globalGlassMenuStyles, !vehiclePosition ? { color: '#FFFFFF44' } : {}]"
+              :class="[!vehiclePosition ? 'active-events-on-disabled' : '']"
+              :color="followerTarget == WhoToFollow.VEHICLE ? 'red' : ''"
+              icon="mdi-airplane-marker"
+              size="x-small"
+              :disabled="!vehiclePosition"
+              @click.stop="targetFollower.goToTarget(WhoToFollow.VEHICLE, true)"
+              @dblclick.stop="targetFollower.follow(WhoToFollow.VEHICLE)"
+            />
+          </template>
+        </v-tooltip>
+      </v-speed-dial>
+    </div>
     <MapNorthIndicator class="north-indicator" />
     <v-progress-linear
       v-if="uploadingMission"
@@ -4978,7 +4983,10 @@ watch(
 /* Style the standard Leaflet scale control */
 :deep(.leaflet-control-scale) {
   position: absolute;
-  right: 293px; /* Position to the left of the buttons */
+  /* Sits 10px to the left of the bottom-right buttons flex row.
+     Container right offset = 44px; flex inner width ≈ 224px (140px Flight-mode
+     button + two 32px icon buttons + 2×10px gaps); + 10px gap = 278px. */
+  right: 278px;
   bottom: 54px;
   background: rgba(255, 255, 255, 0.8);
   border-radius: 1px;

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="mission-planning" :style="glassMenuCssVars">
+  <div
+    class="mission-planning"
+    :class="{ 'mission-planning--fence-mode': planningMode === 'geofence' }"
+    :style="glassMenuCssVars"
+  >
     <div id="planningMap" class="relative" />
     <v-tooltip location="top" text="Generate waypoints">
       <template #activator="{ props }">
@@ -127,42 +131,71 @@
         @regenerate-survey-waypoints="regenerateSurveyWaypoints"
       />
     </div>
-    <div
-      v-show="!interfaceStore.isMainMenuVisible"
-      class="absolute flex flex-col left-10 rounded-[10px] max-h-[80vh] overflow-y-auto z-[200]"
-      :style="[interfaceStore.globalGlassMenuStyles, { height: 'auto', maxHeight: calculatedHeight, width: '320px' }]"
+    <GeoFenceDrawingActionButtons
+      :polygon-vertexes="fencePolygonVertexesPositions"
+      @finish="onFinishFencePolygonDrawing"
+    />
+    <MissionPlanningSidebar
+      v-model:planning-mode="planningMode"
+      :map-center="mapCenter"
+      :calculated-height="calculatedHeight"
+      @mission-loaded="updateWaypointMarkers"
     >
-      <div class="flex flex-col w-full h-full p-2 overflow-y-auto">
-        <button
-          v-if="!isCreatingSimplePath && !isCreatingSurvey"
-          :class="{ ' elevation-4': isCreatingSurvey }"
-          class="h-auto py-2 px-2 m-2 font-medium text-md rounded-md elevation-1 bg-[#FFFFFF33] hover:bg-[#FFFFFF44] transition-colors duration-200"
-          @click="toggleSurvey"
-        >
-          {{ missionStore.currentPlanningWaypoints.length > 0 ? 'ADD SURVEY' : 'CREATE SURVEY' }}
-        </button>
-        <button
-          v-if="!isCreatingSurvey && !isCreatingSimplePath"
-          :class="{ ' elevation-4': isCreatingSimplePath }"
-          class="h-auto py-2 px-2 m-2 font-medium text-md rounded-md elevation-1 bg-[#FFFFFF33] hover:bg-[#FFFFFF44] transition-colors duration-200"
-          @click="toggleSimplePath"
-        >
-          {{ missionStore.currentPlanningWaypoints.length > 0 ? 'ADD SIMPLE PATH' : 'CREATE SIMPLE PATH' }}
-        </button>
+      <template #mission>
         <div
           v-if="!isCreatingSurvey && !isCreatingSimplePath"
-          class="flex flex-row justify-center items-center gap-x-2 mx-4 my-1"
+          class="flex flex-row items-center justify-between m-2 gap-x-2"
         >
-          <p class="text-sm">Cruise speed</p>
-          <input
-            v-model.number="localCruiseSpeed"
-            class="w-[60px] px-2 py-1 rounded-sm bg-[#FFFFFF22]"
-            type="number"
-            min="0"
-            step="0.5"
-            @change="cruiseSpeedTouched = true"
-          />
-          <p class="text-sm">m/s</p>
+          <div class="flex flex-row items-center gap-x-1 w-[130px] -ml-1">
+            <p class="text-xs">Cruise speed</p>
+            <input
+              v-model.number="localCruiseSpeed"
+              class="w-[55px] px-1 py-0 rounded-sm bg-[#FFFFFF22] text-sm"
+              type="number"
+              min="0"
+              step="0.5"
+              @change="cruiseSpeedTouched = true"
+            />
+            <p class="text-xs">m/s</p>
+          </div>
+          <v-divider vertical class="opacity-30 mx-1 h-5 self-center" />
+          <div class="flex flex-row items-center gap-x-2">
+            <span class="text-sm font-medium mr-1">
+              {{ missionStore.currentPlanningWaypoints.length > 0 ? 'Add:' : 'New:' }}
+            </span>
+            <v-tooltip
+              location="top"
+              :text="missionStore.currentPlanningWaypoints.length > 0 ? 'Add survey area' : 'Create survey area'"
+            >
+              <template #activator="{ props: tooltipProps }">
+                <v-btn
+                  v-bind="tooltipProps"
+                  icon="mdi-grid"
+                  variant="elevated"
+                  color="#3B78A8"
+                  size="x-small"
+                  class="rounded-md"
+                  @click="toggleSurvey"
+                />
+              </template>
+            </v-tooltip>
+            <v-tooltip
+              location="top"
+              :text="missionStore.currentPlanningWaypoints.length > 0 ? 'Add simple path' : 'Create simple path'"
+            >
+              <template #activator="{ props: tooltipProps }">
+                <v-btn
+                  v-bind="tooltipProps"
+                  icon="mdi-vector-polyline"
+                  variant="elevated"
+                  color="#3B78A8"
+                  size="x-small"
+                  class="rounded-md"
+                  @click="toggleSimplePath"
+                />
+              </template>
+            </v-tooltip>
+          </div>
         </div>
         <div
           v-if="showMissionCreationTips && !isCreatingSurvey && !isCreatingSimplePath"
@@ -473,8 +506,8 @@
           <v-progress-circular v-if="loading" size="20" class="py-4" />
           <p v-else>DOWNLOAD MISSION FROM VEHICLE</p>
         </button>
-      </div>
-    </div>
+      </template>
+    </MissionPlanningSidebar>
     <div
       class="planning-bottom-buttons absolute right-[52px] mb-3 bottom-12 flex flex-row items-center"
       style="z-index: 1002; gap: 10px"
@@ -671,6 +704,7 @@
     :zoom="zoom"
     :target-follower="targetFollower"
   />
+  <GeoFenceMapLayer :readonly="planningMode !== 'geofence'" />
 
   <v-progress-linear
     v-if="fetchingMission"
@@ -718,11 +752,14 @@ import { type InstanceType, computed, nextTick, onMounted, onUnmounted, ref, sha
 import blueboatMarkerImage from '@/assets/blueboat-marker.avif'
 import brov2MarkerImage from '@/assets/brov2-marker.avif'
 import genericVehicleMarkerImage from '@/assets/generic-vehicle-marker.avif'
+import GeoFenceDrawingActionButtons from '@/components/geofence/GeoFenceDrawingActionButtons.vue'
+import GeoFenceMapLayer from '@/components/geofence/GeoFenceMapLayer.vue'
 import MapNorthIndicator from '@/components/map/MapNorthIndicator.vue'
 import MapOverlaysDialog from '@/components/map/MapOverlaysDialog.vue'
 import ContextMenu from '@/components/mission-planning/ContextMenu.vue'
 import HomePositionSettingHelp from '@/components/mission-planning/HomePositionSettingHelp.vue'
 import MissionEstimatesPanel from '@/components/mission-planning/MissionEstimates.vue'
+import MissionPlanningSidebar from '@/components/mission-planning/MissionPlanningSidebar.vue'
 import ScanDirectionDial from '@/components/mission-planning/ScanDirectionDial.vue'
 import SurveyVertexList from '@/components/mission-planning/SurveyVertexList.vue'
 import WaypointConfigPanel from '@/components/mission-planning/WaypointConfigPanel.vue'
@@ -732,12 +769,15 @@ import RadialMenu, { type RadialMenuItem } from '@/components/RadialMenu.vue'
 import SideConfigPanel from '@/components/SideConfigPanel.vue'
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { useDragMeasureOverlay } from '@/composables/map/useDragMeasureOverlay'
+import { useFenceDrawing } from '@/composables/map/useFenceDrawing'
 import { provideMapContext } from '@/composables/map/useMapContext'
 import { useMapOverlays } from '@/composables/map/useMapOverlays'
 import { useMapTileLayers } from '@/composables/map/useMapTileLayers'
 import { useMapTileLayerSelection } from '@/composables/map/useMapTileLayerSelection'
 import { useVertexAngleOverlay } from '@/composables/map/useVertexAngleOverlay'
+import { useFenceMapInteraction } from '@/composables/mission-planning/useFenceMapInteraction'
 import { useSnackbar } from '@/composables/snackbar'
+import { useGeoFenceEditorDraft } from '@/composables/useGeoFenceEditorDraft'
 import {
   clearAllSurveyAreas,
   removeSurveyAreaSquareMeters,
@@ -768,6 +808,7 @@ import {
 import { degrees } from '@/libs/utils'
 import router from '@/router'
 import { SubMenuComponentName, SubMenuName, useAppInterfaceStore } from '@/stores/appInterface'
+import { useGeoFenceStore } from '@/stores/geoFence'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useMissionStore } from '@/stores/mission'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
@@ -792,6 +833,8 @@ const missionStore = useMissionStore()
 const vehicleStore = useMainVehicleStore()
 const interfaceStore = useAppInterfaceStore()
 const widgetStore = useWidgetManagerStore()
+const fenceStore = useGeoFenceStore()
+const fenceDraft = useGeoFenceEditorDraft()
 const missionEstimates = useMissionEstimates()
 const angleOverlay = useVertexAngleOverlay()
 const dragMeasureOverlay = useDragMeasureOverlay(angleOverlay)
@@ -843,11 +886,61 @@ const cloneCommands = (commands?: MissionCommand[]): MissionCommand[] => {
   return makeDefaultNavCommands()
 }
 
+/**
+ * Inspects the mission waypoints against the active geofence (the editor
+ * draft when present, falling back to the plan currently uploaded to the
+ * vehicle). When at least one waypoint breaches the fence, prompts the user
+ * with a "Back to mission planning" / "Upload to vehicle anyway" choice and
+ * resolves to whether the upload should continue. No-op (returns true) when
+ * there's no fence to check against or no breach is detected.
+ * @returns { Promise<boolean> } True when the upload should proceed.
+ */
+const confirmMissionFenceBreachIfNeeded = async (): Promise<boolean> => {
+  const report = fenceStore.detectMissionBreaches(missionStore.currentPlanningWaypoints)
+  if (!report.hasBreaches) return true
+
+  let confirmed = false
+  await new Promise<void>((resolve) => {
+    showDialog({
+      variant: 'text-only',
+      title: 'Mission breaches geofence',
+      message:
+        `${report.breachedIndices.length} of ${report.totalChecked} waypoints fall outside an inclusion fence ` +
+        'or inside an exclusion fence. Uploading anyway may trigger an in-flight fence breach action ' +
+        '(RTL / Land / Brake, depending on the autopilot configuration).',
+      persistent: false,
+      maxWidth: '720px',
+      actions: [
+        {
+          text: 'Back to mission planning',
+          color: 'white',
+          action: () => {
+            closeDialog()
+            resolve()
+          },
+        },
+        {
+          text: 'Upload to vehicle anyway',
+          color: 'white',
+          action: () => {
+            confirmed = true
+            closeDialog()
+            resolve()
+          },
+        },
+      ],
+    })
+  })
+  return confirmed
+}
+
 const uploadMissionToVehicle = async (): Promise<void> => {
   if (!home.value) {
     showHomePositionNotSetDialog.value = true
     return
   }
+
+  if (!(await confirmMissionFenceBreachIfNeeded())) return
 
   logUserAction('Uploaded mission to vehicle')
   uploadingMission.value = true
@@ -1005,6 +1098,38 @@ const availableFrames = Object.values(AltitudeReferenceType).map((value: Altitud
   value,
 }))
 const waypointMarkers = shallowRef<{ [id: string]: Marker }>({})
+const planningMode = ref<'mission' | 'geofence'>('mission')
+
+watch(planningMode, (mode) => {
+  if (mode !== 'geofence' && fenceDraft.isDrawingPolygon) {
+    fenceDraft.cancelDrawingPolygon()
+  }
+  if (mode !== 'geofence' && fenceDraft.isDrawingCircle) {
+    fenceDraft.cancelDrawingCircle()
+  }
+})
+
+watch(
+  () => fenceDraft.isDrawingPolygon,
+  (drawing) => {
+    if (!drawing) {
+      clearFencePolygonDrawingArtifacts()
+      clearLiveMeasure()
+    }
+    setMapCursor()
+  }
+)
+
+watch(
+  () => fenceDraft.isDrawingCircle,
+  (drawing) => {
+    if (!drawing) {
+      clearPendingFenceCircleArtifacts()
+      clearLiveMeasure()
+    }
+    setMapCursor()
+  }
+)
 const isCreatingSimplePath = ref(false)
 const contextMenuVisible = ref(false)
 const contextMenuPosition = ref({ x: 0, y: 0 })
@@ -1027,6 +1152,32 @@ const surveyPolygonUndoStack: L.LatLng[][] = []
 const surveyPolygonRedoStack: L.LatLng[][] = []
 let undoLimitShown = false
 let redoLimitShown = false
+
+// Fence drawing helpers live in the dedicated composable. The exposed
+// `fencePolygonVertexesPositions` ref is what the template guards and the
+// confirm-button repositioning watch react to; the rest of the API drives
+// the click handlers, the confirm button and the cleanup paths below.
+const {
+  polygonVertexesPositions: fencePolygonVertexesPositions,
+  addPolygonPoint: addFencePolygonPoint,
+  finishPolygonDrawing: onFinishFencePolygonDrawing,
+  clearPolygonDrawingArtifacts: clearFencePolygonDrawingArtifacts,
+  setPendingCircleCenter: setPendingFenceCircleCenter,
+  updatePendingCircleLayer: updatePendingFenceCircleLayer,
+  clearPendingCircleArtifacts: clearPendingFenceCircleArtifacts,
+} = useFenceDrawing({
+  map: planningMap,
+  formatArea: (m2) => missionEstimates.formatArea(m2),
+  makeAreaMarker: (at, text) => makeAreaMarker(at, text),
+  addAreaToMeasureLayer: (m) => addAreaToMeasureLayer(m),
+})
+
+const { handleFenceKeyDown, onFenceMapClick } = useFenceMapInteraction({
+  planningMode,
+  addFencePolygonPoint,
+  setPendingFenceCircleCenter,
+  clearLiveMeasure: () => clearLiveMeasure(),
+})
 
 const pushSurveyPolygonSnapshot = (): void => {
   surveyPolygonUndoStack.push(surveyPolygonVertexesPositions.value.map((ll) => ll.clone()))
@@ -1119,6 +1270,13 @@ const currentMeasureAnchor = (): L.LatLng | null => {
     const last = surveyPolygonVertexesPositions.value[surveyPolygonVertexesPositions.value.length - 1]
     return L.latLng(last.lat, last.lng)
   }
+  if (fenceDraft.isDrawingPolygon && fencePolygonVertexesPositions.value.length > 0) {
+    const last = fencePolygonVertexesPositions.value[fencePolygonVertexesPositions.value.length - 1]
+    return L.latLng(last.lat, last.lng)
+  }
+  if (fenceDraft.isDrawingCircle && fenceDraft.pendingCircleCenter) {
+    return L.latLng(fenceDraft.pendingCircleCenter[0], fenceDraft.pendingCircleCenter[1])
+  }
 
   return null
 }
@@ -1192,7 +1350,9 @@ const destroyMeasureOverlay = (map?: L.Map): void => {
 const isOverSurveyHandle = (evt: L.LeafletMouseEvent): boolean => {
   const el = evt.originalEvent?.target as HTMLElement | null
   if (!el) return false
-  return !!el.closest('.custom-div-icon, .edge-marker, .delete-popup, .delete-button')
+  return !!el.closest(
+    '.custom-div-icon, .edge-marker, .delete-popup, .delete-button, .fence-vertex-div-icon, .fence-edge-marker'
+  )
 }
 
 const handleMapMouseMove = (e: L.LeafletMouseEvent): void => {
@@ -1205,7 +1365,10 @@ const handleMapMouseMove = (e: L.LeafletMouseEvent): void => {
   const measuring =
     !!anchor &&
     !draggingExistingNode &&
-    (isCreatingSimplePath.value || (isCreatingSurvey.value && isDrawingSurveyPolygon.value))
+    (isCreatingSimplePath.value ||
+      (isCreatingSurvey.value && isDrawingSurveyPolygon.value) ||
+      fenceDraft.isDrawingPolygon ||
+      (fenceDraft.isDrawingCircle && !!fenceDraft.pendingCircleCenter))
   if (!measuring) {
     destroyMeasureOverlay(planningMap.value)
     angleOverlay.clearVertexAngles()
@@ -1254,6 +1417,11 @@ const handleMapMouseMove = (e: L.LeafletMouseEvent): void => {
     )
   } else {
     angleOverlay.clearVertexAngles()
+  }
+
+  if (fenceDraft.isDrawingCircle && fenceDraft.pendingCircleCenter) {
+    fenceDraft.setPendingCircleRadius(dist)
+    updatePendingFenceCircleLayer()
   }
 }
 
@@ -1540,7 +1708,12 @@ const setMapCursor = (): void => {
     el.style.cursor = 'pointer'
     return
   }
-  if (isCreatingSurvey.value || isCreatingSimplePath.value) {
+  if (
+    isCreatingSurvey.value ||
+    isCreatingSimplePath.value ||
+    fenceDraft.isDrawingPolygon ||
+    fenceDraft.isDrawingCircle
+  ) {
     el.style.cursor = 'crosshair'
   } else {
     el.style.cursor = ''
@@ -2423,6 +2596,7 @@ const handleKeyDown = (event: KeyboardEvent): void => {
       isCreatingSimplePath.value = false
     }
   }
+  handleFenceKeyDown(event)
   if (event.key === 'Enter' && isCreatingSurvey.value) {
     generateWaypointsFromSurvey()
   }
@@ -3801,6 +3975,8 @@ const onMapClick = (e: L.LeafletMouseEvent): void => {
   // The dedicated home-setting handler owns this click; bail so we don't also drop a survey vertex or waypoint here.
   if (isSettingHomeWaypoint.value) return
 
+  if (onFenceMapClick(e)) return
+
   const oldWaypoint = selectedWaypoint.value
   if (oldWaypoint) {
     const oldMarker = waypointMarkers.value[oldWaypoint.id]
@@ -4869,6 +5045,17 @@ watch(
 </style>
 
 <style scoped>
+.mission-planning--fence-mode :deep(.leaflet-marker-pane > *:not(.fence-breach-return-icon)),
+.mission-planning--fence-mode
+  :deep(
+    .leaflet-overlay-pane
+      > svg
+      path:not(.leaflet-interactive[stroke='#FF8800']):not(.leaflet-interactive[stroke='#3B78A8'])
+  ) {
+  opacity: 0.45;
+  filter: saturate(0.5);
+}
+
 .speed-dial-group {
   display: flex;
   align-items: center;

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="mission-planning" :style="glassMenuCssVars">
-    <div id="planningMap" ref="planningMap" class="relative" />
+    <div id="planningMap" class="relative" />
     <v-tooltip location="top" text="Generate waypoints">
       <template #activator="{ props }">
         <div
@@ -4254,12 +4254,6 @@ watch(home, () => {
     planningMap.value.addLayer(homeMarker.value)
   } else {
     homeMarker.value.setLatLng(position as LatLngTuple)
-  }
-})
-
-watch(planningMap, (newMap, oldMap) => {
-  if (planningMap.value !== undefined && newMap?.options === undefined) {
-    planningMap.value = oldMap
   }
 })
 


### PR DESCRIPTION
- Add a New Mission / GeoFence switch to the Mission Planning sidebar.
- Draw polygon fences with the same interactive flow as surveys; add circle fences by clicking the center then dragging to set the radius.
- Show an INCLUSION (blue) or EXCLUSION (orange) tag on each fence card; click the tag or the card switch to flip the type.
- Add a breach return point and its altitude.
- Edit autopilot fence parameters from a panel (ArduPilot `FENCE_ACTION`, `FENCE_ALT_*`, `FENCE_MARGIN`, `FENCE_AUTOENABLE`; PX4 `GF_ACTION`, `GF_MAX_HOR_DIST`, `GF_MAX_VER_DIST`, `GF_PREDICT`).
- Send the fence to the vehicle, pull the live fence back, or clear it on the vehicle.
- Export/import Cockpit's native `.cfp`, or the MAVLink-ecosystem `.plan` (mission + fence) so the same plan opens in other ground stations.
- Check planned waypoints against the active fence before upload; if any waypoint breaches, a dialog asks whether to go back to planning or upload anyway.
- Group the bottom-right mission-planning toolset buttons into a flex row to fit the new controls.

Diff excluding the borrowed `[drop]` commits: $\color{green}\pmb{+3{,}038}$ $\color{red}\pmb{-210}$
<img width="592" height="219" alt="image" src="https://github.com/user-attachments/assets/682c8aac-e2fb-4e50-8631-9a30a0759762" />

https://github.com/user-attachments/assets/36c4ec92-8309-4739-84fe-2694a2504850

<img width="1241" height="1019" alt="image" src="https://github.com/user-attachments/assets/f8ce808e-0483-46f2-a1c5-75ec7a592ee1" />

Second of three sequential PRs splitting #2671:

To be merged after #2807