### PR TITLE
Mission Planning: Keep last uploaded mission for quick edits

### DIFF
--- a/src/composables/useMissionOperations.ts
+++ b/src/composables/useMissionOperations.ts
@@ -1,0 +1,93 @@
+import { computed, ComputedRef } from 'vue'
+
+import { type DialogOptions, type DialogResult } from '@/composables/interactionDialog'
+import { type SnackbarOptions } from '@/composables/snackbar'
+import { useMissionStore } from '@/stores/mission'
+import { type CockpitMission, instanceOfCockpitMission } from '@/types/mission'
+
+/**
+ * View-owned functions the mission operations rely on, injected so the composable stays decoupled from
+ * the consuming component's map and feedback plumbing.
+ */
+interface MissionOperationsDeps {
+  /**
+   * Loads a mission onto the planner map, replacing the current one.
+   */
+  loadDraftMission: (mission: CockpitMission) => Promise<void>
+  /**
+   * Shows an interaction dialog and resolves once the user confirms or dismisses it.
+   */
+  showDialog: (options: DialogOptions) => Promise<DialogResult>
+  /**
+   * Closes the currently open interaction dialog.
+   */
+  closeDialog: () => void
+  /**
+   * Opens a snackbar with the given options.
+   */
+  openSnackbar: (options: SnackbarOptions) => void
+}
+
+/**
+ * Composable centralizing mission operations shared by the mission-planning surfaces, starting with
+ * restoring the last uploaded mission for quick edits.
+ * @param {MissionOperationsDeps} deps - View-owned map-loading, dialog and snackbar functions.
+ * @returns {{ hasLastUploadedMission: ComputedRef<boolean>, restoreLastUploadedMission: () => void }}
+ * Reactive state and helpers for mission operations.
+ */
+export const useMissionOperations = (
+  deps: MissionOperationsDeps
+): {
+  /**
+   * Whether a restorable last-uploaded mission snapshot is currently stored.
+   */
+  hasLastUploadedMission: ComputedRef<boolean>
+  /**
+   * Restores the last uploaded mission onto the planner, confirming first when a mission is in progress.
+   */
+  restoreLastUploadedMission: () => void
+} => {
+  const { loadDraftMission, showDialog, closeDialog, openSnackbar } = deps
+  const missionStore = useMissionStore()
+
+  const hasLastUploadedMission = computed(() => instanceOfCockpitMission(missionStore.lastUploadedMission))
+
+  const restoreLastUploadedMission = (): void => {
+    const mission = missionStore.lastUploadedMission
+    if (!instanceOfCockpitMission(mission)) return
+
+    const doRestore = (): void => {
+      logUserAction('Restored the last uploaded mission')
+      loadDraftMission(mission).catch((err) => {
+        openSnackbar({ variant: 'error', message: `Failed to restore last uploaded mission: ${err}`, duration: 3500 })
+      })
+    }
+
+    if (missionStore.currentPlanningWaypoints.length === 0) {
+      doRestore()
+      return
+    }
+
+    logUserAction('Opened the restore-last-uploaded-mission dialog')
+    showDialog({
+      variant: 'warning',
+      title: 'Restore last uploaded mission',
+      message: 'This will replace the current mission with the last one uploaded to the vehicle. Continue?',
+      persistent: false,
+      maxWidth: 620,
+      actions: [
+        { text: 'Cancel', color: 'white', action: closeDialog },
+        {
+          text: 'Restore',
+          color: 'white',
+          action: () => {
+            closeDialog()
+            doRestore()
+          },
+        },
+      ],
+    })
+  }
+
+  return { hasLastUploadedMission, restoreLastUploadedMission }
+}

--- a/src/stores/mission.ts
+++ b/src/stores/mission.ts
@@ -56,6 +56,12 @@ export const useMissionStore = defineStore('mission', () => {
   const userLastMapZoom = useBlueOsStorage<number>('cockpit-user-last-map-zoom', DEFAULT_MAP_ZOOM)
   const followVehicleOnMap = useBlueOsStorage<boolean>('cockpit-map-follow-vehicle', false)
   const draftMission = useBlueOsStorage('cockpit-draft-mission', {})
+  // Snapshot of the last mission uploaded to the vehicle, kept so users can restore it for quick edits
+  // even across sessions, without re-downloading it from the (possibly deployed) vehicle.
+  const lastUploadedMission = useBlueOsStorage<CockpitMission | Record<string, never>>(
+    'cockpit-last-uploaded-mission',
+    {}
+  )
   const vehicleMission = useBlueOsStorage<Waypoint[]>('cockpit-vehicle-mission', [])
   const vehicleMissionRevision = useBlueOsStorage<number>('cockpit-vehicle-mission-rev', 0)
   const alwaysSwitchToFlightMode = useBlueOsStorage('cockpit-mission-always-switch-to-flight-mode', false)
@@ -391,6 +397,10 @@ export const useMissionStore = defineStore('mission', () => {
 
   const clearDraft = (): void => {
     draftMission.value = {}
+  }
+
+  const setLastUploadedMission = (mission: CockpitMission): void => {
+    lastUploadedMission.value = mission
   }
 
   const bumpVehicleMissionRevision = (wps: Waypoint[]): void => {
@@ -791,8 +801,10 @@ export const useMissionStore = defineStore('mission', () => {
     requestMapOverlayFocus,
     persistDraft,
     clearDraft,
+    setLastUploadedMission,
     bumpVehicleMissionRevision,
     draftMission,
+    lastUploadedMission,
     vehicleMission,
     vehicleMissionRevision,
     alwaysSwitchToFlightMode,

--- a/src/stores/mission.ts
+++ b/src/stores/mission.ts
@@ -66,6 +66,12 @@ export const useMissionStore = defineStore('mission', () => {
   const userLastMapZoom = useBlueOsStorage<number>('cockpit-user-last-map-zoom', DEFAULT_MAP_ZOOM)
   const followVehicleOnMap = useBlueOsStorage<boolean>('cockpit-map-follow-vehicle', false)
   const draftMission = useBlueOsStorage('cockpit-draft-mission', {})
+  // Snapshot of the last mission uploaded to the vehicle, kept so users can restore it for quick edits
+  // even across sessions, without re-downloading it from the (possibly deployed) vehicle.
+  const lastUploadedMission = useBlueOsStorage<CockpitMission | Record<string, never>>(
+    'cockpit-last-uploaded-mission',
+    {}
+  )
   const vehicleMission = useBlueOsStorage<Waypoint[]>('cockpit-vehicle-mission', [])
   const vehicleMissionRevision = useBlueOsStorage<number>('cockpit-vehicle-mission-rev', 0)
   const alwaysSwitchToFlightMode = useBlueOsStorage('cockpit-mission-always-switch-to-flight-mode', false)
@@ -458,6 +464,10 @@ export const useMissionStore = defineStore('mission', () => {
 
   const clearDraft = (): void => {
     draftMission.value = {}
+  }
+
+  const setLastUploadedMission = (mission: CockpitMission): void => {
+    lastUploadedMission.value = mission
   }
 
   const bumpVehicleMissionRevision = (wps: Waypoint[]): void => {
@@ -897,8 +907,10 @@ export const useMissionStore = defineStore('mission', () => {
     userLastCustomMapProviderId,
     persistDraft,
     clearDraft,
+    setLastUploadedMission,
     bumpVehicleMissionRevision,
     draftMission,
+    lastUploadedMission,
     vehicleMission,
     vehicleMissionRevision,
     alwaysSwitchToFlightMode,

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -487,6 +487,14 @@
           <v-progress-circular v-if="loading" size="20" class="py-4" />
           <p v-else>DOWNLOAD MISSION FROM VEHICLE</p>
         </button>
+        <button
+          v-if="hasLastUploadedMission"
+          :disabled="loading"
+          class="h-auto py-2 px-2 m-2 mt-2 text-sm rounded-md elevation-1 bg-[#FFFFFF11] hover:bg-[#FFFFFF22] transition-colors duration-200"
+          @click="restoreLastUploadedMission"
+        >
+          RESTORE LAST UPLOADED MISSION
+        </button>
       </div>
     </div>
     <v-tooltip location="top" text="Switch to Flight mode">
@@ -760,6 +768,7 @@ import {
   setSurveyAreaSquareMeters,
   useMissionEstimates,
 } from '@/composables/useMissionEstimates'
+import { useMissionOperations } from '@/composables/useMissionOperations'
 import { useOfflineTiles } from '@/composables/useOfflineTiles'
 import { MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import { MavCmd } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
@@ -913,12 +922,14 @@ const uploadMissionToVehicle = async (): Promise<void> => {
       throw 'Vehicle is not online.'
     }
     await vehicleStore.uploadMission(missionItemsToUpload, loadingCallback)
+    // Keep the uploaded mission on the planner (draft) and store a restorable snapshot so quick edits
+    // don't require re-downloading it from the vehicle.
+    missionStore.setLastUploadedMission(buildCurrentMissionSnapshot())
     const message = 'Go to Flight Mode and click the “play” button to start the mission.'
 
     if (missionStore.alwaysSwitchToFlightMode) {
       router.push('/')
       missionStore.bumpVehicleMissionRevision(missionItemsToUpload)
-      missionStore.clearDraft()
       return
     }
     showDialog({
@@ -949,7 +960,6 @@ const uploadMissionToVehicle = async (): Promise<void> => {
     })
     hasUploadedMission.value = true
     missionStore.bumpVehicleMissionRevision(missionItemsToUpload)
-    missionStore.clearDraft()
   } catch (error) {
     showDialog({
       variant: 'error',
@@ -3874,6 +3884,13 @@ const openMissionLibrary = (): void => {
   logUserAction('Opened the mission library')
   interfaceStore.missionLibraryVisibility = true
 }
+
+const { hasLastUploadedMission, restoreLastUploadedMission } = useMissionOperations({
+  loadDraftMission,
+  showDialog,
+  closeDialog,
+  openSnackbar,
+})
 
 const handleLoadMissionFromLibrary = (mission: SavedMission): void => {
   if (mission.vehicleType && !vehicleStore.isVehicleOnline) {

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -3910,8 +3910,11 @@ const buildCurrentMissionSnapshot = (): CockpitMission => ({
     // typed but hasn't committed back to the store yet (e.g. by uploading the mission).
     defaultCruiseSpeed: localCruiseSpeed.value,
   },
-  waypoints: structuredClone(toRaw(missionStore.currentPlanningWaypoints)),
-  surveys: structuredClone(toRaw(missionStore.currentPlanningSurveys)),
+  // Editing a waypoint (e.g. moveWaypoint) re-injects Vue reactive proxies into the arrays, which
+  // toRaw only unwraps at the top level and structuredClone then chokes on. A JSON round-trip strips
+  // that reactivity at every depth, matching how the store already serializes these same arrays.
+  waypoints: JSON.parse(JSON.stringify(missionStore.currentPlanningWaypoints)),
+  surveys: JSON.parse(JSON.stringify(missionStore.currentPlanningSurveys)),
 })
 
 const currentMissionSnapshot = ref<CockpitMission>(buildCurrentMissionSnapshot())

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -129,8 +129,13 @@
     </div>
     <div
       v-show="!interfaceStore.isMainMenuVisible"
+      ref="missionToolboxRef"
       class="absolute flex flex-col left-10 rounded-[10px] max-h-[80vh] overflow-y-auto z-[200]"
-      :style="[interfaceStore.globalGlassMenuStyles, { height: 'auto', maxHeight: calculatedHeight, width: '320px' }]"
+      :style="[
+        interfaceStore.globalGlassMenuStyles,
+        { height: 'auto', maxHeight: calculatedHeight, width: '320px' },
+        missionToolboxPinnedTop !== null ? { top: `${missionToolboxPinnedTop}px` } : {},
+      ]"
     >
       <div class="flex flex-col w-full h-full p-2 overflow-y-auto">
         <button
@@ -386,7 +391,7 @@
         </div>
 
         <div>
-          <div class="flex w-full justify-between my-2 px-1">
+          <div class="flex w-full justify-between my-2 px-3">
             <v-tooltip location="top" text="Undo (Ctrl+Z / Cmd+Z)">
               <template #activator="{ props }">
                 <v-btn
@@ -456,45 +461,100 @@
             </v-tooltip>
           </div>
         </div>
-        <v-divider v-if="isCreatingSimplePath || isCreatingSurvey" class="my-2" />
-        <button
+        <div
           v-if="!isCreatingSimplePath && !isCreatingSurvey && missionStore.currentPlanningWaypoints.length > 0"
-          :disabled="missionStore.currentPlanningWaypoints.length < 2 || !vehicleStore.isVehicleOnline"
-          :class="{
-            'bg-[#FFFFFF11] hover:bg-[#FFFFFF11] text-[#FFFFFF22] elevation-0':
-              missionStore.currentPlanningWaypoints.length < 2 || !vehicleStore.isVehicleOnline,
-          }"
-          class="h-auto py-2 px-2 m-2 mt-2 text-sm rounded-md elevation-1 bg-[#3B78A8] hover:bg-[#3B78A8] transition-colors duration-200"
-          @click="uploadMissionToVehicle"
+          class="flex flex-row items-stretch gap-2 m-2 mt-2"
         >
-          UPLOAD MISSION TO VEHICLE
-        </button>
-        <button
-          v-if="missionStore.currentPlanningWaypoints.length > 0"
-          :disabled="loading"
-          class="h-auto py-1 px-1 m-2 mt-2 text-sm rounded-md elevation-1 bg-[#FFFFFF11] hover:bg-[#FFFFFF22] transition-colors duration-200"
-          @click="openCLearMissionDialog"
+          <button
+            :disabled="missionStore.currentPlanningWaypoints.length < 2 || !vehicleStore.isVehicleOnline"
+            :class="{
+              'bg-[#FFFFFF11] hover:bg-[#FFFFFF11] text-[#FFFFFF22] elevation-0':
+                missionStore.currentPlanningWaypoints.length < 2 || !vehicleStore.isVehicleOnline,
+            }"
+            class="flex-1 min-w-0 h-[40px] py-2 px-2 text-sm rounded-md elevation-1 bg-[#3B78A8] hover:bg-[#3B78A8] transition-colors duration-200"
+            @click="uploadMissionToVehicle"
+          >
+            UPLOAD MISSION TO VEHICLE
+          </button>
+          <v-tooltip
+            location="top"
+            :text="missionActionsMenuExpanded ? 'Hide mission actions' : 'Show mission actions'"
+          >
+            <template #activator="{ props }">
+              <button
+                v-bind="props"
+                :aria-label="missionActionsMenuExpanded ? 'Hide mission actions' : 'Show mission actions'"
+                class="relative flex items-center justify-center h-[40px] py-2 px-1 rounded-md elevation-1 bg-[#FFFFFF11] hover:bg-[#FFFFFF22] transition-colors duration-200"
+                @click="toggleMissionActionsMenu"
+              >
+                <span
+                  v-if="hasLastUploadedMission && !missionActionsMenuExpanded"
+                  class="absolute top-1 right-1 w-2 h-2 rounded-full bg-[#3B78A8]"
+                />
+                <v-icon
+                  size="28"
+                  class="text-white transition-transform duration-200"
+                  :class="{ 'rotate-180': missionActionsMenuExpanded }"
+                >
+                  mdi-menu-down
+                </v-icon>
+              </button>
+            </template>
+          </v-tooltip>
+        </div>
+        <v-expand-transition
+          v-if="!isCreatingSimplePath && !isCreatingSurvey && missionStore.currentPlanningWaypoints.length > 0"
+          @after-enter="clampMissionToolboxWithinView"
+          @after-leave="onMissionActionsMenuCollapsed"
         >
-          <v-progress-circular v-if="loading" size="20" class="py-4" />
-          <p v-else>CLEAR CURRENT MISSION</p>
-        </button>
-        <button
-          :disabled="loading || !vehicleStore.isVehicleOnline"
-          class="h-auto py-2 px-2 m-2 mt-2 text-sm rounded-md elevation-1 bg-[#FFFFFF11] hover:bg-[#FFFFFF22] transition-colors duration-200"
-          :class="{ 'cursor-not-allowed opacity-50 text-[#FFFFFF44]': !vehicleStore.isVehicleOnline }"
-          @click="downloadMissionFromVehicle"
-        >
-          <v-progress-circular v-if="loading" size="20" class="py-4" />
-          <p v-else>DOWNLOAD MISSION FROM VEHICLE</p>
-        </button>
-        <button
-          v-if="hasLastUploadedMission"
-          :disabled="loading"
-          class="h-auto py-2 px-2 m-2 mt-2 text-sm rounded-md elevation-1 bg-[#FFFFFF11] hover:bg-[#FFFFFF22] transition-colors duration-200"
-          @click="restoreLastUploadedMission"
-        >
-          RESTORE LAST UPLOADED MISSION
-        </button>
+          <div v-if="missionActionsMenuExpanded" class="flex flex-col">
+            <v-divider class="mx-2 my-1 opacity-5" />
+            <button
+              :disabled="loading"
+              class="h-auto py-1 px-1 m-2 mt-2 text-sm rounded-md elevation-1 bg-[#FFFFFF11] hover:bg-[#FFFFFF22] transition-colors duration-200"
+              @click="openCLearMissionDialog"
+            >
+              <v-progress-circular v-if="loading" size="20" class="py-4" />
+              <p v-else>CLEAR CURRENT MISSION</p>
+            </button>
+            <button
+              :disabled="loading || !vehicleStore.isVehicleOnline"
+              class="h-auto py-2 px-2 m-2 mt-2 text-sm rounded-md elevation-1 bg-[#FFFFFF11] hover:bg-[#FFFFFF22] transition-colors duration-200"
+              :class="{ 'cursor-not-allowed opacity-50 text-[#FFFFFF44]': !vehicleStore.isVehicleOnline }"
+              @click="downloadMissionFromVehicle"
+            >
+              <v-progress-circular v-if="loading" size="20" class="py-4" />
+              <p v-else>DOWNLOAD MISSION FROM VEHICLE</p>
+            </button>
+            <button
+              v-if="hasLastUploadedMission"
+              :disabled="loading"
+              class="h-auto py-2 px-2 m-2 mt-2 text-sm rounded-md elevation-1 bg-[#FFFFFF11] hover:bg-[#FFFFFF22] transition-colors duration-200"
+              @click="restoreLastUploadedMission"
+            >
+              RESTORE LAST UPLOADED MISSION
+            </button>
+          </div>
+        </v-expand-transition>
+        <div v-else-if="!isCreatingSimplePath && !isCreatingSurvey" class="flex flex-col gap-2 m-2 mt-2">
+          <button
+            :disabled="loading || !vehicleStore.isVehicleOnline"
+            class="h-auto py-2 px-2 text-sm rounded-md elevation-1 bg-[#FFFFFF11] hover:bg-[#FFFFFF22] transition-colors duration-200"
+            :class="{ 'cursor-not-allowed opacity-50 text-[#FFFFFF44]': !vehicleStore.isVehicleOnline }"
+            @click="downloadMissionFromVehicle"
+          >
+            <v-progress-circular v-if="loading" size="20" class="py-4" />
+            <p v-else>DOWNLOAD MISSION FROM VEHICLE</p>
+          </button>
+          <button
+            v-if="hasLastUploadedMission"
+            :disabled="loading"
+            class="h-auto py-2 px-2 text-sm rounded-md elevation-1 bg-[#FFFFFF11] hover:bg-[#FFFFFF22] transition-colors duration-200"
+            @click="restoreLastUploadedMission"
+          >
+            RESTORE LAST UPLOADED MISSION
+          </button>
+        </div>
       </div>
     </div>
     <v-tooltip location="top" text="Switch to Flight mode">
@@ -3891,6 +3951,44 @@ const { hasLastUploadedMission, restoreLastUploadedMission } = useMissionOperati
   closeDialog,
   openSnackbar,
 })
+
+const missionToolboxRef = ref<HTMLElement | null>(null)
+const missionActionsMenuExpanded = ref(false)
+// While the actions menu is open the toolbox is pinned to its current top so it grows downward instead
+// of re-centering (which would shove the whole toolbox up); null lets it re-center at rest.
+const missionToolboxPinnedTop = ref<number | null>(null)
+
+const toggleMissionActionsMenu = (): void => {
+  const willOpen = !missionActionsMenuExpanded.value
+  logUserAction(`${willOpen ? 'Opened' : 'Closed'} the mission actions menu`)
+
+  if (willOpen && missionToolboxRef.value) {
+    missionToolboxPinnedTop.value = missionToolboxRef.value.offsetTop
+  }
+
+  missionActionsMenuExpanded.value = willOpen
+}
+
+// Shift the pinned toolbox up only if the expanded panel would overflow the bottom of the available
+// area, never past the top bar, so it opens downward whenever there is room. Runs on the expand
+// transition's after-enter so the panel is measured at full height, not mid-animation.
+const clampMissionToolboxWithinView = (): void => {
+  const el = missionToolboxRef.value
+  if (!el || missionToolboxPinnedTop.value === null) return
+
+  const topBound = widgetStore.currentTopBarHeightPixels + 10
+  const bottomBound = windowHeight.value - widgetStore.currentBottomBarHeightPixels - 10
+  const rect = el.getBoundingClientRect()
+
+  const bottomOverflow = rect.bottom - bottomBound
+  if (bottomOverflow <= 0) return
+
+  missionToolboxPinnedTop.value -= Math.min(bottomOverflow, rect.top - topBound)
+}
+
+const onMissionActionsMenuCollapsed = (): void => {
+  missionToolboxPinnedTop.value = null
+}
 
 const handleLoadMissionFromLibrary = (mission: SavedMission): void => {
   if (mission.vehicleType && !vehicleStore.isVehicleOnline) {

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -163,8 +163,13 @@
     </div>
     <div
       v-show="!interfaceStore.isMainMenuVisible"
+      ref="missionToolboxRef"
       class="absolute flex flex-col left-10 rounded-[10px] max-h-[80vh] overflow-y-auto z-[200]"
-      :style="[interfaceStore.globalGlassMenuStyles, { height: 'auto', maxHeight: calculatedHeight, width: '320px' }]"
+      :style="[
+        interfaceStore.globalGlassMenuStyles,
+        { height: 'auto', maxHeight: calculatedHeight, width: '320px' },
+        missionToolboxPinnedTop !== null ? { top: `${missionToolboxPinnedTop}px` } : {},
+      ]"
     >
       <div class="flex flex-col w-full h-full p-2 overflow-y-auto">
         <button
@@ -452,7 +457,7 @@
         </div>
 
         <div>
-          <div class="flex w-full justify-between my-2 px-1">
+          <div class="flex w-full justify-between my-2 px-3">
             <v-tooltip location="top" text="Undo (Ctrl+Z / Cmd+Z)">
               <template #activator="{ props }">
                 <v-btn
@@ -522,45 +527,100 @@
             </v-tooltip>
           </div>
         </div>
-        <v-divider v-if="isCreatingSimplePath || isCreatingSurvey" class="my-2" />
-        <button
+        <div
           v-if="!isCreatingSimplePath && !isCreatingSurvey && missionStore.currentPlanningWaypoints.length > 0"
-          :disabled="missionStore.currentPlanningWaypoints.length < 2 || !vehicleStore.isVehicleOnline"
-          :class="{
-            'bg-[#FFFFFF11] hover:bg-[#FFFFFF11] text-[#FFFFFF22] elevation-0':
-              missionStore.currentPlanningWaypoints.length < 2 || !vehicleStore.isVehicleOnline,
-          }"
-          class="h-auto py-2 px-2 m-2 mt-2 text-sm rounded-md elevation-1 bg-[#3B78A8] hover:bg-[#3B78A8] transition-colors duration-200"
-          @click="uploadMissionToVehicle"
+          class="flex flex-row items-stretch gap-2 m-2 mt-2"
         >
-          UPLOAD MISSION TO VEHICLE
-        </button>
-        <button
-          v-if="missionStore.currentPlanningWaypoints.length > 0"
-          :disabled="loading"
-          class="h-auto py-1 px-1 m-2 mt-2 text-sm rounded-md elevation-1 bg-[#FFFFFF11] hover:bg-[#FFFFFF22] transition-colors duration-200"
-          @click="openCLearMissionDialog"
+          <button
+            :disabled="missionStore.currentPlanningWaypoints.length < 2 || !vehicleStore.isVehicleOnline"
+            :class="{
+              'bg-[#FFFFFF11] hover:bg-[#FFFFFF11] text-[#FFFFFF22] elevation-0':
+                missionStore.currentPlanningWaypoints.length < 2 || !vehicleStore.isVehicleOnline,
+            }"
+            class="flex-1 min-w-0 h-[40px] py-2 px-2 text-sm rounded-md elevation-1 bg-[#3B78A8] hover:bg-[#3B78A8] transition-colors duration-200"
+            @click="uploadMissionToVehicle"
+          >
+            UPLOAD MISSION TO VEHICLE
+          </button>
+          <v-tooltip
+            location="top"
+            :text="missionActionsMenuExpanded ? 'Hide mission actions' : 'Show mission actions'"
+          >
+            <template #activator="{ props }">
+              <button
+                v-bind="props"
+                :aria-label="missionActionsMenuExpanded ? 'Hide mission actions' : 'Show mission actions'"
+                class="relative flex items-center justify-center h-[40px] py-2 px-1 rounded-md elevation-1 bg-[#FFFFFF11] hover:bg-[#FFFFFF22] transition-colors duration-200"
+                @click="toggleMissionActionsMenu"
+              >
+                <span
+                  v-if="hasLastUploadedMission && !missionActionsMenuExpanded"
+                  class="absolute top-1 right-1 w-2 h-2 rounded-full bg-[#3B78A8]"
+                />
+                <v-icon
+                  size="28"
+                  class="text-white transition-transform duration-200"
+                  :class="{ 'rotate-180': missionActionsMenuExpanded }"
+                >
+                  mdi-menu-down
+                </v-icon>
+              </button>
+            </template>
+          </v-tooltip>
+        </div>
+        <v-expand-transition
+          v-if="!isCreatingSimplePath && !isCreatingSurvey && missionStore.currentPlanningWaypoints.length > 0"
+          @after-enter="clampMissionToolboxWithinView"
+          @after-leave="onMissionActionsMenuCollapsed"
         >
-          <v-progress-circular v-if="loading" size="20" class="py-4" />
-          <p v-else>CLEAR CURRENT MISSION</p>
-        </button>
-        <button
-          :disabled="loading || !vehicleStore.isVehicleOnline"
-          class="h-auto py-2 px-2 m-2 mt-2 text-sm rounded-md elevation-1 bg-[#FFFFFF11] hover:bg-[#FFFFFF22] transition-colors duration-200"
-          :class="{ 'cursor-not-allowed opacity-50 text-[#FFFFFF44]': !vehicleStore.isVehicleOnline }"
-          @click="downloadMissionFromVehicle"
-        >
-          <v-progress-circular v-if="loading" size="20" class="py-4" />
-          <p v-else>DOWNLOAD MISSION FROM VEHICLE</p>
-        </button>
-        <button
-          v-if="hasLastUploadedMission"
-          :disabled="loading"
-          class="h-auto py-2 px-2 m-2 mt-2 text-sm rounded-md elevation-1 bg-[#FFFFFF11] hover:bg-[#FFFFFF22] transition-colors duration-200"
-          @click="restoreLastUploadedMission"
-        >
-          RESTORE LAST UPLOADED MISSION
-        </button>
+          <div v-if="missionActionsMenuExpanded" class="flex flex-col">
+            <v-divider class="mx-2 my-1 opacity-5" />
+            <button
+              :disabled="loading"
+              class="h-auto py-1 px-1 m-2 mt-2 text-sm rounded-md elevation-1 bg-[#FFFFFF11] hover:bg-[#FFFFFF22] transition-colors duration-200"
+              @click="openCLearMissionDialog"
+            >
+              <v-progress-circular v-if="loading" size="20" class="py-4" />
+              <p v-else>CLEAR CURRENT MISSION</p>
+            </button>
+            <button
+              :disabled="loading || !vehicleStore.isVehicleOnline"
+              class="h-auto py-2 px-2 m-2 mt-2 text-sm rounded-md elevation-1 bg-[#FFFFFF11] hover:bg-[#FFFFFF22] transition-colors duration-200"
+              :class="{ 'cursor-not-allowed opacity-50 text-[#FFFFFF44]': !vehicleStore.isVehicleOnline }"
+              @click="downloadMissionFromVehicle"
+            >
+              <v-progress-circular v-if="loading" size="20" class="py-4" />
+              <p v-else>DOWNLOAD MISSION FROM VEHICLE</p>
+            </button>
+            <button
+              v-if="hasLastUploadedMission"
+              :disabled="loading"
+              class="h-auto py-2 px-2 m-2 mt-2 text-sm rounded-md elevation-1 bg-[#FFFFFF11] hover:bg-[#FFFFFF22] transition-colors duration-200"
+              @click="restoreLastUploadedMission"
+            >
+              RESTORE LAST UPLOADED MISSION
+            </button>
+          </div>
+        </v-expand-transition>
+        <div v-else-if="!isCreatingSimplePath && !isCreatingSurvey" class="flex flex-col gap-2 m-2 mt-2">
+          <button
+            :disabled="loading || !vehicleStore.isVehicleOnline"
+            class="h-auto py-2 px-2 text-sm rounded-md elevation-1 bg-[#FFFFFF11] hover:bg-[#FFFFFF22] transition-colors duration-200"
+            :class="{ 'cursor-not-allowed opacity-50 text-[#FFFFFF44]': !vehicleStore.isVehicleOnline }"
+            @click="downloadMissionFromVehicle"
+          >
+            <v-progress-circular v-if="loading" size="20" class="py-4" />
+            <p v-else>DOWNLOAD MISSION FROM VEHICLE</p>
+          </button>
+          <button
+            v-if="hasLastUploadedMission"
+            :disabled="loading"
+            class="h-auto py-2 px-2 text-sm rounded-md elevation-1 bg-[#FFFFFF11] hover:bg-[#FFFFFF22] transition-colors duration-200"
+            @click="restoreLastUploadedMission"
+          >
+            RESTORE LAST UPLOADED MISSION
+          </button>
+        </div>
       </div>
     </div>
     <v-tooltip location="top" text="Switch to Flight mode">
@@ -4032,6 +4092,44 @@ const { hasLastUploadedMission, restoreLastUploadedMission } = useMissionOperati
   closeDialog,
   openSnackbar,
 })
+
+const missionToolboxRef = ref<HTMLElement | null>(null)
+const missionActionsMenuExpanded = ref(false)
+// While the actions menu is open the toolbox is pinned to its current top so it grows downward instead
+// of re-centering (which would shove the whole toolbox up); null lets it re-center at rest.
+const missionToolboxPinnedTop = ref<number | null>(null)
+
+const toggleMissionActionsMenu = (): void => {
+  const willOpen = !missionActionsMenuExpanded.value
+  logUserAction(`${willOpen ? 'Opened' : 'Closed'} the mission actions menu`)
+
+  if (willOpen && missionToolboxRef.value) {
+    missionToolboxPinnedTop.value = missionToolboxRef.value.offsetTop
+  }
+
+  missionActionsMenuExpanded.value = willOpen
+}
+
+// Shift the pinned toolbox up only if the expanded panel would overflow the bottom of the available
+// area, never past the top bar, so it opens downward whenever there is room. Runs on the expand
+// transition's after-enter so the panel is measured at full height, not mid-animation.
+const clampMissionToolboxWithinView = (): void => {
+  const el = missionToolboxRef.value
+  if (!el || missionToolboxPinnedTop.value === null) return
+
+  const topBound = widgetStore.currentTopBarHeightPixels + 10
+  const bottomBound = windowHeight.value - widgetStore.currentBottomBarHeightPixels - 10
+  const rect = el.getBoundingClientRect()
+
+  const bottomOverflow = rect.bottom - bottomBound
+  if (bottomOverflow <= 0) return
+
+  missionToolboxPinnedTop.value -= Math.min(bottomOverflow, rect.top - topBound)
+}
+
+const onMissionActionsMenuCollapsed = (): void => {
+  missionToolboxPinnedTop.value = null
+}
 
 const handleLoadMissionFromLibrary = (mission: SavedMission): void => {
   if (mission.vehicleType && !vehicleStore.isVehicleOnline) {

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -553,6 +553,14 @@
           <v-progress-circular v-if="loading" size="20" class="py-4" />
           <p v-else>DOWNLOAD MISSION FROM VEHICLE</p>
         </button>
+        <button
+          v-if="hasLastUploadedMission"
+          :disabled="loading"
+          class="h-auto py-2 px-2 m-2 mt-2 text-sm rounded-md elevation-1 bg-[#FFFFFF11] hover:bg-[#FFFFFF22] transition-colors duration-200"
+          @click="restoreLastUploadedMission"
+        >
+          RESTORE LAST UPLOADED MISSION
+        </button>
       </div>
     </div>
     <v-tooltip location="top" text="Switch to Flight mode">
@@ -808,6 +816,7 @@ import {
   setSurveyAreaSquareMeters,
   useMissionEstimates,
 } from '@/composables/useMissionEstimates'
+import { useMissionOperations } from '@/composables/useMissionOperations'
 import { useOfflineTiles } from '@/composables/useOfflineTiles'
 import { MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import { MavCmd } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
@@ -970,12 +979,14 @@ const uploadMissionToVehicle = async (): Promise<void> => {
       throw 'Vehicle is not online.'
     }
     await vehicleStore.uploadMission(missionItemsToUpload, loadingCallback)
+    // Keep the uploaded mission on the planner (draft) and store a restorable snapshot so quick edits
+    // don't require re-downloading it from the vehicle.
+    missionStore.setLastUploadedMission(buildCurrentMissionSnapshot())
     const message = 'Go to Flight Mode and click the “play” button to start the mission.'
 
     if (missionStore.alwaysSwitchToFlightMode) {
       router.push('/')
       missionStore.bumpVehicleMissionRevision(missionItemsToUpload)
-      missionStore.clearDraft()
       return
     }
     showDialog({
@@ -1006,7 +1017,6 @@ const uploadMissionToVehicle = async (): Promise<void> => {
     })
     hasUploadedMission.value = true
     missionStore.bumpVehicleMissionRevision(missionItemsToUpload)
-    missionStore.clearDraft()
   } catch (error) {
     showDialog({
       variant: 'error',
@@ -4015,6 +4025,13 @@ const openMissionLibrary = (): void => {
   logUserAction('Opened the mission library')
   interfaceStore.missionLibraryVisibility = true
 }
+
+const { hasLastUploadedMission, restoreLastUploadedMission } = useMissionOperations({
+  loadDraftMission,
+  showDialog,
+  closeDialog,
+  openSnackbar,
+})
 
 const handleLoadMissionFromLibrary = (mission: SavedMission): void => {
   if (mission.vehicleType && !vehicleStore.isVehicleOnline) {


### PR DESCRIPTION
- After uploading a mission, Cockpit now keeps it on the planning map instead of clearing it, so a small mistake or last-minute tweak can be fixed and re-uploaded right away.
- The last uploaded mission is remembered even across sessions, so it can be brought back at any time. Useful when the vehicle is already deployed or the connection drops, avoiding a slow and interruptible re-download from the vehicle.
- A new "Restore last uploaded mission" action reloads that remembered mission on demand, asking for confirmation first when it would replace a mission currently being edited.
- The mission upload area is tidied up: uploading stays a single prominent button, and the secondary actions (clear current mission, download mission from vehicle, restore last uploaded mission) are grouped under a dropdown that expands smoothly and opens downward without shoving the toolbox around.

![Mission actions dropdown collapsed](https://raw.githubusercontent.com/ArturoManzoli/cockpit/pr-assets-2825/mission-actions-collapsed.png)

![Mission actions dropdown expanded, showing the restore option](https://raw.githubusercontent.com/ArturoManzoli/cockpit/pr-assets-2825/mission-actions-expanded.png)

Closes #2825
Closes #2047 