### PR TITLE
Add support for serial-based (USB) GPSs

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Below is a table summarizing the current status, but in general, you can expect 
 | **Video** | Needs to be downloaded and merged into a working video using the Desktop app | ✅ Final MP4 file saved directly to your folders |
 | **Snapshots** | Needs to be downloaded | ✅ Saved directly to your folders |
 | **Vehicle Discovery** | ❌ Not available | ✅ Auto-scan for vehicles in the network|
+| **External Serial GNSS** | ❌ Not available (browsers can't access serial devices outside a secure context) | ✅ Read one or more USB/serial NMEA GNSS receivers into the data-lake |
 | **Updates** | Manual updates required | ✅ Auto-updates / update notifications |
 | **System Monitoring** | Memory usage only | ✅ CPU and Memory tracking |
 | **Workspace Capture** | ❌ Not available | ✅ Full interface screenshots |

--- a/src/App.vue
+++ b/src/App.vue
@@ -102,7 +102,10 @@
   <ArchitectureWarning v-if="isElectron()" />
   <SnackbarContainer />
   <FloatingWrapper v-model="devStore.showConsole" title="Console">
-    <ConsoleViewer :logging-enabled="devStore.enableSystemLogging" />
+    <ConsoleViewer
+      :disabled="!devStore.enableSystemLogging"
+      disabled-message="System logging is disabled — enable it above to capture console output."
+    />
   </FloatingWrapper>
   <SkullAnimation
     :is-visible="interfaceStore.showSkullAnimation"

--- a/src/components/ConsoleViewer.vue
+++ b/src/components/ConsoleViewer.vue
@@ -22,7 +22,7 @@
       >
         <v-icon>{{ invertSearch ? 'mdi-filter-minus' : 'mdi-filter' }}</v-icon>
       </v-btn>
-      <div class="flex items-center gap-1 flex-wrap">
+      <div v-if="showLevels" class="flex items-center gap-1 flex-wrap">
         <v-chip
           v-for="lvl in availableLevels"
           :key="lvl"
@@ -68,9 +68,12 @@
       >
         <div class="flex items-center gap-2 h-[20px] leading-[20px] px-2">
           <span class="shrink-0 text-gray-500">{{ formatTime(item.epoch) }}</span>
-          <span class="shrink-0 w-[42px] font-bold uppercase" :style="{ color: levelHex(item.level) }">{{
-            item.level
-          }}</span>
+          <span
+            v-if="showLevels && item.level"
+            class="shrink-0 w-[42px] font-bold uppercase"
+            :style="{ color: levelHex(item.level) }"
+            >{{ item.level }}</span
+          >
           <span class="truncate text-gray-200" :title="item.msg">{{ item.msg }}</span>
         </div>
       </RecycleScroller>
@@ -79,8 +82,8 @@
         v-if="displayedEvents.length === 0"
         class="absolute inset-0 flex items-center justify-center px-4 text-center text-sm text-gray-500 pointer-events-none"
       >
-        <span v-if="!loggingEnabled">System logging is disabled — enable it above to capture console output.</span>
-        <span v-else>No log entries{{ isFiltering ? ' match the current filter' : ' captured yet' }}.</span>
+        <span v-if="disabled && disabledMessage">{{ disabledMessage }}</span>
+        <span v-else>{{ isFiltering ? 'No entries match the current filter.' : emptyText }}</span>
       </div>
     </div>
   </div>
@@ -89,13 +92,34 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, shallowRef, watch } from 'vue'
 
-import { type SystemLogViewerEvent, getRecentSystemLogEvents, subscribeToSystemLogEvents } from '@/libs/system-logging'
+import { getRecentSystemLogEvents, subscribeToSystemLogEvents } from '@/libs/system-logging'
+import type { ConsoleViewerEvent } from '@/types/console-viewer'
 
-defineProps<{
+const props = defineProps<{
   /**
-   * Whether system logging (console capture) is currently enabled. Used only to show a helpful empty state.
+   * Returns the initial set of events to render. Defaults to the system console log buffer.
    */
-  loggingEnabled?: boolean
+  getRecentEvents?: () => ConsoleViewerEvent[]
+  /**
+   * Subscribes to new events, returning an unsubscribe function. Defaults to the system console log stream.
+   */
+  subscribe?: (listener: (event: ConsoleViewerEvent) => void) => () => void
+  /**
+   * Severity levels to offer as filter chips. Pass an empty array to hide the level UI entirely.
+   */
+  levels?: string[]
+  /**
+   * Message shown when there are no events and no active filter.
+   */
+  emptyMessage?: string
+  /**
+   * Whether the underlying source is currently disabled (used only for the empty-state message).
+   */
+  disabled?: boolean
+  /**
+   * Message shown when {@link disabled} is true and there are no events.
+   */
+  disabledMessage?: string
 }>()
 
 // Keep the rendered/working set bounded so filtering and memory stay cheap regardless of log volume.
@@ -103,17 +127,20 @@ const maxRows = 2000
 // Coalesce incoming events into a single reactive update at this cadence, instead of one render per log.
 const flushIntervalMs = 150
 
-const availableLevels = ['error', 'warn', 'info', 'debug', 'trace', 'log']
+const defaultLevels = ['error', 'warn', 'info', 'debug', 'trace', 'log']
+const availableLevels = computed(() => props.levels ?? defaultLevels)
+const showLevels = computed(() => availableLevels.value.length > 0)
+const emptyText = computed(() => props.emptyMessage ?? 'No entries captured yet.')
 
 // Master list is a plain (non-reactive) array; only the filtered result is reactive (shallow) for the scroller.
-let allEvents: SystemLogViewerEvent[] = []
-let pending: SystemLogViewerEvent[] = []
-const displayedEvents = shallowRef<SystemLogViewerEvent[]>([])
+let allEvents: ConsoleViewerEvent[] = []
+let pending: ConsoleViewerEvent[] = []
+const displayedEvents = shallowRef<ConsoleViewerEvent[]>([])
 const totalCount = ref(0)
 
 const searchText = ref('')
 const invertSearch = ref(false)
-const activeLevels = ref<string[]>([...availableLevels])
+const activeLevels = ref<string[]>([...availableLevels.value])
 const autoScroll = ref(true)
 const scrollerRef = ref<{
   /** Root scroll element of the virtual scroller */
@@ -122,13 +149,15 @@ const scrollerRef = ref<{
   scrollToBottom?: () => void
 } | null>(null)
 
-const isFiltering = computed(() => searchText.value.trim() !== '' || activeLevels.value.length < availableLevels.length)
+const isFiltering = computed(
+  () => searchText.value.trim() !== '' || activeLevels.value.length < availableLevels.value.length
+)
 
 let unsubscribe: (() => void) | undefined
 let flushTimer: ReturnType<typeof setInterval> | undefined
 
-const matchesFilter = (event: SystemLogViewerEvent): boolean => {
-  if (!activeLevels.value.includes(event.level)) return false
+const matchesFilter = (event: ConsoleViewerEvent): boolean => {
+  if (showLevels.value && event.level !== undefined && !activeLevels.value.includes(event.level)) return false
   const query = searchText.value.trim().toLowerCase()
   if (query) {
     const hit = event.msg.toLowerCase().includes(query)
@@ -192,7 +221,9 @@ const clearView = (): void => {
 }
 
 const copyVisible = (): void => {
-  const text = displayedEvents.value.map((e) => `${formatTime(e.epoch)} [${e.level}] ${e.msg}`).join('\n')
+  const text = displayedEvents.value
+    .map((e) => `${formatTime(e.epoch)}${e.level ? ` [${e.level}]` : ''} ${e.msg}`)
+    .join('\n')
   navigator.clipboard?.writeText(text)
 }
 
@@ -240,12 +271,15 @@ watch(autoScroll, (following) => {
 })
 
 onMounted(() => {
-  allEvents = getRecentSystemLogEvents()
+  const getRecent = props.getRecentEvents ?? getRecentSystemLogEvents
+  const subscribeToSource = props.subscribe ?? subscribeToSystemLogEvents
+
+  allEvents = getRecent()
   if (allEvents.length > maxRows) allEvents = allEvents.slice(allEvents.length - maxRows)
   totalCount.value = allEvents.length
   rebuildDisplayed()
 
-  unsubscribe = subscribeToSystemLogEvents((event) => pending.push(event))
+  unsubscribe = subscribeToSource((event) => pending.push(event))
   flushTimer = setInterval(flush, flushIntervalMs)
 
   nextTick(scrollToBottom)

--- a/src/components/MainMenu.vue
+++ b/src/components/MainMenu.vue
@@ -208,6 +208,7 @@ import ConfigurationJoystickView from '@/views/ConfigurationJoystickView.vue'
 import ConfigurationTelemetryView from '@/views/ConfigurationLogsView.vue'
 import ConfigurationMAVLinkView from '@/views/ConfigurationMAVLinkView.vue'
 import ConfigurationMissionView from '@/views/ConfigurationMissionView.vue'
+import ConfigurationSourcesView from '@/views/ConfigurationSourcesView.vue'
 import ConfigurationUIView from '@/views/ConfigurationUIView.vue'
 import ConfigurationVideoView from '@/views/ConfigurationVideoView.vue'
 import ToolsDataLakeView from '@/views/ToolsDataLakeView.vue'
@@ -384,6 +385,12 @@ const configMenu = computed(() => {
       title: 'Actions',
       componentName: SubMenuComponentName.SettingsActions,
       component: markRaw(ConfigurationActionsView) as SubMenuComponent,
+    },
+    {
+      icon: 'mdi-import',
+      title: 'Sources',
+      componentName: SubMenuComponentName.SettingsSources,
+      component: markRaw(ConfigurationSourcesView) as SubMenuComponent,
     },
   ]
 

--- a/src/components/sources/GnssDeviceDialog.vue
+++ b/src/components/sources/GnssDeviceDialog.vue
@@ -1,0 +1,293 @@
+<template>
+  <InteractionDialog
+    :show-dialog="modelValue"
+    :title="dialogTitle"
+    variant="text-only"
+    max-width="640"
+    @update:show-dialog="onDialogUpdate"
+  >
+    <template #content>
+      <div class="flex gap-x-2 absolute top-0 right-0 py-2 pr-3">
+        <v-btn icon :width="34" :height="34" variant="text" class="bg-transparent top-2 right-2" @click="close">
+          <v-icon :size="22">mdi-close</v-icon>
+        </v-btn>
+      </div>
+      <div v-if="device" class="flex flex-col gap-y-4 px-1 -mt-7 text-white">
+        <v-text-field
+          v-model="device.name"
+          label="Name"
+          variant="outlined"
+          density="compact"
+          hide-details
+          :disabled="!gnss.isSupported"
+        />
+        <div v-if="create" class="-mt-2 text-xs opacity-60">
+          Planned ID: <span class="font-mono">{{ plannedId }}</span>
+        </div>
+
+        <div class="flex items-center gap-x-2">
+          <v-select
+            v-model="device.port"
+            :items="gnss.availablePorts.value"
+            item-title="path"
+            item-value="path"
+            label="Serial port"
+            theme="dark"
+            variant="outlined"
+            density="compact"
+            hide-details
+            :disabled="!gnss.isSupported"
+            no-data-text="No serial ports found"
+            class="flex-1"
+            @update:model-value="onPortSelected"
+          />
+          <v-btn icon="mdi-refresh" variant="text" size="small" :disabled="!gnss.isSupported" @click="onRefreshPorts" />
+        </div>
+        <div v-if="device.port && !device.usbMatch?.vendorId" class="-mt-2 text-xs text-amber-300/80">
+          This device reports no USB model id, so auto-connect won't follow it to other computers.
+        </div>
+
+        <div class="flex items-center gap-x-2">
+          <v-select
+            v-model="device.baud"
+            :items="commonBaudRates"
+            label="Baud rate"
+            theme="dark"
+            variant="outlined"
+            density="compact"
+            hide-details
+            :disabled="!gnss.isSupported"
+            class="flex-1"
+          />
+          <v-btn
+            variant="text"
+            size="small"
+            :loading="gnss.detecting[activeId]"
+            :disabled="!gnss.isSupported || !device.port"
+            @click="onAutodetect"
+          >
+            Auto-detect
+          </v-btn>
+        </div>
+
+        <div class="flex items-center justify-between">
+          <div class="flex items-center gap-x-2">
+            <v-icon :color="statusColor" size="small">{{ statusIcon }}</v-icon>
+            <span class="text-sm capitalize">{{ statusLabel }}</span>
+          </div>
+          <v-btn
+            v-if="isActive"
+            variant="flat"
+            size="small"
+            class="bg-[#FFFFFF22]"
+            @click="gnss.disconnectDevice(activeId)"
+          >
+            Disconnect
+          </v-btn>
+          <v-btn
+            v-else
+            variant="flat"
+            size="small"
+            class="bg-[#FFFFFF22]"
+            :disabled="!gnss.isSupported || !device.port"
+            @click="gnss.connectDevice(activeId)"
+          >
+            Connect
+          </v-btn>
+        </div>
+
+        <ExpansiblePanel compact no-top-divider no-bottom-divider :is-expanded="false">
+          <template #title>Device Status</template>
+          <template #content>
+            <div v-if="fix" class="grid grid-cols-2 gap-2 w-full text-sm mt-2">
+              <div
+                v-for="item in statusItems"
+                :key="item.label"
+                class="flex justify-between px-3 py-1 rounded bg-[#FFFFFF11]"
+              >
+                <span class="opacity-70">{{ item.label }}</span>
+                <span class="font-mono">{{ item.value }}</span>
+              </div>
+            </div>
+            <div v-else class="text-sm opacity-60 mt-2">No data received yet.</div>
+          </template>
+        </ExpansiblePanel>
+
+        <div class="flex items-center justify-between">
+          <span class="text-xs opacity-60 font-mono">Variables: external/positioning/gnss/{{ displayId }}/*</span>
+          <v-btn
+            variant="text"
+            size="small"
+            :prepend-icon="consoleOpen ? 'mdi-chevron-up' : 'mdi-console-line'"
+            @click="toggleConsole"
+          >
+            {{ consoleOpen ? 'Hide console' : 'Serial console' }}
+          </v-btn>
+        </div>
+
+        <div v-if="consoleOpen" class="h-[280px]">
+          <ConsoleViewer
+            :get-recent-events="() => getRecentSerialLines(activeId)"
+            :subscribe="(listener) => subscribeToSerialLines(activeId, listener)"
+            :levels="[]"
+            empty-message="No serial data received yet. Connect the device to see incoming data."
+          />
+        </div>
+      </div>
+    </template>
+    <template #actions>
+      <template v-if="create">
+        <v-spacer></v-spacer>
+        <v-btn text :disabled="!device?.name" @click="onAdd">Add device</v-btn>
+      </template>
+      <template v-else>
+        <v-btn text @click="onDelete">Delete device</v-btn>
+        <v-spacer></v-spacer>
+        <v-btn text @click="close">Close</v-btn>
+      </template>
+    </template>
+  </InteractionDialog>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+import ConsoleViewer from '@/components/ConsoleViewer.vue'
+import ExpansiblePanel from '@/components/ExpansiblePanel.vue'
+import InteractionDialog from '@/components/InteractionDialog.vue'
+import { useInteractionDialog } from '@/composables/interactionDialog'
+import { openSnackbar } from '@/composables/snackbar'
+import { useGnss } from '@/composables/useGnss'
+import {
+  commonBaudRates,
+  getRecentSerialLines,
+  gnssStatusColor,
+  gnssStatusIcon,
+  gnssStatusLabel,
+  subscribeToSerialLines,
+} from '@/libs/sensors/gnss'
+import { fixQualityLabel } from '@/libs/sensors/nmea'
+
+const props = defineProps<{
+  /** Whether the dialog is open. */
+  modelValue: boolean
+  /** The id of the device to configure. Ignored in create mode. */
+  deviceId?: string
+  /** When true, the dialog edits an unsaved draft that is only persisted on "Add device". */
+  create?: boolean
+}>()
+
+const emit = defineEmits<{
+  /** Emitted when the open state changes. */
+  (event: 'update:modelValue', value: boolean): void
+}>()
+
+const gnss = useGnss()
+const { showDialog, closeDialog } = useInteractionDialog()
+
+const device = computed(() =>
+  props.create ? gnss.draft.value : gnss.devices.value.find((e) => e.id === props.deviceId)
+)
+const activeId = computed(() => device.value?.id ?? '')
+const plannedId = computed(() => gnss.planDeviceId(device.value?.name ?? ''))
+const displayId = computed(() => (props.create ? plannedId.value : activeId.value))
+const dialogTitle = computed(() => (props.create ? 'Add GNSS device' : `Configure ${device.value?.name ?? 'device'}`))
+
+const status = computed(() => gnss.statuses[activeId.value] ?? 'disconnected')
+const fix = computed(() => gnss.latestFixes[activeId.value])
+const isActive = computed(() => status.value !== 'disconnected')
+
+const consoleOpen = ref(false)
+
+const onDialogUpdate = (value: boolean): void => {
+  if (!value && props.create && gnss.draft.value) gnss.cancelCreate()
+  emit('update:modelValue', value)
+}
+
+const close = (): void => onDialogUpdate(false)
+
+const statusLabel = computed(() => gnssStatusLabel(status.value))
+const statusColor = computed(() => gnssStatusColor(status.value))
+const statusIcon = computed(() => gnssStatusIcon(status.value))
+
+const formatNumber = (value: number | undefined, digits: number): string =>
+  value === undefined ? '-' : value.toFixed(digits)
+
+const statusItems = computed(() => {
+  const current = fix.value
+  if (!current) return []
+  return [
+    { label: 'Fix', value: current.fixQualityLabel ?? fixQualityLabel(current.fixQuality ?? 0) },
+    { label: 'Fix mode', value: current.fixMode === undefined ? '-' : `${current.fixMode}D`.replace('1D', 'No fix') },
+    { label: 'Latitude', value: formatNumber(current.latitude, 7) },
+    { label: 'Longitude', value: formatNumber(current.longitude, 7) },
+    {
+      label: 'Altitude (MSL)',
+      value: current.altitudeMslM === undefined ? '-' : `${formatNumber(current.altitudeMslM, 1)} m`,
+    },
+    { label: 'Satellites used', value: current.satellitesUsed?.toString() ?? '-' },
+    { label: 'Satellites in view', value: current.satellitesInView?.toString() ?? '-' },
+    { label: 'HDOP', value: formatNumber(current.hdop, 2) },
+    {
+      label: 'Speed',
+      value: current.speedOverGroundMps === undefined ? '-' : `${formatNumber(current.speedOverGroundMps, 2)} m/s`,
+    },
+    { label: 'UTC time', value: current.utcTime ?? '-' },
+  ]
+})
+
+const onRefreshPorts = (): void => {
+  logUserAction('Refreshed GNSS serial port list')
+  gnss.refreshPorts()
+}
+
+const onPortSelected = (path: string | null): void => {
+  const current = device.value
+  if (!current) return
+  const info = gnss.availablePorts.value.find((port) => port.path === path)
+  current.usbMatch = info
+    ? { vendorId: info.vendorId, productId: info.productId, manufacturer: info.manufacturer }
+    : undefined
+}
+
+const toggleConsole = (): void => {
+  consoleOpen.value = !consoleOpen.value
+  logUserAction(`${consoleOpen.value ? 'Opened' : 'Closed'} serial console for GNSS device "${activeId.value}"`)
+}
+
+const onAutodetect = async (): Promise<void> => {
+  const detected = await gnss.autodetect(activeId.value)
+  openSnackbar({
+    message:
+      detected !== null ? `Detected baud rate: ${detected}` : 'Could not detect a baud rate with valid GNSS data.',
+    variant: detected !== null ? 'success' : 'error',
+    duration: 4000,
+  })
+}
+
+const onAdd = async (): Promise<void> => {
+  await gnss.commitCreate()
+  emit('update:modelValue', false)
+}
+
+const onDelete = (): void => {
+  const name = device.value?.name ?? activeId.value
+  showDialog({
+    variant: 'warning',
+    title: 'Delete GNSS device?',
+    message: `Delete "${name}"? This disconnects it and removes its data-lake variables.`,
+    actions: [
+      { text: 'Cancel', size: 'small', action: closeDialog },
+      {
+        text: 'Delete',
+        size: 'small',
+        action: async () => {
+          closeDialog()
+          await gnss.removeDevice(activeId.value)
+          close()
+        },
+      },
+    ],
+  })
+}
+</script>

--- a/src/composables/useGnss.ts
+++ b/src/composables/useGnss.ts
@@ -1,0 +1,211 @@
+import { reactive, ref } from 'vue'
+
+import { useBlueOsStorage } from '@/composables/settingsSyncer'
+import {
+  autodetectBaud,
+  clearSerialLines,
+  defaultBaudRate,
+  deleteDeviceVariables,
+  forgetDeviceState,
+  getDeviceStatus,
+  getLatestFix,
+  gnssDevicesKey,
+  listSerialPorts,
+  registerDeviceVariables,
+  startGnssDevice,
+  stopGnssDevice,
+  subscribeToDeviceState,
+} from '@/libs/sensors/gnss'
+import { isElectron, machinizeString } from '@/libs/utils'
+import type { GnssDevice, GnssState } from '@/types/gnss'
+import type { SerialPortInfo } from '@/types/serial'
+
+let state: GnssState | undefined
+
+/**
+ * Builds a machine-friendly, de-duplicated device id from a display name.
+ * @param {string} name - The device name to derive the id from.
+ * @param {string[]} existingIds - Ids already in use, which the result must not collide with.
+ * @returns {string} A unique machinized id (falls back to `gnss` when the name has no usable characters).
+ */
+const generateDeviceId = (name: string, existingIds: string[]): string => {
+  const base = machinizeString(name) || 'gnss'
+  if (!existingIds.includes(base)) return base
+  let suffix = 2
+  while (existingIds.includes(`${base}-${suffix}`)) suffix++
+  return `${base}-${suffix}`
+}
+
+/**
+ * Builds the shared GNSS UI state: persisted devices, an optional in-progress draft, reactive per-device
+ * status/fix maps mirrored from the manager, and the actions the Sources UI calls into.
+ * @returns {GnssState} The initialized state object.
+ */
+const createState = (): GnssState => {
+  const isSupported = isElectron()
+  const devices = useBlueOsStorage<GnssDevice[]>(gnssDevicesKey, [])
+  const draft = ref<GnssDevice | null>(null)
+  const statuses = reactive<GnssState['statuses']>({})
+  const latestFixes = reactive<GnssState['latestFixes']>({})
+  const detecting = reactive<GnssState['detecting']>({})
+  const availablePorts = ref<SerialPortInfo[]>([])
+
+  // Mirror the manager's device state into reactive maps for the UI. The reading/data-lake pipeline is
+  // driven by the manager (bootstrapped in main.ts), independently of this composable.
+  for (const device of devices.value) {
+    statuses[device.id] = getDeviceStatus(device.id)
+    latestFixes[device.id] = getLatestFix(device.id)
+  }
+  subscribeToDeviceState((id, deviceState) => {
+    statuses[id] = deviceState.status
+    latestFixes[id] = deviceState.fix
+  })
+
+  const findDevice = (id: string): GnssDevice | undefined => devices.value.find((device) => device.id === id)
+  const findDeviceOrDraft = (id: string): GnssDevice | undefined =>
+    draft.value?.id === id ? draft.value : findDevice(id)
+
+  const planDeviceId = (name: string): string =>
+    generateDeviceId(
+      name,
+      devices.value.map((device) => device.id)
+    )
+
+  const refreshPorts = async (): Promise<void> => {
+    availablePorts.value = await listSerialPorts()
+  }
+
+  const connectDevice = async (id: string): Promise<void> => {
+    const isDraft = draft.value?.id === id
+    const device = findDeviceOrDraft(id)
+    if (!isSupported || !device || !device.port) return
+    device.enabled = true
+    // Drafts preview the stream without registering/publishing data-lake variables until saved.
+    await startGnssDevice(device, !isDraft)
+    logUserAction(`Connected GNSS "${device.name}" on ${device.port} at ${device.baud} baud`)
+  }
+
+  const disconnectDevice = async (id: string): Promise<void> => {
+    const device = findDeviceOrDraft(id)
+    if (device) device.enabled = false
+    await stopGnssDevice(id)
+    logUserAction(`Disconnected GNSS "${device?.name ?? id}"`)
+  }
+
+  const beginCreate = (): GnssDevice => {
+    const name = `GNSS ${devices.value.length + 1}`
+    const device: GnssDevice = { id: `draft-${Date.now()}`, name, port: '', baud: defaultBaudRate, enabled: false }
+    draft.value = device
+    statuses[device.id] = 'disconnected'
+    logUserAction('Started GNSS device creation')
+    return device
+  }
+
+  const clearDeviceRuntimeState = async (id: string): Promise<void> => {
+    await stopGnssDevice(id)
+    clearSerialLines(id)
+    forgetDeviceState(id)
+    delete detecting[id]
+  }
+
+  const cancelCreate = async (): Promise<void> => {
+    const current = draft.value
+    if (!current) return
+    logUserAction('Cancelled GNSS device creation')
+    await clearDeviceRuntimeState(current.id)
+    delete statuses[current.id]
+    delete latestFixes[current.id]
+    draft.value = null
+  }
+
+  const commitCreate = async (): Promise<string | null> => {
+    const current = draft.value
+    if (!current) return null
+
+    const wasConnected = (statuses[current.id] ?? 'disconnected') !== 'disconnected'
+    const id = planDeviceId(current.name)
+
+    // Release the preview connection and its transient state before creating the persistent device.
+    await clearDeviceRuntimeState(current.id)
+    delete statuses[current.id]
+    delete latestFixes[current.id]
+    draft.value = null
+
+    const device: GnssDevice = {
+      id,
+      name: current.name,
+      port: current.port,
+      baud: current.baud,
+      enabled: wasConnected,
+      usbMatch: current.usbMatch,
+    }
+    devices.value.push(device)
+    registerDeviceVariables(device)
+    statuses[id] = 'disconnected'
+    logUserAction(`Added GNSS device "${device.name}"`)
+
+    if (wasConnected) {
+      connectDevice(id).catch((error) => console.error('[GNSS] Failed to connect after creation:', error))
+    }
+    return id
+  }
+
+  const removeDevice = async (id: string): Promise<void> => {
+    const device = findDevice(id)
+    logUserAction(`Removed GNSS device "${device?.name ?? id}"`)
+    await clearDeviceRuntimeState(id)
+    deleteDeviceVariables(id)
+    const index = devices.value.findIndex((entry) => entry.id === id)
+    if (index !== -1) devices.value.splice(index, 1)
+    delete statuses[id]
+    delete latestFixes[id]
+  }
+
+  const autodetect = async (id: string): Promise<number | null> => {
+    const device = findDeviceOrDraft(id)
+    if (!isSupported || !device || !device.port) return null
+    logUserAction(`Started GNSS baud auto-detection on ${device.port}`)
+    detecting[id] = true
+    try {
+      const detected = await autodetectBaud(device.port)
+      if (detected !== null) {
+        device.baud = detected
+        logUserAction(`Detected GNSS baud rate: ${detected}`)
+      }
+      return detected
+    } finally {
+      detecting[id] = false
+    }
+  }
+
+  if (isSupported) refreshPorts()
+
+  return {
+    devices,
+    draft,
+    statuses,
+    latestFixes,
+    detecting,
+    availablePorts,
+    isSupported,
+    refreshPorts,
+    beginCreate,
+    cancelCreate,
+    commitCreate,
+    planDeviceId,
+    removeDevice,
+    connectDevice,
+    disconnectDevice,
+    autodetect,
+  }
+}
+
+/**
+ * Reactive access to the GNSS feature for the UI. State is created once and shared across all callers.
+ * The reading/data-lake pipeline itself runs independently via `initGnss` and does not require this.
+ * @returns {GnssState} The shared GNSS state and actions.
+ */
+export const useGnss = (): GnssState => {
+  if (!state) state = createState()
+  return state
+}

--- a/src/electron/services/link/index.ts
+++ b/src/electron/services/link/index.ts
@@ -1,9 +1,15 @@
 import { BrowserWindow, ipcMain } from 'electron'
 
+import type { SerialPortInfo } from '../../../types/serial'
 import { Link } from './link'
 import { SerialLink } from './serial'
 import { TcpLink } from './tcp'
 import { UdpLink } from './udp'
+
+// We need to use SerialPort with require here (as done in serial.ts), because bundling the ESM import as a
+// value pulls the native @serialport/bindings-cpp binary into the bundle and breaks its runtime resolution.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const SerialPortObject = require('serialport').SerialPort
 
 /**
  * Serial service for electron
@@ -34,6 +40,17 @@ class LinkService {
    * Setup IPC handlers
    */
   private setupIpcHandlers(): void {
+    ipcMain.handle('serial-list-ports', async () => {
+      const ports = await SerialPortObject.list()
+      return ports.map((port: SerialPortInfo) => ({
+        path: port.path,
+        manufacturer: port.manufacturer,
+        serialNumber: port.serialNumber,
+        vendorId: port.vendorId,
+        productId: port.productId,
+      }))
+    })
+
     ipcMain.handle('link-open', async (_, { path }): Promise<boolean> => {
       console.log(`Attempting to open link: ${path}`)
 

--- a/src/libs/cosmos.ts
+++ b/src/libs/cosmos.ts
@@ -6,7 +6,7 @@ import type { ElectronSDLJoystickControllerStateEventData } from '@/types/joysti
 import { NetworkInfo } from '@/types/network'
 import type { TelemetrySystemHardwareInfo } from '@/types/platform'
 import { SDLStatus } from '@/types/sdl'
-import type { SerialData } from '@/types/serial'
+import type { SerialData, SerialPortInfo } from '@/types/serial'
 import type { FileDialogOptions, FileStats } from '@/types/storage'
 import type { Go2RTCStreamInfo } from '@/types/video'
 
@@ -356,6 +356,11 @@ declare global {
        * Capture the workspace area of the application
        */
       captureWorkspace(rect?: Electron.Rectangle): Promise<Uint8Array>
+      /**
+       * List the serial ports available on the system
+       * @returns The list of available serial ports
+       */
+      serialListPorts: () => Promise<SerialPortInfo[]>
       /**
        * Open a link connection
        */

--- a/src/libs/sensors/gnss.ts
+++ b/src/libs/sensors/gnss.ts
@@ -1,0 +1,606 @@
+/**
+ * Orchestrates one or more external USB/serial NMEA GNSS receivers and publishes their data into the data
+ * lake.
+ *
+ * This module is Electron-only: it reuses the existing serial byte pipeline exposed on
+ * `window.electronAPI` (`linkOpen`/`onLinkData`/`linkClose`, backed by the `serialport` package in the
+ * main process) to stream raw bytes, decodes them with {@link NmeaAggregator}, and mirrors the resulting
+ * {@link GnssFix} into per-device `external/positioning/gnss/<id>/*` variables. It has no Vue dependencies; reactive
+ * orchestration lives in the `useGnss` composable.
+ */
+
+import {
+  createDataLakeVariable,
+  DataLakeVariable,
+  deleteDataLakeVariable,
+  getDataLakeVariableInfo,
+  setDataLakeVariableData,
+  updateDataLakeVariableInfo,
+} from '@/libs/actions/data-lake'
+import { NmeaAggregator, parseNmeaSentence } from '@/libs/sensors/nmea'
+import { settingsManager } from '@/libs/settings-management'
+import { isElectron } from '@/libs/utils'
+import type {
+  GnssDevice,
+  GnssDeviceInfo,
+  GnssDeviceRuntime,
+  GnssDeviceState,
+  GnssDeviceStateListener,
+  GnssField,
+  GnssFix,
+  GnssStatus,
+  SerialLineEvent,
+} from '@/types/gnss'
+import type { SerialPortInfo } from '@/types/serial'
+
+/** Baud rates offered in the UI, ordered by likelihood for consumer GNSS receivers. */
+export const commonBaudRates = [9600, 4800, 38400, 19200, 57600, 115200]
+
+/** Default baud rate, matching the most common consumer GNSS default. */
+export const defaultBaudRate = 9600
+
+/** Persistence key for the configured GNSS devices. */
+export const gnssDevicesKey = 'cockpit-gnss-devices'
+
+/** Field definitions published per device, shared by variable registration and value publishing. */
+export const gnssFields: GnssField[] = [
+  {
+    suffix: 'latitude',
+    label: 'Latitude',
+    type: 'number',
+    description: 'Latitude in decimal degrees.',
+    read: (f) => f.latitude,
+  },
+  {
+    suffix: 'longitude',
+    label: 'Longitude',
+    type: 'number',
+    description: 'Longitude in decimal degrees.',
+    read: (f) => f.longitude,
+  },
+  {
+    suffix: 'altitude-msl',
+    label: 'Altitude (MSL)',
+    type: 'number',
+    description: 'Altitude above mean sea level, in meters.',
+    read: (f) => f.altitudeMslM,
+  },
+  {
+    suffix: 'geoid-separation',
+    label: 'Geoid separation',
+    type: 'number',
+    description: 'Geoidal separation, in meters.',
+    read: (f) => f.geoidSeparationM,
+  },
+  {
+    suffix: 'satellites-used',
+    label: 'Satellites used',
+    type: 'number',
+    description: 'Satellites used in the position solution.',
+    read: (f) => f.satellitesUsed,
+  },
+  {
+    suffix: 'satellites-in-view',
+    label: 'Satellites in view',
+    type: 'number',
+    description: 'Satellites currently in view.',
+    read: (f) => f.satellitesInView,
+  },
+  {
+    suffix: 'fix-quality',
+    label: 'Fix quality',
+    type: 'number',
+    description: 'GGA fix quality code (0 none, 1 GNSS, 2 DGPS, 4 RTK fixed, 5 RTK float).',
+    read: (f) => f.fixQuality,
+  },
+  {
+    suffix: 'fix-quality-label',
+    label: 'Fix quality label',
+    type: 'string',
+    description: 'Human-readable fix quality.',
+    read: (f) => f.fixQualityLabel,
+  },
+  {
+    suffix: 'fix-mode',
+    label: 'Fix mode',
+    type: 'number',
+    description: 'GSA fix mode (1 none, 2 = 2D, 3 = 3D).',
+    read: (f) => f.fixMode,
+  },
+  {
+    suffix: 'hdop',
+    label: 'HDOP',
+    type: 'number',
+    description: 'Horizontal dilution of precision.',
+    read: (f) => f.hdop,
+  },
+  {
+    suffix: 'pdop',
+    label: 'PDOP',
+    type: 'number',
+    description: 'Positional dilution of precision.',
+    read: (f) => f.pdop,
+  },
+  {
+    suffix: 'vdop',
+    label: 'VDOP',
+    type: 'number',
+    description: 'Vertical dilution of precision.',
+    read: (f) => f.vdop,
+  },
+  {
+    suffix: 'speed-over-ground',
+    label: 'Speed over ground',
+    type: 'number',
+    description: 'Speed over ground, in meters per second.',
+    read: (f) => f.speedOverGroundMps,
+  },
+  {
+    suffix: 'course-over-ground',
+    label: 'Course over ground',
+    type: 'number',
+    description: 'Course over ground, in degrees.',
+    read: (f) => f.courseOverGroundDeg,
+  },
+  {
+    suffix: 'utc-time',
+    label: 'UTC time',
+    type: 'string',
+    description: 'UTC time of the last position report.',
+    read: (f) => f.utcTime,
+  },
+]
+
+const noDataTimeoutMs = 5000
+// Delay after closing a probed port before opening the next, giving the OS time to release the device.
+const probeSettleMs = 300
+const validSentenceThreshold = 3
+const maxSerialLines = 2000
+
+const pathHandlers = new Map<string, (bytes: number[]) => void>()
+const runtimes = new Map<string, GnssDeviceRuntime>()
+const deviceStatuses = new Map<string, GnssStatus>()
+const deviceFixes = new Map<string, GnssFix>()
+const stateListeners = new Set<GnssDeviceStateListener>()
+const serialLineBuffers = new Map<string, SerialLineEvent[]>()
+const serialLineListeners = new Map<string, Set<(event: SerialLineEvent) => void>>()
+
+let listenerRegistered = false
+let serialLineIdCounter = 0
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+const notifyDeviceState = (deviceId: string): void => {
+  const state: GnssDeviceState = {
+    status: deviceStatuses.get(deviceId) ?? 'disconnected',
+    fix: deviceFixes.get(deviceId),
+  }
+  stateListeners.forEach((listener) => listener(deviceId, state))
+}
+
+/**
+ * Returns a device's current connection status.
+ * @param {string} deviceId - The device id.
+ * @returns {GnssStatus} The current status.
+ */
+export const getDeviceStatus = (deviceId: string): GnssStatus => deviceStatuses.get(deviceId) ?? 'disconnected'
+
+/**
+ * Returns a device's latest consolidated fix, if any.
+ * @param {string} deviceId - The device id.
+ * @returns {GnssFix | undefined} The latest fix, or undefined when no data has been received.
+ */
+export const getLatestFix = (deviceId: string): GnssFix | undefined => deviceFixes.get(deviceId)
+
+/**
+ * Subscribes to per-device status and fix changes.
+ * @param {GnssDeviceStateListener} listener - Called whenever a device's status or fix changes.
+ * @returns {() => void} An unsubscribe function.
+ */
+export const subscribeToDeviceState = (listener: GnssDeviceStateListener): (() => void) => {
+  stateListeners.add(listener)
+  return () => stateListeners.delete(listener)
+}
+
+/**
+ * Maps a connection status to a display color.
+ * @param {GnssStatus} status - The connection status.
+ * @returns {string} The corresponding color name.
+ */
+export const gnssStatusColor = (status: GnssStatus): string => {
+  switch (status) {
+    case 'connected':
+      return 'success'
+    case 'connecting':
+    case 'no-data':
+      return 'warning'
+    default:
+      return 'grey'
+  }
+}
+
+/**
+ * Maps a connection status to a display icon.
+ * @param {GnssStatus} status - The connection status.
+ * @returns {string} The corresponding mdi icon name.
+ */
+export const gnssStatusIcon = (status: GnssStatus): string => {
+  switch (status) {
+    case 'connected':
+      return 'mdi-check-circle'
+    case 'connecting':
+      return 'mdi-progress-clock'
+    case 'no-data':
+      return 'mdi-alert-circle'
+    default:
+      return 'mdi-circle-outline'
+  }
+}
+
+/**
+ * Maps a connection status to a human-readable label.
+ * @param {GnssStatus} status - The connection status.
+ * @returns {string} The label.
+ */
+export const gnssStatusLabel = (status: GnssStatus): string => (status === 'no-data' ? 'connected (no data)' : status)
+
+const recordSerialLine = (deviceId: string, line: string): void => {
+  const msg = line.replace(/\r$/, '').trim()
+  if (!msg) return
+  serialLineIdCounter += 1
+  const event: SerialLineEvent = { id: serialLineIdCounter, epoch: Date.now(), msg }
+  let buffer = serialLineBuffers.get(deviceId)
+  if (!buffer) {
+    buffer = []
+    serialLineBuffers.set(deviceId, buffer)
+  }
+  buffer.push(event)
+  if (buffer.length > maxSerialLines) buffer.shift()
+  serialLineListeners.get(deviceId)?.forEach((listener) => listener(event))
+}
+
+/**
+ * Returns the recently captured raw serial lines for a device.
+ * @param {string} deviceId - The device id.
+ * @returns {SerialLineEvent[]} A copy of the device's recent serial lines.
+ */
+export const getRecentSerialLines = (deviceId: string): SerialLineEvent[] =>
+  (serialLineBuffers.get(deviceId) ?? []).slice()
+
+/**
+ * Subscribes to raw serial lines received from a device.
+ * @param {string} deviceId - The device id.
+ * @param {(event: SerialLineEvent) => void} listener - Called for each new line.
+ * @returns {() => void} An unsubscribe function.
+ */
+export const subscribeToSerialLines = (deviceId: string, listener: (event: SerialLineEvent) => void): (() => void) => {
+  let set = serialLineListeners.get(deviceId)
+  if (!set) {
+    set = new Set()
+    serialLineListeners.set(deviceId, set)
+  }
+  set.add(listener)
+  return () => serialLineListeners.get(deviceId)?.delete(listener)
+}
+
+/**
+ * Clears the captured serial line buffer for a device.
+ * @param {string} deviceId - The device id.
+ * @returns {void}
+ */
+export const clearSerialLines = (deviceId: string): void => {
+  serialLineBuffers.delete(deviceId)
+}
+
+/**
+ * Forgets a device's cached status and fix, notifying listeners of the reset.
+ * @param {string} deviceId - The device id.
+ * @returns {void}
+ */
+export const forgetDeviceState = (deviceId: string): void => {
+  deviceStatuses.delete(deviceId)
+  deviceFixes.delete(deviceId)
+  notifyDeviceState(deviceId)
+}
+
+/**
+ * Builds the data-lake variable id for a device field.
+ * @param {string} deviceId - The device id.
+ * @param {string} suffix - The field suffix.
+ * @returns {string} The full variable id.
+ */
+export const deviceVariableId = (deviceId: string, suffix: string): string =>
+  `external/positioning/gnss/${deviceId}/${suffix}`
+
+/**
+ * Builds the list of data-lake variables produced by a device.
+ * @param {GnssDeviceInfo} device - The device to build variables for.
+ * @returns {DataLakeVariable[]} The device's data-lake variables.
+ */
+export const gnssVariablesForDevice = (device: GnssDeviceInfo): DataLakeVariable[] =>
+  gnssFields.map((field) => ({
+    id: deviceVariableId(device.id, field.suffix),
+    name: `${device.name} - ${field.label}`,
+    type: field.type,
+    description: field.description,
+  }))
+
+/**
+ * Builds a serial URI that opens the given port at the given baud rate.
+ *
+ * POSIX ports (e.g. `/dev/ttyUSB0`) already start with a slash and become `serial:///dev/ttyUSB0`, while
+ * Windows ports (e.g. `COM3`) become the opaque `serial:COM3`; both resolve to the correct `pathname` used
+ * by the main-process `SerialLink`.
+ * @param {string} port - The serial port path.
+ * @param {number} baud - The baud rate.
+ * @returns {string} The serial URI.
+ */
+const buildSerialUri = (port: string, baud: number): string => {
+  const normalizedPort = port.startsWith('/') ? `//${port}` : port
+  return `serial:${normalizedPort}?baudrate=${baud}`
+}
+
+const setStatus = (deviceId: string, status: GnssStatus): void => {
+  if (deviceStatuses.get(deviceId) === status) return
+  deviceStatuses.set(deviceId, status)
+  notifyDeviceState(deviceId)
+}
+
+const publishDeviceFix = (deviceId: string, fix: GnssFix): void => {
+  for (const field of gnssFields) {
+    const value = field.read(fix)
+    if (value !== undefined) setDataLakeVariableData(deviceVariableId(deviceId, field.suffix), value)
+  }
+}
+
+/**
+ * Registers (or refreshes the name of) a device's `external/positioning/gnss/<id>/*` variables in the data lake, so they
+ * are discoverable (e.g. in POI editors) even before any data arrives.
+ * @param {GnssDeviceInfo} device - The device to register variables for.
+ * @returns {void}
+ */
+export const registerDeviceVariables = (device: GnssDeviceInfo): void => {
+  for (const variable of gnssVariablesForDevice(device)) {
+    if (getDataLakeVariableInfo(variable.id) === undefined) {
+      createDataLakeVariable(variable)
+    } else {
+      updateDataLakeVariableInfo(variable)
+    }
+  }
+}
+
+/**
+ * Removes a device's `external/positioning/gnss/<id>/*` variables from the data lake.
+ * @param {string} deviceId - The device id.
+ * @returns {void}
+ */
+export const deleteDeviceVariables = (deviceId: string): void => {
+  for (const field of gnssFields) {
+    const id = deviceVariableId(deviceId, field.suffix)
+    if (getDataLakeVariableInfo(id) !== undefined) deleteDataLakeVariable(id)
+  }
+}
+
+// A single `onLinkData` listener dispatches to the right per-path handler. `onLinkData` fires for every
+// serial link (including MAVLink) and cannot be unsubscribed, so we register it once and keep the per-event
+// work to a cheap Map lookup rather than adding a listener per device.
+const ensureLinkListener = (): void => {
+  if (listenerRegistered || !isElectron() || !window.electronAPI) return
+  window.electronAPI.onLinkData((data) => {
+    const handler = pathHandlers.get(data.path)
+    if (handler) handler(data.data)
+  })
+  listenerRegistered = true
+}
+
+const stopWatchdog = (runtime: GnssDeviceRuntime): void => {
+  if (runtime.watchdog === undefined) return
+  clearInterval(runtime.watchdog)
+  runtime.watchdog = undefined
+}
+
+const startWatchdog = (deviceId: string): void => {
+  const runtime = runtimes.get(deviceId)
+  if (!runtime) return
+  stopWatchdog(runtime)
+  runtime.watchdog = setInterval(() => {
+    if (Date.now() - runtime.lastValidLineAt > noDataTimeoutMs) setStatus(deviceId, 'no-data')
+  }, noDataTimeoutMs)
+}
+
+const handleDeviceBytes = (deviceId: string, bytes: number[]): void => {
+  const runtime = runtimes.get(deviceId)
+  if (!runtime) return
+  runtime.buffer += runtime.decoder.decode(new Uint8Array(bytes), { stream: true })
+  const lines = runtime.buffer.split('\n')
+  runtime.buffer = lines.pop() ?? ''
+  for (const line of lines) {
+    recordSerialLine(deviceId, line)
+    if (!runtime.aggregator.ingest(line)) continue
+    runtime.lastValidLineAt = Date.now()
+    const fix = runtime.aggregator.snapshot()
+    deviceStatuses.set(deviceId, 'connected')
+    deviceFixes.set(deviceId, fix)
+    if (runtime.publish) publishDeviceFix(deviceId, fix)
+    notifyDeviceState(deviceId)
+  }
+}
+
+/**
+ * Stops the reader for a device and closes its serial port, if open.
+ * @param {string} deviceId - The device id.
+ * @returns {Promise<void>} Resolves once the port is closed.
+ */
+export const stopGnssDevice = async (deviceId: string): Promise<void> => {
+  const runtime = runtimes.get(deviceId)
+  if (runtime) {
+    stopWatchdog(runtime)
+    pathHandlers.delete(runtime.path)
+    runtimes.delete(deviceId)
+    await window.electronAPI?.linkClose(runtime.path)
+  }
+  setStatus(deviceId, 'disconnected')
+}
+
+/**
+ * Starts reading a device's GNSS receiver from its serial port.
+ *
+ * When `publish` is true (the default) the device's data-lake variables are registered and updated; pass
+ * `publish: false` to preview an unsaved draft (parses and surfaces status/fix/serial lines without touching
+ * the data lake).
+ * @param {GnssDeviceInfo} device - The device to read from.
+ * @param {boolean} [publish] - Whether to register/update data-lake variables (false to preview a draft).
+ * @returns {Promise<void>} Resolves once the port is open.
+ * @throws {Error} When not running in Electron, or when the port cannot be opened.
+ */
+export const startGnssDevice = async (device: GnssDeviceInfo, publish = true): Promise<void> => {
+  if (!isElectron() || !window.electronAPI) {
+    throw new Error('GNSS reading is only available in the desktop version of Cockpit.')
+  }
+
+  await stopGnssDevice(device.id)
+  if (publish) registerDeviceVariables(device)
+  ensureLinkListener()
+
+  const resolvedPort = await resolveDevicePort(device)
+  if (!resolvedPort) {
+    setStatus(device.id, 'disconnected')
+    throw new Error(`No matching serial port found for "${device.name}" on this machine.`)
+  }
+
+  const path = buildSerialUri(resolvedPort, device.baud)
+  const runtime: GnssDeviceRuntime = {
+    path,
+    aggregator: new NmeaAggregator(),
+    decoder: new TextDecoder(),
+    buffer: '',
+    publish,
+    lastValidLineAt: Date.now(),
+  }
+  runtimes.set(device.id, runtime)
+  setStatus(device.id, 'connecting')
+
+  const opened = await window.electronAPI.linkOpen(path)
+  if (!opened) {
+    runtimes.delete(device.id)
+    setStatus(device.id, 'disconnected')
+    throw new Error(`Failed to open serial port ${resolvedPort}.`)
+  }
+
+  pathHandlers.set(path, (bytes) => handleDeviceBytes(device.id, bytes))
+  setStatus(device.id, 'no-data')
+  startWatchdog(device.id)
+}
+
+const stopDevicesOnPort = async (port: string): Promise<void> => {
+  const portPrefix = buildSerialUri(port, 0).split('?')[0]
+  const toStop = [...runtimes.entries()].filter(([, runtime]) => runtime.path.startsWith(portPrefix))
+  for (const [deviceId] of toStop) {
+    await stopGnssDevice(deviceId)
+  }
+}
+
+/**
+ * Probes a serial port at several baud rates and returns the first one that yields valid NMEA sentences.
+ *
+ * Any device currently reading from the same port is stopped first, since a serial port can only be opened
+ * by one reader at a time.
+ * @param {string} port - The serial port path to probe.
+ * @param {number[]} [candidates] - The baud rates to try, in order.
+ * @param {number} [perBaudMs] - How long to listen at each baud rate, in milliseconds.
+ * @returns {Promise<number | null>} The detected baud rate, or null when none produced valid data.
+ * @throws {Error} When not running in Electron.
+ */
+export const autodetectBaud = async (
+  port: string,
+  candidates: number[] = commonBaudRates,
+  perBaudMs = 1500
+): Promise<number | null> => {
+  if (!isElectron() || !window.electronAPI) {
+    throw new Error('GNSS reading is only available in the desktop version of Cockpit.')
+  }
+
+  await stopDevicesOnPort(port)
+  ensureLinkListener()
+
+  for (const baud of candidates) {
+    const uri = buildSerialUri(port, baud)
+    const probeDecoder = new TextDecoder()
+    let buffer = ''
+    let validCount = 0
+
+    pathHandlers.set(uri, (bytes) => {
+      buffer += probeDecoder.decode(new Uint8Array(bytes), { stream: true })
+      const lines = buffer.split('\n')
+      buffer = lines.pop() ?? ''
+      for (const line of lines) {
+        if (parseNmeaSentence(line)) validCount++
+      }
+    })
+
+    const opened = await window.electronAPI.linkOpen(uri)
+    if (!opened) {
+      pathHandlers.delete(uri)
+      continue
+    }
+
+    await sleep(perBaudMs)
+    await window.electronAPI.linkClose(uri)
+    pathHandlers.delete(uri)
+    await sleep(probeSettleMs)
+
+    if (validCount >= validSentenceThreshold) return baud
+  }
+
+  return null
+}
+
+/**
+ * Lists the serial ports available on the system, including USB descriptors.
+ * @returns {Promise<SerialPortInfo[]>} The available serial ports (empty when not in Electron).
+ */
+export const listSerialPorts = async (): Promise<SerialPortInfo[]> => {
+  if (!isElectron() || !window.electronAPI) return []
+  return window.electronAPI.serialListPorts()
+}
+
+/**
+ * Resolves the serial port a device should open on this machine.
+ *
+ * Devices are matched by model (USB vendor + product id), so a same-model unit on another computer still
+ * resolves. When no USB model is stored, or none of the connected ports match it, the last-selected path is
+ * used only if it currently exists; otherwise the device cannot be resolved here.
+ * @param {GnssDeviceInfo} device - The device to resolve a port for.
+ * @returns {Promise<string | undefined>} The resolved port path, or undefined when none is available.
+ */
+export const resolveDevicePort = async (device: GnssDeviceInfo): Promise<string | undefined> => {
+  const ports = await listSerialPorts()
+  const { vendorId, productId } = device.usbMatch ?? {}
+
+  if (vendorId && productId) {
+    const matches = ports.filter((port) => port.vendorId === vendorId && port.productId === productId)
+    if (matches.length === 1) return matches[0].path
+    // Multiple identical-model devices: prefer the exact last-used path, else the first match.
+    if (matches.length > 1) return (matches.find((port) => port.path === device.port) ?? matches[0]).path
+  }
+
+  return ports.find((port) => port.path === device.port)?.path
+}
+
+/**
+ * Boots the GNSS reading pipeline: registers each configured device's data-lake variables and auto-connects
+ * the enabled ones. Reads the persisted configuration directly (no Vue), so the data-lake posting works
+ * independently of any UI being mounted. No-op outside Electron.
+ * @returns {void}
+ */
+export const initGnss = (): void => {
+  if (!isElectron()) return
+  const devices = settingsManager.getKeyValue<GnssDevice[]>(gnssDevicesKey)
+  if (!devices) return
+  for (const device of devices) {
+    registerDeviceVariables(device)
+    if (device.enabled && device.port) {
+      startGnssDevice(device).catch((error) => console.error('[GNSS] Failed to auto-connect:', error))
+    }
+  }
+}

--- a/src/libs/sensors/nmea.ts
+++ b/src/libs/sensors/nmea.ts
@@ -1,0 +1,266 @@
+/**
+ * Framework-agnostic NMEA 0183 parsing utilities for GNSS receivers.
+ *
+ * NMEA is self-describing (each sentence starts with a talker+type header such as `GPGGA`), so the
+ * message kind never needs to be configured by the user. This module validates checksums, decodes the
+ * sentence types Cockpit cares about (GGA/RMC/GSA/GSV/VTG/GLL) and merges them, via {@link NmeaAggregator},
+ * into a single consolidated {@link GnssFix}. It intentionally has no Vue/data-lake dependencies so it can
+ * be unit-tested and reused.
+ */
+
+import type { GnssFix, ParsedNmeaSentence } from '@/types/gnss'
+
+const KNOTS_TO_MPS = 0.514444
+
+const fixQualityLabels: Record<number, string> = {
+  0: 'No fix',
+  1: 'GNSS',
+  2: 'DGPS',
+  3: 'PPS',
+  4: 'RTK fixed',
+  5: 'RTK float',
+  6: 'Estimated',
+  7: 'Manual',
+  8: 'Simulation',
+}
+
+/**
+ * Maps a GGA fix quality code to a human-readable label.
+ * @param {number} quality - The GGA fix quality code.
+ * @returns {string} The label for the given quality, or 'Unknown' if unrecognized.
+ */
+export const fixQualityLabel = (quality: number): string => fixQualityLabels[quality] ?? 'Unknown'
+
+/**
+ * Validates the XOR checksum of an NMEA sentence.
+ * @param {string} sentence - The raw NMEA sentence, including the leading `$` and trailing `*HH`.
+ * @returns {boolean} True when the computed checksum matches the one in the sentence.
+ */
+export const validateNmeaChecksum = (sentence: string): boolean => {
+  const start = sentence.indexOf('$')
+  const asterisk = sentence.indexOf('*')
+  if (start === -1 || asterisk === -1 || asterisk < start) return false
+
+  const body = sentence.slice(start + 1, asterisk)
+  const provided = sentence.slice(asterisk + 1, asterisk + 3).toUpperCase()
+  if (provided.length < 2) return false
+
+  let computed = 0
+  for (let i = 0; i < body.length; i++) {
+    computed ^= body.charCodeAt(i)
+  }
+  return computed.toString(16).toUpperCase().padStart(2, '0') === provided
+}
+
+/**
+ * Parses and checksum-validates a single NMEA sentence.
+ * @param {string} line - The raw sentence line.
+ * @returns {ParsedNmeaSentence | null} The parsed sentence, or null when invalid.
+ */
+export const parseNmeaSentence = (line: string): ParsedNmeaSentence | null => {
+  const trimmed = line.trim()
+  if (!trimmed.startsWith('$') || !trimmed.includes('*')) return null
+  if (!validateNmeaChecksum(trimmed)) return null
+
+  const body = trimmed.slice(1, trimmed.indexOf('*'))
+  const parts = body.split(',')
+  const header = parts[0]
+  if (header.length < 5) return null
+
+  return { talker: header.slice(0, 2), type: header.slice(2), fields: parts.slice(1) }
+}
+
+const floatOrUndefined = (value: string | undefined): number | undefined => {
+  if (value === undefined || value === '') return undefined
+  const parsed = parseFloat(value)
+  return Number.isNaN(parsed) ? undefined : parsed
+}
+
+const intOrUndefined = (value: string | undefined): number | undefined => {
+  if (value === undefined || value === '') return undefined
+  const parsed = parseInt(value, 10)
+  return Number.isNaN(parsed) ? undefined : parsed
+}
+
+/**
+ * Converts an NMEA ddmm.mmmm / dddmm.mmmm coordinate to decimal degrees.
+ * @param {string | undefined} value - The coordinate value (degrees and minutes concatenated).
+ * @param {string | undefined} hemisphere - The hemisphere indicator (N/S/E/W).
+ * @returns {number | undefined} The coordinate in decimal degrees, or undefined when not parseable.
+ */
+export const parseCoordinate = (value: string | undefined, hemisphere: string | undefined): number | undefined => {
+  if (!value || !hemisphere) return undefined
+  const raw = parseFloat(value)
+  if (Number.isNaN(raw)) return undefined
+
+  const degrees = Math.floor(raw / 100)
+  const minutes = raw - degrees * 100
+  const decimal = degrees + minutes / 60
+  return hemisphere === 'S' || hemisphere === 'W' ? -decimal : decimal
+}
+
+/**
+ * Accumulates NMEA sentences into a single, always-current {@link GnssFix}.
+ *
+ * Position is treated as authoritative from GGA (and RMC/GLL when they report an active fix), and is
+ * withheld while the receiver reports no fix, so downstream consumers never see stale coordinates.
+ */
+export class NmeaAggregator {
+  private fix: GnssFix = { hasValidFix: false }
+  private ggaHasFix = false
+  private rmcHasFix = false
+
+  /**
+   * Ingests a single raw NMEA line, updating the internal state.
+   * @param {string} line - The raw NMEA sentence line.
+   * @returns {boolean} True when the line was a valid, recognized NMEA sentence.
+   */
+  ingest(line: string): boolean {
+    const parsed = parseNmeaSentence(line)
+    if (!parsed) return false
+
+    switch (parsed.type) {
+      case 'GGA':
+        this.applyGga(parsed.fields)
+        break
+      case 'RMC':
+        this.applyRmc(parsed.fields)
+        break
+      case 'GSA':
+        this.applyGsa(parsed.fields)
+        break
+      case 'GSV':
+        this.applyGsv(parsed.fields)
+        break
+      case 'VTG':
+        this.applyVtg(parsed.fields)
+        break
+      case 'GLL':
+        this.applyGll(parsed.fields)
+        break
+      default:
+        return false
+    }
+    return true
+  }
+
+  /**
+   * Returns a snapshot copy of the current consolidated GNSS state.
+   * @returns {GnssFix} The current fix.
+   */
+  snapshot(): GnssFix {
+    return { ...this.fix }
+  }
+
+  /**
+   * Recomputes the overall fix validity from the latest GGA and RMC sentences.
+   * @returns {void}
+   */
+  private updateHasValidFix(): void {
+    this.fix.hasValidFix = this.ggaHasFix || this.rmcHasFix
+  }
+
+  /**
+   * Applies a GGA sentence (position, altitude, fix quality, satellites used, HDOP).
+   * @param {string[]} fields - The GGA data fields.
+   * @returns {void}
+   */
+  private applyGga(fields: string[]): void {
+    const quality = intOrUndefined(fields[5])
+    const latitude = parseCoordinate(fields[1], fields[2])
+    const longitude = parseCoordinate(fields[3], fields[4])
+
+    if (fields[0]) this.fix.utcTime = fields[0]
+    this.fix.fixQuality = quality
+    if (quality !== undefined) this.fix.fixQualityLabel = fixQualityLabel(quality)
+    this.fix.satellitesUsed = intOrUndefined(fields[6])
+    this.fix.hdop = floatOrUndefined(fields[7])
+    this.fix.altitudeMslM = floatOrUndefined(fields[8])
+    this.fix.geoidSeparationM = floatOrUndefined(fields[10])
+
+    const valid = quality !== undefined && quality > 0 && latitude !== undefined && longitude !== undefined
+    this.ggaHasFix = valid
+    if (valid) {
+      this.fix.latitude = latitude
+      this.fix.longitude = longitude
+    } else if (quality === 0) {
+      this.fix.latitude = undefined
+      this.fix.longitude = undefined
+    }
+    this.updateHasValidFix()
+  }
+
+  /**
+   * Applies an RMC sentence (position, speed, course, and active/void status).
+   * @param {string[]} fields - The RMC data fields.
+   * @returns {void}
+   */
+  private applyRmc(fields: string[]): void {
+    if (fields[0]) this.fix.utcTime = fields[0]
+    const speedKnots = floatOrUndefined(fields[6])
+    if (speedKnots !== undefined) this.fix.speedOverGroundMps = speedKnots * KNOTS_TO_MPS
+    const course = floatOrUndefined(fields[7])
+    if (course !== undefined) this.fix.courseOverGroundDeg = course
+
+    this.rmcHasFix = fields[1] === 'A'
+    if (this.rmcHasFix) {
+      const latitude = parseCoordinate(fields[2], fields[3])
+      const longitude = parseCoordinate(fields[4], fields[5])
+      if (latitude !== undefined && longitude !== undefined) {
+        this.fix.latitude = latitude
+        this.fix.longitude = longitude
+      }
+    }
+    this.updateHasValidFix()
+  }
+
+  /**
+   * Applies a GSA sentence (fix mode and dilution-of-precision values).
+   * @param {string[]} fields - The GSA data fields.
+   * @returns {void}
+   */
+  private applyGsa(fields: string[]): void {
+    this.fix.fixMode = intOrUndefined(fields[1])
+    this.fix.pdop = floatOrUndefined(fields[14])
+    const hdop = floatOrUndefined(fields[15])
+    if (hdop !== undefined) this.fix.hdop = hdop
+    this.fix.vdop = floatOrUndefined(fields[16])
+  }
+
+  /**
+   * Applies a GSV sentence (number of satellites in view).
+   * @param {string[]} fields - The GSV data fields.
+   * @returns {void}
+   */
+  private applyGsv(fields: string[]): void {
+    const satellitesInView = intOrUndefined(fields[2])
+    if (satellitesInView !== undefined) this.fix.satellitesInView = satellitesInView
+  }
+
+  /**
+   * Applies a VTG sentence (course and ground speed).
+   * @param {string[]} fields - The VTG data fields.
+   * @returns {void}
+   */
+  private applyVtg(fields: string[]): void {
+    const course = floatOrUndefined(fields[0])
+    if (course !== undefined) this.fix.courseOverGroundDeg = course
+    const speedKnots = floatOrUndefined(fields[4])
+    if (speedKnots !== undefined) this.fix.speedOverGroundMps = speedKnots * KNOTS_TO_MPS
+  }
+
+  /**
+   * Applies a GLL sentence (position, when the status is active).
+   * @param {string[]} fields - The GLL data fields.
+   * @returns {void}
+   */
+  private applyGll(fields: string[]): void {
+    if (fields[5] !== 'A') return
+    const latitude = parseCoordinate(fields[0], fields[1])
+    const longitude = parseCoordinate(fields[2], fields[3])
+    if (latitude !== undefined && longitude !== undefined) {
+      this.fix.latitude = latitude
+      this.fix.longitude = longitude
+    }
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ import eventTracker, {
 } from '@/libs/external-telemetry/event-tracking'
 import { setupPredefinedLakeAndActionResources } from '@/libs/joystick/protocols/predefined-resources'
 import { setupPostPiniaConnections } from '@/libs/post-pinia-connections'
+import { initGnss } from '@/libs/sensors/gnss'
 import { datalogger } from '@/libs/sensors-logging'
 import { runMigrations } from '@/utils/migrations'
 
@@ -96,6 +97,9 @@ setupPredefinedLakeAndActionResources()
 
 // Initialize auto-run for actions
 initializeActionAutoRun()
+
+// Boot the GNSS reading pipeline so configured devices post to the data lake independently of the UI
+initGnss()
 
 // Start logging as soon as the app is loaded to always have telemetry for videos
 datalogger.startLogging('cockpit-telemetry-logging')

--- a/src/stores/appInterface.ts
+++ b/src/stores/appInterface.ts
@@ -29,6 +29,7 @@ export enum SubMenuComponentName {
   SettingsDev = 'settings-dev',
   SettingsMission = 'settings-mission',
   SettingsActions = 'settings-actions',
+  SettingsSources = 'settings-sources',
   SettingsDataLake = 'settings-datalake',
   SettingsMAVLink = 'settings-mavlink',
   ToolsMAVLink = 'tools-mavlink',

--- a/src/types/console-viewer.ts
+++ b/src/types/console-viewer.ts
@@ -1,0 +1,14 @@
+/**
+ * A single event rendered by the console viewer. Any source (system logs, serial streams, etc.) can feed
+ * these; `level` is optional so sources without severity levels can be shown without the level column.
+ */
+export interface ConsoleViewerEvent {
+  /** Stable key for virtualized rendering. */
+  id: number | string
+  /** Time the event occurred (epoch ms). */
+  epoch: number
+  /** The message to display. */
+  msg: string
+  /** Optional severity level (enables the level column and filter chips when levels are provided). */
+  level?: string
+}

--- a/src/types/gnss.ts
+++ b/src/types/gnss.ts
@@ -1,0 +1,199 @@
+import type { Ref } from 'vue'
+
+import type { DataLakeVariableType } from '@/libs/actions/data-lake'
+import type { NmeaAggregator } from '@/libs/sensors/nmea'
+import type { SerialPortInfo } from '@/types/serial'
+
+/**
+ * USB descriptor used to re-find a device's port across machines/reboots. Matching is by model
+ * (vendor + product id), not by physical unit, so a different unit of the same model still matches.
+ */
+export interface GnssUsbMatch {
+  /** USB vendor id (identifies the model together with {@link GnssUsbMatch.productId}). */
+  vendorId?: string
+  /** USB product id. */
+  productId?: string
+  /** Manufacturer string, kept for display only. */
+  manufacturer?: string
+}
+
+/**
+ * Consolidated GNSS state built from the most recent NMEA sentences.
+ * Coordinates are only present when the receiver reports a valid fix.
+ */
+export interface GnssFix {
+  /** Latitude in decimal degrees (positive north). Undefined when there is no fix. */
+  latitude?: number
+  /** Longitude in decimal degrees (positive east). Undefined when there is no fix. */
+  longitude?: number
+  /** Altitude above mean sea level, in meters. */
+  altitudeMslM?: number
+  /** Geoidal separation (difference between WGS-84 ellipsoid and mean sea level), in meters. */
+  geoidSeparationM?: number
+  /** Number of satellites used in the position solution. */
+  satellitesUsed?: number
+  /** Number of satellites currently in view. */
+  satellitesInView?: number
+  /** GGA fix quality (0 no fix, 1 GNSS, 2 DGPS, 4 RTK fixed, 5 RTK float, ...). */
+  fixQuality?: number
+  /** Human-readable label for {@link GnssFix.fixQuality}. */
+  fixQualityLabel?: string
+  /** GSA fix mode (1 no fix, 2 = 2D, 3 = 3D). */
+  fixMode?: number
+  /** Horizontal dilution of precision. */
+  hdop?: number
+  /** Positional (3D) dilution of precision. */
+  pdop?: number
+  /** Vertical dilution of precision. */
+  vdop?: number
+  /** Speed over ground, in meters per second. */
+  speedOverGroundMps?: number
+  /** Course over ground, in degrees. */
+  courseOverGroundDeg?: number
+  /** UTC time of the last position report (hhmmss.sss as reported by the receiver). */
+  utcTime?: string
+  /** Whether the receiver currently reports a valid position fix. */
+  hasValidFix: boolean
+}
+
+/**
+ * A single parsed NMEA sentence, split into its talker, type and data fields.
+ */
+export interface ParsedNmeaSentence {
+  /** Talker id (e.g. `GP`, `GN`, `GL`). */
+  talker: string
+  /** Sentence type (e.g. `GGA`, `RMC`). */
+  type: string
+  /** Comma-separated data fields following the header, in order. */
+  fields: string[]
+}
+
+/**
+ * Connection status of a single GNSS reader.
+ */
+export type GnssStatus = 'disconnected' | 'connecting' | 'connected' | 'no-data'
+
+/**
+ * The subset of a device's configuration needed to open and identify its serial stream.
+ */
+export interface GnssDeviceInfo {
+  /** Machine-friendly id, used as the data-lake variable namespace. */
+  id: string
+  /** User-facing device name. */
+  name: string
+  /** Last-selected serial port path (e.g. /dev/ttyUSB0 or COM3). Used as a same-machine hint only. */
+  port: string
+  /** Baud rate to open the port at. */
+  baud: number
+  /** USB model descriptor used to resolve the port on any machine; undefined for devices without USB ids. */
+  usbMatch?: GnssUsbMatch
+}
+
+/**
+ * Persisted configuration for a single GNSS device.
+ */
+export interface GnssDevice extends GnssDeviceInfo {
+  /** Whether the device should auto-connect and be actively read. */
+  enabled: boolean
+}
+
+/**
+ * A device's current runtime state, surfaced to reactive consumers.
+ */
+export interface GnssDeviceState {
+  /** The device's current connection status. */
+  status: GnssStatus
+  /** The device's latest consolidated fix, when any data has been received. */
+  fix?: GnssFix
+}
+
+/**
+ * Listener notified whenever a device's status or latest fix changes.
+ */
+export type GnssDeviceStateListener = (deviceId: string, state: GnssDeviceState) => void
+
+/**
+ * Definition of a single GNSS field published to the data lake.
+ */
+export interface GnssField {
+  /** Variable id suffix appended after the device namespace. */
+  suffix: string
+  /** Human-readable label for the field. */
+  label: string
+  /** Data-lake variable type. */
+  type: DataLakeVariableType
+  /** Variable description. */
+  description: string
+  /** Extracts the field value from a consolidated fix. */
+  read: (fix: GnssFix) => string | number | undefined
+}
+
+/**
+ * A single raw serial line captured for debugging, in a shape compatible with the console viewer.
+ */
+export interface SerialLineEvent {
+  /** Monotonic id, used as a stable key for virtualized rendering. */
+  id: number
+  /** Time the line was received (epoch ms). */
+  epoch: number
+  /** The raw line content. */
+  msg: string
+}
+
+/**
+ * Per-device runtime state for an active serial reader.
+ */
+export interface GnssDeviceRuntime {
+  /** The serial URI currently open for this device. */
+  path: string
+  /** The NMEA aggregator building this device's consolidated fix. */
+  aggregator: NmeaAggregator
+  /** Per-device text decoder, kept isolated so streamed multi-byte sequences don't corrupt other devices. */
+  decoder: TextDecoder
+  /** Partial line buffer for bytes not yet terminated by a newline. */
+  buffer: string
+  /** Whether parsed fixes are published to the data lake (false while previewing an unsaved draft). */
+  publish: boolean
+  /** Timestamp (ms) of the last valid NMEA sentence received. */
+  lastValidLineAt: number
+  /** Handle of the no-data watchdog interval, when running. */
+  watchdog?: ReturnType<typeof setInterval>
+}
+
+/**
+ * Shared reactive state and actions for the GNSS feature.
+ */
+export interface GnssState {
+  /** Persisted device configurations. */
+  devices: Ref<GnssDevice[]>
+  /** The in-progress draft device being created, or null when not creating. Not persisted. */
+  draft: Ref<GnssDevice | null>
+  /** Per-device connection status, keyed by device id. */
+  statuses: Record<string, GnssStatus>
+  /** Per-device latest consolidated fix, keyed by device id. */
+  latestFixes: Record<string, GnssFix | undefined>
+  /** Per-device auto-detection flag, keyed by device id. */
+  detecting: Record<string, boolean>
+  /** Serial ports available on the system. */
+  availablePorts: Ref<SerialPortInfo[]>
+  /** Whether the current environment supports the feature (Electron only). */
+  isSupported: boolean
+  /** Refreshes the list of available serial ports. */
+  refreshPorts: () => Promise<void>
+  /** Starts a new draft device (in-memory only) and returns it. */
+  beginCreate: () => GnssDevice
+  /** Discards the current draft, closing any preview connection. */
+  cancelCreate: () => Promise<void>
+  /** Persists the current draft as a real device, returning its final id (or null when no draft). */
+  commitCreate: () => Promise<string | null>
+  /** Plans the persistent id a device with the given name would get (machinized, de-duplicated). */
+  planDeviceId: (name: string) => string
+  /** Removes a device, closing its connection and deleting its data-lake variables. */
+  removeDevice: (id: string) => Promise<void>
+  /** Connects a device using its current port and baud rate. */
+  connectDevice: (id: string) => Promise<void>
+  /** Disconnects a device. */
+  disconnectDevice: (id: string) => Promise<void>
+  /** Auto-detects the baud rate for a device's port, applying it on success. */
+  autodetect: (id: string) => Promise<number | null>
+}

--- a/src/types/serial.ts
+++ b/src/types/serial.ts
@@ -11,3 +11,29 @@ export interface SerialData {
    */
   data: number[]
 }
+
+/**
+ * Information about an available serial port, as reported by the OS.
+ */
+export interface SerialPortInfo {
+  /**
+   * The system path of the port (e.g. /dev/ttyUSB0 or COM3)
+   */
+  path: string
+  /**
+   * The manufacturer of the device, when available
+   */
+  manufacturer?: string
+  /**
+   * The device serial number, when available
+   */
+  serialNumber?: string
+  /**
+   * The USB vendor id, when available
+   */
+  vendorId?: string
+  /**
+   * The USB product id, when available
+   */
+  productId?: string
+}

--- a/src/views/ConfigurationSourcesView.vue
+++ b/src/views/ConfigurationSourcesView.vue
@@ -1,0 +1,132 @@
+<template>
+  <BaseConfigurationView>
+    <template #title>Sources</template>
+    <template #content>
+      <div
+        class="flex-col h-full overflow-y-auto ml-[10px] pr-3 -mr-[10px]"
+        :class="interfaceStore.isOnSmallScreen ? 'max-w-[80vw] max-h-[90vh]' : 'max-w-[650px] max-h-[85vh]'"
+      >
+        <ExpansiblePanel no-top-divider no-bottom-divider :is-expanded="!interfaceStore.isOnPhoneScreen">
+          <template #title>Positioning</template>
+          <template #info>
+            <div class="w-full">
+              <p>
+                Read one or more external USB/serial GNSS receivers and inject their position and fix data into the
+                data-lake, where it can drive live points of interest and widgets.
+              </p>
+              <p class="mt-2">
+                Message formats are detected automatically (standard NMEA 0183). Each device publishes variables under
+                <span class="font-mono">external/positioning/gnss/&lt;id&gt;/*</span>.
+              </p>
+            </div>
+          </template>
+          <template #content>
+            <div class="flex flex-col w-full mt-2 pb-4">
+              <div v-if="!gnss.isSupported" class="bg-amber-900/30 border border-amber-500/30 rounded-lg p-4 mb-4">
+                <div class="flex items-start gap-3">
+                  <v-icon color="amber" class="mt-1">mdi-information</v-icon>
+                  <div>
+                    <h4 class="text-amber-200 font-medium mb-2">Browser Version</h4>
+                    <p class="text-amber-100 text-sm">
+                      Reading external serial GNSS receivers is only available in the standalone (desktop) version of
+                      Cockpit. Browsers cannot access serial devices outside of a secure context, so this feature is
+                      disabled here.
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <div v-if="gnss.devices.value.length === 0" class="text-sm opacity-60 py-4 text-center">
+                No GNSS devices configured.
+              </div>
+
+              <div v-else class="flex flex-col">
+                <div class="flex items-center gap-2 px-3 py-1 text-xs uppercase opacity-60">
+                  <span class="flex-1">Name</span>
+                  <span class="w-[30%] text-center">Port</span>
+                  <span class="w-[24%] text-center">Status</span>
+                  <span class="w-[24px]" />
+                </div>
+                <div
+                  v-for="device in gnss.devices.value"
+                  :key="device.id"
+                  class="flex items-center gap-2 px-3 py-2 mb-1 rounded bg-[#FFFFFF11]"
+                >
+                  <div class="flex items-center gap-2 flex-1 min-w-0">
+                    <v-icon :color="statusColor(device.id)" size="small">{{ statusIcon(device.id) }}</v-icon>
+                    <span class="truncate">{{ device.name }}</span>
+                  </div>
+                  <span class="w-[30%] truncate font-mono text-xs opacity-80 text-center">{{
+                    device.port || '—'
+                  }}</span>
+                  <span class="w-[24%] truncate text-xs opacity-80 text-center">{{ fixLabel(device.id) }}</span>
+                  <v-btn
+                    icon="mdi-cog"
+                    variant="text"
+                    size="x-small"
+                    title="Configure"
+                    @click="openDialog(device.id)"
+                  />
+                </div>
+              </div>
+
+              <div class="flex justify-center mt-3">
+                <v-btn variant="outlined" class="rounded-lg" :disabled="!gnss.isSupported" @click="onAddDevice">
+                  <v-icon start>mdi-plus</v-icon>
+                  Add USB/serial GNSS source
+                </v-btn>
+              </div>
+            </div>
+          </template>
+        </ExpansiblePanel>
+      </div>
+
+      <GnssDeviceDialog v-if="creatingDevice" model-value create @update:model-value="creatingDevice = false" />
+      <GnssDeviceDialog
+        v-else-if="dialogDeviceId"
+        model-value
+        :device-id="dialogDeviceId"
+        @update:model-value="dialogDeviceId = null"
+      />
+    </template>
+  </BaseConfigurationView>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+import ExpansiblePanel from '@/components/ExpansiblePanel.vue'
+import GnssDeviceDialog from '@/components/sources/GnssDeviceDialog.vue'
+import { useGnss } from '@/composables/useGnss'
+import { gnssStatusColor, gnssStatusIcon } from '@/libs/sensors/gnss'
+import { useAppInterfaceStore } from '@/stores/appInterface'
+
+import BaseConfigurationView from './BaseConfigurationView.vue'
+
+const interfaceStore = useAppInterfaceStore()
+const gnss = useGnss()
+
+const dialogDeviceId = ref<string | null>(null)
+const creatingDevice = ref(false)
+
+const openDialog = (id: string): void => {
+  dialogDeviceId.value = id
+  logUserAction(`Opened configuration for GNSS device "${id}"`)
+}
+
+const onAddDevice = (): void => {
+  gnss.beginCreate()
+  creatingDevice.value = true
+}
+
+const fixLabel = (id: string): string => {
+  if ((gnss.statuses[id] ?? 'disconnected') === 'disconnected') return '—'
+  const fix = gnss.latestFixes[id]
+  if (!fix) return 'No data'
+  return fix.fixQualityLabel ?? (fix.hasValidFix ? 'Fix' : 'No fix')
+}
+
+const statusColor = (id: string): string => gnssStatusColor(gnss.statuses[id] ?? 'disconnected')
+
+const statusIcon = (id: string): string => gnssStatusIcon(gnss.statuses[id] ?? 'disconnected')
+</script>


### PR DESCRIPTION
## Summary

Adds support for reading external USB/serial NMEA GNSS receivers (Electron-only) and feeding their data into the data lake, primarily to drive dynamic points of interest.

- **Electron serial IPC**: new `serial-list-ports` handler to enumerate serial ports.
- **GNSS engine**: framework-agnostic NMEA 0183 parser/aggregator (`GGA/RMC/GSA/GSV/VTG/GLL`, checksum validation, coordinate/fix-quality decoding, coordinates withheld until a valid fix) plus an orchestrator that reads multiple devices and publishes per-device `external/gnss/<id>/*` variables (lat, lon, altitude, satellites, fix quality incl. RTK float/fixed, DOPs, speed, course). Includes baud auto-detection and raw serial-line capture for debugging.
- **Generic console viewer**: `ConsoleViewer` is now source-agnostic so it can render any stream (used for the per-device serial console).
- **Sources settings page**: new "Sources" menu with a GNSS panel listing devices (name/port/status), a per-unit config dialog (built on `InteractionDialog`), and an "Add device" button.

Browsers can't access serial devices outside a secure context, so this is standalone-only; documented in the README feature table.

## Test plan

- [ ] Plug in a USB GNSS, add a device under Settings → Sources → GNSS, pick the port.
- [ ] Confirm auto-detect finds the baud (or 9600 works) and `external/gnss/<id>/*` variables populate.
- [ ] Verify the status column reflects the fix type and the serial console shows raw NMEA.
- [ ] Bind a live POI to `external/gnss/<id>/latitude`/`longitude` and confirm it tracks.
- [ ] Confirm the Sources page shows the Lite notice and disabled controls in the browser build.

https://github.com/user-attachments/assets/9f772a93-6f0e-4889-bc49-42adb3b1f9d1



Close #650
Contributes to #300
Contributes to #1842 