### PR TITLE
VGIs: Add support for custom SVG icons

### DIFF
--- a/src/components/mini-widgets/VeryGenericIndicator.vue
+++ b/src/components/mini-widgets/VeryGenericIndicator.vue
@@ -20,201 +20,228 @@
   </div>
   <v-dialog
     v-model="widgetStore.miniWidgetManagerVars(miniWidget.hash).configMenuOpen"
-    class="w-[100vw] flex justify-center items-center"
+    max-width="620px"
     @after-leave="closeVgiDialog"
   >
-    <v-card class="config-modal p-8" :style="interfaceStore.globalGlassMenuStyles">
-      <div class="close-icon mdi mdi-close" @click.stop="closeVgiDialog"></div>
-      <v-card-title class="text-white">
-        <div class="flex items-center mb-3 mt-[-5px] justify-evenly">
-          <div
-            class="px-3 py-1 transition-all rounded-md cursor-pointer select-none text-slate-100 hover:bg-[#FFFFFF33]"
-            :class="{ 'bg-[#FFFFFF22]': currentTab === 'presets' }"
-            @click="currentTab = 'presets'"
-          >
-            Presets
-          </div>
-          <div
-            class="px-3 py-1 transition-all rounded-md cursor-pointer select-none text-slate-100 hover:bg-[#FFFFFF33]"
-            :class="{ 'bg-[#FFFFFF22]': currentTab === 'custom' }"
-            @click="currentTab = 'custom'"
-          >
-            Custom
-          </div>
-        </div>
+    <v-card class="rounded-lg" :style="interfaceStore.globalGlassMenuStyles">
+      <v-card-title class="relative py-4 text-center text-h6 font-weight-bold">
+        Very Generic Indicator
+        <v-btn
+          icon="mdi-close"
+          variant="text"
+          size="small"
+          class="text-[16px] absolute top-3 right-3"
+          @click="closeVgiDialog"
+        />
       </v-card-title>
+      <v-tabs v-model="currentTab" color="white" fixed-tabs class="px-6 -mt-[10px]">
+        <v-tab value="presets" class="text-white">Presets</v-tab>
+        <v-tab value="custom" class="text-white">Custom</v-tab>
+      </v-tabs>
+      <v-card-text class="px-8 py-5 max-h-[65vh] overflow-y-auto">
+        <v-window v-model="currentTab">
+          <v-window-item value="custom">
+            <div class="flex flex-col gap-5 mt-[6px]">
+              <div class="flex gap-4">
+                <v-text-field
+                  v-model="miniWidget.options.displayName"
+                  label="Display name"
+                  variant="outlined"
+                  density="compact"
+                  hide-details
+                  class="w-3/4"
+                />
+                <v-text-field
+                  v-model="miniWidget.options.widgetWidth"
+                  label="Display width"
+                  type="number"
+                  variant="outlined"
+                  density="compact"
+                  hide-details
+                  class="w-[100px]"
+                />
+              </div>
 
-      <div v-if="currentTab === 'custom'" class="flex flex-col items-center justify-around">
-        <div class="flex w-full gap-x-10">
-          <div class="flex flex-col items-center justify-between w-3/4 mt-3">
-            <span class="w-full mb-1 text-sm text-slate-100/50">Display name</span>
-            <input v-model="miniWidget.options.displayName" class="w-full px-2 py-1 rounded-md bg-[#FFFFFF12]" />
-          </div>
-          <div class="flex flex-col items-center justify-between w-1/4 mt-3">
-            <span class="w-full text-sm text-slate-100/50">Display Width</span>
-            <input
-              v-model="miniWidget.options.widgetWidth"
-              type="number"
-              class="w-full px-2 py-1 rounded-md bg-[#FFFFFF12]"
-            />
-          </div>
-        </div>
-        <div class="flex flex-col items-center justify-between w-full mt-3">
-          <span class="w-full mb-1 text-sm text-slate-100/50">Variable</span>
-          <div class="relative w-full">
-            <button
-              class="w-full py-1 pl-2 pr-8 text-left transition-all rounded-md bg-[#FFFFFF12] hover:bg-slate-400"
-              @click="showVariableChooseModal = !showVariableChooseModal"
-            >
-              <p class="text-ellipsis overflow-x-clip">
-                {{ miniWidget.options.variableName || 'Click to choose...' }}
-              </p>
-            </button>
-            <span
-              class="absolute right-0.5 m-1 text-2xl -translate-y-1 cursor-pointer text-slate-500 mdi mdi-swap-horizontal-bold"
-            />
-          </div>
-        </div>
+              <div>
+                <v-text-field
+                  :model-value="miniWidget.options.variableName"
+                  label="Variable"
+                  placeholder="Click to choose..."
+                  variant="outlined"
+                  density="compact"
+                  hide-details
+                  readonly
+                  append-inner-icon="mdi-swap-horizontal-bold"
+                  class="cursor-pointer"
+                  @click="showVariableChooseModal = !showVariableChooseModal"
+                />
+                <Transition>
+                  <div v-if="showVariableChooseModal" class="mt-2">
+                    <v-text-field
+                      v-model="variableNameSearchString"
+                      placeholder="Search variable..."
+                      variant="outlined"
+                      density="compact"
+                      hide-details
+                    />
+                    <div class="grid w-full h-32 grid-cols-1 mt-2 overflow-x-hidden overflow-y-auto">
+                      <span
+                        v-for="(variable, i) in variableNamesToShow"
+                        :key="i"
+                        class="h-8 p-1 m-1 overflow-x-hidden text-white transition-all rounded-md cursor-pointer select-none bg-slate-700 hover:bg-slate-400/20"
+                        @click="onChooseVariable(variable)"
+                      >
+                        {{ variable }}
+                      </span>
+                    </div>
+                  </div>
+                </Transition>
+              </div>
 
-        <Transition>
-          <div v-if="showVariableChooseModal" class="flex flex-col justify-center w-full mx-1 my-3 align-center">
-            <input
-              v-model="variableNameSearchString"
-              placeholder="Search variable..."
-              class="w-full px-2 py-1 rounded-md bg-[#FFFFFF12]"
-            />
-            <div class="grid w-full h-32 grid-cols-1 my-2 overflow-x-hidden overflow-y-scroll">
-              <span
-                v-for="(variable, i) in variableNamesToShow"
+              <v-checkbox
+                v-model="miniWidget.options.useStringVariable"
+                label="Use string variable (don't parse as number)"
+                density="compact"
+                hide-details
+                class="-my-2"
+              />
+
+              <div class="flex gap-4">
+                <v-text-field
+                  v-model="miniWidget.options.variableUnit"
+                  label="Unit"
+                  variant="outlined"
+                  density="compact"
+                  hide-details
+                  class="flex-1"
+                />
+                <v-text-field
+                  v-model="miniWidget.options.variableMultiplier"
+                  :disabled="miniWidget.options.useStringVariable"
+                  label="Multiplier"
+                  variant="outlined"
+                  density="compact"
+                  hide-details
+                  class="flex-1"
+                />
+                <v-text-field
+                  v-model="miniWidget.options.decimalPlaces"
+                  :disabled="miniWidget.options.useStringVariable"
+                  label="Decimal places"
+                  type="number"
+                  min="0"
+                  max="5"
+                  placeholder="Auto-formatting"
+                  variant="outlined"
+                  density="compact"
+                  hide-details
+                  class="flex-1"
+                />
+              </div>
+              <v-divider class="mt-2 mb-1 opacity-10" />
+              <div>
+                <div class="flex items-center gap-3">
+                  <div
+                    class="flex items-center justify-center w-[50px] h-[50px] text-[34px] text-slate-300 transition-all rounded-md cursor-pointer shrink-0 bg-[#FFFFFF12] hover:bg-slate-400 elevation-1"
+                    @click="showIconChooseModal = !showIconChooseModal"
+                  >
+                    <span class="mdi" :class="[miniWidget.options.iconName]" />
+                  </div>
+                  <v-text-field
+                    :model-value="miniWidget.options.iconName"
+                    label="Icon"
+                    placeholder="Click to choose..."
+                    variant="outlined"
+                    density="compact"
+                    hide-details
+                    readonly
+                    class="flex-1 cursor-pointer"
+                    @click="showIconChooseModal = !showIconChooseModal"
+                  />
+                </div>
+                <Transition>
+                  <div v-if="showIconChooseModal" class="flex flex-col items-center w-full mt-4">
+                    <v-text-field
+                      v-model="iconSearchString"
+                      placeholder="Search icons..."
+                      variant="outlined"
+                      density="compact"
+                      hide-details
+                      class="w-full"
+                    />
+                    <RecycleScroller
+                      v-if="iconSearchString === ''"
+                      ref="iconGridRef"
+                      v-slot="{ item }"
+                      class="w-full h-40 mt-3"
+                      :style="{ fontSize: iconGridFontSize }"
+                      :items="iconsNames"
+                      :item-size="iconGridRowHeight"
+                      :item-secondary-size="iconGridSecondarySize"
+                      :grid-items="iconGridColumns"
+                    >
+                      <span
+                        :class="[
+                          `block w-full h-full text-center text-white cursor-pointer mdi icon-symbol leading-[${iconGridRowHeight}px]`,
+                          item,
+                        ]"
+                        @click="chooseIcon(item)"
+                      />
+                    </RecycleScroller>
+                    <div
+                      v-else
+                      class="grid w-full h-40 mt-3 overflow-x-hidden overflow-y-scroll"
+                      :style="{
+                        gridTemplateColumns: `repeat(${iconGridColumns}, minmax(0, 1fr))`,
+                        gridAutoRows: `${iconGridRowHeight}px`,
+                        fontSize: iconGridFontSize,
+                      }"
+                    >
+                      <span
+                        v-for="icon in iconsToShow"
+                        :key="icon"
+                        :class="[
+                          `block text-center text-white cursor-pointer mdi icon-symbol leading-[${iconGridRowHeight}px]`,
+                          icon,
+                        ]"
+                        @click="chooseIcon(icon)"
+                      />
+                    </div>
+                  </div>
+                </Transition>
+              </div>
+            </div>
+          </v-window-item>
+
+          <v-window-item value="presets">
+            <div class="flex flex-wrap items-center justify-around">
+              <div
+                v-for="(template, i) in veryGenericIndicatorPresets"
                 :key="i"
-                class="h-8 p-1 m-1 overflow-x-hidden text-white transition-all rounded-md cursor-pointer select-none bg-slate-700 hover:bg-slate-400/20"
-                @click="onChooseVariable(variable)"
+                class="flex items-center justify-center px-2 m-2 text-white transition-all rounded-md cursor-pointer hover:bg-slate-100/20"
+                @click="setIndicatorFromTemplate(template)"
               >
-                {{ variable }}
-              </span>
+                <span class="relative w-[2rem] mdi icon-symbol text-[34px] mx-2" :class="[template.iconName]"></span>
+                <div class="flex flex-col items-start justify-center min-w-[4rem] max-w-[6rem] select-none">
+                  <span class="text-xl font-semibold leading-6 w-fit">
+                    {{ round(Math.random() * Number(template.variableMultiplier)).toFixed(0) }}
+                    {{ template.variableUnit }}
+                  </span>
+                  <span class="w-full text-sm font-semibold leading-4 whitespace-nowrap">
+                    {{ template.displayName }}
+                  </span>
+                </div>
+              </div>
             </div>
-          </div>
-        </Transition>
-        <div class="flex items-center justify-start w-full mt-3">
-          <input
-            id="useStringVariable"
-            v-model="miniWidget.options.useStringVariable"
-            type="checkbox"
-            class="mr-2 w-4 h-4 rounded bg-[#FFFFFF12] border-gray-300 focus:ring-blue-500"
-          />
-          <label for="useStringVariable" class="text-sm text-slate-100/75">
-            Use string variable (don't parse as number)
-          </label>
+          </v-window-item>
+        </v-window>
+      </v-card-text>
+      <v-divider class="mx-10" />
+      <v-card-actions>
+        <div class="flex items-center justify-end w-full pa-2">
+          <v-btn color="white" @click="closeVgiDialog">Done</v-btn>
         </div>
-        <div class="flex items-center justify-between w-full mt-2">
-          <div class="flex flex-col items-center justify-between w-full mx-5">
-            <span class="w-full mb-1 text-sm text-slate-100/50">Unit</span>
-            <input v-model="miniWidget.options.variableUnit" class="w-full px-2 py-1 rounded-md bg-[#FFFFFF12]" />
-          </div>
-          <div class="flex flex-col items-center justify-between w-full mx-5">
-            <span class="w-full mb-1 text-sm text-slate-100/50">Multiplier</span>
-            <input
-              v-model="miniWidget.options.variableMultiplier"
-              :disabled="miniWidget.options.useStringVariable"
-              class="w-full px-2 py-1 rounded-md bg-[#FFFFFF12] disabled:cursor-not-allowed"
-              :class="{ 'opacity-50': miniWidget.options.useStringVariable }"
-            />
-          </div>
-          <div class="flex flex-col items-center justify-between w-full mx-5">
-            <span class="w-full mb-1 text-sm text-slate-100/50">Decimal Places</span>
-            <input
-              v-model="miniWidget.options.decimalPlaces"
-              :disabled="miniWidget.options.useStringVariable"
-              type="number"
-              min="0"
-              max="5"
-              placeholder="Auto-formatting"
-              class="w-full px-2 py-1 rounded-md bg-[#FFFFFF12] disabled:cursor-not-allowed"
-              :class="{ 'opacity-50': miniWidget.options.useStringVariable }"
-            />
-          </div>
-        </div>
-        <div class="flex flex-col items-center justify-between w-full mt-3">
-          <span class="w-full mb-1 text-sm text-slate-100/50">Icon</span>
-          <div class="relative w-full">
-            <button
-              class="w-full py-1 pl-2 pr-8 text-left transition-all rounded-md bg-[#FFFFFF12] hover:bg-slate-400"
-              @click="showIconChooseModal = !showIconChooseModal"
-            >
-              <p class="text-ellipsis overflow-x-clip">{{ miniWidget.options.iconName || 'Click to choose...' }}</p>
-            </button>
-            <span
-              class="absolute right-0.5 m-1 text-2xl -translate-y-1 cursor-pointer text-slate-500 mdi"
-              :class="[miniWidget.options.iconName]"
-            />
-          </div>
-        </div>
-        <Transition>
-          <div v-if="showIconChooseModal" class="flex flex-col items-center justify-center w-full mt-2">
-            <div>
-              <input
-                v-model="iconSearchString"
-                class="w-full px-2 py-1 rounded-md bg-[#FFFFFF12]"
-                placeholder="Search icons..."
-              />
-            </div>
-            <RecycleScroller
-              v-if="iconSearchString === '' && showIconChooseModal"
-              ref="iconGridRef"
-              v-slot="{ item }"
-              class="w-full h-40 mt-3"
-              :style="{ fontSize: iconGridFontSize }"
-              :items="iconsNames"
-              :item-size="iconGridRowHeight"
-              :item-secondary-size="iconGridSecondarySize"
-              :grid-items="iconGridColumns"
-            >
-              <span
-                :class="[
-                  `block w-full h-full text-center text-white cursor-pointer mdi icon-symbol leading-[${iconGridRowHeight}px]`,
-                  item,
-                ]"
-                @click="chooseIcon(item)"
-              />
-            </RecycleScroller>
-            <div
-              v-if="iconSearchString !== '' && showIconChooseModal"
-              class="grid w-full h-40 mt-3 overflow-x-hidden overflow-y-scroll"
-              :style="{
-                gridTemplateColumns: `repeat(${iconGridColumns}, minmax(0, 1fr))`,
-                gridAutoRows: `${iconGridRowHeight}px`,
-                fontSize: iconGridFontSize,
-              }"
-            >
-              <span
-                v-for="icon in iconsToShow"
-                :key="icon"
-                :class="[
-                  `block text-center text-white cursor-pointer mdi icon-symbol leading-[${iconGridRowHeight}px]`,
-                  icon,
-                ]"
-                @click="chooseIcon(icon)"
-              />
-            </div>
-          </div>
-        </Transition>
-      </div>
-      <div v-if="currentTab === 'presets'" class="flex flex-wrap items-center justify-around max-w-[24rem]">
-        <div
-          v-for="(template, i) in veryGenericIndicatorPresets"
-          :key="i"
-          class="flex items-center justify-center px-2 m-2 text-white transition-all rounded-md cursor-pointer hover:bg-slate-100/20"
-          @click="setIndicatorFromTemplate(template)"
-        >
-          <span class="relative w-[2rem] mdi icon-symbol text-[34px] mx-2" :class="[template.iconName]"></span>
-          <div class="flex flex-col items-start justify-center min-w-[4rem] max-w-[6rem] select-none">
-            <span class="text-xl font-semibold leading-6 w-fit">
-              {{ round(Math.random() * Number(template.variableMultiplier)).toFixed(0) }} {{ template.variableUnit }}
-            </span>
-            <span class="w-full text-sm font-semibold leading-4 whitespace-nowrap">{{ template.displayName }}</span>
-          </div>
-        </div>
-      </div>
+      </v-card-actions>
     </v-card>
   </v-dialog>
 </template>
@@ -526,26 +553,6 @@ const setIndicatorFromTemplate = (template: VeryGenericIndicatorPreset): void =>
 </script>
 
 <style scoped>
-.close-icon {
-  position: fixed;
-  top: 5px;
-  right: 10px;
-  cursor: pointer;
-  color: white;
-  font-size: 26px;
-  border-radius: 8px;
-}
-
-.config-modal {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  margin-right: -50%;
-  transform: translate(-50%, -50%);
-  height: fit-content;
-  border-radius: 5px;
-}
-
 .scroll-container {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/components/mini-widgets/VeryGenericIndicator.vue
+++ b/src/components/mini-widgets/VeryGenericIndicator.vue
@@ -7,7 +7,10 @@
     }"
     :style="{ width: miniWidget.options.widgetWidth + 'px' }"
   >
-    <span class="h-full left-[0.5rem] bottom-[5%] absolute mdi text-[2.25rem]" :class="[miniWidget.options.iconName]" />
+    <VgiIcon
+      class="h-full left-[0.5rem] bottom-[5%] absolute text-[2.25rem]"
+      :icon-name="miniWidget.options.iconName"
+    />
     <div class="absolute left-[3rem] h-full select-none font-semibold scroll-container w-full">
       <div class="w-full" :class="{ 'scroll-text': valueIsOverflowing }">
         <span class="font-mono text-xl leading-6">{{ parsedState }}</span>
@@ -145,10 +148,10 @@
                     class="flex items-center justify-center w-[50px] h-[50px] text-[34px] text-slate-300 transition-all rounded-md cursor-pointer shrink-0 bg-[#FFFFFF12] hover:bg-slate-400 elevation-1"
                     @click="showIconChooseModal = !showIconChooseModal"
                   >
-                    <span class="mdi" :class="[miniWidget.options.iconName]" />
+                    <VgiIcon :icon-name="miniWidget.options.iconName" />
                   </div>
                   <v-text-field
-                    :model-value="miniWidget.options.iconName"
+                    :model-value="iconDisplayName"
                     label="Icon"
                     placeholder="Click to choose..."
                     variant="outlined"
@@ -158,55 +161,109 @@
                     class="flex-1 cursor-pointer"
                     @click="showIconChooseModal = !showIconChooseModal"
                   />
+                  <v-btn-toggle
+                    v-model="iconCategory"
+                    mandatory
+                    divided
+                    density="compact"
+                    class="shrink-0 vgi-category-toggle elevation-1"
+                    @update:model-value="onIconCategoryChange"
+                  >
+                    <v-btn value="stock" size="small" class="text-white">Basic icons</v-btn>
+                    <v-btn value="custom" size="small" class="text-white">Custom icons</v-btn>
+                  </v-btn-toggle>
                 </div>
                 <Transition>
                   <div v-if="showIconChooseModal" class="flex flex-col items-center w-full mt-4">
-                    <v-text-field
-                      v-model="iconSearchString"
-                      placeholder="Search icons..."
-                      variant="outlined"
-                      density="compact"
-                      hide-details
-                      class="w-full"
-                    />
-                    <RecycleScroller
-                      v-if="iconSearchString === ''"
-                      ref="iconGridRef"
-                      v-slot="{ item }"
-                      class="w-full h-40 mt-3"
-                      :style="{ fontSize: iconGridFontSize }"
-                      :items="iconsNames"
-                      :item-size="iconGridRowHeight"
-                      :item-secondary-size="iconGridSecondarySize"
-                      :grid-items="iconGridColumns"
-                    >
-                      <span
-                        :class="[
-                          `block w-full h-full text-center text-white cursor-pointer mdi icon-symbol leading-[${iconGridRowHeight}px]`,
-                          item,
-                        ]"
-                        @click="chooseIcon(item)"
+                    <template v-if="iconCategory === 'stock'">
+                      <v-text-field
+                        v-model="iconSearchString"
+                        placeholder="Search icons..."
+                        variant="outlined"
+                        density="compact"
+                        hide-details
+                        class="w-full"
                       />
-                    </RecycleScroller>
-                    <div
-                      v-else
-                      class="grid w-full h-40 mt-3 overflow-x-hidden overflow-y-scroll"
-                      :style="{
-                        gridTemplateColumns: `repeat(${iconGridColumns}, minmax(0, 1fr))`,
-                        gridAutoRows: `${iconGridRowHeight}px`,
-                        fontSize: iconGridFontSize,
-                      }"
-                    >
-                      <span
-                        v-for="icon in iconsToShow"
-                        :key="icon"
-                        :class="[
-                          `block text-center text-white cursor-pointer mdi icon-symbol leading-[${iconGridRowHeight}px]`,
-                          icon,
-                        ]"
-                        @click="chooseIcon(icon)"
-                      />
-                    </div>
+                      <RecycleScroller
+                        v-if="iconSearchString === ''"
+                        ref="iconGridRef"
+                        v-slot="{ item }"
+                        class="w-full h-40 mt-3"
+                        :style="{ fontSize: iconGridFontSize }"
+                        :items="iconsNames"
+                        :item-size="iconGridRowHeight"
+                        :item-secondary-size="iconGridSecondarySize"
+                        :grid-items="iconGridColumns"
+                      >
+                        <span
+                          :class="[
+                            `block w-full h-full text-center text-white cursor-pointer mdi icon-symbol leading-[${iconGridRowHeight}px]`,
+                            item,
+                          ]"
+                          @click="chooseIcon(item)"
+                        />
+                      </RecycleScroller>
+                      <div
+                        v-else
+                        class="grid w-full h-40 mt-3 overflow-x-hidden overflow-y-scroll"
+                        :style="{
+                          gridTemplateColumns: `repeat(${iconGridColumns}, minmax(0, 1fr))`,
+                          gridAutoRows: `${iconGridRowHeight}px`,
+                          fontSize: iconGridFontSize,
+                        }"
+                      >
+                        <span
+                          v-for="icon in iconsToShow"
+                          :key="icon"
+                          :class="[
+                            `block text-center text-white cursor-pointer mdi icon-symbol leading-[${iconGridRowHeight}px]`,
+                            icon,
+                          ]"
+                          @click="chooseIcon(icon)"
+                        />
+                      </div>
+                    </template>
+
+                    <template v-else>
+                      <div class="flex items-center justify-between w-full">
+                        <span class="text-xs text-slate-100/50">Your uploaded icons</span>
+                        <v-btn
+                          variant="elevated"
+                          size="small"
+                          prepend-icon="mdi-upload"
+                          class="self-center bg-[#FFFFFF12]"
+                          @click="iconUploadInput?.click()"
+                        >
+                          Upload SVG
+                        </v-btn>
+                        <input
+                          ref="iconUploadInput"
+                          type="file"
+                          accept=".svg,image/svg+xml"
+                          class="hidden"
+                          @change="onCustomIconFileSelected"
+                        />
+                      </div>
+                      <span v-if="customIconError" class="w-full mt-1 text-xs text-red-400">{{ customIconError }}</span>
+                      <div v-if="customIconsList.length > 0" class="grid w-full grid-cols-7 gap-1 mt-3">
+                        <div
+                          v-for="icon in customIconsList"
+                          :key="icon.id"
+                          class="relative flex items-center justify-center w-full h-10 text-2xl text-white rounded-md cursor-pointer group"
+                          :title="icon.name"
+                          @click="chooseIcon(customIconRefFromId(icon.id))"
+                        >
+                          <VgiIcon :icon-name="customIconRefFromId(icon.id)" />
+                          <span
+                            class="absolute top-[-10px] right-[10px] hidden text-[13px] text-white mdi mdi-close-circle group-hover:block"
+                            @click.stop="confirmRemoveCustomIcon(icon)"
+                          />
+                        </div>
+                      </div>
+                      <div v-else class="w-full py-6 text-sm text-center text-slate-100/40">
+                        No custom icons uploaded yet. Use "Upload SVG" to add one.
+                      </div>
+                    </template>
                   </div>
                 </Transition>
               </div>
@@ -221,7 +278,7 @@
                 class="flex items-center justify-center px-2 m-2 text-white transition-all rounded-md cursor-pointer hover:bg-slate-100/20"
                 @click="setIndicatorFromTemplate(template)"
               >
-                <span class="relative w-[2rem] mdi icon-symbol text-[34px] mx-2" :class="[template.iconName]"></span>
+                <VgiIcon class="relative w-[2rem] icon-symbol text-[34px] mx-2" :icon-name="template.iconName" />
                 <div class="flex flex-col items-start justify-center min-w-[4rem] max-w-[6rem] select-none">
                   <span class="text-xl font-semibold leading-6 w-fit">
                     {{ round(Math.random() * Number(template.variableMultiplier)).toFixed(0) }}
@@ -251,13 +308,16 @@ import { useElementSize, watchThrottled } from '@vueuse/core'
 import Fuse from 'fuse.js'
 import { computed, onBeforeMount, onMounted, ref, toRefs, watch } from 'vue'
 
+import VgiIcon from '@/components/mini-widgets/VgiIcon.vue'
 import { useInteractionDialog } from '@/composables/interactionDialog'
+import { useCustomIcons } from '@/composables/useCustomIcons'
 import {
   getDataLakeVariableData,
   listenDataLakeVariable,
   listenToDataLakeVariablesInfoChanges,
 } from '@/libs/actions/data-lake'
 import { getAllDataLakeVariablesInfo } from '@/libs/actions/data-lake'
+import { type CustomIcon, customIconRefFromId, idFromCustomIconRef, isCustomIconRef } from '@/libs/custom-icons'
 import { CurrentlyLoggedVariables, datalogger } from '@/libs/sensors-logging'
 import { round } from '@/libs/utils'
 import { useAppInterfaceStore } from '@/stores/appInterface'
@@ -265,7 +325,7 @@ import { useWidgetManagerStore } from '@/stores/widgetManager'
 import { type VeryGenericIndicatorPreset, veryGenericIndicatorPresets } from '@/types/genericIndicator'
 import type { MiniWidget } from '@/types/widgets'
 
-const { showDialog } = useInteractionDialog()
+const { showDialog, closeDialog } = useInteractionDialog()
 const interfaceStore = useAppInterfaceStore()
 
 const props = defineProps<{
@@ -497,6 +557,58 @@ const variableNameSearchString = ref('')
 const allVariablesNames = ref<string[]>([])
 const showVariableChooseModal = ref(false)
 const showIconChooseModal = ref(false)
+const iconCategory = ref<'stock' | 'custom'>('stock')
+
+const {
+  icons: customIconsList,
+  addIconFromFile: addCustomIconFromFile,
+  removeIcon: removeCustomIcon,
+} = useCustomIcons()
+const customIconError = ref('')
+const iconUploadInput = ref<HTMLInputElement | null>(null)
+
+// For custom icons the stored value is an opaque `custom:<id>` ref, so show the icon's name instead
+const iconDisplayName = computed(() => {
+  const iconName = miniWidget.value.options.iconName
+  if (!isCustomIconRef(iconName)) return iconName
+  const id = idFromCustomIconRef(iconName)
+  return customIconsList.value.find((icon) => icon.id === id)?.name ?? iconName
+})
+
+const onIconCategoryChange = (category: 'stock' | 'custom'): void => {
+  logUserAction(`Switched to '${category}' indicator icon category`)
+  showIconChooseModal.value = true
+}
+
+const onCustomIconFileSelected = async (event: Event): Promise<void> => {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  input.value = ''
+  if (!file) return
+
+  const { id, error } = await addCustomIconFromFile(file)
+  customIconError.value = error ?? ''
+  if (id) chooseIcon(customIconRefFromId(id))
+}
+
+const confirmRemoveCustomIcon = (icon: CustomIcon): void => {
+  logUserAction(`Opened delete confirmation for custom icon '${icon.name}'`)
+  showDialog({
+    title: 'Delete custom icon',
+    message: `Delete the custom icon "${icon.name}"? Indicators using it will show a placeholder instead.`,
+    variant: 'warning',
+    actions: [
+      { text: 'Cancel', action: () => closeDialog() },
+      {
+        text: 'Delete',
+        action: () => {
+          removeCustomIcon(icon.id)
+          closeDialog()
+        },
+      },
+    ],
+  })
+}
 
 const variableNamesToShow = computed(() => {
   if (variableNameSearchString.value === '') {
@@ -525,7 +637,7 @@ const chooseIcon = (iconName: string): void => {
   logUserAction(`Selected indicator icon '${iconName}'`)
   miniWidget.value.options.iconName = iconName
   iconSearchString.value = ''
-  showIconChooseModal.value = false
+  if (!isCustomIconRef(iconName)) showIconChooseModal.value = false
 }
 
 watch(showVariableChooseModal, async (newValue) => {
@@ -553,6 +665,20 @@ const setIndicatorFromTemplate = (template: VeryGenericIndicatorPreset): void =>
 </script>
 
 <style scoped>
+.vgi-category-toggle {
+  background-color: transparent;
+  border: 1px solid #ffffff1a;
+}
+.vgi-category-toggle :deep(.v-btn) {
+  background-color: transparent;
+}
+.vgi-category-toggle :deep(.v-btn.v-btn--active) {
+  background-color: #ffffff11;
+}
+.vgi-category-toggle :deep(.v-btn__overlay) {
+  opacity: 0;
+}
+
 .scroll-container {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/components/mini-widgets/VgiIcon.vue
+++ b/src/components/mini-widgets/VgiIcon.vue
@@ -1,0 +1,27 @@
+<template>
+  <span v-if="!isCustom" class="mdi" :class="[iconName]" />
+  <span v-else-if="iconUrl" class="inline-flex items-center justify-center">
+    <img :src="iconUrl" class="w-[1em] h-[1em] object-contain" alt="" />
+  </span>
+  <span v-else class="mdi mdi-image-off-outline" />
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import { useCustomIcons } from '@/composables/useCustomIcons'
+import { isCustomIconRef } from '@/libs/custom-icons'
+
+const props = defineProps<{
+  /**
+   * Icon reference: an MDI class name (e.g. `mdi-thermometer`) or a custom icon reference
+   * (as produced by `customIconRefFromId`), resolved via the custom icon library.
+   */
+  iconName: string
+}>()
+
+const { resolveIconUrl } = useCustomIcons()
+
+const isCustom = computed(() => isCustomIconRef(props.iconName))
+const iconUrl = computed(() => resolveIconUrl(props.iconName))
+</script>

--- a/src/composables/useCustomIcons.ts
+++ b/src/composables/useCustomIcons.ts
@@ -1,0 +1,104 @@
+import { type ComputedRef } from 'vue'
+
+import { createVehicleFileStorage } from '@/composables/useVehicleFileStorage'
+import {
+  type CustomIcon,
+  createCustomIcon,
+  idFromCustomIconRef,
+  isCustomIconRef,
+  validateCustomIconSvg,
+} from '@/libs/custom-icons'
+
+// Singleton so every call site shares the same reactive library. The SVG bytes are cached in IndexedDB
+// and synced to the vehicle as real files; only the `{ id, name, createdAt }` index rides in settings.
+const iconStorage = createVehicleFileStorage<CustomIcon>({
+  settingsKey: 'cockpit-custom-icons-v1',
+  indexedDbStoreName: 'cockpit-custom-icons',
+  vehicleSubfolder: 'custom-icons',
+  mimeType: 'image/svg+xml',
+  fileExtension: 'svg',
+})
+
+/**
+ * Outcome of an `addIcon` call: the new icon's id when it was stored, or an error message.
+ */
+export interface AddIconResult {
+  /**
+   * The stored icon's id when the upload succeeded.
+   */
+  id?: string
+  /**
+   * A user-facing reason the SVG was rejected, when the upload failed.
+   */
+  error?: string
+}
+
+/**
+ * Reactive API for managing the user's custom SVG icon library, synced to the vehicle via BlueOS.
+ */
+export interface CustomIconsApi {
+  /**
+   * All custom icons currently in the library.
+   */
+  icons: ComputedRef<CustomIcon[]>
+  /**
+   * Validates and adds a new custom icon to the library.
+   * @param {string} name - User-facing name for the icon.
+   * @param {string} svg - Raw SVG markup to validate and store.
+   * @returns {Promise<AddIconResult>} The new icon's id on success, or an error message if the SVG is invalid.
+   */
+  addIcon: (name: string, svg: string) => Promise<AddIconResult>
+  /**
+   * Reads an uploaded SVG file and adds it to the library, deriving the icon name from the filename.
+   * @param {File} file - The user-selected `.svg` file.
+   * @returns {Promise<AddIconResult>} The new icon's id on success, or an error message if the SVG is invalid.
+   */
+  addIconFromFile: (file: File) => Promise<AddIconResult>
+  /**
+   * Removes a custom icon from the library.
+   * @param {string} id - The custom icon's id.
+   * @returns {void}
+   */
+  removeIcon: (id: string) => void
+  /**
+   * Resolves an `iconName` reference to a renderable URL.
+   * @param {string} iconRef - A custom icon reference (as produced by `customIconRefFromId`).
+   * @returns {string | undefined} The icon's object URL, or `undefined` if its bytes aren't cached yet.
+   */
+  resolveIconUrl: (iconRef: string) => string | undefined
+}
+
+/**
+ * Provides reactive access to the custom SVG icon library shared by all Very Generic Indicators.
+ * @returns {CustomIconsApi} Reactive icon list plus add/remove/resolve helpers.
+ */
+export function useCustomIcons(): CustomIconsApi {
+  const addIcon = async (name: string, svg: string): Promise<AddIconResult> => {
+    const error = validateCustomIconSvg(svg)
+    if (error) return { error }
+
+    const normalizedSvg = svg.replace(/^\uFEFF/, '').trim()
+    const icon = createCustomIcon(name)
+    await iconStorage.add(icon, normalizedSvg)
+    logUserAction(`Uploaded custom icon '${icon.name}'`)
+    return { id: icon.id }
+  }
+
+  const addIconFromFile = async (file: File): Promise<AddIconResult> => {
+    const svg = await file.text()
+    return addIcon(file.name.replace(/\.svg$/i, ''), svg)
+  }
+
+  const removeIcon = (id: string): void => {
+    const icon = iconStorage.entries.value.find((entry) => entry.id === id)
+    iconStorage.remove(id).catch((error) => console.error(`Could not remove custom icon '${id}'. ${error}`))
+    logUserAction(`Deleted custom icon '${icon?.name ?? id}'`)
+  }
+
+  const resolveIconUrl = (iconRef: string): string | undefined => {
+    if (!isCustomIconRef(iconRef)) return undefined
+    return iconStorage.urlFor(idFromCustomIconRef(iconRef))
+  }
+
+  return { icons: iconStorage.entries, addIcon, addIconFromFile, removeIcon, resolveIconUrl }
+}

--- a/src/composables/useVehicleFileStorage.ts
+++ b/src/composables/useVehicleFileStorage.ts
@@ -1,0 +1,225 @@
+import localforage from 'localforage'
+import { type ComputedRef, computed, ref, watch } from 'vue'
+
+import { useBlueOsStorage } from '@/composables/settingsSyncer'
+import {
+  deleteFileFromVehicle,
+  downloadFileFromVehicle,
+  listVehicleFiles,
+  uploadFileToVehicle,
+} from '@/libs/blueos-files'
+
+/**
+ * Minimal metadata every stored file carries. Consumers extend this with their own fields (e.g. a name).
+ */
+export interface VehicleFileMeta {
+  /**
+   * Unique identifier, also used to derive the file name on the vehicle and the IndexedDB key.
+   */
+  id: string
+  /**
+   * Epoch milliseconds when the file was created.
+   */
+  createdAt: number
+}
+
+/**
+ * Configuration for a vehicle-synced file store instance.
+ */
+export interface VehicleFileStorageConfig {
+  /**
+   * Settings key holding the lightweight metadata index. Must start with `cockpit-` so it is tracked
+   * and synced across control stations by the settings backend.
+   */
+  settingsKey: string
+  /**
+   * IndexedDB store name for the local blob cache.
+   */
+  indexedDbStoreName: string
+  /**
+   * Folder under `userdata/cockpit` on the vehicle where the blobs are synced.
+   */
+  vehicleSubfolder: string
+  /**
+   * MIME type used when wrapping raw string content into a Blob.
+   */
+  mimeType: string
+  /**
+   * Extension (without the dot) appended to each blob's file name on the vehicle.
+   */
+  fileExtension: string
+}
+
+/**
+ * Reactive API of a vehicle-synced file store: metadata lives in settings, bytes live in IndexedDB
+ * locally and in File Browser on the vehicle.
+ */
+export interface VehicleFileStore<M extends VehicleFileMeta> {
+  /**
+   * The metadata entries currently in the store.
+   */
+  entries: ComputedRef<M[]>
+  /**
+   * Resolves a stored file's renderable object URL, or `undefined` when its bytes are not cached locally.
+   * @param {string} id - The file's id.
+   * @returns {string | undefined} A `blob:` URL usable as an `<img>` src, or `undefined`.
+   */
+  urlFor: (id: string) => string | undefined
+  /**
+   * Stores a file locally (and pushes it to the vehicle when connected).
+   * @param {M} meta - The file's metadata; its `id` keys the stored bytes.
+   * @param {Blob | string} content - The file's content.
+   * @returns {Promise<void>} Resolves once the bytes and metadata have been persisted locally.
+   */
+  add: (meta: M, content: Blob | string) => Promise<void>
+  /**
+   * Removes a file locally (and from the vehicle when connected).
+   * @param {string} id - The file's id.
+   * @returns {Promise<void>} Resolves once the bytes and metadata have been removed locally.
+   */
+  remove: (id: string) => Promise<void>
+}
+
+// A single `vehicle-sync-complete` listener fans out to every store instance, so adding more asset
+// kinds (each with its own store) never stacks additional window listeners on the app singleton.
+const vehicleSyncSubscribers = new Set<(vehicleAddress: string) => void>()
+let vehicleSyncListenerRegistered = false
+
+const ensureVehicleSyncListener = (): void => {
+  if (vehicleSyncListenerRegistered) return
+  vehicleSyncListenerRegistered = true
+  // Wait for `vehicle-sync-complete` (dispatched after the settings pipeline runs) rather than the raw
+  // `vehicle-online`, so the metadata index has already been imported from the vehicle before we
+  // reconcile bytes; otherwise a fresh control station wouldn't yet know which files to pull.
+  window.addEventListener('vehicle-sync-complete', (event) => {
+    const vehicleAddress = (event as CustomEvent).detail?.vehicleAddress
+    if (!vehicleAddress) return
+    vehicleSyncSubscribers.forEach((notify) => notify(vehicleAddress))
+  })
+}
+
+/**
+ * Creates a reusable store that keeps a set of small files local-first while syncing them to the
+ * vehicle's File Browser. Only lightweight metadata is kept in the settings JSON; the bytes live in
+ * IndexedDB (so rendering works offline and across vehicles) and as real files under
+ * `userdata/cockpit/<subfolder>` on the vehicle (so they are shared across control stations).
+ *
+ * Intended to be instantiated once per asset kind at module scope (e.g. custom icons, and mission
+ * thumbnails in the future), each with its own config.
+ * @param {VehicleFileStorageConfig} config - Per-store settings key, IndexedDB store, vehicle folder and file type.
+ * @returns {VehicleFileStore<M>} The reactive store API.
+ */
+export const createVehicleFileStorage = <M extends VehicleFileMeta>(
+  config: VehicleFileStorageConfig
+): VehicleFileStore<M> => {
+  // The map key is the id (single source of truth), so the stored value omits it to avoid duplicating
+  // the id in the persisted settings; `entries` re-attaches it from the key.
+  const metaById = useBlueOsStorage<Record<string, Omit<M, 'id'>>>(config.settingsKey, {})
+  const blobStore = localforage.createInstance({
+    driver: localforage.INDEXEDDB,
+    name: 'Cockpit - Vehicle File Cache',
+    storeName: config.indexedDbStoreName,
+  })
+  const urls = ref<Record<string, string>>({})
+  const loadedIds = new Set<string>()
+
+  const fileNameFor = (id: string): string => `${id}.${config.fileExtension}`
+
+  const setUrl = (id: string, blob: Blob): void => {
+    if (urls.value[id]) URL.revokeObjectURL(urls.value[id])
+    urls.value = { ...urls.value, [id]: URL.createObjectURL(blob) }
+  }
+
+  const dropUrl = (id: string): void => {
+    if (urls.value[id]) URL.revokeObjectURL(urls.value[id])
+    const next = { ...urls.value }
+    delete next[id]
+    urls.value = next
+  }
+
+  // The metadata index is the source of truth (kept in sync across control stations by the settings
+  // backend). Keep the local object-URL cache aligned with it: load bytes for new ids, drop removed ones.
+  watch(
+    () => Object.keys(metaById.value),
+    async (ids) => {
+      Object.keys(urls.value)
+        .filter((id) => !ids.includes(id))
+        .forEach((id) => {
+          dropUrl(id)
+          loadedIds.delete(id)
+        })
+
+      for (const id of ids) {
+        if (loadedIds.has(id)) continue
+        loadedIds.add(id)
+        const blob = await blobStore.getItem<Blob>(id)
+        if (blob) setUrl(id, blob)
+      }
+    },
+    { immediate: true }
+  )
+
+  const add = async (meta: M, content: Blob | string): Promise<void> => {
+    const { id, ...rest } = meta
+    const blob = typeof content === 'string' ? new Blob([content], { type: config.mimeType }) : content
+    await blobStore.setItem(id, blob)
+    loadedIds.add(id)
+    setUrl(id, blob)
+    metaById.value = { ...metaById.value, [id]: rest }
+    if (currentVehicleAddress) {
+      uploadFileToVehicle(currentVehicleAddress, config.vehicleSubfolder, fileNameFor(id), blob).catch((error) =>
+        console.error(`Could not upload '${config.vehicleSubfolder}/${id}' to the vehicle. ${error}`)
+      )
+    }
+  }
+
+  const remove = async (id: string): Promise<void> => {
+    dropUrl(id)
+    loadedIds.delete(id)
+    await blobStore.removeItem(id)
+    const next = { ...metaById.value }
+    delete next[id]
+    metaById.value = next
+    if (currentVehicleAddress) {
+      deleteFileFromVehicle(currentVehicleAddress, config.vehicleSubfolder, fileNameFor(id)).catch((error) =>
+        console.error(`Could not delete '${config.vehicleSubfolder}/${id}' from the vehicle. ${error}`)
+      )
+    }
+  }
+
+  // Reconcile bytes with the vehicle: pull entries whose bytes we lack, push local bytes the vehicle lacks.
+  // The metadata index already arrived via settings sync, so it drives which files should exist.
+  let currentVehicleAddress: string | undefined
+  const syncWithVehicle = async (vehicleAddress: string): Promise<void> => {
+    currentVehicleAddress = vehicleAddress
+    const remoteFiles = new Set(await listVehicleFiles(vehicleAddress, config.vehicleSubfolder))
+
+    await Promise.all(
+      Object.keys(metaById.value).map(async (id) => {
+        const localBlob = await blobStore.getItem<Blob>(id)
+        const isRemote = remoteFiles.has(fileNameFor(id))
+        if (!localBlob && isRemote) {
+          const blob = await downloadFileFromVehicle(vehicleAddress, config.vehicleSubfolder, fileNameFor(id))
+          await blobStore.setItem(id, blob)
+          setUrl(id, blob)
+        } else if (localBlob && !isRemote) {
+          await uploadFileToVehicle(vehicleAddress, config.vehicleSubfolder, fileNameFor(id), localBlob)
+        }
+      })
+    )
+  }
+
+  ensureVehicleSyncListener()
+  vehicleSyncSubscribers.add((vehicleAddress) =>
+    syncWithVehicle(vehicleAddress).catch((error) =>
+      console.error(`Could not sync '${config.vehicleSubfolder}' files with the vehicle. ${error}`)
+    )
+  )
+
+  return {
+    entries: computed<M[]>(() => Object.entries(metaById.value).map(([id, meta]) => ({ ...meta, id } as M))),
+    urlFor: (id: string) => urls.value[id],
+    add,
+    remove,
+  }
+}

--- a/src/libs/blueos-files.ts
+++ b/src/libs/blueos-files.ts
@@ -1,0 +1,184 @@
+import ky, { HTTPError } from 'ky'
+
+import { protocol } from '@/libs/blueos'
+
+// BlueOS bundles the File Browser service behind `/file-browser`, exposing a REST API for reading and
+// writing real files on the vehicle. Unlike the bag-of-holding (a single JSON document), it stores
+// each asset as its own file, so it fits large/binary artifacts without bloating the settings payload.
+const requestTimeout = 15000
+
+// Persistent user-data volume on the vehicle (survives reboots and BlueOS updates). File Browser maps
+// its `userdata` shortcut here, so everything Cockpit writes lives under `userdata/cockpit/<subfolder>`.
+const cockpitAssetsRoot = ['userdata', 'cockpit']
+
+// File Browser hands out a session token even when configured with `--auth.method=noauth`; cache it per
+// vehicle so we don't log in on every request.
+const tokenByAddress = new Map<string, string>()
+
+/**
+ * A single entry in a File Browser folder listing.
+ */
+interface FileBrowserEntry {
+  /**
+   * Entry name, including the file extension.
+   */
+  name: string
+  /**
+   * Whether the entry is a directory rather than a file.
+   */
+  isDir: boolean
+}
+
+/**
+ * Response body of a File Browser `resources/<folder>` listing request.
+ */
+interface FileBrowserListing {
+  /**
+   * The files and folders contained in the listed directory.
+   */
+  items?: FileBrowserEntry[]
+}
+
+const fileBrowserUrl = (vehicleAddress: string, path: string): string =>
+  `${protocol}//${vehicleAddress}/file-browser/api/${path}`
+
+const encodeSegments = (segments: string[]): string => segments.map(encodeURIComponent).join('/')
+
+const authToken = async (vehicleAddress: string): Promise<string> => {
+  const cached = tokenByAddress.get(vehicleAddress)
+  if (cached) return cached
+  const token = await ky
+    .post(fileBrowserUrl(vehicleAddress, 'login'), {
+      json: { username: '', password: '', recaptcha: '' },
+      timeout: requestTimeout,
+      retry: 0,
+    })
+    .text()
+  tokenByAddress.set(vehicleAddress, token)
+  return token
+}
+
+// File Browser issues expiring JWTs even in noauth mode, so a cached token can go stale (e.g. after a
+// vehicle reboot). Refresh the token once on an auth error and retry before surfacing the failure.
+const withAuth = async <T>(vehicleAddress: string, request: (token: string) => Promise<T>): Promise<T> => {
+  try {
+    return await request(await authToken(vehicleAddress))
+  } catch (error) {
+    const status = error instanceof HTTPError ? error.response.status : undefined
+    if (status !== 401 && status !== 403) throw error
+    tokenByAddress.delete(vehicleAddress)
+    return await request(await authToken(vehicleAddress))
+  }
+}
+
+// File Browser does not create missing parent directories on upload, so the destination chain has to be
+// created explicitly before writing a file into it.
+const ensureFolderExists = async (vehicleAddress: string, token: string, subfolder: string): Promise<void> => {
+  const folderChains = [cockpitAssetsRoot, [...cockpitAssetsRoot, subfolder]]
+  for (const chain of folderChains) {
+    await ky
+      .post(fileBrowserUrl(vehicleAddress, `resources/${encodeSegments(chain)}/?override=false`), {
+        headers: { 'X-Auth': token },
+        timeout: requestTimeout,
+        retry: 0,
+      })
+      .catch(() => undefined)
+  }
+}
+
+/**
+ * Uploads (creating or overwriting) a single file into the vehicle's Cockpit assets folder.
+ * @param {string} vehicleAddress - The vehicle's address.
+ * @param {string} subfolder - Folder under `userdata/cockpit` to store the file in.
+ * @param {string} fileName - Name of the file to write, including its extension.
+ * @param {Blob | string} content - The file's content.
+ * @returns {Promise<void>} Resolves once the file has been written.
+ */
+export const uploadFileToVehicle = async (
+  vehicleAddress: string,
+  subfolder: string,
+  fileName: string,
+  content: Blob | string
+): Promise<void> => {
+  await withAuth(vehicleAddress, async (token) => {
+    await ensureFolderExists(vehicleAddress, token, subfolder)
+    await ky.post(
+      fileBrowserUrl(
+        vehicleAddress,
+        `resources/${encodeSegments([...cockpitAssetsRoot, subfolder, fileName])}?override=true`
+      ),
+      {
+        headers: { 'X-Auth': token },
+        body: content,
+        timeout: requestTimeout,
+        retry: 0,
+      }
+    )
+  })
+}
+
+/**
+ * Downloads a single file from the vehicle's Cockpit assets folder.
+ * @param {string} vehicleAddress - The vehicle's address.
+ * @param {string} subfolder - Folder under `userdata/cockpit` the file lives in.
+ * @param {string} fileName - Name of the file to read, including its extension.
+ * @returns {Promise<Blob>} The file's content as a Blob.
+ */
+export const downloadFileFromVehicle = async (
+  vehicleAddress: string,
+  subfolder: string,
+  fileName: string
+): Promise<Blob> => {
+  return await withAuth(vehicleAddress, (token) => {
+    const rawPath = `raw/${encodeSegments([...cockpitAssetsRoot, subfolder, fileName])}?auth=${token}`
+    return ky.get(fileBrowserUrl(vehicleAddress, rawPath), { timeout: requestTimeout, retry: 0 }).blob()
+  })
+}
+
+/**
+ * Deletes a single file from the vehicle's Cockpit assets folder.
+ * @param {string} vehicleAddress - The vehicle's address.
+ * @param {string} subfolder - Folder under `userdata/cockpit` the file lives in.
+ * @param {string} fileName - Name of the file to delete, including its extension.
+ * @returns {Promise<void>} Resolves once the file has been deleted.
+ */
+export const deleteFileFromVehicle = async (
+  vehicleAddress: string,
+  subfolder: string,
+  fileName: string
+): Promise<void> => {
+  await withAuth(vehicleAddress, async (token) => {
+    await ky.delete(
+      fileBrowserUrl(vehicleAddress, `resources/${encodeSegments([...cockpitAssetsRoot, subfolder, fileName])}`),
+      {
+        headers: { 'X-Auth': token },
+        timeout: requestTimeout,
+        retry: 0,
+      }
+    )
+  })
+}
+
+/**
+ * Lists the file names present in the vehicle's Cockpit assets subfolder.
+ * @param {string} vehicleAddress - The vehicle's address.
+ * @param {string} subfolder - Folder under `userdata/cockpit` to list.
+ * @returns {Promise<string[]>} The names of the files in the folder, or an empty array when the folder does not exist.
+ */
+export const listVehicleFiles = async (vehicleAddress: string, subfolder: string): Promise<string[]> => {
+  try {
+    const folder = await withAuth(vehicleAddress, (token) =>
+      ky
+        .get(fileBrowserUrl(vehicleAddress, `resources/${encodeSegments([...cockpitAssetsRoot, subfolder])}`), {
+          headers: { 'X-Auth': token },
+          timeout: requestTimeout,
+          retry: 0,
+        })
+        .json<FileBrowserListing>()
+    )
+    return (folder.items ?? []).filter((item) => !item.isDir).map((item) => item.name)
+  } catch {
+    // A missing folder (nothing uploaded yet) returns 404; treat it as an empty listing.
+    return []
+  }
+}

--- a/src/libs/blueos.ts
+++ b/src/libs/blueos.ts
@@ -21,7 +21,7 @@ const defaultTimeout = 10000
 const quickStatusTimeout = 3000
 const beaconTimeout = 5000
 
-const protocol = window.location.protocol.includes('file') ? 'http:' : window.location.protocol
+export const protocol = window.location.protocol.includes('file') ? 'http:' : window.location.protocol
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export const getBagOfHoldingFromVehicle = async (

--- a/src/libs/custom-icons.ts
+++ b/src/libs/custom-icons.ts
@@ -1,0 +1,101 @@
+import { v4 as uuid } from 'uuid'
+
+import type { VehicleFileMeta } from '@/composables/useVehicleFileStorage'
+
+// Keeps a single icon small so it stays cheap to cache in IndexedDB, upload to the vehicle, and render.
+export const MAX_CUSTOM_ICON_SVG_SIZE_BYTES = 50 * 1024
+
+// Distinguishes custom SVG icon references from MDI class names inside `iconName` fields.
+const customIconRefPrefix = 'custom:'
+
+/**
+ * Metadata for a user-uploaded SVG icon available to Very Generic Indicators. The SVG bytes are not
+ * kept here — they live in the local IndexedDB cache and, when connected, on the vehicle's File Browser.
+ */
+export interface CustomIcon extends VehicleFileMeta {
+  /**
+   * User-facing name shown in the icon library and pickers.
+   */
+  name: string
+}
+
+/**
+ * Checks whether an `iconName` value refers to a custom icon rather than an MDI class.
+ * @param {string | undefined} iconName - The value stored in `miniWidget.options.iconName`.
+ * @returns {boolean} True if the value is a custom icon reference.
+ */
+export const isCustomIconRef = (iconName: string | undefined): boolean => {
+  return typeof iconName === 'string' && iconName.startsWith(customIconRefPrefix)
+}
+
+/**
+ * Builds the `iconName` reference for a custom icon id.
+ * @param {string} id - The custom icon's id.
+ * @returns {string} The `iconName` value to store on a widget's options.
+ */
+export const customIconRefFromId = (id: string): string => `${customIconRefPrefix}${id}`
+
+/**
+ * Extracts the custom icon id from an `iconName` reference.
+ * @param {string} iconRef - A value for which `isCustomIconRef` returns true.
+ * @returns {string} The custom icon's id.
+ */
+export const idFromCustomIconRef = (iconRef: string): string => iconRef.slice(customIconRefPrefix.length)
+
+/**
+ * Validates that uploaded content is a small, well-formed SVG.
+ * @param {string} svg - The raw file content to validate.
+ * @returns {string | undefined} An error message if invalid, or `undefined` if the SVG is acceptable.
+ */
+export const validateCustomIconSvg = (svg: string): string | undefined => {
+  // Strip a leading BOM and surrounding whitespace so files exported by editors like Inkscape
+  // (which prepend an <?xml ...?> prolog, a DOCTYPE and comments before the root) still validate.
+  const content = svg.replace(/^\uFEFF/, '').trim()
+
+  if (!content) {
+    return 'The selected file is empty.'
+  }
+
+  const sizeBytes = new TextEncoder().encode(content).length
+  if (sizeBytes > MAX_CUSTOM_ICON_SVG_SIZE_BYTES) {
+    const currentKb = Math.ceil(sizeBytes / 1024)
+    const maxKb = MAX_CUSTOM_ICON_SVG_SIZE_BYTES / 1024
+    return (
+      `Icon is too large (${currentKb} KB, the limit is ${maxKb} KB). SVGs that embed a full raster ` +
+      'image (e.g. an imported or traced PNG/JPEG) are usually this big. Export a simplified vector SVG, ' +
+      'or shrink the embedded image before uploading.'
+    )
+  }
+
+  // file.text() decodes bytes as UTF-8, so any binary file (PNG/JPEG/etc.) renamed to .svg ends up
+  // containing U+FFFD replacement characters. Genuine SVG is plain text and never does.
+  if (content.includes('\uFFFD')) {
+    return (
+      'This looks like a binary image (e.g. PNG or JPEG), not a text-based SVG. Renaming a .png/.jpg ' +
+      'file to .svg does not convert it. In Inkscape, open the image and use File > Save As > "Plain SVG" ' +
+      '(or "Optimized SVG") to export a real vector file.'
+    )
+  }
+
+  // Look for the <svg> root anywhere, not only at the very start, so a leading XML prolog, DOCTYPE
+  // or comment does not cause a false rejection.
+  if (!/<svg[\s>]/i.test(content)) {
+    return (
+      'No <svg> element was found in the file, so it is not a valid SVG. Make sure you exported the ' +
+      'vector graphic itself — in Inkscape use File > Save As > "Plain SVG" or "Optimized SVG".'
+    )
+  }
+
+  return undefined
+}
+
+/**
+ * Creates a new custom icon metadata record.
+ * @param {string} name - User-facing name for the icon.
+ * @returns {CustomIcon} The new custom icon metadata, with a freshly generated id and timestamp.
+ */
+export const createCustomIcon = (name: string): CustomIcon => ({
+  id: uuid(),
+  name,
+  createdAt: Date.now(),
+})

--- a/src/libs/mission/library.ts
+++ b/src/libs/mission/library.ts
@@ -1,4 +1,5 @@
 import { MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
+import { utf8ToBase64 } from '@/libs/utils'
 import { CockpitMission, SavedMission, Waypoint, WaypointCoordinates } from '@/types/mission'
 
 // Square so it matches the mission library card's `aspect-square` thumbnail, avoiding
@@ -44,13 +45,6 @@ export const vehicleTypeLabel = (type?: MavType): string => {
       .replace(/(^|_)([a-z])/g, (_m, _p1, c) => ` ${c.toUpperCase()}`)
       .trim()
   )
-}
-
-const utf8ToBase64 = (input: string): string => {
-  const bytes = new TextEncoder().encode(input)
-  let binary = ''
-  for (const byte of bytes) binary += String.fromCharCode(byte)
-  return btoa(binary)
 }
 
 type LatLngBounds = {

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -36,6 +36,18 @@ export const sequentialArray = (length: number): number[] => {
 }
 
 /**
+ * Base64-encodes a UTF-8 string, preserving the multi-byte characters that `btoa` alone would mangle.
+ * @param {string} input - The UTF-8 string to encode.
+ * @returns {string} The base64-encoded representation.
+ */
+export const utf8ToBase64 = (input: string): string => {
+  const bytes = new TextEncoder().encode(input)
+  let binary = ''
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return btoa(binary)
+}
+
+/**
  * Simple scale function
  * @param {number} input Input value
  * @param {number} inputMin Input lowest point

--- a/src/types/genericIndicator.ts
+++ b/src/types/genericIndicator.ts
@@ -11,7 +11,8 @@ export interface VeryGenericIndicatorPreset {
    */
   variableName: string
   /**
-   * Name of the icon to be used (only supporting MDI icons currently)
+   * Name of the icon to be used. Either an MDI class name (e.g. `mdi-thermometer`) or a custom
+   * icon reference (`custom:<id>`) pointing to the user's uploaded SVG icon library.
    */
   iconName: string
   /**


### PR DESCRIPTION
- Very Generic Indicators can now use user-uploaded SVG icons alongside the stock MDI set.
- New reusable `useVehicleFileStorage` service keeps file assets local-first in IndexedDB and syncs the real files to BlueOS File Browser under `userdata/cockpit/<subfolder>`, keeping only a lightweight metadata index in settings instead of base64 blobs; ready to be shared by mission thumbnails later.
- Custom icons build on that service via `useCustomIcons`: SVGs are validated and 50 KB size-capped in a framework-agnostic `custom-icons` module, while only the `{ id, name, createdAt }` index (`cockpit-custom-icons-v1`) syncs across control stations.
- Shared `VgiIcon` component resolves either an MDI class or a `custom:<id>` reference, rendering custom SVGs through an `<img>` object URL (no inline SVG) to avoid embedded-script execution.
- Icon picker gains a stock/custom category toggle with an inline upload that auto-selects the newly uploaded icon, plus per-icon delete with confirmation.
- Config dialog restyled to the current Cockpit Vuetify pattern (titled card, tabs, outlined inputs, footer).

![Live VGI showing a custom icon](https://raw.githubusercontent.com/ArturoManzoli/cockpit/pr-assets-2793/vgi-custom-icon-live.png)

<img width="633" height="632" alt="image" src="https://github.com/user-attachments/assets/973773dc-e640-4c5d-a532-1f8c69405b87" />

![Config dialog — basic icons category](https://raw.githubusercontent.com/ArturoManzoli/cockpit/pr-assets-2793/vgi-custom-icons-modal-basic.png)

Closes #2793
