### PR TITLE
Fix settings sync logic for key-value pairs that never stop updating

### DIFF
--- a/src/composables/settingsSyncer.ts
+++ b/src/composables/settingsSyncer.ts
@@ -7,6 +7,13 @@ import { settingsManager } from '@/libs/settings-management'
 import { deserialize, isEqual } from '@/libs/utils'
 import type { CockpitSetting } from '@/types/settings-management'
 
+// Idle time a value must stay stable before it is persisted to the settings manager / BlueOS.
+const settingsSyncDebounceMs = 3000
+
+// Upper bound on how long a continuously-changing value can keep deferring its write, so
+// high-frequency writers still get checkpointed instead of the debounce resetting forever.
+const settingsSyncMaxWaitMs = 30000
+
 /**
  * This composable will keep a setting in sync between the browser's local storage and BlueOS.
  *
@@ -28,6 +35,7 @@ export function useBlueOsStorage<T>(key: string, defaultValue: MaybeRef<T>): Rem
   const unrefedDefaultValue = unref(defaultValue)
   const valueOnLocalStorage = settingsManager.getKeyValue(key)
   let watchUpdaterTimeout: ReturnType<typeof setTimeout> | undefined = undefined
+  let firstPendingChangeEpoch: number | undefined = undefined
   let valueToBeUsedOnStart: T | undefined = undefined
 
   if (valueOnLocalStorage === undefined) {
@@ -65,6 +73,15 @@ export function useBlueOsStorage<T>(key: string, defaultValue: MaybeRef<T>): Rem
         clearTimeout(watchUpdaterTimeout)
       }
 
+      if (firstPendingChangeEpoch === undefined) {
+        firstPendingChangeEpoch = Date.now()
+      }
+
+      // Clamp the debounce so a value that keeps changing is still forced out once it has been
+      // pending for `settingsSyncMaxWaitMs`, instead of the reset-on-every-change debounce never firing.
+      const remainingMaxWait = Math.max(0, settingsSyncMaxWaitMs - (Date.now() - firstPendingChangeEpoch))
+      const writeDelay = Math.min(settingsSyncDebounceMs, remainingMaxWait)
+
       watchUpdaterTimeout = setTimeout(() => {
         const diffInValue = diff(oldRefedValue, newValue, {
           expand: false,
@@ -80,7 +97,8 @@ export function useBlueOsStorage<T>(key: string, defaultValue: MaybeRef<T>): Rem
         console.log(`[SettingsSyncer] Key ${key} changed on watch:\n${diffToPrint}.`)
         settingsManager.setKeyValue(key, newValue)
         oldRefedValue = deserialize(JSON.stringify(newValue)) as T
-      }, 3000)
+        firstPendingChangeEpoch = undefined
+      }, writeDelay)
     },
     { deep: true }
   )

--- a/src/composables/settingsSyncer.ts
+++ b/src/composables/settingsSyncer.ts
@@ -8,11 +8,28 @@ import { deserialize, isEqual } from '@/libs/utils'
 import type { CockpitSetting } from '@/types/settings-management'
 
 // Idle time a value must stay stable before it is persisted to the settings manager / BlueOS.
-const settingsSyncDebounceMs = 3000
+const defaultSettingsSyncDebounceMs = 3000
 
 // Upper bound on how long a continuously-changing value can keep deferring its write, so
 // high-frequency writers still get checkpointed instead of the debounce resetting forever.
-const settingsSyncMaxWaitMs = 30000
+const defaultSettingsSyncMaxWaitMs = 30000
+
+/**
+ * Per-key overrides for the settings-sync write timing.
+ */
+type BlueOsStorageOptions = {
+  /**
+   * Idle time in milliseconds the value must stay stable before it is written. Defaults to
+   * `defaultSettingsSyncDebounceMs`.
+   */
+  debounceMs?: number
+  /**
+   * Maximum time in milliseconds a continuously-changing value can defer its write before being
+   * forced out, so high-frequency writers still get checkpointed. Defaults to
+   * `defaultSettingsSyncMaxWaitMs`.
+   */
+  maxWaitMs?: number
+}
 
 /**
  * This composable will keep a setting in sync between the browser's local storage and BlueOS.
@@ -29,9 +46,16 @@ const settingsSyncMaxWaitMs = 30000
  *  is the local value.
  * @param { string } key
  * @param { T } defaultValue
+ * @param { BlueOsStorageOptions } [options] - Per-key overrides for the write debounce and max-wait
  * @returns { RemovableRef<T> }
  */
-export function useBlueOsStorage<T>(key: string, defaultValue: MaybeRef<T>): RemovableRef<T> {
+export function useBlueOsStorage<T>(
+  key: string,
+  defaultValue: MaybeRef<T>,
+  options: BlueOsStorageOptions = {}
+): RemovableRef<T> {
+  const debounceMs = options.debounceMs ?? defaultSettingsSyncDebounceMs
+  const maxWaitMs = options.maxWaitMs ?? defaultSettingsSyncMaxWaitMs
   const unrefedDefaultValue = unref(defaultValue)
   const valueOnLocalStorage = settingsManager.getKeyValue(key)
   let watchUpdaterTimeout: ReturnType<typeof setTimeout> | undefined = undefined
@@ -78,9 +102,9 @@ export function useBlueOsStorage<T>(key: string, defaultValue: MaybeRef<T>): Rem
       }
 
       // Clamp the debounce so a value that keeps changing is still forced out once it has been
-      // pending for `settingsSyncMaxWaitMs`, instead of the reset-on-every-change debounce never firing.
-      const remainingMaxWait = Math.max(0, settingsSyncMaxWaitMs - (Date.now() - firstPendingChangeEpoch))
-      const writeDelay = Math.min(settingsSyncDebounceMs, remainingMaxWait)
+      // pending for `maxWaitMs`, instead of the reset-on-every-change debounce never firing.
+      const remainingMaxWait = Math.max(0, maxWaitMs - (Date.now() - firstPendingChangeEpoch))
+      const writeDelay = Math.min(debounceMs, remainingMaxWait)
 
       watchUpdaterTimeout = setTimeout(() => {
         const diffInValue = diff(oldRefedValue, newValue, {


### PR DESCRIPTION
When a settings keep being updated, like the odometer implemented on #2676, the value is never pushed to the vehicle, since it never stops being updated and the timeout for pushing (debounce) never resets.

This PR introduces the usage of `maxWait`, so every few seconds (30), the value is pushed independently of it not having stalled.

It also introduces support for callers to configure both the debouncing and maxWait times.