### PR TITLE
Video: Sanitize allowed WebRTC IP entries

### DIFF
--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -60,23 +60,51 @@ export const resetCanvas = (context: CanvasRenderingContext2D): void => {
   context.globalCompositeOperation = 'source-over'
 }
 
+// Regex from https://stackoverflow.com/a/106223/3850957
+const ipv4AddressRegex = new RegExp(
+  '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$'
+)
+
 export const isValidNetworkAddress = (maybeAddress: string): boolean => {
   if (maybeAddress && maybeAddress.length >= 255) {
     return false
   }
 
-  // Regexes from https://stackoverflow.com/a/106223/3850957
-  const ipRegex = new RegExp(
-    '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$'
-  )
+  // Regex from https://stackoverflow.com/a/106223/3850957
   const hostnameRegex = new RegExp(
     '^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$'
   )
 
-  if (ipRegex.test(maybeAddress) || hostnameRegex.test(maybeAddress)) {
+  if (ipv4AddressRegex.test(maybeAddress) || hostnameRegex.test(maybeAddress)) {
     return true
   }
   return false
+}
+
+/**
+ * Checks whether a value is a bare IPv4 address, with no scheme, port, or path.
+ * @param {string} value - The value to test.
+ * @returns {boolean} Whether the value is a bare IPv4 address.
+ */
+export const isValidIpv4Address = (value: string): boolean => {
+  return ipv4AddressRegex.test(value)
+}
+
+/**
+ * Extracts a bare IPv4 address from a value that may carry a scheme, port, or path/CIDR suffix
+ * (e.g. `http://192.168.2.2:554/stream`, `192.168.2.0/24`).
+ * @param {string} rawValue - The raw, possibly prefixed or suffixed address.
+ * @returns {string | undefined} The bare IPv4 address, or `undefined` if none could be extracted.
+ */
+export const sanitizeIpv4Address = (rawValue: string): string | undefined => {
+  let candidate = rawValue.trim()
+  if (!candidate) return undefined
+
+  candidate = candidate.replace(/^\w+:\/\//, '')
+  candidate = candidate.split(/[/\\]/)[0]
+  candidate = candidate.split(':')[0]
+
+  return isValidIpv4Address(candidate) ? candidate : undefined
 }
 
 export const isValidURL = (maybeURL: string): boolean => {

--- a/src/views/ConfigurationVideoView.vue
+++ b/src/views/ConfigurationVideoView.vue
@@ -185,7 +185,7 @@
           <template #content>
             <div class="flex justify-center flex-col w-[90%] ml-2">
               <v-combobox
-                v-model="allowedIceIps"
+                :model-value="allowedIceIps"
                 multiple
                 :items="availableIceIps"
                 label="Allowed WebRTC remote IP Addresses"
@@ -196,6 +196,7 @@
                 density="compact"
                 clearable
                 hide-details
+                @update:model-value="handleAllowedIpsUpdate"
               />
               <v-checkbox
                 v-model="videoStore.enableAutoIceIpFetch"
@@ -453,7 +454,8 @@ import { computed, onMounted, ref } from 'vue'
 import ExpansiblePanel from '@/components/ExpansiblePanel.vue'
 import InteractionDialog from '@/components/InteractionDialog.vue'
 import ScrollingText from '@/components/ScrollingText.vue'
-import { isElectron } from '@/libs/utils'
+import { openSnackbar } from '@/composables/snackbar'
+import { isElectron, isValidIpv4Address, sanitizeIpv4Address } from '@/libs/utils'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useSnapshotStore } from '@/stores/snapshot'
 import { useVideoStore } from '@/stores/video'
@@ -620,6 +622,55 @@ onMounted(async () => {
     allowedIceProtocols.value = availableICEProtocols
   }
 })
+
+/**
+ * Sanitizes the list of allowed WebRTC IPs, stripping schemes/ports/paths from prefixed entries and
+ * dropping ones with no extractable IPv4 address, notifying the user of any changes made.
+ * @param {string[] | null} newValue - The raw list of IPs coming from the combobox.
+ */
+function handleAllowedIpsUpdate(newValue: string[] | null): void {
+  if (!newValue) {
+    allowedIceIps.value = []
+    return
+  }
+
+  const cleanedIps: string[] = []
+  const cleanedNotes: string[] = []
+  const rejectedValues: string[] = []
+
+  newValue.forEach((value) => {
+    if (isValidIpv4Address(value)) {
+      cleanedIps.push(value)
+      return
+    }
+
+    const sanitized = sanitizeIpv4Address(value)
+    if (sanitized === undefined) {
+      rejectedValues.push(value)
+      return
+    }
+
+    cleanedIps.push(sanitized)
+    cleanedNotes.push(`'${value}' -> '${sanitized}'`)
+  })
+
+  allowedIceIps.value = [...new Set(cleanedIps)]
+
+  if (cleanedNotes.length > 0) {
+    openSnackbar({
+      message: `Cleaned up allowed WebRTC IP(s): ${cleanedNotes.join(', ')}.`,
+      variant: 'info',
+      persistent: true,
+    })
+  }
+  if (rejectedValues.length > 0) {
+    openSnackbar({
+      message: `Could not extract a valid IP address from: ${rejectedValues.join(', ')}. Entry not added.`,
+      variant: 'warning',
+    })
+  }
+  logUserAction(`Updated allowed WebRTC IPs to [${allowedIceIps.value.join(', ')}]`)
+}
 
 const openVideoLibrary = (): void => {
   logUserAction('Opened Video Library')


### PR DESCRIPTION
**Problem:**

- The "Allowed WebRTC remote IP Addresses" field accepted any typed string verbatim (e.g. `http://192.168.2.2`, `192.168.2.2:554`, `192.168.2.0/24`), which then silently matched no ICE candidates and broke video streaming with no clear explanation.

**Fix:**

- `isValidIpv4Address`/`sanitizeIpv4Address` helpers in `src/libs/utils.ts` extract a bare IPv4 address from scheme/port/path-suffixed input.
- The combobox sanitizes every entry on update, keeping bare IPs as-is, cleaning up extractable ones, and dropping unparseable ones.
- Snackbars notify the user of cleaned-up (persistent) or rejected entries, so there is no misunderstanding on how the feature works.

Closes #2821