### PR TITLE
Base Station: Add map marker and radio/tether coverage

### DIFF
--- a/src/components/BaseStationConfigPanel.vue
+++ b/src/components/BaseStationConfigPanel.vue
@@ -1,0 +1,831 @@
+<template>
+  <div
+    v-if="store.configPanelOpen"
+    class="flex fixed w-[300px] right-0 top-0 border-l-[1px] border-[#FFFFFF44] text-white elevation-5 bg-[#051e2d] overflow-y-auto"
+    :style="getMarginsFromBarsHeight"
+  >
+    <div class="flex flex-col h-full text-center w-full [&>*]:shrink-0">
+      <v-btn
+        class="absolute top-0 left-0"
+        variant="text"
+        size="small"
+        icon="mdi-close"
+        style="z-index: 50000"
+        @click="closePanel"
+      />
+
+      <ExpansiblePanel
+        mark-expanded
+        compact
+        elevation-effect
+        no-bottom-divider
+        darken-content
+        invert-chevron
+        :is-expanded="true"
+      >
+        <template #title><p class="ml-10">Base station</p></template>
+        <template #content>
+          <div class="flex flex-col pt-1 w-full gap-y-1">
+            <div class="config-row">
+              <p class="config-label">Latitude</p>
+              <input
+                :value="latText"
+                type="number"
+                step="0.000001"
+                class="config-input"
+                :disabled="config.trackByGps"
+                @input="(e) => onLatLngInput('lat', (e.target as HTMLInputElement).value)"
+              />
+            </div>
+            <div class="config-row">
+              <p class="config-label">Longitude</p>
+              <input
+                :value="lngText"
+                type="number"
+                step="0.000001"
+                class="config-input"
+                :disabled="config.trackByGps"
+                @input="(e) => onLatLngInput('lng', (e.target as HTMLInputElement).value)"
+              />
+            </div>
+            <div class="config-row config-gps-row" :class="{ 'config-row-with-source': config.trackByGps }">
+              <p class="config-label">Track by GPS</p>
+              <v-checkbox
+                :model-value="config.trackByGps"
+                hide-details
+                density="compact"
+                class="config-checkbox"
+                :disabled="!config.position"
+                @update:model-value="setTrackByGps"
+              />
+              <select
+                v-if="config.trackByGps"
+                :value="store.gpsSource"
+                class="config-input"
+                aria-label="GPS source"
+                @change="onGpsSourceChange"
+              >
+                <option v-for="source in store.gpsSourceOptions" :key="source.id" :value="source.id">
+                  {{ source.label }}
+                </option>
+                <option :value="configureSourcesOption">Configure sources...</option>
+              </select>
+            </div>
+          </div>
+        </template>
+      </ExpansiblePanel>
+
+      <ExpansiblePanel
+        mark-expanded
+        compact
+        elevation-effect
+        no-bottom-divider
+        darken-content
+        invert-chevron
+        :is-expanded="true"
+      >
+        <template #title><p class="ml-10">Setup</p></template>
+        <template #content>
+          <div class="flex flex-col pt-1 w-full gap-y-1">
+            <div class="config-row">
+              <p class="config-label">Comms</p>
+              <select v-model="config.commsType" class="config-input">
+                <option v-for="comms in commsTypes" :key="comms" :value="comms">{{ comms }}</option>
+              </select>
+            </div>
+          </div>
+        </template>
+      </ExpansiblePanel>
+
+      <ExpansiblePanel
+        v-if="isRadioLink"
+        mark-expanded
+        compact
+        elevation-effect
+        no-bottom-divider
+        darken-content
+        invert-chevron
+        :is-expanded="true"
+      >
+        <template #title><p class="ml-10">Radio</p></template>
+        <template #content>
+          <div class="flex flex-col pt-1 w-full gap-y-1">
+            <div class="config-row">
+              <p class="config-label">Radio model</p>
+              <select :value="config.radioBaseStationKind" class="config-input" @change="onRadioKindChange">
+                <option v-for="kind in radioKinds" :key="kind" :value="kind">{{ kind }}</option>
+              </select>
+            </div>
+            <div v-if="isCustomRadio" class="config-row">
+              <p class="config-label">TX power (mW)</p>
+              <input
+                :value="txPowerText"
+                type="number"
+                step="100"
+                min="1"
+                class="config-input"
+                @input="(e) => onTxPowerInput((e.target as HTMLInputElement).value)"
+                @focus="txPowerFocused = true"
+                @blur="onTxPowerBlur"
+              />
+            </div>
+            <div class="config-row">
+              <p class="config-label">Antenna</p>
+              <select :value="config.antenna.type" class="config-input" @change="onAntennaTypeChange">
+                <option v-for="type in antennaTypes" :key="type" :value="type">{{ type }}</option>
+              </select>
+            </div>
+            <div class="config-row">
+              <div class="config-label-with-info">
+                <p class="config-label">Antenna height (m)</p>
+                <v-tooltip location="top" max-width="300">
+                  <template #activator="{ props }">
+                    <button
+                      type="button"
+                      class="config-info-btn"
+                      title="Base station antenna height information"
+                      aria-label="Base station antenna height information"
+                      v-bind="props"
+                    >
+                      <v-icon icon="mdi-information-outline" size="14" />
+                    </button>
+                  </template>
+                  <div class="config-open-cell-id-tip">
+                    Higher antennas see farther over the horizon. For line-of-sight links, usable range grows roughly
+                    with the square root of height (for example, 4× the height ≈ 2× the range). The default 1 m matches
+                    the baseline used for the preset range values.
+                  </div>
+                </v-tooltip>
+              </div>
+              <input
+                v-model.number="config.baseStationAntennaHeightMeters"
+                type="number"
+                step="0.5"
+                min="0.5"
+                max="50"
+                class="config-input"
+              />
+            </div>
+            <div class="config-row">
+              <p class="config-label">Gain (dBi)</p>
+              <input
+                :value="gainText"
+                type="number"
+                step="0.1"
+                class="config-input"
+                @input="(e) => onGainInput((e.target as HTMLInputElement).value)"
+                @focus="gainFocused = true"
+                @blur="onGainBlur"
+              />
+            </div>
+            <div class="config-row">
+              <p class="config-label">Beamwidth (°)</p>
+              <input
+                v-model.number="config.antenna.beamwidth"
+                type="number"
+                step="1"
+                min="1"
+                max="360"
+                class="config-input"
+                :disabled="isOmni"
+              />
+            </div>
+            <div class="config-row">
+              <p class="config-label">Range (m)</p>
+              <input v-model.number="config.antenna.range" type="number" step="10" min="1" class="config-input" />
+            </div>
+            <div class="config-row config-checkbox-row">
+              <div class="config-label-with-info">
+                <p class="config-label">Vehicle has antenna mast</p>
+                <v-tooltip location="top" max-width="300">
+                  <template #activator="{ props }">
+                    <button
+                      type="button"
+                      class="config-info-btn"
+                      title="BlueBoat antenna mast information"
+                      aria-label="BlueBoat antenna mast information"
+                      v-bind="props"
+                    >
+                      <v-icon icon="mdi-information-outline" size="14" />
+                    </button>
+                  </template>
+                  <div class="config-open-cell-id-tip">
+                    The BlueBoat Antenna and Accessory Mast raises the vehicle antenna about 50 cm above the deck for
+                    clearer line of sight, which can increase communication range by up to 1.75× compared with the
+                    default deck mount.
+                  </div>
+                </v-tooltip>
+              </div>
+              <v-checkbox
+                v-model="config.vehicleHasBlueBoatAntennaMast"
+                hide-details
+                density="compact"
+                class="config-checkbox"
+              />
+            </div>
+            <div v-if="!isOmni" class="config-row">
+              <p class="config-label">Bearing (°)</p>
+              <input
+                :value="bearingText"
+                type="number"
+                step="1"
+                class="config-input"
+                @input="(e) => onBearingInput((e.target as HTMLInputElement).value)"
+                @focus="bearingFocused = true"
+                @blur="onBearingBlur"
+              />
+            </div>
+
+            <div v-if="!isOmni" class="flex w-full justify-between gap-x-1 mt-[5px]">
+              <v-btn
+                size="x-small"
+                variant="elevated"
+                class="bg-[#FFFFFF22] flex-1 disabled:!bg-[#FFFFFF22] disabled:!text-white/55 disabled:!opacity-50"
+                :disabled="!canSnapToVehicle"
+                @click="snapBearingToVehicle"
+              >
+                Aim at vehicle
+              </v-btn>
+              <v-btn
+                size="x-small"
+                variant="elevated"
+                class="bg-[#FFFFFF22] flex-1 disabled:!bg-[#FFFFFF22] disabled:!text-white/55 disabled:!opacity-50"
+                :disabled="!canSnapToMission"
+                @click="snapBearingToMission"
+              >
+                Aim at mission
+              </v-btn>
+            </div>
+
+            <v-btn
+              size="x-small"
+              variant="elevated"
+              class="bg-[#2b5779] my-2 w-3/4 mx-auto"
+              prepend-icon="mdi-restore"
+              @click="resetAntenna"
+            >
+              Reset antenna defaults
+            </v-btn>
+          </div>
+        </template>
+      </ExpansiblePanel>
+
+      <ExpansiblePanel
+        v-if="isTethered"
+        mark-expanded
+        compact
+        elevation-effect
+        no-bottom-divider
+        darken-content
+        invert-chevron
+        :is-expanded="true"
+      >
+        <template #title><p class="ml-10">Tether</p></template>
+        <template #content>
+          <div class="flex flex-col pt-1 w-full gap-y-1">
+            <div class="config-row">
+              <p class="config-label">Length (m)</p>
+              <input v-model.number="config.tetherLengthMeters" type="number" step="1" min="1" class="config-input" />
+            </div>
+          </div>
+        </template>
+      </ExpansiblePanel>
+
+      <ExpansiblePanel
+        v-if="isRadioLink || isTethered"
+        mark-expanded
+        compact
+        elevation-effect
+        no-bottom-divider
+        darken-content
+        invert-chevron
+        :is-expanded="true"
+      >
+        <template #title><p class="ml-10">Display</p></template>
+        <template #content>
+          <div class="flex flex-col pt-1 w-full gap-y-1">
+            <div class="config-row">
+              <p class="config-label">Color</p>
+              <v-menu :close-on-content-click="false" location="bottom end">
+                <template #activator="{ props: activatorProps }">
+                  <button
+                    v-bind="activatorProps"
+                    type="button"
+                    class="config-input config-color-swatch"
+                    :style="{ backgroundColor: config.coverageColor }"
+                    aria-label="Pick coverage color"
+                  />
+                </template>
+                <v-color-picker
+                  v-model="config.coverageColor"
+                  mode="hex"
+                  :modes="['hex']"
+                  theme="dark"
+                  width="220"
+                  class="base-station-color-picker"
+                />
+              </v-menu>
+            </div>
+            <div class="config-row config-slider-row">
+              <p class="config-label">Opacity</p>
+              <v-slider
+                v-model="config.coverageOpacity"
+                :min="0"
+                :max="1"
+                :step="0.05"
+                :thumb-size="12"
+                :track-size="2"
+                hide-details
+                density="compact"
+                color="white"
+                track-color="rgba(255,255,255,0.2)"
+                class="config-slider"
+              />
+              <p class="config-slider-value">{{ Math.round(config.coverageOpacity * 100) }}%</p>
+            </div>
+          </div>
+        </template>
+      </ExpansiblePanel>
+
+      <div class="base-station-panel-footer">
+        <v-btn
+          class="base-station-panel-remove-btn bg-[#FFFFFF22] text-white"
+          variant="elevated"
+          size="small"
+          prepend-icon="mdi-delete"
+          @click="removeBaseStation"
+        >
+          Remove base station
+        </v-btn>
+        <v-btn
+          class="base-station-panel-info-btn bg-[#FFFFFF22] text-white"
+          variant="elevated"
+          size="small"
+          rounded="sm"
+          icon="mdi-information-outline"
+          aria-label="About coverage estimates"
+          @click="estimatesInfoDialogOpen = true"
+        />
+      </div>
+
+      <v-dialog v-model="estimatesInfoDialogOpen" max-width="480">
+        <v-card class="rounded-lg" :style="interfaceStore.globalGlassMenuStyles">
+          <v-card-title class="text-h6 py-3 px-6">
+            <div class="relative flex items-center justify-center w-full min-h-[28px]">
+              <span class="text-center">About coverage estimates</span>
+              <v-btn
+                icon="mdi-close"
+                size="small"
+                variant="text"
+                color="white"
+                class="absolute right-0 -mr-4"
+                aria-label="Close about coverage estimates dialog"
+                @click="estimatesInfoDialogOpen = false"
+              />
+            </div>
+          </v-card-title>
+          <v-card-text class="text-body-2 base-station-estimates-dialog-text px-8">
+            <p>
+              The ranges and overlays shown here are estimates, not a guarantee of what you will see on the water or in
+              the field.
+            </p>
+            <p>
+              <strong>Radio and tether links</strong> are modeled from Blue Robotics product specifications — antenna
+              patterns, transmit power, and typical operating assumptions for our radios and related gear.
+            </p>
+            <p>
+              <strong>Mobile data coverage</strong> comes from open-source tower databases (OpenCellID and
+              OpenStreetMap). Records can be incomplete or out of date, and carriers change their networks over time.
+            </p>
+            <p class="mb-0">
+              Real-world signal also depends on terrain, weather, interference, and how your vehicle is set up. Use
+              these visuals to compare options, and verify connectivity on site when it really matters.
+            </p>
+          </v-card-text>
+          <div class="flex justify-center w-full px-6">
+            <v-divider class="opacity-10 border-[#fafafa] w-full" />
+          </div>
+          <v-card-actions class="px-6 pb-2 pt-2">
+            <v-spacer />
+            <v-btn variant="text" color="white" class="-mt-[1px]" @click="estimatesInfoDialogOpen = false"
+              >Got it</v-btn
+            >
+          </v-card-actions>
+        </v-card>
+      </v-dialog>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useWindowSize } from '@vueuse/core'
+import { computed, ref, watch } from 'vue'
+
+import ExpansiblePanel from '@/components/ExpansiblePanel.vue'
+import { confirmRemoveBaseStation, useBaseStation } from '@/composables/baseStation/useBaseStation'
+import { useInteractionDialog } from '@/composables/interactionDialog'
+import { bearingBetween, centroidOf, rangeAfterGainChange, rangeAfterTxPowerChange } from '@/libs/baseStation/coverage'
+import { SubMenuComponentName, SubMenuName, useAppInterfaceStore } from '@/stores/appInterface'
+import { useMainVehicleStore } from '@/stores/mainVehicle'
+import { useMissionStore } from '@/stores/mission'
+import { useWidgetManagerStore } from '@/stores/widgetManager'
+import { AntennaType, BaseStationCommsType, BLUE_ROBOTICS_TX_POWER_MW, RadioBaseStationKind } from '@/types/baseStation'
+import type { WaypointCoordinates } from '@/types/mission'
+
+const store = useBaseStation()
+const widgetStore = useWidgetManagerStore()
+const vehicleStore = useMainVehicleStore()
+const missionStore = useMissionStore()
+const interfaceStore = useAppInterfaceStore()
+
+const config = computed(() => store.config)
+
+const commsTypes = Object.values(BaseStationCommsType)
+const radioKinds = Object.values(RadioBaseStationKind)
+const antennaTypes = Object.values(AntennaType)
+
+const isRadioLink = computed(() => config.value.commsType === BaseStationCommsType.RadioLink)
+const isTethered = computed(() => config.value.commsType === BaseStationCommsType.Tethered)
+const isOmni = computed(() => config.value.antenna.type === AntennaType.Omni)
+const isCustomRadio = computed(() => config.value.radioBaseStationKind === RadioBaseStationKind.Custom)
+
+const latText = ref('')
+const lngText = ref('')
+const bearingText = ref('')
+const bearingFocused = ref(false)
+const gainText = ref('')
+const gainFocused = ref(false)
+const txPowerText = ref('')
+const txPowerFocused = ref(false)
+
+const formatBearing = (bearing: number): string => bearing.toFixed(1)
+const formatGain = (gain: number): string => gain.toFixed(1)
+const formatTxPower = (mw: number): string => Math.round(mw).toString()
+
+watch(
+  () => config.value.position,
+  (pos) => {
+    latText.value = pos ? pos[0].toString() : ''
+    lngText.value = pos ? pos[1].toString() : ''
+  },
+  { immediate: true }
+)
+
+// Skip the formatting round-trip while the user is editing — otherwise toFixed() rewrites the
+// input mid-keystroke (e.g. "1" -> "1.0") and the next digit lands in the decimal spot.
+watch(
+  () => config.value.antenna.bearing,
+  (b) => {
+    if (!bearingFocused.value) bearingText.value = formatBearing(b)
+  },
+  { immediate: true }
+)
+
+watch(
+  () => config.value.antenna.gain,
+  (g) => {
+    if (!gainFocused.value) gainText.value = formatGain(g)
+  },
+  { immediate: true }
+)
+
+watch(
+  () => config.value.txPowerMilliwatts,
+  (p) => {
+    if (!txPowerFocused.value) txPowerText.value = formatTxPower(p)
+  },
+  { immediate: true }
+)
+
+const onLatLngInput = (axis: 'lat' | 'lng', value: string): void => {
+  if (axis === 'lat') latText.value = value
+  else lngText.value = value
+  const lat = parseFloat(latText.value)
+  const lng = parseFloat(lngText.value)
+  if (Number.isFinite(lat) && Number.isFinite(lng)) store.setPosition([lat, lng])
+}
+
+const configureSourcesOption = 'action:configure-sources'
+
+const setTrackByGps = (value: boolean | null): void => {
+  const enabled = Boolean(value)
+  logUserAction(`${enabled ? 'Enabled' : 'Disabled'} base station GPS tracking`)
+  config.value.trackByGps = enabled
+}
+
+const onGpsSourceChange = (event: Event): void => {
+  const select = event.target as HTMLSelectElement
+  if (select.value === configureSourcesOption) {
+    // The native select keeps showing the picked entry, so put the real source back before navigating.
+    select.value = store.gpsSource
+    logUserAction('Opened the sources settings from the base station panel')
+    interfaceStore.isMainMenuVisible = true
+    interfaceStore.mainMenuCurrentStep = 2
+    interfaceStore.currentSubMenuName = SubMenuName.settings
+    interfaceStore.currentSubMenuComponentName = SubMenuComponentName.SettingsSources
+    return
+  }
+  config.value.gpsSourceId = select.value
+  const label = store.gpsSourceOptions.find((source) => source.id === select.value)?.label ?? select.value
+  logUserAction(`Set the base station GPS source to "${label}"`)
+}
+
+const onBearingInput = (value: string): void => {
+  bearingText.value = value
+  const parsed = parseFloat(value)
+  if (Number.isFinite(parsed)) store.setBearing(parsed)
+}
+
+const onBearingBlur = (): void => {
+  bearingFocused.value = false
+  bearingText.value = formatBearing(config.value.antenna.bearing)
+}
+
+const onGainInput = (value: string): void => {
+  gainText.value = value
+  const parsed = parseFloat(value)
+  if (!Number.isFinite(parsed)) return
+  const oldGain = config.value.antenna.gain
+  if (parsed === oldGain) return
+  config.value.antenna.range = rangeAfterGainChange(config.value.antenna.range, oldGain, parsed)
+  config.value.antenna.gain = parsed
+}
+
+const onGainBlur = (): void => {
+  gainFocused.value = false
+  gainText.value = formatGain(config.value.antenna.gain)
+}
+
+const applyTxPower = (newPowerMw: number): void => {
+  const oldPower = config.value.txPowerMilliwatts
+  if (!Number.isFinite(newPowerMw) || newPowerMw <= 0 || newPowerMw === oldPower) return
+  config.value.antenna.range = rangeAfterTxPowerChange(config.value.antenna.range, oldPower, newPowerMw)
+  config.value.txPowerMilliwatts = newPowerMw
+}
+
+const onTxPowerInput = (value: string): void => {
+  txPowerText.value = value
+  const parsed = parseFloat(value)
+  if (Number.isFinite(parsed) && parsed > 0) applyTxPower(parsed)
+}
+
+const onTxPowerBlur = (): void => {
+  txPowerFocused.value = false
+  txPowerText.value = formatTxPower(config.value.txPowerMilliwatts)
+}
+
+// Switching back to the BR base station snaps power to its known 1 W radio and rescales range
+// accordingly, so the panel never claims BR-branded hardware while running off-spec power.
+const onRadioKindChange = (event: Event): void => {
+  const newKind = (event.target as HTMLSelectElement).value as RadioBaseStationKind
+  config.value.radioBaseStationKind = newKind
+  if (newKind === RadioBaseStationKind.BlueRobotics) applyTxPower(BLUE_ROBOTICS_TX_POWER_MW)
+}
+
+const estimatesInfoDialogOpen = ref(false)
+
+watch(estimatesInfoDialogOpen, (open) => {
+  logUserAction(
+    open ? 'Opened the base station coverage estimates info' : 'Closed the base station coverage estimates info'
+  )
+})
+
+const onAntennaTypeChange = (event: Event): void => {
+  const value = (event.target as HTMLSelectElement).value as AntennaType
+  store.setAntennaType(value)
+}
+
+const closePanel = (): void => {
+  logUserAction('Closed the base station configuration panel')
+  store.configPanelOpen = false
+}
+
+const { showDialog, closeDialog } = useInteractionDialog()
+
+const removeBaseStation = (): void => {
+  confirmRemoveBaseStation(showDialog, closeDialog)
+}
+
+const resetAntenna = (): void => {
+  logUserAction('Reset the base station antenna to defaults')
+  store.resetAntennaToDefaults()
+}
+
+const vehiclePosition = computed<WaypointCoordinates | null>(() => {
+  const lat = vehicleStore.coordinates?.latitude
+  const lng = vehicleStore.coordinates?.longitude
+  return lat != null && lng != null ? [lat, lng] : null
+})
+
+const missionCentroid = computed<WaypointCoordinates | null>(() => {
+  const planning = missionStore.currentPlanningWaypoints
+  const wps = planning.length > 0 ? planning : missionStore.vehicleMission
+  return centroidOf((wps ?? []).map((wp) => wp.coordinates))
+})
+
+const canSnapToVehicle = computed(() => Boolean(config.value.position && vehiclePosition.value))
+const canSnapToMission = computed(() => Boolean(config.value.position && missionCentroid.value))
+
+const snapBearingToVehicle = (): void => {
+  const position = config.value.position
+  const vehicle = vehiclePosition.value
+  if (!position || !vehicle) return
+  store.setBearing(bearingBetween(position, vehicle))
+  logUserAction('Aimed the base station antenna at the vehicle')
+}
+
+const snapBearingToMission = (): void => {
+  const position = config.value.position
+  const centroid = missionCentroid.value
+  if (!position || !centroid) return
+  store.setBearing(bearingBetween(position, centroid))
+  logUserAction('Aimed the base station antenna at the mission')
+}
+
+const { height: windowHeight } = useWindowSize()
+
+const getMarginsFromBarsHeight = computed(() => {
+  return {
+    marginTop: widgetStore.editingMode ? '0px' : widgetStore.currentTopBarHeightPixels + 'px',
+    marginBottom: widgetStore.editingMode ? '0px' : widgetStore.currentBottomBarHeightPixels + 'px',
+    height: widgetStore.editingMode
+      ? windowHeight.value + 'px'
+      : windowHeight.value -
+        widgetStore.currentTopBarHeightPixels -
+        widgetStore.currentBottomBarHeightPixels -
+        1 +
+        'px',
+    zIndex: 600,
+  }
+})
+</script>
+
+<style scoped>
+.config-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid #ffffff17;
+  padding: 2px 0 8px 0;
+  margin-top: 2px;
+  min-height: 36px;
+  box-sizing: border-box;
+}
+
+/* Drop the divider after the bottom-most row of each section so the section header below it
+   isn't visually attached to the previous control. */
+.config-row:last-child {
+  border-bottom: none;
+}
+
+.config-label {
+  text-align: start;
+  margin-left: 4px;
+  font-size: 13px;
+  width: 50%;
+}
+
+.config-input {
+  background-color: #ffffff11;
+  padding: 4px 8px;
+  width: 130px;
+  font-size: 13px;
+  color: white;
+  box-sizing: border-box;
+  border: 1px solid transparent;
+}
+
+/* Strip the native number-input spinner so number fields render at the same usable width as
+   the <select>s in the same column. */
+.config-input[type='number']::-webkit-inner-spin-button,
+.config-input[type='number']::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+.config-input[type='number'] {
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+
+/* Native <option> popups inherit OS chrome by default and render light-on-light over the
+   dark panel; force them onto the panel palette so the dropdowns stay readable. */
+.config-input option {
+  background-color: #0a2a3d;
+  color: white;
+}
+
+.config-input:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.config-checkbox {
+  margin-right: 6px;
+}
+
+.config-checkbox-row {
+  padding: 0 0 4px 0;
+  min-height: auto;
+}
+
+/* Fixed height so showing the source select on toggle doesn't shift the rows below, while the inherited
+   padding keeps the contents aligned with the other rows. */
+.config-gps-row {
+  height: 36px;
+}
+
+/* The source select takes the row's right slot, so the label frees the space it needs. */
+.config-row-with-source .config-label {
+  width: auto;
+}
+
+.config-row-with-source .config-checkbox {
+  margin-left: auto;
+}
+
+.config-label-with-info {
+  display: flex;
+  align-items: center;
+  flex: 1 1 auto;
+  justify-content: space-between;
+  min-width: 0;
+  margin-right: 8px;
+}
+
+.config-label-with-info .config-label {
+  width: auto;
+}
+
+.config-checkbox :deep(.v-selection-control) {
+  min-height: auto;
+}
+
+.config-checkbox :deep(.v-selection-control__wrapper) {
+  transform: scale(0.8);
+  transform-origin: center;
+}
+
+.config-color-swatch {
+  height: 24px;
+  border: 1px solid #ffffff33;
+  border-radius: 3px;
+  cursor: pointer;
+  padding: 0;
+}
+
+/* Eyedropper hijacks the v-menu's outside-click and the OS picker UX is shaky on web; drop it. */
+.base-station-color-picker :deep(.v-color-picker-preview__eye-dropper) {
+  display: none;
+}
+
+.config-slider-row {
+  gap: 6px;
+}
+
+.config-slider {
+  flex: 1;
+  margin: 0;
+}
+
+.config-slider-value {
+  font-size: 12px;
+  width: 36px;
+  text-align: right;
+  color: #ffffffcc;
+}
+
+.base-station-panel-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  box-sizing: border-box;
+  margin-top: auto;
+  margin-bottom: 8px;
+  padding: 0 8px;
+}
+
+.base-station-panel-info-btn {
+  flex: 0 0 auto;
+  width: 28px;
+  min-width: 28px;
+  height: 28px;
+  padding: 0;
+  border-radius: 4px !important;
+}
+
+.base-station-panel-remove-btn {
+  flex: 0 0 auto;
+}
+
+.base-station-estimates-dialog-text {
+  padding-left: 40px;
+  padding-right: 40px;
+  text-align: justify;
+  hyphens: auto;
+}
+
+.base-station-estimates-dialog-text p + p {
+  margin-top: 12px;
+}
+</style>

--- a/src/components/BaseStationContextPopup.vue
+++ b/src/components/BaseStationContextPopup.vue
@@ -1,0 +1,158 @@
+<template>
+  <Teleport to="body">
+    <div
+      v-if="store.contextPopupOpen && config.position"
+      class="base-station-context-popup fixed z-[99999] flex flex-col rounded-md text-white"
+      :style="[
+        interfaceStore.globalGlassMenuStyles,
+        { background: '#333333EE', border: '1px solid #FFFFFF44' },
+        { top: `${position.y}px`, left: `${position.x}px`, width: `${POPUP_WIDTH}px` },
+      ]"
+      @click.stop
+      @contextmenu.stop.prevent
+    >
+      <div class="flex justify-between items-center pt-1 pb-2 px-2">
+        <p class="text-[14px] truncate mr-2">Base station</p>
+        <div class="flex shrink-0 items-center gap-x-1">
+          <v-btn
+            v-tooltip="{ text: 'Remove base station', zIndex: TOOLTIP_Z_INDEX }"
+            icon="mdi-trash-can"
+            variant="text"
+            size="x-small"
+            color="white"
+            aria-label="Remove base station"
+            @click="onDelete"
+          />
+          <v-btn
+            v-tooltip="{ text: 'Configure base station', zIndex: TOOLTIP_Z_INDEX }"
+            icon="mdi-cog"
+            variant="text"
+            size="x-small"
+            color="white"
+            aria-label="Configure base station"
+            @click="onConfigure"
+          />
+        </div>
+      </div>
+
+      <v-divider />
+
+      <div
+        class="flex flex-col justify-center w-full items-center py-1 px-2 bg-[#EEEEEE] text-black rounded-bl-md rounded-br-md"
+      >
+        <div class="flex w-full items-center gap-x-2 text-[10px] py-[1px] mb-[2px]">
+          <v-icon
+            v-tooltip="{ text: 'Copy latitude to clipboard', zIndex: TOOLTIP_Z_INDEX }"
+            variant="text"
+            icon="mdi-content-copy"
+            size="x-small"
+            color="black"
+            class="text-[12px] cursor-pointer shrink-0"
+            @click="onCopyCoordinate(0)"
+          />
+          <p class="flex-1">Lat.:</p>
+          <p>{{ config.position[0].toFixed(7) }}</p>
+        </div>
+        <v-divider class="border-black w-full" />
+        <div class="flex w-full items-center gap-x-2 text-[10px] py-[1px]">
+          <v-icon
+            v-tooltip="{ text: 'Copy longitude to clipboard', zIndex: TOOLTIP_Z_INDEX }"
+            variant="text"
+            icon="mdi-content-copy"
+            size="x-small"
+            color="black"
+            class="text-[12px] cursor-pointer shrink-0"
+            @click="onCopyCoordinate(1)"
+          />
+          <p class="flex-1">Long.:</p>
+          <p>{{ config.position[1].toFixed(7) }}</p>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted } from 'vue'
+
+import { confirmRemoveBaseStation, useBaseStation } from '@/composables/baseStation/useBaseStation'
+import { useInteractionDialog } from '@/composables/interactionDialog'
+import { openSnackbar } from '@/composables/snackbar'
+import { copyToClipboard } from '@/libs/utils'
+import { useAppInterfaceStore } from '@/stores/appInterface'
+
+// Approximate rendered popup size in px; used only to clamp the popup inside the viewport.
+const POPUP_WIDTH = 221
+const POPUP_HEIGHT = 110
+const TOOLTIP_Z_INDEX = 100000
+
+// Popup state lives in the store, so the click/keydown listeners are registered once at the
+// module level, regardless of how many widgets mount this component.
+let activeInstanceCount = 0
+let documentClickHandler: ((event: MouseEvent) => void) | null = null
+let documentKeydownHandler: ((event: KeyboardEvent) => void) | null = null
+
+const store = useBaseStation()
+const interfaceStore = useAppInterfaceStore()
+const { showDialog, closeDialog } = useInteractionDialog()
+
+const config = computed(() => store.config)
+
+// Clamp the popup inside the viewport so it never opens off-screen near the map edges.
+const position = computed(() => {
+  const margin = 8
+  let x = store.contextPopupPosition.x
+  let y = store.contextPopupPosition.y
+  if (x + POPUP_WIDTH > window.innerWidth - margin) x = window.innerWidth - POPUP_WIDTH - margin
+  if (y + POPUP_HEIGHT > window.innerHeight - margin) y = window.innerHeight - POPUP_HEIGHT - margin
+  if (x < margin) x = margin
+  if (y < margin) y = margin
+  return { x, y }
+})
+
+const onDelete = (): void => {
+  store.closeContextPopup()
+  confirmRemoveBaseStation(showDialog, closeDialog)
+}
+
+const onConfigure = (): void => {
+  store.configPanelOpen = true
+  store.closeContextPopup()
+}
+
+const onCopyCoordinate = async (index: 0 | 1): Promise<void> => {
+  if (!config.value.position) return
+  const label = index === 0 ? 'Latitude' : 'Longitude'
+  try {
+    await copyToClipboard(`${config.value.position[index]}`)
+    logUserAction(`Copied the base station ${label.toLowerCase()} to the clipboard`)
+    openSnackbar({ message: `${label} copied to clipboard.`, variant: 'success' })
+  } catch (error) {
+    openSnackbar({ message: `Failed to copy ${label.toLowerCase()}: ${(error as Error).message}`, variant: 'error' })
+  }
+}
+
+onMounted(() => {
+  if (activeInstanceCount === 0) {
+    documentClickHandler = () => {
+      if (store.contextPopupOpen) store.closeContextPopup()
+    }
+    documentKeydownHandler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && store.contextPopupOpen) store.closeContextPopup()
+    }
+    document.addEventListener('click', documentClickHandler)
+    window.addEventListener('keydown', documentKeydownHandler)
+  }
+  activeInstanceCount++
+})
+
+onBeforeUnmount(() => {
+  activeInstanceCount--
+  if (activeInstanceCount === 0) {
+    if (documentClickHandler) document.removeEventListener('click', documentClickHandler)
+    if (documentKeydownHandler) window.removeEventListener('keydown', documentKeydownHandler)
+    documentClickHandler = null
+    documentKeydownHandler = null
+  }
+})
+</script>

--- a/src/components/mission-planning/ContextMenu.vue
+++ b/src/components/mission-planning/ContextMenu.vue
@@ -206,6 +206,44 @@
           <span class="text-white text-sm ml-4">Set home waypoint</span>
         </v-list-item>
         <v-divider />
+        <v-list-item class="flex items-center gap-x-2 pb-2" @click="handlePlaceBaseStation">
+          <v-icon
+            variant="text"
+            :icon="baseStationMenuIcon"
+            rounded="full"
+            size="x-small"
+            color="white"
+            class="text-[16px]"
+          ></v-icon>
+          <span class="text-white text-sm ml-4">{{ baseStationPlaceMenuLabel(baseStationStore.config.enabled) }}</span>
+        </v-list-item>
+        <template v-if="baseStationStore.config.enabled">
+          <v-divider />
+          <v-list-item class="flex items-center gap-x-2 pb-2" @click="handleConfigureBaseStation">
+            <v-icon
+              variant="text"
+              :icon="configureBaseStationMenuIcon"
+              rounded="full"
+              size="x-small"
+              color="white"
+              class="text-[16px]"
+            />
+            <span class="text-white text-sm ml-4">{{ configureBaseStationMenuLabel }}</span>
+          </v-list-item>
+          <v-divider />
+          <v-list-item class="flex items-center gap-x-2 pb-2" @click="handleRemoveBaseStation">
+            <v-icon
+              variant="text"
+              :icon="baseStationMenuIcon"
+              rounded="full"
+              size="x-small"
+              color="white"
+              class="text-[16px]"
+            />
+            <span class="text-white text-sm ml-4">{{ removeBaseStationMenuLabel }}</span>
+          </v-list-item>
+        </template>
+        <v-divider />
         <v-list-item class="flex items-center gap-x-2 pb-2" @click="handleClearVehiclePathHistory">
           <v-icon
             variant="text"
@@ -292,12 +330,21 @@
 import { computed, defineEmits, defineProps, nextTick, ref, watch } from 'vue'
 
 import ScanDirectionDial from '@/components/mission-planning/ScanDirectionDial.vue'
+import { useBaseStation } from '@/composables/baseStation/useBaseStation'
+import {
+  baseStationMenuIcon,
+  baseStationPlaceMenuLabel,
+  configureBaseStationMenuIcon,
+  configureBaseStationMenuLabel,
+  removeBaseStationMenuLabel,
+} from '@/libs/baseStation/menu'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMissionStore } from '@/stores/mission'
 import { ContextMenuTypes, Survey, Waypoint } from '@/types/mission'
 
 const missionStore = useMissionStore()
 const interfaceStore = useAppInterfaceStore()
+const baseStationStore = useBaseStation()
 const menuEl = ref<HTMLElement | null>(null)
 
 /* eslint-disable jsdoc/require-jsdoc */
@@ -334,6 +381,9 @@ const emit = defineEmits<{
   (event: 'setHomePosition'): void
   (event: 'clearVehiclePathHistory'): void
   (event: 'openMapOverlays'): void
+  (event: 'placeBaseStation'): void
+  (event: 'configureBaseStation'): void
+  (event: 'removeBaseStation'): void
 }>()
 
 const menuType = computed(() => props.menuType)
@@ -451,6 +501,21 @@ const handleSetHomePosition = (): void => {
 
 const handleClearVehiclePathHistory = (): void => {
   emit('clearVehiclePathHistory')
+  emit('close')
+}
+
+const handlePlaceBaseStation = (): void => {
+  emit('placeBaseStation')
+  emit('close')
+}
+
+const handleConfigureBaseStation = (): void => {
+  emit('configureBaseStation')
+  emit('close')
+}
+
+const handleRemoveBaseStation = (): void => {
+  emit('removeBaseStation')
   emit('close')
 }
 

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -175,6 +175,7 @@
 
   <PoiManager ref="poiManagerMapWidgetRef" />
   <MapOverlaysDialog v-model="overlaysDialogOpen" :loading-ids="overlayLoadingIds" />
+  <BaseStationContextPopup />
   <MissionChecklist
     :model-value="isMissionChecklistOpen"
     @confirmed="executeMissionOnVehicle"
@@ -224,6 +225,7 @@ import copterMarkerImage from '@/assets/arducopter-top-view.avif'
 import blueboatMarkerImage from '@/assets/blueboat-marker.avif'
 import brov2MarkerImage from '@/assets/brov2-marker.avif'
 import genericVehicleMarkerImage from '@/assets/generic-vehicle-marker.avif'
+import BaseStationContextPopup from '@/components/BaseStationContextPopup.vue'
 import ExpansiblePanel from '@/components/ExpansiblePanel.vue'
 import GlobalOriginDialog from '@/components/GlobalOriginDialog.vue'
 import MapNorthIndicator from '@/components/map/MapNorthIndicator.vue'
@@ -233,6 +235,8 @@ import MissionChecklist from '@/components/MissionChecklist.vue'
 import PoiActionPopup from '@/components/poi/PoiActionPopup.vue'
 import PoiManager from '@/components/poi/PoiManager.vue'
 import PoiMapArrows from '@/components/poi/PoiMapArrows.vue'
+import { confirmRemoveBaseStation, useBaseStation } from '@/composables/baseStation/useBaseStation'
+import { useBaseStationOverlay } from '@/composables/baseStation/useBaseStationOverlay'
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { provideMapContext } from '@/composables/map/useMapContext'
 import { useMapOverlays } from '@/composables/map/useMapOverlays'
@@ -243,6 +247,13 @@ import { useMapTileLayerSelection } from '@/composables/map/useMapTileLayerSelec
 import { openSnackbar } from '@/composables/snackbar'
 import { useOfflineTiles } from '@/composables/useOfflineTiles'
 import { usePointsOfInterest } from '@/composables/usePointsOfInterest'
+import {
+  baseStationMenuIcon,
+  baseStationPlaceMenuLabel,
+  configureBaseStationMenuIcon,
+  configureBaseStationMenuLabel,
+  removeBaseStationMenuLabel,
+} from '@/libs/baseStation/menu'
 import { MavCmd, MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import type { NoiseTileOptions } from '@/libs/map/map-tile-fallback'
 import { attachTileNoiseFallback, refreshNoiseFallbackTiles } from '@/libs/map/map-tile-fallback'
@@ -290,6 +301,7 @@ const {
 const vehicleStore = useMainVehicleStore()
 const missionStore = useMissionStore()
 const widgetStore = useWidgetManagerStore()
+const baseStationStore = useBaseStation()
 const router = useRouter()
 
 const { removePointOfInterest } = usePointsOfInterest()
@@ -1140,6 +1152,8 @@ const targetFollower = new TargetFollower(
 targetFollower.setTrackableTarget(WhoToFollow.VEHICLE, () => vehiclePosition.value)
 targetFollower.setTrackableTarget(WhoToFollow.HOME, () => home.value)
 
+useBaseStationOverlay(map, mapReady)
+
 // Calculate live vehicle position
 const vehiclePosition = computed(() =>
   vehicleStore.coordinates.latitude
@@ -1437,33 +1451,20 @@ const globalOriginLatitude = ref(0)
 const globalOriginLongitude = ref(0)
 const globalOriginMarker = shallowRef<L.Marker>()
 
-const menuItems = reactive([
-  {
-    item: 'Set home waypoint',
-    action: () => onMenuOptionSelect('set-home-waypoint'),
-    icon: 'mdi-home-map-marker',
-  },
-  {
-    item: 'Set Global Origin',
-    action: () => onMenuOptionSelect('set-global-origin'),
-    icon: 'mdi-crosshairs-question',
-  },
-  {
-    item: 'Place Point of Interest',
-    action: () => onMenuOptionSelect('place-poi'),
-    icon: 'mdi-map-marker-plus',
-  },
+const staticTopMenuItems = [
+  { item: 'Set home waypoint', action: () => onMenuOptionSelect('set-home-waypoint'), icon: 'mdi-home-map-marker' },
+  { item: 'Set Global Origin', action: () => onMenuOptionSelect('set-global-origin'), icon: 'mdi-crosshairs-question' },
+  { item: 'Place Point of Interest', action: () => onMenuOptionSelect('place-poi'), icon: 'mdi-map-marker-plus' },
   {
     item: 'Add overlay (GeoTIFF)',
     action: () => onMenuOptionSelect('add-overlay'),
     icon: 'mdi-image-plus',
     _isOverlay: true,
   },
-  {
-    item: 'Copy coordinates',
-    action: () => onMenuOptionSelect('copy-coordinates'),
-    icon: 'mdi-content-copy',
-  },
+  { item: 'Copy coordinates', action: () => onMenuOptionSelect('copy-coordinates'), icon: 'mdi-content-copy' },
+]
+
+const staticBottomMenuItems = [
   { item: 'GoTo', action: () => onMenuOptionSelect('goto'), icon: 'mdi-crosshairs-gps' },
   {
     item: 'Set default map position',
@@ -1475,7 +1476,40 @@ const menuItems = reactive([
     action: () => onMenuOptionSelect('clear-vehicle-path-history'),
     icon: 'mdi-gesture',
   },
-])
+]
+
+const baseStationMenuEntries = computed(() => {
+  const entries = [
+    {
+      item: baseStationPlaceMenuLabel(baseStationStore.config.enabled),
+      action: () => onMenuOptionSelect('place-base-station'),
+      icon: baseStationMenuIcon,
+    },
+  ]
+  if (baseStationStore.config.enabled) {
+    entries.push(
+      {
+        item: configureBaseStationMenuLabel,
+        action: () => onMenuOptionSelect('configure-base-station'),
+        icon: configureBaseStationMenuIcon,
+      },
+      {
+        item: removeBaseStationMenuLabel,
+        action: () => onMenuOptionSelect('remove-base-station'),
+        icon: baseStationMenuIcon,
+      }
+    )
+  }
+  return entries
+})
+
+const menuItems = reactive([...staticTopMenuItems, ...baseStationMenuEntries.value, ...staticBottomMenuItems])
+
+// The base-station entries change label/visibility with the store; rebuild the fixed segments
+// around them so the reactive array handed to the context menu keeps its identity.
+watch(baseStationMenuEntries, (entries) => {
+  menuItems.splice(0, menuItems.length, ...staticTopMenuItems, ...entries, ...staticBottomMenuItems)
+})
 
 const updateSkipToWpMenu = (): void => {
   const want = contextMenuSelectedWpIndex.value !== null
@@ -1679,6 +1713,22 @@ const onMenuOptionSelect = async (option: string): Promise<void> => {
     case 'clear-vehicle-path-history':
       missionStore.clearVehicleHistory()
       openSnackbar({ message: 'Vehicle path history cleared', variant: 'success' })
+      break
+
+    case 'place-base-station':
+      if (clickedLocation.value) {
+        baseStationStore.setPosition(clickedLocation.value)
+        baseStationStore.configPanelOpen = true
+        logUserAction('Placed the base station via the map context menu')
+      }
+      break
+
+    case 'configure-base-station':
+      baseStationStore.configPanelOpen = true
+      break
+
+    case 'remove-base-station':
+      confirmRemoveBaseStation(showDialog, closeDialog)
       break
 
     default:

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -175,6 +175,7 @@
 
   <PoiManager ref="poiManagerMapWidgetRef" />
   <MapOverlaysDialog v-model="overlaysDialogOpen" :loading-ids="overlayLoadingIds" />
+  <BaseStationConfigPanel />
   <BaseStationContextPopup />
   <MissionChecklist
     :model-value="isMissionChecklistOpen"
@@ -225,6 +226,7 @@ import copterMarkerImage from '@/assets/arducopter-top-view.avif'
 import blueboatMarkerImage from '@/assets/blueboat-marker.avif'
 import brov2MarkerImage from '@/assets/brov2-marker.avif'
 import genericVehicleMarkerImage from '@/assets/generic-vehicle-marker.avif'
+import BaseStationConfigPanel from '@/components/BaseStationConfigPanel.vue'
 import BaseStationContextPopup from '@/components/BaseStationContextPopup.vue'
 import ExpansiblePanel from '@/components/ExpansiblePanel.vue'
 import GlobalOriginDialog from '@/components/GlobalOriginDialog.vue'

--- a/src/composables/baseStation/baseStationOverlay.css
+++ b/src/composables/baseStation/baseStationOverlay.css
@@ -1,0 +1,39 @@
+/* Base-station overlay styles must be global because Leaflet's `divIcon` renders the markup
+   outside the consuming component's scoped boundary. They live with the overlay composable so
+   any view that mounts it gets the styles, instead of relying on an unrelated component. */
+.base-station-marker-icon {
+  background: none;
+  border: none;
+}
+
+.base-station-marker-container {
+  position: relative;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: grab;
+}
+
+.base-station-marker-background {
+  position: absolute;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background-color: #005fad;
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  z-index: 1;
+}
+
+.base-station-marker-label {
+  position: absolute;
+  bottom: -12px;
+  background-color: rgba(0, 0, 0, 0.7);
+  color: white;
+  font-size: 10px;
+  padding: 1px 4px;
+  border-radius: 2px;
+  white-space: nowrap;
+}

--- a/src/composables/baseStation/baseStationOverlay.css
+++ b/src/composables/baseStation/baseStationOverlay.css
@@ -37,3 +37,18 @@
   border-radius: 2px;
   white-space: nowrap;
 }
+
+.base-station-bearing-handle {
+  background: none;
+  border: none;
+  cursor: grab;
+}
+
+.base-station-bearing-handle-dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background-color: #fff;
+  border: 2px solid #008bff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+}

--- a/src/composables/baseStation/useBaseStation.ts
+++ b/src/composables/baseStation/useBaseStation.ts
@@ -1,0 +1,97 @@
+import { reactive, ref } from 'vue'
+
+import type { DialogOptions, DialogResult } from '@/composables/interactionDialog'
+import { useBlueOsStorage } from '@/composables/settingsSyncer'
+import { type BaseStationConfig, DEFAULT_BASE_STATION_CONFIG } from '@/types/baseStation'
+import type { DialogActions } from '@/types/general'
+import type { WaypointCoordinates } from '@/types/mission'
+
+// eslint-disable-next-line jsdoc/require-jsdoc, @typescript-eslint/explicit-function-return-type -- type inferred for the reactive() output to keep per-state-field typing local to this file
+function initialize() {
+  const config = useBlueOsStorage<BaseStationConfig>('cockpit-base-station-config', DEFAULT_BASE_STATION_CONFIG)
+
+  // Merge defaults so newly-added fields are populated for existing users.
+  config.value = { ...DEFAULT_BASE_STATION_CONFIG, ...config.value }
+
+  const configPanelOpen = ref(false)
+
+  const contextPopupOpen = ref(false)
+  const contextPopupPosition = ref({ x: 0, y: 0 })
+
+  const openContextPopup = (x: number, y: number): void => {
+    contextPopupPosition.value = { x, y }
+    contextPopupOpen.value = true
+  }
+
+  const closeContextPopup = (): void => {
+    contextPopupOpen.value = false
+  }
+
+  const setPosition = (position: WaypointCoordinates): void => {
+    config.value.position = [Number(position[0].toFixed(8)), Number(position[1].toFixed(8))]
+    config.value.enabled = true
+  }
+
+  const remove = (): void => {
+    config.value = { ...DEFAULT_BASE_STATION_CONFIG }
+    configPanelOpen.value = false
+    contextPopupOpen.value = false
+  }
+
+  return reactive({
+    config,
+    configPanelOpen,
+    contextPopupOpen,
+    contextPopupPosition,
+    openContextPopup,
+    closeContextPopup,
+    setPosition,
+    remove,
+  })
+}
+
+let api: ReturnType<typeof initialize> | null = null
+
+/**
+ * Singleton-style composable holding the base-station configuration, transient UI state
+ * (config panel / context popup / coverage controls), and the actions that mutate them.
+ * State is shared across all callers; the first call lazily initializes it so dependent
+ * stores (Pinia, BlueOS settings) are guaranteed to be ready.
+ * @returns {ReturnType<typeof initialize>} Reactive base-station state and actions.
+ */
+export const useBaseStation = (): ReturnType<typeof initialize> => {
+  if (!api) api = initialize()
+  return api
+}
+
+/**
+ * Shows the shared confirmation dialog for removing the base station and clears it once confirmed.
+ * Centralizes the prompt so every entry point (context popup, config panel, map context menu)
+ * asks before the destructive, undo-less removal.
+ * @param {(options: DialogOptions) => Promise<DialogResult>} showDialog - Opens the caller's interaction dialog.
+ * @param {() => void} closeDialog - Closes the caller's interaction dialog.
+ * @returns {void}
+ */
+export const confirmRemoveBaseStation = (
+  showDialog: (options: DialogOptions) => Promise<DialogResult>,
+  closeDialog: () => void
+): void => {
+  showDialog({
+    variant: 'text-only',
+    message: 'Remove the base station? This will clear its position and configuration.',
+    persistent: false,
+    maxWidth: '480px',
+    actions: [
+      { text: 'Cancel', color: 'white', action: closeDialog },
+      {
+        text: 'Remove',
+        color: 'white',
+        action: () => {
+          logUserAction('Removed the base station')
+          useBaseStation().remove()
+          closeDialog()
+        },
+      },
+    ] as DialogActions[],
+  })
+}

--- a/src/composables/baseStation/useBaseStation.ts
+++ b/src/composables/baseStation/useBaseStation.ts
@@ -1,19 +1,45 @@
-import { reactive, ref } from 'vue'
+import { useThrottleFn } from '@vueuse/core'
+import { computed, reactive, ref, watch } from 'vue'
 
 import type { DialogOptions, DialogResult } from '@/composables/interactionDialog'
 import { useBlueOsStorage } from '@/composables/settingsSyncer'
-import { type BaseStationConfig, DEFAULT_BASE_STATION_CONFIG } from '@/types/baseStation'
+import { openSnackbar } from '@/composables/snackbar'
+import { useGnss } from '@/composables/useGnss'
+import { normalizeBearing } from '@/libs/baseStation/coverage'
+import { useAppInterfaceStore } from '@/stores/appInterface'
+import {
+  type BaseStationConfig,
+  ANTENNA_FACTORY_DEFAULTS,
+  AntennaType,
+  BaseStationCommsType,
+  BROWSER_GEOLOCATION_SOURCE_ID,
+  DEFAULT_BASE_STATION_CONFIG,
+} from '@/types/baseStation'
 import type { DialogActions } from '@/types/general'
 import type { WaypointCoordinates } from '@/types/mission'
+
+// GNSS receivers report at up to 10 Hz while a base station barely moves, so fixes are sampled down
+// before they reach the persisted config and the coverage overlay that redraws with it.
+const gnssPositionSampleRateMs = 1000
 
 // eslint-disable-next-line jsdoc/require-jsdoc, @typescript-eslint/explicit-function-return-type -- type inferred for the reactive() output to keep per-state-field typing local to this file
 function initialize() {
   const config = useBlueOsStorage<BaseStationConfig>('cockpit-base-station-config', DEFAULT_BASE_STATION_CONFIG)
 
   // Merge defaults so newly-added fields are populated for existing users.
-  config.value = { ...DEFAULT_BASE_STATION_CONFIG, ...config.value }
+  config.value = {
+    ...DEFAULT_BASE_STATION_CONFIG,
+    ...config.value,
+    antenna: { ...DEFAULT_BASE_STATION_CONFIG.antenna, ...(config.value.antenna ?? {}) },
+  }
 
   const configPanelOpen = ref(false)
+
+  const interfaceStore = useAppInterfaceStore()
+  watch(configPanelOpen, (isOpen) => {
+    interfaceStore.configPanelVisible = isOpen
+    if (isOpen) logUserAction('Opened the base station configuration panel')
+  })
 
   const contextPopupOpen = ref(false)
   const contextPopupPosition = ref({ x: 0, y: 0 })
@@ -27,6 +53,14 @@ function initialize() {
     contextPopupOpen.value = false
   }
 
+  const showCoverage = computed(
+    () =>
+      config.value.enabled &&
+      config.value.position !== null &&
+      (config.value.commsType === BaseStationCommsType.RadioLink ||
+        config.value.commsType === BaseStationCommsType.Tethered)
+  )
+
   const setPosition = (position: WaypointCoordinates): void => {
     config.value.position = [Number(position[0].toFixed(8)), Number(position[1].toFixed(8))]
     config.value.enabled = true
@@ -38,14 +72,100 @@ function initialize() {
     contextPopupOpen.value = false
   }
 
+  const resetAntennaToDefaults = (): void => {
+    const factory = ANTENNA_FACTORY_DEFAULTS[config.value.antenna.type]
+    config.value.antenna = { ...factory, bearing: config.value.antenna.bearing }
+  }
+
+  const setAntennaType = (type: AntennaType): void => {
+    const factory = ANTENNA_FACTORY_DEFAULTS[type]
+    config.value.antenna = { ...factory, bearing: config.value.antenna.bearing }
+  }
+
+  const setBearing = (bearing: number): void => {
+    config.value.antenna.bearing = normalizeBearing(bearing)
+  }
+
+  const gnss = useGnss()
+
+  // Serial GNSS receivers only work on Standalone, so Lite is left with the browser's Geolocation API.
+  const gpsSourceOptions = computed(() => [
+    { id: BROWSER_GEOLOCATION_SOURCE_ID, label: 'Browser geolocation' },
+    ...(gnss.isSupported ? gnss.devices.value.map((device) => ({ id: device.id, label: device.name })) : []),
+  ])
+
+  // Sources that are gone (device removed, or a device id synced in from a Standalone install) fall back
+  // to the browser, so tracking never waits on a source that cannot report a position.
+  const gpsSource = computed(() =>
+    gpsSourceOptions.value.some((source) => source.id === config.value.gpsSourceId)
+      ? config.value.gpsSourceId
+      : BROWSER_GEOLOCATION_SOURCE_ID
+  )
+
+  const isTracking = computed(() => config.value.trackByGps && config.value.enabled)
+
+  let geoWatchId: number | null = null
+  const stopGeoWatch = (): void => {
+    if (geoWatchId !== null && navigator?.geolocation) {
+      navigator.geolocation.clearWatch(geoWatchId)
+      geoWatchId = null
+    }
+  }
+  const startGeoWatch = (): void => {
+    if (geoWatchId !== null || !navigator?.geolocation) return
+    geoWatchId = navigator.geolocation.watchPosition(
+      (position) => setPosition([position.coords.latitude, position.coords.longitude]),
+      (error) => {
+        openSnackbar({
+          variant: 'error',
+          message: `Base station GPS tracking failed: ${error.message}. Disabling.`,
+          duration: 4000,
+        })
+        config.value.trackByGps = false
+      },
+      { enableHighAccuracy: true, timeout: 10000, maximumAge: 1000 }
+    )
+  }
+
+  watch(
+    () => isTracking.value && gpsSource.value === BROWSER_GEOLOCATION_SOURCE_ID,
+    (usingBrowserGeolocation) => (usingBrowserGeolocation ? startGeoWatch() : stopGeoWatch()),
+    { immediate: true }
+  )
+
+  const trackedGnssDeviceId = computed(() =>
+    isTracking.value && gpsSource.value !== BROWSER_GEOLOCATION_SOURCE_ID ? gpsSource.value : null
+  )
+
+  const applyGnssPosition = useThrottleFn(setPosition, gnssPositionSampleRateMs, true, true)
+
+  watch(
+    () => (trackedGnssDeviceId.value === null ? undefined : gnss.latestFixes[trackedGnssDeviceId.value]),
+    (fix) => {
+      if (fix?.latitude == null || fix.longitude == null || !fix.hasValidFix) return
+      applyGnssPosition([fix.latitude, fix.longitude])
+    },
+    { immediate: true }
+  )
+
+  // This singleton never unmounts, so the watch above can't release the geolocation watch on a
+  // full app teardown; clear it on window unload to avoid leaking it across reloads.
+  if (typeof window !== 'undefined') window.addEventListener('beforeunload', stopGeoWatch)
+
   return reactive({
     config,
     configPanelOpen,
     contextPopupOpen,
     contextPopupPosition,
+    showCoverage,
+    gpsSource,
+    gpsSourceOptions,
+    setPosition,
+    setBearing,
+    setAntennaType,
+    resetAntennaToDefaults,
     openContextPopup,
     closeContextPopup,
-    setPosition,
     remove,
   })
 }

--- a/src/composables/baseStation/useBaseStationOverlay.ts
+++ b/src/composables/baseStation/useBaseStationOverlay.ts
@@ -1,0 +1,102 @@
+import './baseStationOverlay.css'
+
+import L from 'leaflet'
+import { type Ref, type ShallowRef, onBeforeUnmount, shallowRef, watch } from 'vue'
+
+import { useBaseStation } from '@/composables/baseStation/useBaseStation'
+import type { BaseStationConfig } from '@/types/baseStation'
+
+/* eslint-disable jsdoc/require-jsdoc -- internal helper return shape, name is self-describing. */
+type BaseStationOverlayApi = { openConfigPanel: () => void }
+/* eslint-enable jsdoc/require-jsdoc */
+
+const baseStationMarkerHtml = (label: string): string => `
+  <div class="base-station-marker-container">
+    <div class="base-station-marker-background"></div>
+    <i class="v-icon notranslate mdi mdi-radio-tower" style="color: white; position: relative; z-index: 2; font-size: 16px;"></i>
+    <div class="base-station-marker-label">${label}</div>
+  </div>
+`
+
+/**
+ * Renders the base-station marker on a Leaflet map and keeps it in sync with the
+ * {@link useBaseStation} state. Mounting and unmounting are handled automatically.
+ * @param {ShallowRef<L.Map | undefined>} map Reactive reference to the Leaflet map instance.
+ * @param {Ref<boolean>} mapReady Reactive flag that becomes true once the map is initialized.
+ * @returns {BaseStationOverlayApi} Helpers to drive the overlay from the host view.
+ */
+export const useBaseStationOverlay = (
+  map: ShallowRef<L.Map | undefined>,
+  mapReady: Ref<boolean>
+): BaseStationOverlayApi => {
+  const store = useBaseStation()
+
+  const marker = shallowRef<L.Marker | undefined>()
+
+  const openConfigPanel = (): void => {
+    store.configPanelOpen = true
+  }
+
+  const removeLayer = (layer: L.Layer | undefined): void => {
+    if (layer && map.value) map.value.removeLayer(layer)
+  }
+
+  const buildMarkerIcon = (): L.DivIcon =>
+    L.divIcon({
+      className: 'base-station-marker-icon',
+      html: baseStationMarkerHtml('Base'),
+      iconSize: [24, 24],
+      iconAnchor: [12, 12],
+    })
+
+  const ensureMarker = (config: BaseStationConfig): void => {
+    if (!map.value || !config.position) return
+    if (marker.value) {
+      marker.value.setLatLng(config.position)
+      return
+    }
+    const m = L.marker(config.position, {
+      icon: buildMarkerIcon(),
+      draggable: true,
+      zIndexOffset: 600,
+      // The marker owns its own right-click popup; don't propagate to the map context menu.
+      bubblingMouseEvents: false,
+    })
+    m.on('drag', (event: L.LeafletEvent) => {
+      const target = event.target as L.Marker
+      const { lat, lng } = target.getLatLng()
+      store.setPosition([lat, lng])
+    })
+    m.on('contextmenu', (event: L.LeafletMouseEvent) => {
+      L.DomEvent.stopPropagation(event)
+      event.originalEvent.stopPropagation()
+      event.originalEvent.preventDefault()
+      store.openContextPopup(event.originalEvent.clientX, event.originalEvent.clientY)
+    })
+    m.addTo(map.value)
+    marker.value = m
+  }
+
+  const refreshAll = (): void => {
+    if (!mapReady.value || !(map.value instanceof L.Map)) return
+    const config = store.config
+
+    if (!config.enabled || !config.position) {
+      removeLayer(marker.value)
+      marker.value = undefined
+      return
+    }
+
+    ensureMarker(config)
+  }
+
+  watch([map, mapReady], refreshAll, { immediate: true })
+  watch(() => store.config, refreshAll, { deep: true })
+
+  onBeforeUnmount(() => {
+    removeLayer(marker.value)
+    marker.value = undefined
+  })
+
+  return { openConfigPanel }
+}

--- a/src/composables/baseStation/useBaseStationOverlay.ts
+++ b/src/composables/baseStation/useBaseStationOverlay.ts
@@ -4,7 +4,20 @@ import L from 'leaflet'
 import { type Ref, type ShallowRef, onBeforeUnmount, shallowRef, watch } from 'vue'
 
 import { useBaseStation } from '@/composables/baseStation/useBaseStation'
-import type { BaseStationConfig } from '@/types/baseStation'
+import {
+  aimingArcLatLngs,
+  bearingBetween,
+  bearingHandlePosition,
+  effectiveAntennaRangeMeters,
+  sectorPolygonLatLngs,
+} from '@/libs/baseStation/coverage'
+import { type BaseStationConfig, AntennaType, BaseStationCommsType } from '@/types/baseStation'
+
+// Concentric coverage rings with decreasing radius. Stacking them at the same per-layer opacity
+// produces a smooth radial fade that mimics the pattern published in BR's directional antenna
+// guide while keeping the brightest band where the signal is strongest.
+const COVERAGE_GRADIENT_STEPS = 12
+const COVERAGE_STEP_OPACITY = 0.045
 
 /* eslint-disable jsdoc/require-jsdoc -- internal helper return shape, name is self-describing. */
 type BaseStationOverlayApi = { openConfigPanel: () => void }
@@ -19,8 +32,9 @@ const baseStationMarkerHtml = (label: string): string => `
 `
 
 /**
- * Renders the base-station marker on a Leaflet map and keeps it in sync with the
- * {@link useBaseStation} state. Mounting and unmounting are handled automatically.
+ * Renders the base-station marker, antenna coverage and tether circle on a Leaflet map and
+ * keeps them in sync with the {@link useBaseStation} state. Mounting and unmounting are
+ * handled automatically.
  * @param {ShallowRef<L.Map | undefined>} map Reactive reference to the Leaflet map instance.
  * @param {Ref<boolean>} mapReady Reactive flag that becomes true once the map is initialized.
  * @returns {BaseStationOverlayApi} Helpers to drive the overlay from the host view.
@@ -32,6 +46,13 @@ export const useBaseStationOverlay = (
   const store = useBaseStation()
 
   const marker = shallowRef<L.Marker | undefined>()
+  const coverageLayer = shallowRef<L.LayerGroup | undefined>()
+  const coverageSteps = shallowRef<(L.Circle | L.Polygon)[]>([])
+  const coverageAntennaType = shallowRef<AntennaType | undefined>()
+  const tetherLayer = shallowRef<L.Circle | undefined>()
+  const bearingHandle = shallowRef<L.Marker | undefined>()
+  const bearingLine = shallowRef<L.Polyline | undefined>()
+  const aimingArc = shallowRef<L.Polyline | undefined>()
 
   const openConfigPanel = (): void => {
     store.configPanelOpen = true
@@ -49,10 +70,19 @@ export const useBaseStationOverlay = (
       iconAnchor: [12, 12],
     })
 
+  const buildBearingHandleIcon = (): L.DivIcon =>
+    L.divIcon({
+      className: 'base-station-bearing-handle',
+      html: '<div class="base-station-bearing-handle-dot"></div>',
+      iconSize: [18, 18],
+      iconAnchor: [9, 9],
+    })
+
   const ensureMarker = (config: BaseStationConfig): void => {
     if (!map.value || !config.position) return
     if (marker.value) {
       marker.value.setLatLng(config.position)
+      applyMarkerColor(config.coverageColor)
       return
     }
     const m = L.marker(config.position, {
@@ -75,6 +105,172 @@ export const useBaseStationOverlay = (
     })
     m.addTo(map.value)
     marker.value = m
+    applyMarkerColor(config.coverageColor)
+  }
+
+  // Marker stays fully visible regardless of the opacity slider — only the coverage and
+  // bearing/arc dotted lines fade with `coverageOpacity`. The trailing `cc` keeps the
+  // marker's original 80% fill so the icon underneath stays legible against the map.
+  const applyMarkerColor = (color: string): void => {
+    const el = marker.value?.getElement()
+    if (!el) return
+    const bg = el.querySelector('.base-station-marker-background') as HTMLElement | null
+    if (bg) bg.style.backgroundColor = `${color.slice(0, 7)}cc`
+  }
+
+  const updateCoverage = (config: BaseStationConfig): void => {
+    if (!map.value || !store.showCoverage || !config.position || config.commsType !== BaseStationCommsType.RadioLink) {
+      removeLayer(coverageLayer.value)
+      coverageLayer.value = undefined
+      coverageSteps.value = []
+      coverageAntennaType.value = undefined
+      return
+    }
+
+    const position = config.position
+    const isOmni = config.antenna.type === AntennaType.Omni
+    const rangeMeters = effectiveAntennaRangeMeters(config)
+    const stepStyle = {
+      color: config.coverageColor,
+      weight: 0,
+      fillColor: config.coverageColor,
+      fillOpacity: COVERAGE_STEP_OPACITY * config.coverageOpacity,
+      interactive: false,
+    }
+    const stepRadius = (step: number): number => (rangeMeters * step) / COVERAGE_GRADIENT_STEPS
+
+    // Recreating every gradient layer on each config change thrashes Leaflet during a bearing
+    // drag, so reuse the existing step layers in place and only rebuild when the shape changes.
+    const canUpdateInPlace =
+      coverageLayer.value !== undefined &&
+      coverageAntennaType.value === config.antenna.type &&
+      coverageSteps.value.length === COVERAGE_GRADIENT_STEPS
+
+    if (canUpdateInPlace) {
+      coverageSteps.value.forEach((layer, index) => {
+        const radius = stepRadius(index + 1)
+        if (isOmni) {
+          const circle = layer as L.Circle
+          circle.setLatLng(position)
+          circle.setRadius(radius)
+          circle.setStyle(stepStyle)
+        } else {
+          const polygon = layer as L.Polygon
+          polygon.setLatLngs(sectorPolygonLatLngs(position, radius, config.antenna.bearing, config.antenna.beamwidth))
+          polygon.setStyle(stepStyle)
+        }
+      })
+      return
+    }
+
+    removeLayer(coverageLayer.value)
+    const group = L.layerGroup()
+    const steps: (L.Circle | L.Polygon)[] = []
+    for (let step = 1; step <= COVERAGE_GRADIENT_STEPS; step++) {
+      const radius = stepRadius(step)
+      const layer = isOmni
+        ? L.circle(position, { ...stepStyle, radius })
+        : L.polygon(sectorPolygonLatLngs(position, radius, config.antenna.bearing, config.antenna.beamwidth), stepStyle)
+      layer.addTo(group)
+      steps.push(layer)
+    }
+    group.addTo(map.value)
+    coverageLayer.value = group
+    coverageSteps.value = steps
+    coverageAntennaType.value = config.antenna.type
+  }
+
+  const updateTether = (config: BaseStationConfig): void => {
+    removeLayer(tetherLayer.value)
+    tetherLayer.value = undefined
+
+    if (!map.value || !store.showCoverage || !config.position) return
+    if (config.commsType !== BaseStationCommsType.Tethered) return
+
+    tetherLayer.value = L.circle(config.position, {
+      radius: config.tetherLengthMeters,
+      color: config.coverageColor,
+      weight: 1,
+      opacity: config.coverageOpacity,
+      fillColor: config.coverageColor,
+      fillOpacity: 0.1 * config.coverageOpacity,
+      dashArray: '4 4',
+      interactive: false,
+    }).addTo(map.value)
+  }
+
+  const updateBearingHandle = (config: BaseStationConfig): void => {
+    const shouldShow =
+      map.value !== undefined &&
+      config.position !== null &&
+      config.commsType === BaseStationCommsType.RadioLink &&
+      config.antenna.type !== AntennaType.Omni
+
+    if (!shouldShow) {
+      removeLayer(bearingHandle.value)
+      removeLayer(bearingLine.value)
+      removeLayer(aimingArc.value)
+      bearingHandle.value = undefined
+      bearingLine.value = undefined
+      aimingArc.value = undefined
+      return
+    }
+
+    const rangeMeters = effectiveAntennaRangeMeters(config)
+    const handleLatLng = bearingHandlePosition(config.position!, rangeMeters, config.antenna.bearing)
+    const lineLatLngs = [config.position!, handleLatLng] as L.LatLngExpression[]
+    const arcLatLngs = aimingArcLatLngs(config.position!, rangeMeters, config.antenna.bearing)
+    const lineOpacity = 0.3 * config.coverageOpacity
+    const arcOpacity = 0.25 * config.coverageOpacity
+
+    if (bearingLine.value) {
+      bearingLine.value.setLatLngs(lineLatLngs)
+      bearingLine.value.setStyle({ color: config.coverageColor, opacity: lineOpacity })
+    } else {
+      bearingLine.value = L.polyline(lineLatLngs, {
+        color: config.coverageColor,
+        weight: 1,
+        dashArray: '6 4',
+        opacity: lineOpacity,
+        interactive: false,
+      }).addTo(map.value!)
+    }
+
+    if (aimingArc.value) {
+      aimingArc.value.setLatLngs(arcLatLngs)
+      aimingArc.value.setStyle({ color: config.coverageColor, opacity: arcOpacity })
+    } else {
+      aimingArc.value = L.polyline(arcLatLngs, {
+        color: config.coverageColor,
+        weight: 1,
+        dashArray: '6 4',
+        opacity: arcOpacity,
+        interactive: false,
+      }).addTo(map.value!)
+    }
+
+    // Update in place; recreating during drag would destroy the handle Leaflet is tracking
+    // and stop the rotation after a single drag step.
+    if (bearingHandle.value) {
+      bearingHandle.value.setLatLng(handleLatLng)
+      return
+    }
+
+    const handle = L.marker(handleLatLng, {
+      icon: buildBearingHandleIcon(),
+      draggable: true,
+      zIndexOffset: 700,
+      bubblingMouseEvents: true,
+    })
+    handle.on('drag', (event: L.LeafletEvent) => {
+      const center = store.config.position
+      if (!center) return
+      const target = event.target as L.Marker
+      const { lat, lng } = target.getLatLng()
+      store.setBearing(bearingBetween(center, [lat, lng]))
+    })
+    handle.addTo(map.value!)
+    bearingHandle.value = handle
   }
 
   const refreshAll = (): void => {
@@ -83,11 +279,24 @@ export const useBaseStationOverlay = (
 
     if (!config.enabled || !config.position) {
       removeLayer(marker.value)
+      removeLayer(coverageLayer.value)
+      removeLayer(tetherLayer.value)
+      removeLayer(bearingHandle.value)
+      removeLayer(bearingLine.value)
+      removeLayer(aimingArc.value)
       marker.value = undefined
+      coverageLayer.value = undefined
+      tetherLayer.value = undefined
+      bearingHandle.value = undefined
+      bearingLine.value = undefined
+      aimingArc.value = undefined
       return
     }
 
     ensureMarker(config)
+    updateCoverage(config)
+    updateTether(config)
+    updateBearingHandle(config)
   }
 
   watch([map, mapReady], refreshAll, { immediate: true })
@@ -95,7 +304,17 @@ export const useBaseStationOverlay = (
 
   onBeforeUnmount(() => {
     removeLayer(marker.value)
+    removeLayer(coverageLayer.value)
+    removeLayer(tetherLayer.value)
+    removeLayer(bearingHandle.value)
+    removeLayer(bearingLine.value)
+    removeLayer(aimingArc.value)
     marker.value = undefined
+    coverageLayer.value = undefined
+    tetherLayer.value = undefined
+    bearingHandle.value = undefined
+    bearingLine.value = undefined
+    aimingArc.value = undefined
   })
 
   return { openConfigPanel }

--- a/src/libs/baseStation/coverage.ts
+++ b/src/libs/baseStation/coverage.ts
@@ -1,0 +1,168 @@
+import * as turf from '@turf/turf'
+
+import {
+  type BaseStationConfig,
+  BaseStationCommsType,
+  BLUEBOAT_ANTENNA_MAST_RANGE_MULTIPLIER,
+  DEFAULT_BASE_STATION_ANTENNA_HEIGHT_METERS,
+} from '@/types/baseStation'
+import type { WaypointCoordinates } from '@/types/mission'
+
+/**
+ * Number of segments used to approximate a coverage arc.
+ */
+export const SECTOR_ARC_STEPS = 64
+
+const MIN_BASE_STATION_ANTENNA_HEIGHT_METERS = 0.5
+const MAX_BASE_STATION_ANTENNA_HEIGHT_METERS = 50
+
+/**
+ * Range multiplier from base-station antenna height. Over flat water/terrain, radio horizon distance
+ * scales as √h (d_km ≈ 4.12·√h with standard 4/3 Earth-radius refraction), so practical range grows
+ * with the square root of height relative to {@link DEFAULT_BASE_STATION_ANTENNA_HEIGHT_METERS}.
+ * @param {number} heightMeters Antenna height above ground in meters.
+ * @returns {number} Multiplier applied to the entered range for map coverage.
+ */
+export const baseStationAntennaHeightRangeMultiplier = (heightMeters: number): number => {
+  const clamped = Math.min(
+    MAX_BASE_STATION_ANTENNA_HEIGHT_METERS,
+    Math.max(MIN_BASE_STATION_ANTENNA_HEIGHT_METERS, heightMeters)
+  )
+  return Math.sqrt(clamped / DEFAULT_BASE_STATION_ANTENNA_HEIGHT_METERS)
+}
+
+/**
+ * Practical antenna range (m) used for map coverage, including height and vehicle mast adjustments.
+ * @param {BaseStationConfig} config Current base-station configuration.
+ * @returns {number} Range in meters for overlay geometry.
+ */
+export const effectiveAntennaRangeMeters = (config: BaseStationConfig): number => {
+  if (config.commsType !== BaseStationCommsType.RadioLink) return config.antenna.range
+
+  let range = config.antenna.range * baseStationAntennaHeightRangeMultiplier(config.baseStationAntennaHeightMeters)
+  if (config.vehicleHasBlueBoatAntennaMast) range *= BLUEBOAT_ANTENNA_MAST_RANGE_MULTIPLIER
+
+  return Math.max(1, Math.round(range))
+}
+
+/**
+ * Rescale antenna range after a gain change. Friis: a single-end gain delta scales LOS range by
+ * 10^(ΔG_dB/20).
+ * @param {number} currentRange Current range in meters.
+ * @param {number} oldGain Previous antenna gain in dBi.
+ * @param {number} newGain New antenna gain in dBi.
+ * @returns {number} Rescaled range in meters (at least 1).
+ */
+export const rangeAfterGainChange = (currentRange: number, oldGain: number, newGain: number): number => {
+  const ratio = Math.pow(10, (newGain - oldGain) / 20)
+  return Math.max(1, Math.round(currentRange * ratio))
+}
+
+/**
+ * Rescale antenna range after a transmit-power change. Friis: range ∝ √P_t, so the range scales by
+ * √(P_new/P_old).
+ * @param {number} currentRange Current range in meters.
+ * @param {number} oldPowerMw Previous transmit power in milliwatts.
+ * @param {number} newPowerMw New transmit power in milliwatts.
+ * @returns {number} Rescaled range in meters (at least 1).
+ */
+export const rangeAfterTxPowerChange = (currentRange: number, oldPowerMw: number, newPowerMw: number): number => {
+  const ratio = Math.sqrt(newPowerMw / oldPowerMw)
+  return Math.max(1, Math.round(currentRange * ratio))
+}
+
+/**
+ * Normalize a bearing to the [0, 360) range.
+ * @param {number} bearing Bearing in degrees.
+ * @returns {number} Equivalent bearing within [0, 360).
+ */
+export const normalizeBearing = (bearing: number): number => ((bearing % 360) + 360) % 360
+
+/**
+ * Great-circle bearing from one coordinate to another.
+ * @param {WaypointCoordinates} from Origin coordinate as [latitude, longitude].
+ * @param {WaypointCoordinates} to Target coordinate as [latitude, longitude].
+ * @returns {number} Bearing in degrees, where 0 = north and angles grow clockwise.
+ */
+export const bearingBetween = (from: WaypointCoordinates, to: WaypointCoordinates): number =>
+  turf.bearing(turf.point([from[1], from[0]]), turf.point([to[1], to[0]]))
+
+/**
+ * Centroid (mean position) of a set of coordinates.
+ * @param {WaypointCoordinates[]} points Coordinates as [latitude, longitude].
+ * @returns {WaypointCoordinates | null} Mean coordinate, or null when the list is empty.
+ */
+export const centroidOf = (points: WaypointCoordinates[]): WaypointCoordinates | null => {
+  if (points.length === 0) return null
+  const [sumLat, sumLng] = points.reduce<[number, number]>(
+    ([lat, lng], [pLat, pLng]) => [lat + pLat, lng + pLng],
+    [0, 0]
+  )
+  return [sumLat / points.length, sumLng / points.length]
+}
+
+/**
+ * Closed polygon ring outlining a directional (sector) coverage area, anchored at the center.
+ * @param {WaypointCoordinates} center Sector apex as [latitude, longitude].
+ * @param {number} rangeMeters Sector radius in meters.
+ * @param {number} bearingDeg Boresight bearing in degrees.
+ * @param {number} beamwidthDeg Horizontal beamwidth in degrees.
+ * @returns {WaypointCoordinates[]} Closed polygon ring as [latitude, longitude] points.
+ */
+export const sectorPolygonLatLngs = (
+  center: WaypointCoordinates,
+  rangeMeters: number,
+  bearingDeg: number,
+  beamwidthDeg: number
+): WaypointCoordinates[] => {
+  const halfBeam = beamwidthDeg / 2
+  const arc = turf.lineArc(
+    turf.point([center[1], center[0]]),
+    rangeMeters / 1000,
+    bearingDeg - halfBeam,
+    bearingDeg + halfBeam,
+    {
+      steps: SECTOR_ARC_STEPS,
+    }
+  )
+  const arcPoints = arc.geometry.coordinates.map(([lng, lat]) => [lat, lng] as WaypointCoordinates)
+  return [center, ...arcPoints, center]
+}
+
+/**
+ * Position of the draggable bearing handle at the antenna's max range along the boresight.
+ * @param {WaypointCoordinates} center Antenna position as [latitude, longitude].
+ * @param {number} rangeMeters Range in meters.
+ * @param {number} bearingDeg Boresight bearing in degrees.
+ * @returns {WaypointCoordinates} Handle position as [latitude, longitude].
+ */
+export const bearingHandlePosition = (
+  center: WaypointCoordinates,
+  rangeMeters: number,
+  bearingDeg: number
+): WaypointCoordinates => {
+  const dest = turf.destination(turf.point([center[1], center[0]]), rangeMeters / 1000, bearingDeg, {
+    units: 'kilometers',
+  })
+  const [lng, lat] = dest.geometry.coordinates
+  return [lat, lng]
+}
+
+/**
+ * 180° front-facing arc at the antenna's max range, previewing where the signal lands as the
+ * operator rotates the antenna.
+ * @param {WaypointCoordinates} center Antenna position as [latitude, longitude].
+ * @param {number} rangeMeters Range in meters.
+ * @param {number} bearingDeg Boresight bearing in degrees.
+ * @returns {WaypointCoordinates[]} Arc points as [latitude, longitude].
+ */
+export const aimingArcLatLngs = (
+  center: WaypointCoordinates,
+  rangeMeters: number,
+  bearingDeg: number
+): WaypointCoordinates[] => {
+  const arc = turf.lineArc(turf.point([center[1], center[0]]), rangeMeters / 1000, bearingDeg - 90, bearingDeg + 90, {
+    steps: SECTOR_ARC_STEPS,
+  })
+  return arc.geometry.coordinates.map(([lng, lat]) => [lat, lng] as WaypointCoordinates)
+}

--- a/src/libs/baseStation/menu.ts
+++ b/src/libs/baseStation/menu.ts
@@ -1,0 +1,13 @@
+export const baseStationMenuIcon = 'mdi-radio-tower'
+export const configureBaseStationMenuIcon = 'mdi-cog'
+export const configureBaseStationMenuLabel = 'Configure base station'
+export const removeBaseStationMenuLabel = 'Remove base station'
+
+/**
+ * Label for the "place base station" context-menu entry, shared by the Map widget and the
+ * mission-planning context menus so both surfaces stay in sync.
+ * @param {boolean} enabled Whether a base station is already placed.
+ * @returns {string} Menu entry label.
+ */
+export const baseStationPlaceMenuLabel = (enabled: boolean): string =>
+  enabled ? 'Move base station here' : 'Set base station here'

--- a/src/types/baseStation.ts
+++ b/src/types/baseStation.ts
@@ -1,0 +1,17 @@
+import type { WaypointCoordinates } from '@/types/mission'
+
+export type BaseStationConfig = {
+  /**
+   * Whether the base station is placed on the map. False until the user sets a position.
+   */
+  enabled: boolean
+  /**
+   * Geographical position of the base station as [latitude, longitude].
+   */
+  position: WaypointCoordinates | null
+}
+
+export const DEFAULT_BASE_STATION_CONFIG: BaseStationConfig = {
+  enabled: false,
+  position: null,
+}

--- a/src/types/baseStation.ts
+++ b/src/types/baseStation.ts
@@ -1,5 +1,56 @@
 import type { WaypointCoordinates } from '@/types/mission'
 
+/**
+ * Communication link type between the topside (base station) and the vehicle.
+ */
+export enum BaseStationCommsType {
+  Tethered = 'Tethered',
+  MobileData = 'Mobile data (4G/5G)',
+  RadioLink = 'Radio link',
+}
+
+/**
+ * Radio base station product family, used to seed antenna defaults.
+ */
+export enum RadioBaseStationKind {
+  BlueRobotics = 'Blue Robotics BaseStation',
+  Custom = 'Custom',
+}
+
+/**
+ * Antenna form factor. Determines the shape of the coverage drawn on the map (full circle
+ * for omni, sector/cone for directional ones) and seeds gain/beamwidth/range defaults.
+ */
+export enum AntennaType {
+  Omni = 'Omnidirectional',
+  Panel = 'Panel',
+  Yagi = 'Yagi',
+}
+
+export type AntennaSpec = {
+  /**
+   * Antenna form factor.
+   */
+  type: AntennaType
+  /**
+   * Antenna gain in dBi.
+   */
+  gain: number
+  /**
+   * Horizontal beamwidth in degrees. Use 360 for omnidirectional antennas.
+   */
+  beamwidth: number
+  /**
+   * Practical communication range in meters used to draw the coverage on the map.
+   */
+  range: number
+  /**
+   * Bearing/azimuth of the antenna boresight in degrees, where 0 = north and angles grow clockwise.
+   * Ignored for omnidirectional antennas.
+   */
+  bearing: number
+}
+
 export type BaseStationConfig = {
   /**
    * Whether the base station is placed on the map. False until the user sets a position.
@@ -9,9 +60,106 @@ export type BaseStationConfig = {
    * Geographical position of the base station as [latitude, longitude].
    */
   position: WaypointCoordinates | null
+  /**
+   * Whether to keep the base-station position synced with the GPS given by {@link gpsSourceId}.
+   */
+  trackByGps: boolean
+  /**
+   * Positioning source used while {@link trackByGps} is on: either {@link BROWSER_GEOLOCATION_SOURCE_ID}
+   * or the id of a GNSS device configured under Settings > Sources.
+   */
+  gpsSourceId: string
+  /**
+   * Communication link type between the topside and the vehicle.
+   */
+  commsType: BaseStationCommsType
+  /**
+   * Radio base station product family. Only used when {@link commsType} is RadioLink.
+   */
+  radioBaseStationKind: RadioBaseStationKind
+  /**
+   * Antenna parameters used to draw coverage. Only used when {@link commsType} is RadioLink.
+   */
+  antenna: AntennaSpec
+  /**
+   * Height of the base-station antenna above ground in meters. Map coverage scales with √height using
+   * the radio-horizon range model.
+   */
+  baseStationAntennaHeightMeters: number
+  /**
+   * Whether the vehicle mounts the BlueBoat Antenna and Accessory Mast (vehicle-side extender).
+   * When true, map coverage uses {@link BLUEBOAT_ANTENNA_MAST_RANGE_MULTIPLIER}× the entered range.
+   */
+  vehicleHasBlueBoatAntennaMast: boolean
+  /**
+   * Tether length in meters used to draw coverage. Only used when {@link commsType} is Tethered.
+   */
+  tetherLengthMeters: number
+  /**
+   * Transmitter power in milliwatts. Drives a Friis-based range scaling
+   * (range ∝ √P_t) when the operator picks a Custom radio.
+   */
+  txPowerMilliwatts: number
+  /**
+   * Hex color used to render the projected antenna signal coverage on the map.
+   */
+  coverageColor: string
+  /**
+   * Multiplier (0..1) applied to the coverage fill opacity. 1.0 keeps the default look, 0 makes it
+   * invisible.
+   */
+  coverageOpacity: number
 }
+
+/**
+ * {@link BaseStationConfig.gpsSourceId} value standing for the browser's Geolocation API. The colon keeps it
+ * distinct from any GNSS device id, as those are machinized to `[a-z0-9-]`.
+ */
+export const BROWSER_GEOLOCATION_SOURCE_ID = 'browser:geolocation'
+
+/**
+ * Factory antenna specs derived from the BlueBoat BaseStation and Directional Antenna Kit guides.
+ * Range values are the practical (rest-of-world) ranges from BR's tested data; gain values are
+ * the rest-of-world recommended values that account for connector loss.
+ *
+ * Sources: bluerobotics.com/store/boat/blueboat-components-spares/basestation and
+ * bluerobotics.com/learn/directional-antenna-guide.
+ */
+export const ANTENNA_FACTORY_DEFAULTS: Record<AntennaType, Omit<AntennaSpec, 'bearing'>> = {
+  [AntennaType.Omni]: { type: AntennaType.Omni, gain: 7, beamwidth: 360, range: 250 },
+  [AntennaType.Panel]: { type: AntennaType.Panel, gain: 12, beamwidth: 40, range: 500 },
+  [AntennaType.Yagi]: { type: AntennaType.Yagi, gain: 16, beamwidth: 25, range: 800 },
+}
+
+/**
+ * BlueRobotics BaseStation TX power (Microhard pMDDL/pDDL 900 MHz, 1 W max).
+ */
+export const BLUE_ROBOTICS_TX_POWER_MW = 1000
+
+/**
+ * Communication range multiplier with the BlueBoat Antenna and Accessory Mast on the vehicle.
+ * @see https://bluerobotics.com/store/boat/blueboat-accessories/blueboat-antenna-and-accessory-mast/
+ */
+export const BLUEBOAT_ANTENNA_MAST_RANGE_MULTIPLIER = 1.75
+
+/**
+ * Reference base-station antenna height (m). Factory range values assume roughly this height on a
+ * typical tripod or short mast.
+ */
+export const DEFAULT_BASE_STATION_ANTENNA_HEIGHT_METERS = 1
 
 export const DEFAULT_BASE_STATION_CONFIG: BaseStationConfig = {
   enabled: false,
   position: null,
+  trackByGps: false,
+  gpsSourceId: BROWSER_GEOLOCATION_SOURCE_ID,
+  commsType: BaseStationCommsType.RadioLink,
+  radioBaseStationKind: RadioBaseStationKind.BlueRobotics,
+  antenna: { ...ANTENNA_FACTORY_DEFAULTS[AntennaType.Omni], bearing: 0 },
+  baseStationAntennaHeightMeters: DEFAULT_BASE_STATION_ANTENNA_HEIGHT_METERS,
+  vehicleHasBlueBoatAntennaMast: false,
+  tetherLengthMeters: 150,
+  txPowerMilliwatts: BLUE_ROBOTICS_TX_POWER_MW,
+  coverageColor: '#3B82F6',
+  coverageOpacity: 1,
 }

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -581,6 +581,9 @@
     @add-waypoint-at-cursor="addWaypointFromContextMenu"
     @clear-vehicle-path-history="clearVehiclePathHistory"
     @open-map-overlays="overlaysDialogOpen = true"
+    @place-base-station="placeBaseStationFromContextMenu"
+    @configure-base-station="baseStationStore.configPanelOpen = true"
+    @remove-base-station="confirmRemoveBaseStation(showDialog, closeDialog)"
   />
   <MapOverlaysDialog v-model="overlaysDialogOpen" :loading-ids="overlayLoadingIds" />
   <Teleport to="#planningMap">
@@ -614,6 +617,7 @@
   </SideConfigPanel>
   <HomePositionSettingHelp v-model="showHomePositionNotSetDialog" />
   <PoiManager ref="poiManagerRef" />
+  <BaseStationContextPopup />
   <Teleport to="#planningMap">
     <PoiMapArrows
       :map-ready="mapReady"
@@ -680,6 +684,7 @@ import { type InstanceType, computed, nextTick, onMounted, onUnmounted, ref, sha
 import blueboatMarkerImage from '@/assets/blueboat-marker.avif'
 import brov2MarkerImage from '@/assets/brov2-marker.avif'
 import genericVehicleMarkerImage from '@/assets/generic-vehicle-marker.avif'
+import BaseStationContextPopup from '@/components/BaseStationContextPopup.vue'
 import MapNorthIndicator from '@/components/map/MapNorthIndicator.vue'
 import MapOverlaysDialog from '@/components/map/MapOverlaysDialog.vue'
 import MapCenterControl from '@/components/MapCenterControl.vue'
@@ -694,6 +699,8 @@ import PoiManager from '@/components/poi/PoiManager.vue'
 import PoiMapArrows from '@/components/poi/PoiMapArrows.vue'
 import RadialMenu, { type RadialMenuItem } from '@/components/RadialMenu.vue'
 import SideConfigPanel from '@/components/SideConfigPanel.vue'
+import { confirmRemoveBaseStation, useBaseStation } from '@/composables/baseStation/useBaseStation'
+import { useBaseStationOverlay } from '@/composables/baseStation/useBaseStationOverlay'
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { useDragMeasureOverlay } from '@/composables/map/useDragMeasureOverlay'
 import { provideMapContext } from '@/composables/map/useMapContext'
@@ -760,6 +767,7 @@ const missionStore = useMissionStore()
 const vehicleStore = useMainVehicleStore()
 const interfaceStore = useAppInterfaceStore()
 const widgetStore = useWidgetManagerStore()
+const baseStationStore = useBaseStation()
 const missionEstimates = useMissionEstimates()
 const angleOverlay = useVertexAngleOverlay()
 const dragMeasureOverlay = useDragMeasureOverlay(angleOverlay)
@@ -963,6 +971,8 @@ watch(
   () => missionStore.mapOverlayFocusRequest.revision,
   () => mapOverlays.zoomToOverlay(missionStore.mapOverlayFocusRequest.id)
 )
+
+useBaseStationOverlay(planningMap, mapReady)
 
 const mapCenter = ref<WaypointCoordinates>(missionStore.userLastMapCenter ?? missionStore.defaultMapCenter)
 const zoom = ref(missionStore.userLastMapZoom ?? missionStore.defaultMapZoom)
@@ -2104,6 +2114,13 @@ const clearVehiclePathHistory = (): void => {
 const setHomePositionFromContextMenu = async (): Promise<void> => {
   logUserAction('Set mission home position from context menu')
   await setHomePosition()
+}
+
+const placeBaseStationFromContextMenu = (): void => {
+  if (!currentCursorGeoCoordinates.value) return
+  baseStationStore.setPosition(currentCursorGeoCoordinates.value)
+  baseStationStore.configPanelOpen = true
+  logUserAction('Placed the base station via the mission-planning context menu')
 }
 
 const setHomePosition = async (): Promise<void> => {

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -128,7 +128,7 @@
       />
     </div>
     <div
-      v-show="!interfaceStore.isMainMenuVisible"
+      v-show="!interfaceStore.isMainMenuVisible && !interfaceStore.isConfigPanelVisible"
       class="absolute flex flex-col left-10 rounded-[10px] max-h-[80vh] overflow-y-auto z-[200]"
       :style="[interfaceStore.globalGlassMenuStyles, { height: 'auto', maxHeight: calculatedHeight, width: '320px' }]"
     >
@@ -617,6 +617,7 @@
   </SideConfigPanel>
   <HomePositionSettingHelp v-model="showHomePositionNotSetDialog" />
   <PoiManager ref="poiManagerRef" />
+  <BaseStationConfigPanel />
   <BaseStationContextPopup />
   <Teleport to="#planningMap">
     <PoiMapArrows
@@ -684,6 +685,7 @@ import { type InstanceType, computed, nextTick, onMounted, onUnmounted, ref, sha
 import blueboatMarkerImage from '@/assets/blueboat-marker.avif'
 import brov2MarkerImage from '@/assets/brov2-marker.avif'
 import genericVehicleMarkerImage from '@/assets/generic-vehicle-marker.avif'
+import BaseStationConfigPanel from '@/components/BaseStationConfigPanel.vue'
 import BaseStationContextPopup from '@/components/BaseStationContextPopup.vue'
 import MapNorthIndicator from '@/components/map/MapNorthIndicator.vue'
 import MapOverlaysDialog from '@/components/map/MapOverlaysDialog.vue'


### PR DESCRIPTION
- Adds a base-station feature with a draggable map marker, a right-click context popup, and a side configuration panel.
- Configurable comms type (tether or radio link) with antenna type (omni/sector/dish), gain, beamwidth, range, bearing, antenna height, and BlueBoat mast multiplier.
- Coverage overlay drawn as omni rings or a sector arc, with a draggable bearing handle for radio links and "Aim at vehicle / mission" snap helpers.

First of three sequential PRs splitting #2739 — the follow-ups land on top of this one:

* base-station-mobile-coverage (#2811) - mobile-data coverage overlays via OpenCellID and OSM Overpass, heatmap and coverage-rings display modes, and the standalone Electron bridge.
* base-station-path-signal (#2812) - offscreen edge arrow and CompassHUD bearing tick, mission/survey path coloring by expected comms quality, and the on-map signal toggles.

https://github.com/user-attachments/assets/e2ff024f-e800-4a95-8d04-07da92c772bf

<img width="740" height="968" alt="image" src="https://github.com/user-attachments/assets/e4bff07f-288a-4430-865b-e434315f9351" />

<img width="1369" height="1022" alt="image" src="https://github.com/user-attachments/assets/51f271af-0671-4a04-bdbb-91baa905ade3" />

