### PR TITLE
Video: Fix leaked WebRTC sessions from unused streams

### DIFF
--- a/src/components/mini-widgets/MiniVideoRecorder.vue
+++ b/src/components/mini-widgets/MiniVideoRecorder.vue
@@ -128,7 +128,8 @@ import { storeToRefs } from 'pinia'
 import { computed, onBeforeMount, onBeforeUnmount, onMounted, ref, toRefs, watch } from 'vue'
 
 import { useInteractionDialog } from '@/composables/interactionDialog'
-import { isEqual, sleep } from '@/libs/utils'
+import { openSnackbar } from '@/composables/snackbar'
+import { isEqual } from '@/libs/utils'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useVideoStore } from '@/stores/video'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
@@ -383,29 +384,30 @@ const timePassedString = computed(() => {
   return `${durationHours}:${durationMinutes}:${durationSeconds}`
 })
 
-const updateCurrentStream = async (internalStreamName: string | undefined): Promise<void> => {
+// Generous ceiling for how long we show the connecting state before warning; well above typical WebRTC
+// negotiation so merely-slow streams aren't cut off, unlike the old 3s hard timeout.
+const streamLoadingTimeoutMs = 20000
+let streamLoadingTimeout: ReturnType<typeof setTimeout> | undefined = undefined
+
+const updateCurrentStream = (internalStreamName: string | undefined): void => {
   logUserAction(`Selected recording stream '${internalStreamName}'`)
   assertStreamIsSelectedAndAvailable(internalStreamName)
 
   mediaStream.value = undefined
   isLoadingStream.value = true
-
-  let millisPassed = 0
-  const timeStep = 100
-  const waitingTime = 3000
-  while (isLoadingStream.value && millisPassed < waitingTime) {
-    // @ts-ignore: The media stream can (and probably will) get defined as we selected a stream
-    isLoadingStream.value = mediaStream.value === undefined || !mediaStream.value.active
-    await sleep(timeStep)
-    millisPassed += timeStep
-  }
-
-  if (isLoadingStream.value) {
-    showDialog({ message: 'Could not load media stream.', variant: 'error' })
-    return
-  }
-
   miniWidget.value.options.internalStreamName = internalStreamName
+
+  // streamConnectionRoutine clears isLoadingStream once media is flowing; if it never connects, stop spinning
+  // and surface a non-blocking warning so the record button becomes usable again instead of staying disabled.
+  clearTimeout(streamLoadingTimeout)
+  streamLoadingTimeout = setTimeout(() => {
+    if (!isLoadingStream.value) return
+    isLoadingStream.value = false
+    openSnackbar({
+      message: `Could not load media stream '${internalStreamName}'. Check the stream source and try again.`,
+      variant: 'error',
+    })
+  }, streamLoadingTimeoutMs)
 }
 
 let streamConnectionRoutine: ReturnType<typeof setInterval> | undefined = undefined
@@ -429,6 +431,10 @@ if (widgetStore.isRealMiniWidget(miniWidget.value.hash)) {
       if (!isEqual(updatedMediaStream, mediaStream.value)) {
         mediaStream.value = updatedMediaStream
       }
+      if (isLoadingStream.value && mediaStream.value?.active) {
+        isLoadingStream.value = false
+        clearTimeout(streamLoadingTimeout)
+      }
     }
 
     if (!namesAvailableStreams.value.isEmpty() && !namesAvailableStreams.value.includes(nameSelectedStream.value!)) {
@@ -442,6 +448,7 @@ if (widgetStore.isRealMiniWidget(miniWidget.value.hash)) {
 }
 onBeforeUnmount(() => {
   clearInterval(streamConnectionRoutine)
+  clearTimeout(streamLoadingTimeout)
   if (externalStreamId.value) videoStore.unregisterStreamConsumer(externalStreamId.value, miniWidget.value.hash)
 })
 

--- a/src/components/mini-widgets/MiniVideoRecorder.vue
+++ b/src/components/mini-widgets/MiniVideoRecorder.vue
@@ -174,6 +174,17 @@ const selectedExternalId = ref<string | undefined>()
 
 const externalStreamId = computed(() => selectedExternalId.value)
 
+// Register/unregister this widget as a consumer of the stream, so the video store can tear down streams that no
+// widget points to anymore instead of leaking their WebRTC session.
+watch(
+  externalStreamId,
+  (newId, oldId) => {
+    if (oldId) videoStore.unregisterStreamConsumer(oldId, miniWidget.value.hash)
+    if (newId) videoStore.registerStreamConsumer(newId, miniWidget.value.hash)
+  },
+  { immediate: true }
+)
+
 const openVideoLibraryModal = (): void => {
   logUserAction('Opened Video Library')
   interfaceStore.videoLibraryMode = 'videos'
@@ -429,7 +440,10 @@ if (widgetStore.isRealMiniWidget(miniWidget.value.hash)) {
     }
   }, 1000)
 }
-onBeforeUnmount(() => clearInterval(streamConnectionRoutine))
+onBeforeUnmount(() => {
+  clearInterval(streamConnectionRoutine)
+  if (externalStreamId.value) videoStore.unregisterStreamConsumer(externalStreamId.value, miniWidget.value.hash)
+})
 
 watch(
   () => isVideoLibraryDialogOpen.value,

--- a/src/components/widgets/VideoPlayer.vue
+++ b/src/components/widgets/VideoPlayer.vue
@@ -233,6 +233,17 @@ const externalStreamId = computed(() => {
   return nameSelectedStream.value ? videoStore.externalStreamId(nameSelectedStream.value) : undefined
 })
 
+// Register/unregister this widget as a consumer of the stream, so the video store can tear down streams that no
+// widget points to anymore instead of leaking their WebRTC session.
+watch(
+  externalStreamId,
+  (newId, oldId) => {
+    if (oldId) videoStore.unregisterStreamConsumer(oldId, widget.value.hash)
+    if (newId) videoStore.registerStreamConsumer(newId, widget.value.hash)
+  },
+  { immediate: true }
+)
+
 watch(
   () => videoStore.streamsCorrespondency,
   () => {
@@ -293,6 +304,7 @@ const streamConnectionRoutine = setInterval(() => {
 onBeforeUnmount(() => {
   clearInterval(streamConnectionRoutine)
   if (successTimeoutId) clearTimeout(successTimeoutId)
+  if (externalStreamId.value) videoStore.unregisterStreamConsumer(externalStreamId.value, widget.value.hash)
 })
 
 watch(nameSelectedStream, () => {

--- a/src/stores/snapshot.ts
+++ b/src/stores/snapshot.ts
@@ -4,6 +4,7 @@ import { format } from 'date-fns'
 import saveAs from 'file-saver'
 import piexif from 'piexifjs'
 import { defineStore } from 'pinia'
+import { v4 as uuid } from 'uuid'
 
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { useBlueOsStorage } from '@/composables/settingsSyncer'
@@ -262,6 +263,11 @@ export const useSnapshotStore = defineStore('snapshot', () => {
     }
 
     for (const streamName of streamNames) {
+      // Register as a transient consumer for the whole capture so an ad-hoc snapshot of a stream no widget is
+      // showing doesn't leave it (and its WebRTC session) active afterwards, while keeping it alive for both the
+      // frame grab and the track-settings read below.
+      const consumerId = uuid()
+      videoStore.registerStreamConsumer(streamName, consumerId)
       try {
         let stBlob = await captureStreamFrame(streamName)
         const thumbBlob = await createThumbnail(stBlob, 200, 113)
@@ -278,6 +284,8 @@ export const useSnapshotStore = defineStore('snapshot', () => {
       } catch (err) {
         console.error(`Failed to capture snapshot for stream '${streamName}':`, err)
         failed.push(streamName)
+      } finally {
+        videoStore.unregisterStreamConsumer(streamName, consumerId)
       }
     }
 

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -1015,6 +1015,9 @@ export const useVideoStore = defineStore('video', () => {
 
       if (activeStreams.value[streamName]) {
         activeStreams.value[streamName]!.mediaRecorder = undefined
+        // The recording guard may have kept this stream alive after its last consumer left (e.g. the recorder
+        // widget was unmounted mid-recording); now that recording is done, release it if nothing needs it.
+        deactivateStreamIfUnused(streamName)
       } else {
         console.warn(`Stream '${streamName}' was removed during video processing finalization.`)
       }

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -58,6 +58,9 @@ export const useVideoStore = defineStore('video', () => {
   const allowedIceProtocols = useBlueOsStorage<string[]>('cockpit-allowed-stream-protocols', [])
   const jitterBufferTarget = useBlueOsStorage<number>('cockpit-jitter-buffer-target', 0)
   const activeStreams = ref<{ [key in string]: StreamData | undefined }>({})
+  // Tracks which consumers (widgets, snapshot captures, etc.) currently need each external stream active, so it
+  // can be torn down once nothing references it anymore. Intentionally not reactive/persisted, it's just bookkeeping.
+  const streamConsumers = new Map<string, Set<string>>()
   const mainWebRTCManager = new WebRTCManager(webRTCSignallingURI, rtcConfiguration)
   const availableIceIps = ref<string[]>([])
   const unprocessedVideos = useStorage<{ [key in string]: UnprocessedVideoInfo }>('cockpit-unprocessed-video-info', {})
@@ -465,6 +468,100 @@ export const useVideoStore = defineStore('video', () => {
   }
 
   /**
+   * Tear down all resources tied to an active stream (WebRTC/go2rtc connections, media tracks, recorder), and
+   * remove it from the active streams map.
+   * @param {string} externalId - External stream identifier
+   * @param {string} reason - Human-readable reason, forwarded to the underlying stream managers on close
+   */
+  const teardownStreamResources = (externalId: string, reason: string): void => {
+    const externalStreamData = activeStreams.value[externalId]
+    if (!externalStreamData) return
+
+    // Stop recording if it's active
+    if (externalStreamData.mediaRecorder?.state === 'recording') {
+      externalStreamData.mediaRecorder.stop()
+    }
+
+    // Stop all tracks in the media stream
+    if (externalStreamData.mediaStream) {
+      externalStreamData.mediaStream.getTracks().forEach((track) => {
+        track.stop()
+        console.log(`Stopped track: ${track.kind} for external stream '${externalId}'`)
+      })
+    }
+
+    // Close WebRTC connection
+    if (externalStreamData.webRtcManager) {
+      try {
+        const session = externalStreamData.webRtcManager.session
+        if (session?.peerConnection) {
+          session.peerConnection.close()
+        }
+        externalStreamData.webRtcManager.close(reason)
+        console.log(`Stopped WebRTC manager for external stream '${externalId}'`)
+      } catch (error) {
+        console.warn(`Error stopping WebRTC manager for external stream '${externalId}':`, error)
+      }
+    }
+
+    if (externalStreamData.go2rtcManager) {
+      externalStreamData.go2rtcManager.close(reason)
+      if (window.electronAPI) {
+        void window.electronAPI.go2rtcRemoveStream(externalId).catch((error) => {
+          console.warn(`Error removing go2rtc stream '${externalId}':`, error)
+        })
+      }
+    }
+
+    delete activeStreams.value[externalId]
+    console.log(`Cleaned up all resources for external stream '${externalId}'`)
+  }
+
+  /**
+   * Tear down an external stream if it has no remaining consumers and no recorder attached to it (i.e. neither
+   * recording nor finalizing a just-stopped recording)
+   * @param {string} externalId - External stream identifier
+   */
+  const deactivateStreamIfUnused = (externalId: string): void => {
+    const consumers = streamConsumers.get(externalId)
+    if (consumers && consumers.size > 0) return
+
+    streamConsumers.delete(externalId)
+
+    // Never tear down a stream while a recorder is attached, even if no widget references it: mediaRecorder stays
+    // set through recording and the async stop() finalizer (telemetry/processing), and onstop clears it when done.
+    if (activeStreams.value[externalId]?.mediaRecorder !== undefined) return
+
+    teardownStreamResources(externalId, `External stream '${externalId}' is no longer used by any consumer`)
+  }
+
+  /**
+   * Register a consumer (e.g. a widget) as actively needing an external stream, activating it if needed
+   * @param {string} externalId - External stream identifier
+   * @param {string} consumerId - Unique identifier for the consumer (e.g. widget hash)
+   */
+  const registerStreamConsumer = (externalId: string, consumerId: string): void => {
+    if (!streamConsumers.has(externalId)) {
+      streamConsumers.set(externalId, new Set())
+    }
+    streamConsumers.get(externalId)!.add(consumerId)
+
+    if (activeStreams.value[externalId] === undefined) {
+      activateStream(externalId)
+    }
+  }
+
+  /**
+   * Release a consumer's reference to an external stream, tearing it down if it becomes unused
+   * @param {string} externalId - External stream identifier
+   * @param {string} consumerId - Unique identifier for the consumer (e.g. widget hash)
+   */
+  const unregisterStreamConsumer = (externalId: string, consumerId: string): void => {
+    streamConsumers.get(externalId)?.delete(consumerId)
+    deactivateStreamIfUnused(externalId)
+  }
+
+  /**
    * Get all data related to a given stream, if available
    * @param {string} streamName - Name of the stream
    * @returns {StreamData | undefined} The StreamData object, if available
@@ -754,10 +851,8 @@ export const useVideoStore = defineStore('video', () => {
 
         console.debug(`Live processing started for ${recordingHash}`)
       } catch (error) {
-        // Stop recording and reset the stream data
-        activeStreams.value[streamName]!.mediaRecorder!.stop()
-        activeStreams.value[streamName]!.mediaRecorder = undefined
-        delete activeStreams.value[streamName]
+        // Stop recording and release all resources tied to the stream (WebRTC/go2rtc, tracks, recorder)
+        teardownStreamResources(streamName, `Live processing failed to start for external stream '${streamName}'`)
 
         // Stop live processing if it's running
         if (liveProcessors.value[recordingHash]) {
@@ -1141,48 +1236,10 @@ export const useVideoStore = defineStore('video', () => {
       // Remove from correspondency list
       streamsCorrespondency.value.splice(streamIndex, 1)
 
-      // Clean up all resources for the stream
+      // Clean up all resources for the stream, and any consumer bookkeeping tied to it
+      streamConsumers.delete(externalId)
       if (activeStreams.value[externalId]) {
-        const externalStreamData = activeStreams.value[externalId]
-
-        // Stop recording if it's active
-        if (externalStreamData?.mediaRecorder && externalStreamData.mediaRecorder.state === 'recording') {
-          externalStreamData.mediaRecorder.stop()
-        }
-
-        // Stop all tracks in the media stream
-        if (externalStreamData?.mediaStream) {
-          externalStreamData.mediaStream.getTracks().forEach((track) => {
-            track.stop()
-            console.log(`Stopped track: ${track.kind} for external stream '${externalId}'`)
-          })
-        }
-
-        // Close WebRTC connection
-        if (externalStreamData?.webRtcManager) {
-          try {
-            const session = externalStreamData.webRtcManager.session
-            if (session?.peerConnection) {
-              session.peerConnection.close()
-            }
-            externalStreamData.webRtcManager.close(`External stream '${externalId}' was ignored by user`)
-            console.log(`Stopped WebRTC manager for external stream '${externalId}'`)
-          } catch (error) {
-            console.warn(`Error stopping WebRTC manager for external stream '${externalId}':`, error)
-          }
-        }
-
-        if (externalStreamData?.go2rtcManager) {
-          externalStreamData.go2rtcManager.close(`Stream '${externalId}' deleted by user`)
-          if (window.electronAPI) {
-            void window.electronAPI.go2rtcRemoveStream(externalId).catch((error) => {
-              console.warn(`Error removing go2rtc stream '${externalId}':`, error)
-            })
-          }
-        }
-
-        delete activeStreams.value[externalId]
-        console.log(`Cleaned up all resources for external stream '${externalId}'`)
+        teardownStreamResources(externalId, `External stream '${externalId}' was ignored by user`)
       }
 
       openSnackbar({ variant: 'success', message: `Stream '${stream.name}' deleted and added to ignored list.` })
@@ -1299,6 +1356,8 @@ export const useVideoStore = defineStore('video', () => {
     discardProcessedFilesFromVideoDB,
     getMediaStream,
     getStreamData,
+    registerStreamConsumer,
+    unregisterStreamConsumer,
     getSignallerStatus,
     getStreamStatus,
     getStreamPeerConnection,


### PR DESCRIPTION
- Streams were only torn down on explicit deletion, so switching a MiniVideoRecorder or VideoPlayer between streams left the previous WebRTC session running indefinitely.
- Track consumers per external stream in the video store and close the underlying WebRTC/go2rtc session once nothing references a stream, unless it is currently being recorded.
- VideoPlayer and MiniVideoRecorder register/unregister as consumers when they switch streams and on unmount; snapshot captures register a transient consumer so an ad-hoc capture does not leave an orphaned stream active.
- Release a mid-recording stream once its recording finishes when its consumer already went away (e.g. the recorder widget was unmounted while still recording).
- Reset MiniVideoRecorder's loading state on both failed and successful stream loads, so the Record button no longer stays stuck disabled after a "Could not load media" error.

Closes #2734