### PR TITLE
fix: Windows Electron window and Task Manager titles

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,6 +176,9 @@
     ],
     "appId": "org.bluerobotics.cockpit",
     "productName": "Cockpit",
+    "extraMetadata": {
+      "description": "Cockpit"
+    },
     "publish": {
       "provider": "github",
       "owner": "bluerobotics"
@@ -199,7 +202,8 @@
     },
     "linux": {
       "icon": "public/pwa-512x512.png",
-      "target": ["AppImage"]
+      "target": ["AppImage"],
+      "description": "An intuitive and customizable cross-platform ground control station for remote vehicles of all types."
     },
     "flatpak": {
       "base": "org.electronjs.Electron2.BaseApp",

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -83,6 +83,10 @@ function createWindow(): void {
     event.preventDefault()
   })
 
+  mainWindow.webContents.on('did-finish-load', () => {
+    mainWindow?.setTitle(`Cockpit (${app.getVersion()})`)
+  })
+
   if (process.env.VITE_DEV_SERVER_URL) {
     mainWindow.loadURL(process.env.VITE_DEV_SERVER_URL)
   } else {


### PR DESCRIPTION
## Summary
- Re-set the Electron window title on `did-finish-load` so Windows does not keep the HTML `Cockpit Lite` title.
- Override the Windows `FileDescription` via `build.extraMetadata.description: Cockpit` so Task Manager shows **Cockpit** instead of the long package description. The long text is preserved on `build.linux.description` for the AppImage desktop Comment.

<img width="889" height="141" alt="image" src="https://github.com/user-attachments/assets/4843454b-4b06-40c1-9327-b35a18a17b05" />

## Test plan
- [x] `yarn lint:fix` / `yarn typecheck`
- [x] Packaged Windows `--dir` build with Developer Mode (symlink privilege for winCodeSign)
- [x] Window title shows `Cockpit (<version>)`
- [x] Task Manager process group shows **Cockpit** (not Electron / not the long description)

## Notes
Local Windows packaging needs Developer Mode (or admin) so electron-builder can extract `winCodeSign` symlinks; CI Windows runners are fine. Dev `yarn dev:electron` still shows **Electron** in Task Manager because the exe is `electr
on.exe` — only the packaged `Cockpit.exe` is authoritative for that name.

Closes #2373
