### PR TITLE
Add global helper for logging user interactions

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -15,6 +15,10 @@ module.exports = {
     'es2022': true,
     'vue/setup-compiler-macros': true,
   },
+  globals: {
+    // Global helper defined in src/libs/cosmos.ts and assigned at bootstrap, so it is callable without importing.
+    logUserAction: 'readonly',
+  },
   plugins: ['jsdoc', 'simple-import-sort'],
   ignorePatterns: ['**/src/libs/connection/m2r/**'],
   rules: {

--- a/src/libs/cosmos.ts
+++ b/src/libs/cosmos.ts
@@ -57,6 +57,13 @@ declare global {
   function unused<T>(variable: T): void
 
   /**
+   * Log a user-initiated interaction to the system log with a standard prefix
+   * @param {string} message - Description of the action the user performed
+   * @returns {void}
+   */
+  function logUserAction(message: string): void
+
+  /**
    * Expand Array interface for internal usage
    */
   interface Array<T> {
@@ -609,6 +616,12 @@ global!.unimplemented = function (message?: string) {
 global!.unused = function <T>(variable: T) { } // eslint-disable-line
 
 /* c8 ignore stop */
+
+// Standardized logging for user-initiated interactions. Centralizing the prefix here lets call sites just
+// describe the action (e.g. logUserAction('Opened joystick calibration dialog')) without importing anything.
+global!.logUserAction = function (message: string) {
+  console.info(`[UserAction] ${message}`)
+}
 
 // Extend types
 Array.prototype.first = function <T>(this: T[]): T | undefined {


### PR DESCRIPTION
Adds a logUserAction(message) global in cosmos.ts (alongside the existing assert/unimplemented/unused helpers) that prepends the standard "[UserAction] " prefix and writes via console.info. Being a bootstrap-assigned global, call sites use it without importing. Registered in ESLint globals so no-undef passes in .vue files (where it is, unlike the .ts-only existing helpers, actually used).