### PR TITLE
Mission Planning: Back mission library thumbnails with vehicle file storage

### DIFF
--- a/src/components/MissionLibraryModal.vue
+++ b/src/components/MissionLibraryModal.vue
@@ -399,7 +399,7 @@ const formatDate = (date: Date): string => format(date, 'LLL dd, yyyy HH:mm')
 const googleEarthUrl = (coords: WaypointCoordinates): string =>
   `https://earth.google.com/web/@${coords[0]},${coords[1]},500a,1000d`
 
-const thumbnailFor = (mission: SavedMission): string | undefined => missionStore.savedMissionThumbnails[mission.id]
+const thumbnailFor = (mission: SavedMission): string | undefined => missionStore.thumbnailUrlFor(mission.id)
 
 const openDetail = (mission: SavedMission): void => {
   logUserAction(`Opened details for saved mission "${mission.name}"`)

--- a/src/composables/useMissionThumbnails.ts
+++ b/src/composables/useMissionThumbnails.ts
@@ -1,0 +1,68 @@
+import { type VehicleFileMeta, createVehicleFileStorage } from '@/composables/useVehicleFileStorage'
+
+// Singleton so every call site shares the same reactive cache. The SVG bytes are cached in IndexedDB
+// and synced to the vehicle as real files; only the `{ id, createdAt }` index rides in settings.
+const thumbnailStorage = createVehicleFileStorage<VehicleFileMeta>({
+  settingsKey: 'cockpit-mission-thumbnails-v1',
+  indexedDbStoreName: 'cockpit-mission-thumbnails',
+  vehicleSubfolder: 'mission-thumbnails',
+  mimeType: 'image/svg+xml',
+  fileExtension: 'svg',
+})
+
+/**
+ * Reactive API for the saved missions' thumbnail bytes, synced to the vehicle via BlueOS.
+ */
+export interface MissionThumbnailsApi {
+  /**
+   * Resolves a saved mission's thumbnail to a renderable URL.
+   * @param {string} missionId - The saved mission's id.
+   * @returns {string | undefined} The thumbnail's `blob:` object URL (must not be persisted), or `undefined` if its bytes aren't cached yet.
+   */
+  urlFor: (missionId: string) => string | undefined
+  /**
+   * Stores (creating or overwriting) a mission's thumbnail.
+   * @param {string} missionId - The saved mission's id.
+   * @param {string} svg - The thumbnail's raw SVG markup.
+   * @returns {Promise<void>} Resolves once the local write has been attempted; failures are logged, not thrown.
+   */
+  setThumbnail: (missionId: string, svg: string) => Promise<void>
+  /**
+   * Removes a mission's thumbnail.
+   * @param {string} missionId - The saved mission's id.
+   * @returns {Promise<void>} Resolves once the local removal has been attempted; failures are logged, not thrown.
+   */
+  removeThumbnail: (missionId: string) => Promise<void>
+}
+
+/**
+ * Provides reactive access to the saved missions' thumbnails, kept local-first in IndexedDB and synced
+ * to the vehicle's File Browser so they are shared across control stations without bloating the settings.
+ * @returns {MissionThumbnailsApi} Thumbnail URL resolver plus set/remove helpers.
+ */
+export function useMissionThumbnails(): MissionThumbnailsApi {
+  const setThumbnail = async (missionId: string, svg: string): Promise<void> => {
+    // Preserve the original creation time when re-saving an existing mission's thumbnail.
+    const createdAt = thumbnailStorage.entries.value.find((entry) => entry.id === missionId)?.createdAt ?? Date.now()
+    // Callers fire-and-forget, so swallow local-write failures here instead of leaking a rejection.
+    try {
+      await thumbnailStorage.add({ id: missionId, createdAt }, svg)
+    } catch (error) {
+      console.error(`Could not store thumbnail for mission '${missionId}'. ${error}`)
+    }
+  }
+
+  const removeThumbnail = async (missionId: string): Promise<void> => {
+    try {
+      await thumbnailStorage.remove(missionId)
+    } catch (error) {
+      console.error(`Could not remove thumbnail for mission '${missionId}'. ${error}`)
+    }
+  }
+
+  return {
+    urlFor: thumbnailStorage.urlFor,
+    setThumbnail,
+    removeThumbnail,
+  }
+}

--- a/src/libs/mission/library.ts
+++ b/src/libs/mission/library.ts
@@ -1,5 +1,4 @@
 import { MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
-import { utf8ToBase64 } from '@/libs/utils'
 import { CockpitMission, SavedMission, Waypoint, WaypointCoordinates } from '@/types/mission'
 
 // Square so it matches the mission library card's `aspect-square` thumbnail, avoiding
@@ -82,22 +81,22 @@ const computeBounds = (coordinates: WaypointCoordinates[]): LatLngBounds | null 
 }
 
 /**
- * Generates a lightweight SVG thumbnail (base64 data URL) of a mission's geometry.
+ * Generates a lightweight SVG thumbnail of a mission's geometry as raw markup.
  * @param {CockpitMission} mission - The mission to render.
- * @returns {string} A base64 `data:image/svg+xml` URL.
+ * @returns {string} The thumbnail's raw SVG markup.
  */
-export const generateMissionThumbnail = (mission: CockpitMission): string => {
+export const generateMissionThumbnailSvg = (mission: CockpitMission): string => {
   const waypointCoords: WaypointCoordinates[] = (mission.waypoints ?? []).map((w) => w.coordinates)
   const surveyCoords: WaypointCoordinates[] = (mission.surveys ?? []).flatMap((s) => s.polygonCoordinates ?? [])
   const allCoords = [...waypointCoords, ...surveyCoords]
 
   if (allCoords.length === 0) {
-    const emptySvg =
+    return (
       `<svg xmlns="http://www.w3.org/2000/svg" width="${THUMBNAIL_WIDTH}" height="${THUMBNAIL_HEIGHT}" viewBox="0 0 ${THUMBNAIL_WIDTH} ${THUMBNAIL_HEIGHT}">` +
       `<rect width="100%" height="100%" fill="#1f2a37"/>` +
       `<text x="50%" y="50%" fill="#ffffff66" font-family="sans-serif" font-size="16" text-anchor="middle" dominant-baseline="middle">No path</text>` +
       `</svg>`
-    return `data:image/svg+xml;base64,${utf8ToBase64(emptySvg)}`
+    )
   }
 
   const bounds = computeBounds(allCoords)!
@@ -146,15 +145,14 @@ export const generateMissionThumbnail = (mission: CockpitMission): string => {
     })
     .join('')
 
-  const svg =
+  return (
     `<svg xmlns="http://www.w3.org/2000/svg" width="${THUMBNAIL_WIDTH}" height="${THUMBNAIL_HEIGHT}" viewBox="0 0 ${THUMBNAIL_WIDTH} ${THUMBNAIL_HEIGHT}">` +
     `<rect width="100%" height="100%" fill="#1f2a37"/>` +
     surveyPolygons +
     pathElement +
     waypointMarkers +
     `</svg>`
-
-  return `data:image/svg+xml;base64,${utf8ToBase64(svg)}`
+  )
 }
 
 /**

--- a/src/stores/mission.ts
+++ b/src/stores/mission.ts
@@ -7,10 +7,11 @@ import { computed, reactive, ref, watch } from 'vue'
 import { defaultMapFallbackBaseColor, defaultMapFallbackNoiseIntensity } from '@/assets/defaults'
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { useBlueOsStorage } from '@/composables/settingsSyncer'
+import { useMissionThumbnails } from '@/composables/useMissionThumbnails'
 import { askForUsername } from '@/composables/usernamePrompDialog'
 import { MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import { generateSessionSeed } from '@/libs/map/map-tile-fallback'
-import { generateMissionThumbnail } from '@/libs/mission/library'
+import { generateMissionThumbnailSvg } from '@/libs/mission/library'
 import { eventCategoriesDefaultMapping } from '@/libs/slide-to-confirm'
 import {
   AltitudeReferenceType,
@@ -105,10 +106,10 @@ export const useMissionStore = defineStore('mission', () => {
 
   // Fallback vehicle type used by vehicle-specific planning features when no vehicle is connected.
   const plannedVehicleType = useBlueOsStorage<MavType | undefined>('cockpit-planned-vehicle-type', undefined)
-  // Thumbnails are stored separately from the saved missions so that adding many entries doesn't
-  // bloat the main library payload (each thumbnail is ~1-2 KB of base64 SVG).
   const savedMissions = useBlueOsStorage<SavedMission[]>('cockpit-mission-library', [])
-  const savedMissionThumbnails = useBlueOsStorage<Record<string, string>>('cockpit-mission-library-thumbnails', {})
+  // Thumbnail bytes live local-first in IndexedDB and sync to the vehicle as real files, so adding many
+  // entries never bloats the settings payload the way inlined base64 SVGs would.
+  const { urlFor: thumbnailUrlFor, setThumbnail, removeThumbnail } = useMissionThumbnails()
 
   const { showDialog } = useInteractionDialog()
 
@@ -707,7 +708,7 @@ export const useMissionStore = defineStore('mission', () => {
     id?: string
   }): SavedMission => {
     const now = Date.now()
-    const thumbnail = generateMissionThumbnail(payload.mission)
+    const thumbnailSvg = generateMissionThumbnailSvg(payload.mission)
     const existingIndex = payload.id ? savedMissions.value.findIndex((m) => m.id === payload.id) : -1
 
     if (existingIndex !== -1) {
@@ -723,7 +724,7 @@ export const useMissionStore = defineStore('mission', () => {
         estimates: payload.estimates,
       }
       savedMissions.value.splice(existingIndex, 1, updated)
-      savedMissionThumbnails.value = { ...savedMissionThumbnails.value, [updated.id]: thumbnail }
+      setThumbnail(updated.id, thumbnailSvg)
       return updated
     }
 
@@ -738,18 +739,14 @@ export const useMissionStore = defineStore('mission', () => {
       estimates: payload.estimates,
     }
     savedMissions.value.unshift(created)
-    savedMissionThumbnails.value = { ...savedMissionThumbnails.value, [created.id]: thumbnail }
+    setThumbnail(created.id, thumbnailSvg)
     return created
   }
 
   const deleteSavedMission = (id: string): void => {
     const index = savedMissions.value.findIndex((m) => m.id === id)
     if (index !== -1) savedMissions.value.splice(index, 1)
-    if (savedMissionThumbnails.value[id]) {
-      const next = { ...savedMissionThumbnails.value }
-      delete next[id]
-      savedMissionThumbnails.value = next
-    }
+    removeThumbnail(id)
   }
 
   return {
@@ -833,7 +830,7 @@ export const useMissionStore = defineStore('mission', () => {
     plannedVehicleType,
     effectiveVehicleType,
     savedMissions,
-    savedMissionThumbnails,
+    thumbnailUrlFor,
     saveMissionToLibrary,
     deleteSavedMission,
   }


### PR DESCRIPTION
- Follow-up to #2795: moves saved-mission thumbnails off base64-in-settings onto the shared vehicle file storage (IndexedDB locally, BlueOS File Browser for sync).
- Keeps only a lightweight `{ id, createdAt }` index in settings under `cockpit-mission-thumbnails-v1`; the SVG bytes live in IndexedDB and sync to the vehicle as real files.
- Thumbnail generator now emits raw SVG markup; the library modal renders the resulting object URL via the new `useMissionThumbnails` composable.
- Thumbnails are shared across control stations through vehicle sync instead of bloating the settings JSON.
- Thumbnail set/remove swallow-and-log local write failures so best-effort background writes can't leak an unhandled rejection.

To be merged after #2824 