### PR TITLE
Mission Planning: Improve survey entry point, crosshatch spacing and entry/exit direction

### DIFF
--- a/src/components/mission-planning/ContextMenu.vue
+++ b/src/components/mission-planning/ContextMenu.vue
@@ -70,18 +70,18 @@
         </v-tooltip>
       </div>
       <div id="button-4" class="orbit-button orbit-button-4">
-        <v-tooltip text="Swap start and end point of the survey">
+        <v-tooltip text="Rotate the survey entry point to the next corner">
           <template #activator="{ props: tooltipProps3 }">
             <v-btn
               v-bind="tooltipProps3"
               variant="elevated"
-              icon="mdi-swap-horizontal"
+              icon="mdi-rotate-right"
               :style="{ backgroundColor: '#333333EE' }"
               rounded="full"
               size="x-small"
               color="#FFFFFF22"
               class="text-[13px] rotate-[230deg]"
-              @click="handleSwapSurveyEntryExit"
+              @click="handleRotateSurveyEntryPoint"
             ></v-btn>
           </template>
         </v-tooltip>
@@ -328,7 +328,7 @@ const emit = defineEmits<{
   (event: 'surveyLinesAngle', angle: number): void
   (event: 'regenerateSurveyWaypoints', angle: number): void
   (event: 'toggleCrosshatch'): void
-  (event: 'swapSurveyEntryExit'): void
+  (event: 'rotateSurveyEntryPoint'): void
   (event: 'removeWaypoint'): void
   (event: 'placePointOfInterest'): void
   (event: 'setHomePosition'): void
@@ -348,9 +348,10 @@ const crosshatchEnabled = computed(
 const clampedPosition = ref({ x: 0, y: 0 })
 
 watch(
-  () => [props.visible, props.position] as const,
+  () => [props.visible, props.position, props.menuType] as const,
   ([isVisible, pos]) => {
-    clampedPosition.value = { ...pos }
+    const offsetX = props.menuType === 'survey' ? 100 : 0
+    clampedPosition.value = { x: pos.x + offsetX, y: pos.y }
     if (!isVisible) return
     nextTick(() => {
       const el = menuEl.value
@@ -360,7 +361,8 @@ watch(
       const elH = el.offsetHeight
       const vw = window.innerWidth
       const vh = window.innerHeight
-      let { x, y } = pos
+      let x = pos.x + offsetX
+      let y = pos.y
       if (x + elW > vw - margin) x = vw - elW - margin
       if (y + elH > vh - margin) y = vh - elH - margin
       if (x < margin) x = margin
@@ -428,8 +430,8 @@ const handleUndoGenerateWaypoints = (): void => {
   emit('undoGeneratedWaypoints')
 }
 
-const handleSwapSurveyEntryExit = (): void => {
-  emit('swapSurveyEntryExit')
+const handleRotateSurveyEntryPoint = (): void => {
+  emit('rotateSurveyEntryPoint')
 }
 
 const handleToggleCrosshatch = (): void => {

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -33,12 +33,35 @@
           <v-list-item class="py-0" title="Save visible Seamarks tiles" @click="saveSeamarks" />
         </v-list>
       </v-menu>
+      <v-tooltip
+        location="top"
+        :text="
+          missionStore.alwaysShowWaypointNumbers
+            ? 'Hide waypoint numbers when zoomed out'
+            : 'Always show waypoint numbers'
+        "
+      >
+        <template #activator="{ props: tooltipProps }">
+          <v-btn
+            v-show="showButtons"
+            :style="interfaceStore.globalGlassMenuStyles"
+            v-bind="tooltipProps"
+            class="absolute right-[134px] m-3 bottom-button bg-slate-50 text-[14px]"
+            elevation="2"
+            size="x-small"
+            style="z-index: 1002; border-radius: 0px"
+            :color="missionStore.alwaysShowWaypointNumbers ? 'primary' : ''"
+            icon="mdi-numeric-1-circle-outline"
+            @click="missionStore.toggleAlwaysShowWaypointNumbers()"
+          />
+        </template>
+      </v-tooltip>
       <v-tooltip location="top" text="Switch to Mission Planning mode">
         <template #activator="{ props: tooltipProps }">
           <v-btn
             v-if="showButtons"
             v-bind="tooltipProps"
-            class="absolute right-[148px] w-[140px] mb-[13px] bottom-button bg-slate-50 text-[12px] font-bold"
+            class="absolute right-[193px] w-[140px] mb-[13px] bottom-button bg-slate-50 text-[12px] font-bold"
             elevation="4"
             text="Edit mission"
             append-icon="mdi-map-marker-radius-outline"
@@ -240,6 +263,7 @@ import { useMapPoiGoTo } from '@/composables/map/useMapPoiGoTo'
 import { useMapPoiMarkers } from '@/composables/map/useMapPoiMarkers'
 import { useMapTileLayers } from '@/composables/map/useMapTileLayers'
 import { useMapTileLayerSelection } from '@/composables/map/useMapTileLayerSelection'
+import { useWaypointMarkerSize } from '@/composables/map/useWaypointMarkerSize'
 import { openSnackbar } from '@/composables/snackbar'
 import { useOfflineTiles } from '@/composables/useOfflineTiles'
 import { usePointsOfInterest } from '@/composables/usePointsOfInterest'
@@ -393,11 +417,9 @@ const getReachedWaypointIndices = computed(() => {
   return waypointIndices
 })
 
-const getMarkerSizeFromZoom = (zoomLevel: number): MarkerSizes => {
-  if (zoomLevel <= 17) return 'xs'
-  if (zoomLevel > 17 && zoomLevel <= 19) return 'sm'
-  return 'md'
-}
+const { getEffectiveMarkerSize } = useWaypointMarkerSize(() => {
+  if (map.value) refreshReachedWaypointMarkerStyles()
+})
 
 const getIconDimensionsFromMarkerSize = (size: MarkerSizes): IconDimensions => {
   if (size === 'xs') {
@@ -416,7 +438,7 @@ const createWaypointMarkerHtml = (isReached: boolean, isCurrent = false): string
   } else if (isCurrent) {
     baseClass = 'marker-icon marker-icon-active'
   }
-  const size = getMarkerSizeFromZoom(zoom.value)
+  const size = getEffectiveMarkerSize(zoom.value)
   const markerSizeClass = `wp-marker-${size}`
 
   return `
@@ -427,7 +449,7 @@ const createWaypointMarkerHtml = (isReached: boolean, isCurrent = false): string
 }
 
 const createWaypointMarkerIcon = (isReached: boolean, isCurrent = false): L.DivIcon => {
-  const markerSize = getMarkerSizeFromZoom(zoom.value)
+  const markerSize = getEffectiveMarkerSize(zoom.value)
   const dimensions = getIconDimensionsFromMarkerSize(markerSize)
 
   return L.divIcon({
@@ -444,7 +466,7 @@ const applyWaypointMarkerStyle = (seq: number): void => {
   const isReached = getReachedWaypointIndices.value.has(seq)
   const idx = seq - 1
   const isCurrent = currentMapWpIndex.value >= 0 && idx === currentMapWpIndex.value
-  const markerSize = getMarkerSizeFromZoom(zoom.value)
+  const markerSize = getEffectiveMarkerSize(zoom.value)
   const dimensions = getIconDimensionsFromMarkerSize(markerSize)
 
   marker.setIcon(
@@ -459,11 +481,7 @@ const applyWaypointMarkerStyle = (seq: number): void => {
   // Updates the tooltip class for reached/current waypoints and visibility based on size
   const tooltip = marker.getTooltip()
   if (tooltip) {
-    if (markerSize === 'xs' || markerSize === 'sm') {
-      tooltip.setOpacity(0)
-    } else {
-      tooltip.setOpacity(1)
-    }
+    tooltip.setOpacity(markerSize === 'md' ? 1 : 0)
 
     const tooltipElement = tooltip.getElement()
     if (tooltipElement) {
@@ -1328,7 +1346,7 @@ watch(mapWaypoints, (newWaypoints) => {
       marker = L.marker(waypoint.coordinates, { icon: markerIcon })
       reachedWaypoints.value[seq] = marker
 
-      const markerSizeForTooltip = getMarkerSizeFromZoom(zoom.value)
+      const markerSizeForTooltip = getEffectiveMarkerSize(zoom.value)
       const markerTooltip = L.tooltip({
         content: seq.toString(),
         permanent: true,
@@ -1351,15 +1369,12 @@ watch(mapWaypoints, (newWaypoints) => {
       map.value?.addLayer(marker)
     } else {
       marker.setLatLng(waypoint.coordinates as LatLngTuple)
-      const markerSizeForUpdate = getMarkerSizeFromZoom(zoom.value)
+      const markerSizeForUpdate = getEffectiveMarkerSize(zoom.value)
       const tooltip = marker.getTooltip()
       if (tooltip) {
-        if (markerSizeForUpdate === 'xs' || markerSizeForUpdate === 'sm') {
-          tooltip.setOpacity(0)
-        } else {
-          tooltip.setContent(seq.toString())
-          tooltip.setOpacity(1)
-        }
+        const showNumber = markerSizeForUpdate === 'md'
+        if (showNumber) tooltip.setContent(seq.toString())
+        tooltip.setOpacity(showNumber ? 1 : 0)
       }
       applyWaypointMarkerStyle(seq)
     }
@@ -2056,7 +2071,7 @@ const centerOnMission = (): void => {
   position: absolute;
   bottom: v-bind('bottomButtonsDisplacement');
   margin-bottom: 12px;
-  right: 293px; /* Position to the left of the buttons */
+  right: 338px; /* Position to the left of the buttons */
   background: rgba(255, 255, 255, 0.8);
   border-radius: 1px;
   padding: 6px 6px;

--- a/src/composables/map/useSurveyArrowOverlay.ts
+++ b/src/composables/map/useSurveyArrowOverlay.ts
@@ -4,10 +4,11 @@ import { type WatchStopHandle, watch } from 'vue'
 import {
   type SurveyArrowAnchor,
   computeSurveyArrowAnchors,
+  computeSurveyEntryExitAnchors,
   partitionArrowsByLength,
   partitionArrowsByOrientation,
 } from '@/libs/map/survey-arrows'
-import type { Survey, WaypointCoordinates } from '@/types/mission'
+import type { Survey, Waypoint, WaypointCoordinates } from '@/types/mission'
 
 const ARROW_PANE = 'surveyArrowPane'
 const REFLY_PANE = 'surveyReflyPane'
@@ -56,6 +57,8 @@ export interface SurveyArrowSources {
   surveys: () => Survey[]
   /** The survey preview being drawn, or null when no survey preview is on the map. */
   previewPath: () => SurveyPreview | null
+  /** Ordered mission waypoints; the legs entering and leaving each survey get an arrow. */
+  missionWaypoints: () => Waypoint[]
 }
 
 /**
@@ -94,12 +97,14 @@ interface SurveyRenderData {
 
 /**
  * Draws direction-of-travel arrows at the middle of each survey leg (the survey being drawn and the legs of every
- * generated survey), never on plain waypoint-to-waypoint segments. For generated crosshatch surveys it also
+ * generated survey) and on each survey's mission entry and exit legs, never on any other plain
+ * waypoint-to-waypoint segment. For generated crosshatch surveys it also
  * repaints the transects over the blue base line: the crosshatch re-fly pass in purple and the primary pass in
  * blue on top, so the two passes read distinctly and the blue lines win every crossing. Owns its panes, watchers,
  * and teardown so a view only wires an init/destroy pair. Renders are coalesced to one per animation frame so the
  * overlay tracks the survey lines live during dial rotation and waypoint drags without redundant work.
- * @param {SurveyArrowSources} sources - Reactive getters for the survey list and the live survey preview path.
+ * @param {SurveyArrowSources} sources - Reactive getters for the survey list, the live survey preview path, and the
+ * mission waypoints.
  * @returns {UseSurveyArrowOverlayReturn} Methods to initialize and tear down the overlay.
  */
 export const useSurveyArrowOverlay = (sources: SurveyArrowSources): UseSurveyArrowOverlayReturn => {
@@ -149,6 +154,10 @@ export const useSurveyArrowOverlay = (sources: SurveyArrowSources): UseSurveyArr
       })
       short.forEach((anchor) => anchors.push({ ...anchor, color: surveyArrowColor, opacity: faintArrowOpacity }))
     })
+
+    computeSurveyEntryExitAnchors(sources.missionWaypoints(), sources.surveys()).forEach((anchor) =>
+      anchors.push({ ...anchor, color: surveyArrowColor, opacity: 1 })
+    )
 
     return {
       anchors: anchors.filter((a) => a.lengthMeters / metersPerPixel(a.position[0], zoom) >= minArrowLegPixels),
@@ -246,9 +255,11 @@ export const useSurveyArrowOverlay = (sources: SurveyArrowSources): UseSurveyArr
     }
 
     map.on('zoomend', scheduleRender)
-    stopWatch = watch([() => sources.previewPath(), () => sources.surveys()], () => scheduleRender(), {
-      immediate: true,
-    })
+    stopWatch = watch(
+      [() => sources.previewPath(), () => sources.surveys(), () => sources.missionWaypoints()],
+      () => scheduleRender(),
+      { immediate: true }
+    )
   }
 
   const destroyArrowOverlay = (): void => {

--- a/src/composables/map/useWaypointMarkerSize.ts
+++ b/src/composables/map/useWaypointMarkerSize.ts
@@ -1,0 +1,36 @@
+import { watch } from 'vue'
+
+import { useMissionStore } from '@/stores/mission'
+import type { MarkerSizes } from '@/types/mission'
+
+const getMarkerSizeFromZoom = (zoomLevel: number): MarkerSizes => {
+  if (zoomLevel <= 17) return 'xs'
+  if (zoomLevel > 17 && zoomLevel <= 19) return 'sm'
+  return 'md'
+}
+
+/**
+ * Return type of {@link useWaypointMarkerSize}.
+ */
+export interface UseWaypointMarkerSizeReturn {
+  /** Resolves the effective marker size for a zoom level, forcing full size when numbers are always shown. */
+  getEffectiveMarkerSize: (zoomLevel: number) => MarkerSizes
+}
+
+/**
+ * Shared waypoint-marker sizing for the map widget and the mission-planning view. The effective size honors the
+ * user's always-show-numbers toggle, and flipping that toggle re-renders the caller's markers.
+ * @param {() => void} refreshMarkers - Re-renders the caller's waypoint markers when the toggle changes.
+ * @returns {UseWaypointMarkerSizeReturn} Resolver for the effective marker size.
+ */
+export const useWaypointMarkerSize = (refreshMarkers: () => void): UseWaypointMarkerSizeReturn => {
+  const missionStore = useMissionStore()
+
+  // Forces the full-size numbered marker when the user opts to always show waypoint numbers, regardless of zoom.
+  const getEffectiveMarkerSize = (zoomLevel: number): MarkerSizes =>
+    missionStore.alwaysShowWaypointNumbers ? 'md' : getMarkerSizeFromZoom(zoomLevel)
+
+  watch(() => missionStore.alwaysShowWaypointNumbers, refreshMarkers)
+
+  return { getEffectiveMarkerSize }
+}

--- a/src/libs/map/survey-arrows.ts
+++ b/src/libs/map/survey-arrows.ts
@@ -44,6 +44,29 @@ export const computeSurveyArrowAnchors = (path: WaypointCoordinates[]): SurveyAr
   return anchors
 }
 
+/**
+ * Computes a direction arrow on the mission leg entering and the leg leaving each survey, so those connecting
+ * segments reveal whether the vehicle is heading into the survey or back out to the rest of the mission.
+ * @param {Waypoint[]} missionWaypoints - Ordered mission waypoints the surveys are embedded in.
+ * @param {Survey[]} surveys - Surveys whose entry and exit legs get an arrow.
+ * @returns {SurveyArrowAnchor[]} One anchor per existing entry/exit leg; legs at the mission ends are skipped.
+ */
+export const computeSurveyEntryExitAnchors = (missionWaypoints: Waypoint[], surveys: Survey[]): SurveyArrowAnchor[] => {
+  const indexById = new Map(missionWaypoints.map((waypoint, index) => [waypoint.id, index]))
+  const path = missionWaypoints.map((waypoint) => waypoint.coordinates)
+
+  return surveys.flatMap((survey) => {
+    const start = indexById.get(survey.waypoints[0]?.id ?? '')
+    const end = indexById.get(survey.waypoints.at(-1)?.id ?? '')
+    if (start === undefined || end === undefined) return []
+
+    const legs: WaypointCoordinates[][] = []
+    if (start > 0) legs.push([path[start - 1], path[start]])
+    if (end < path.length - 1) legs.push([path[end], path[end + 1]])
+    return legs.flatMap(computeSurveyArrowAnchors)
+  })
+}
+
 /** Arrows split by leg length relative to the longest leg in the set. */
 export interface LengthPartitionedArrows {
   /** Legs at least `minLengthRatio` of the longest leg (the transect sweeps). */

--- a/src/libs/map/utils-map.ts
+++ b/src/libs/map/utils-map.ts
@@ -293,10 +293,12 @@ export const persistLiveMapView = (
  * @param {number} turnaroundDistance - Distance in meters to extend (positive) or inset (negative) from the polygon
  *   boundary before turning. Positive values make the vehicle fly past the edges; negative values keep it away.
  * @param {boolean} crosshatch - When true, appends a second pass rotated 90 degrees to form a crosshatch grid.
- * @param {boolean} reverseSweep - When true, sweeps the survey lines from the far side inward, so the path
- *   enters the polygon from the opposite corner. Used to pick the crosshatch pass orientation.
- * @param {boolean} startReversed - When true, the first survey line is traversed in the opposite direction, so
- *   the path enters from the other end of that line. Used to pick the crosshatch pass orientation.
+ * @param {number} crosshatchDistanceBetweenLines - Distance between lines for the crosshatch second pass, in
+ *   meters. Falls back to `distanceBetweenLines` when unset.
+ * @param {boolean} startReversed - When true, each transect starts from the opposite end (flips the line
+ *   direction), moving the entry along the first line to the adjacent corner.
+ * @param {boolean} reverseSweep - When true, the sweep runs from the far side of the area first, moving the
+ *   entry to the opposite side. Combined with `startReversed` this reaches all four survey corners.
  * @returns {SurveyPath} The generated survey path and turnaround segments.
  */
 export const generateSurveyPath = (
@@ -305,8 +307,9 @@ export const generateSurveyPath = (
   linesAngle: number,
   turnaroundDistance = 0,
   crosshatch = false,
-  reverseSweep = false,
-  startReversed = false
+  crosshatchDistanceBetweenLines?: number,
+  startReversed = false,
+  reverseSweep = false
 ): SurveyPath => {
   if (polygonPoints.length < 4) return { path: [], turnaroundSegments: [] }
 
@@ -432,11 +435,48 @@ export const generateSurveyPath = (
       // with the two directions of the first survey line. Enter at the corner nearest the first pass exit so
       // the transit leg is short and does not double back, instead of always entering at a fixed path endpoint.
       const secondAngle = linesAngle + 90
+      const crosshatchDistance = crosshatchDistanceBetweenLines ?? distanceBetweenLines
       const sweeps = [
-        generateSurveyPath(polygonPoints, distanceBetweenLines, secondAngle, turnaroundDistance, false, false, false),
-        generateSurveyPath(polygonPoints, distanceBetweenLines, secondAngle, turnaroundDistance, false, false, true),
-        generateSurveyPath(polygonPoints, distanceBetweenLines, secondAngle, turnaroundDistance, false, true, false),
-        generateSurveyPath(polygonPoints, distanceBetweenLines, secondAngle, turnaroundDistance, false, true, true),
+        generateSurveyPath(
+          polygonPoints,
+          crosshatchDistance,
+          secondAngle,
+          turnaroundDistance,
+          false,
+          undefined,
+          false,
+          false
+        ),
+        generateSurveyPath(
+          polygonPoints,
+          crosshatchDistance,
+          secondAngle,
+          turnaroundDistance,
+          false,
+          undefined,
+          true,
+          false
+        ),
+        generateSurveyPath(
+          polygonPoints,
+          crosshatchDistance,
+          secondAngle,
+          turnaroundDistance,
+          false,
+          undefined,
+          false,
+          true
+        ),
+        generateSurveyPath(
+          polygonPoints,
+          crosshatchDistance,
+          secondAngle,
+          turnaroundDistance,
+          false,
+          undefined,
+          true,
+          true
+        ),
       ]
 
       let bestPass: SurveyPath | null = null
@@ -462,6 +502,104 @@ export const generateSurveyPath = (
     console.error('Error in generateSurveyPath:', error)
     return { path: [], turnaroundSegments: [] }
   }
+}
+
+const cornersPerPass = 4
+
+/**
+ * Number of distinct entry points a survey path exposes. A crosshatch survey doubles the count because the
+ * entry can sit on either pass's endpoint at each of the four physical corners.
+ * @param {boolean} crosshatch - Whether the survey includes a crosshatch pass.
+ * @returns {number} The number of selectable entry points (4 or 8).
+ */
+export const surveyEntryCornerCount = (crosshatch = false): number => (crosshatch ? cornersPerPass * 2 : cornersPerPass)
+
+/**
+ * Parameters shared by the entry-corner helpers, mirroring {@link generateSurveyPath} minus `startReversed`.
+ */
+interface SurveyGenerationParams {
+  /** Polygon vertices to survey. */
+  polygonPoints: L.LatLng[]
+  /** Distance between survey lines, in meters. */
+  distanceBetweenLines: number
+  /** Angle of the survey lines, in degrees. */
+  linesAngle: number
+  /** Turnaround extension/inset distance, in meters. */
+  turnaroundDistance?: number
+  /** Whether to append a 90° crosshatch pass. */
+  crosshatch?: boolean
+  /** Distance between lines for the crosshatch pass, in meters. */
+  crosshatchDistanceBetweenLines?: number
+}
+
+/**
+ * Generates a survey path that begins at the requested entry corner. Corners `0-3` decode into the two
+ * orientation flips so the entry lands on each physical corner along the primary pass; for a crosshatch
+ * survey, corners `4-7` fly the crosshatch pass first, so the entry sits on the perpendicular pass's endpoint
+ * at those same four corners.
+ * @param {SurveyGenerationParams} params - Survey generation parameters.
+ * @param {number} entryCorner - Which entry point (0-3, or 0-7 for a crosshatch survey) to start from.
+ * @returns {SurveyPath} The survey path (with turnaround segments and crosshatch index) whose first point sits on the chosen entry point.
+ */
+export const orderedSurveyPath = (params: SurveyGenerationParams, entryCorner = 0): SurveyPath => {
+  const swapPasses = Boolean(params.crosshatch) && entryCorner >= cornersPerPass
+  const corner = entryCorner % cornersPerPass
+  const startReversed = corner % 2 === 1
+  const reverseSweep = corner >= 2
+
+  const crosshatchDistance = params.crosshatchDistanceBetweenLines ?? params.distanceBetweenLines
+  const primaryDistance = swapPasses ? crosshatchDistance : params.distanceBetweenLines
+  const secondaryDistance = swapPasses ? params.distanceBetweenLines : params.crosshatchDistanceBetweenLines
+  const primaryAngle = swapPasses ? params.linesAngle + 90 : params.linesAngle
+
+  return generateSurveyPath(
+    params.polygonPoints,
+    primaryDistance,
+    primaryAngle,
+    params.turnaroundDistance,
+    params.crosshatch,
+    secondaryDistance,
+    startReversed,
+    reverseSweep
+  )
+}
+
+/**
+ * Computes the outward bearing of the polygon edge nearest a survey entrance/exit, i.e. the direction
+ * perpendicular to that edge pointing away from the polygon interior. A marker sitting on the boundary can
+ * then be oriented relative to the edge it lies on.
+ * @param {L.LatLng[]} polygonPoints - The survey polygon vertices (open ring; the first vertex is not repeated).
+ * @param {L.LatLng} endpoint - The entrance or exit point, on or near the polygon boundary.
+ * @returns {number} The outward compass bearing (degrees clockwise from north) of the nearest edge's normal.
+ */
+export const surveyEndpointEdgeBearing = (polygonPoints: L.LatLng[], endpoint: L.LatLng): number => {
+  const coords = polygonPoints.map((p) => [p.lng, p.lat] as Position)
+  if (coords.length < 3) return 0
+
+  const norm = (bearing: number): number => ((bearing % 360) + 360) % 360
+  const point = turf.point([endpoint.lng, endpoint.lat])
+
+  let closestEdge = 0
+  let closestDistance = Infinity
+  for (let i = 0; i < coords.length; i++) {
+    const edge = turf.lineString([coords[i], coords[(i + 1) % coords.length]])
+    const distance = turf.pointToLineDistance(point, edge, { units: 'meters' })
+    if (distance < closestDistance) {
+      closestDistance = distance
+      closestEdge = i
+    }
+  }
+
+  const edgeBearing = turf.bearing(
+    turf.point(coords[closestEdge]),
+    turf.point(coords[(closestEdge + 1) % coords.length])
+  )
+  const towardCentroid = turf.bearing(point, turf.centroid(turf.polygon([[...coords, coords[0]]])))
+  const normalA = norm(edgeBearing + 90)
+  const normalB = norm(edgeBearing - 90)
+
+  // Of the two edge normals, the outward one is the further from the direction toward the polygon centroid.
+  return deltaBearing(normalA, towardCentroid) > deltaBearing(normalB, towardCentroid) ? normalA : normalB
 }
 
 /**

--- a/src/stores/mission.ts
+++ b/src/stores/mission.ts
@@ -70,6 +70,7 @@ export const useMissionStore = defineStore('mission', () => {
   const showMissionCreationTips = useBlueOsStorage('cockpit-show-mission-creation-tips', true)
   const showChecklistBeforeArm = useBlueOsStorage('cockpit-show-checklist-before-arm', true)
   const showGridOnMissionPlanning = useBlueOsStorage('cockpit-show-grid-on-mission-planning', false)
+  const alwaysShowWaypointNumbers = useBlueOsStorage('cockpit-always-show-waypoint-numbers', false, { debounceMs: 0 })
   const showMissionEstimates = useBlueOsStorage('cockpit-show-mission-estimates', true)
   const defaultCruiseSpeed = useBlueOsStorage<number>('cockpit-default-cruise-speed', 1)
   const cruiseSpeed = ref<number>(Number(defaultCruiseSpeed.value))
@@ -824,6 +825,11 @@ export const useMissionStore = defineStore('mission', () => {
     removeThumbnail(id)
   }
 
+  const toggleAlwaysShowWaypointNumbers = (): void => {
+    alwaysShowWaypointNumbers.value = !alwaysShowWaypointNumbers.value
+    logUserAction(`${alwaysShowWaypointNumbers.value ? 'Enabled' : 'Disabled'} always-visible waypoint numbers`)
+  }
+
   return {
     username,
     lastConnectedUser,
@@ -862,6 +868,8 @@ export const useMissionStore = defineStore('mission', () => {
     showMissionCreationTips,
     showChecklistBeforeArm,
     showGridOnMissionPlanning,
+    alwaysShowWaypointNumbers,
+    toggleAlwaysShowWaypointNumbers,
     showMissionEstimates,
     addCommandToWaypoint,
     removeCommandFromWaypoint,

--- a/src/types/mission.ts
+++ b/src/types/mission.ts
@@ -261,6 +261,16 @@ export interface Survey {
    */
   crosshatch?: boolean
   /**
+   * Density of the crosshatch second pass. Falls back to `distanceBetweenLines` when unset, which also
+   * covers surveys saved before this field existed.
+   */
+  crosshatchDistanceBetweenLines?: number
+  /**
+   * Which of the four survey corners the first waypoint sits on, as a value from 0 to 3. Rotating it
+   * cycles the entry corner. Falls back to 0 when unset (surveys saved before this field existed).
+   */
+  entryCorner?: number
+  /**
    * Executable mission waypoints.
    */
   waypoints: Waypoint[]

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -559,7 +559,7 @@
       <template #activator="{ props: tooltipProps }">
         <v-btn
           v-bind="tooltipProps"
-          class="absolute right-[135px] w-[140px] m-3 mb-[13px] bottom-12 bg-slate-50 text-[12px] font-bold"
+          class="absolute right-[180px] w-[140px] m-3 mb-[13px] bottom-12 bg-slate-50 text-[12px] font-bold"
           elevation="8"
           text="Flight mode"
           append-icon="mdi-send"
@@ -589,6 +589,26 @@
             <v-list-item class="py-0" title="Save visible OSM tiles" @click="saveOSM" />
           </v-list>
         </v-menu>
+      </template>
+    </v-tooltip>
+    <v-tooltip
+      location="top center"
+      :text="
+        missionStore.alwaysShowWaypointNumbers
+          ? 'Hide waypoint numbers when zoomed out'
+          : 'Always show waypoint numbers'
+      "
+    >
+      <template #activator="{ props: tooltipProps }">
+        <v-btn
+          v-bind="tooltipProps"
+          class="absolute m-3 rounded-sm shadow-sm bottom-12 bg-slate-50 right-[132px] text-[14px]"
+          :style="interfaceStore.globalGlassMenuStyles"
+          :color="missionStore.alwaysShowWaypointNumbers ? 'primary' : ''"
+          size="x-small"
+          icon="mdi-numeric-1-circle-outline"
+          @click="missionStore.toggleAlwaysShowWaypointNumbers()"
+        />
       </template>
     </v-tooltip>
     <MapCenterControl
@@ -769,6 +789,7 @@ import { useMapTileLayers } from '@/composables/map/useMapTileLayers'
 import { useMapTileLayerSelection } from '@/composables/map/useMapTileLayerSelection'
 import { type SurveyPreview, useSurveyArrowOverlay } from '@/composables/map/useSurveyArrowOverlay'
 import { useVertexAngleOverlay } from '@/composables/map/useVertexAngleOverlay'
+import { useWaypointMarkerSize } from '@/composables/map/useWaypointMarkerSize'
 import { useSnackbar } from '@/composables/snackbar'
 import {
   clearAllSurveyAreas,
@@ -2813,7 +2834,7 @@ const addWaypoint = (
     showContextMenu(e)
   })
 
-  const currentMarkerSize = getMarkerSizeFromZoom(zoom.value)
+  const currentMarkerSize = getEffectiveMarkerSize(zoom.value)
   const iconDimensions = getIconDimensionsFromMarkerSize(currentMarkerSize)
   const markerIcon = L.divIcon({
     html: createWaypointMarkerHtml(waypoint.commands.length, false, surveyEntryExitWaypointIds.value.has(waypoint.id)),
@@ -3429,7 +3450,7 @@ const generateWaypointsFromSurvey = (): void => {
 // Helper function to create waypoint marker HTML with command count indicator
 const createWaypointMarkerHtml = (commandCount: number, isSelected = false, isEntryExit = false): string => {
   const baseClass = isSelected ? 'selected-marker' : 'marker-icon'
-  const size = getMarkerSizeFromZoom(zoom.value)
+  const size = getEffectiveMarkerSize(zoom.value)
   const markerSizeClass = `wp-marker-${size}`
   const showSmallCommandCount = size !== 'md' && commandCount > 1
   const showCommandCount = size === 'md' && commandCount > 1
@@ -3449,7 +3470,7 @@ const updateWaypointMarkers = (): void => {
   if (!planningMap.value) return
 
   const currentZoom = zoom.value
-  const markerSize = getMarkerSizeFromZoom(currentZoom)
+  const markerSize = getEffectiveMarkerSize(currentZoom)
 
   missionStore.currentPlanningWaypoints.forEach((wp) => {
     const marker = waypointMarkers.value[wp.id]
@@ -3470,13 +3491,9 @@ const updateWaypointMarkers = (): void => {
       // Update tooltip visibility and content based on size
       const tooltip = marker.getTooltip()
       if (tooltip) {
-        if (markerSize === 'xs' || markerSize === 'sm') {
-          tooltip.setContent('')
-          tooltip.setOpacity(0)
-        } else {
-          tooltip.setContent(`${cumulativeCommandCount}`)
-          tooltip.setOpacity(1)
-        }
+        const showNumber = markerSize === 'md'
+        tooltip.setContent(showNumber ? `${cumulativeCommandCount}` : '')
+        tooltip.setOpacity(showNumber ? 1 : 0)
       }
 
       cumulativeCommandCount += wp.commands.length
@@ -3771,7 +3788,7 @@ const addWaypointMarker = (waypoint: Waypoint): void => {
     interfaceStore.configPanelVisible = true
   })
 
-  const currentMarkerSize = getMarkerSizeFromZoom(zoom.value)
+  const currentMarkerSize = getEffectiveMarkerSize(zoom.value)
   const dimensions = getIconDimensionsFromMarkerSize(currentMarkerSize)
   const markerIcon = L.divIcon({
     html: createWaypointMarkerHtml(waypoint.commands.length, false, surveyEntryExitWaypointIds.value.has(waypoint.id)),
@@ -3781,7 +3798,7 @@ const addWaypointMarker = (waypoint: Waypoint): void => {
   })
   newMarker.setIcon(markerIcon)
 
-  const currentMarkerSizeForTooltip = getMarkerSizeFromZoom(zoom.value)
+  const currentMarkerSizeForTooltip = getEffectiveMarkerSize(zoom.value)
   const markerTooltip = L.tooltip({
     content: '',
     permanent: true,
@@ -3795,11 +3812,9 @@ const addWaypointMarker = (waypoint: Waypoint): void => {
   waypointMarkers.value[waypoint.id] = newMarker
 }
 
-const getMarkerSizeFromZoom = (zoomLevel: number): MarkerSizes => {
-  if (zoomLevel <= 17) return 'xs'
-  if (zoomLevel > 17 && zoomLevel <= 19) return 'sm'
-  return 'md'
-}
+const { getEffectiveMarkerSize } = useWaypointMarkerSize(() => {
+  if (planningMap.value) updateWaypointMarkers()
+})
 
 const getIconDimensionsFromMarkerSize = (size: MarkerSizes): IconDimensions => {
   if (size === 'xs') {
@@ -3813,7 +3828,7 @@ const getIconDimensionsFromMarkerSize = (size: MarkerSizes): IconDimensions => {
 
 // single source of truth for selected-marker visuals
 const applySelectedWaypointMarkerVisual = (newWaypointId?: string, oldWaypointId?: string): void => {
-  const markerSize = getMarkerSizeFromZoom(zoom.value)
+  const markerSize = getEffectiveMarkerSize(zoom.value)
 
   if (oldWaypointId) {
     const oldMarker = waypointMarkers.value[oldWaypointId]
@@ -3990,7 +4005,7 @@ const onMapClick = (e: L.LeafletMouseEvent): void => {
   if (oldWaypoint) {
     const oldMarker = waypointMarkers.value[oldWaypoint.id]
     if (oldMarker) {
-      const markerSize = getMarkerSizeFromZoom(zoom.value)
+      const markerSize = getEffectiveMarkerSize(zoom.value)
       const dimensions = getIconDimensionsFromMarkerSize(markerSize)
       oldMarker.setIcon(
         L.divIcon({
@@ -4949,7 +4964,7 @@ watch(
 /* Style the standard Leaflet scale control */
 :deep(.leaflet-control-scale) {
   position: absolute;
-  right: 293px; /* Position to the left of the buttons */
+  right: 338px; /* Position to the left of the buttons */
   bottom: 54px;
   background: rgba(255, 255, 255, 0.8);
   border-radius: 1px;

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -835,6 +835,7 @@ const dragMeasureOverlay = useDragMeasureOverlay(angleOverlay)
 const surveyArrowOverlay = useSurveyArrowOverlay({
   surveys: () => surveysWithLiveWaypoints.value,
   previewPath: () => surveyPreviewPath.value,
+  missionWaypoints: () => missionStore.currentPlanningWaypoints,
 })
 
 const { height: windowHeight } = useWindowSize()

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -69,6 +69,22 @@
         </div>
       </template>
     </v-tooltip>
+    <v-tooltip location="top" text="Rotate the survey entry point to the next corner">
+      <template #activator="{ props }">
+        <div
+          v-if="isCreatingSurvey && surveyPolygonVertexesPositions.length >= 3"
+          v-bind="props"
+          :style="confirmButtonStyle"
+          class="absolute mt-[24px] -ml-[165px] bg-transparent cursor-pointer elevation-4"
+          variant="text"
+          @click="rotateDraftSurveyEntryPoint"
+        >
+          <div class="flex items-center justify-center w-8 h-8 border-2 rounded-full bg-[#333333EE]">
+            <v-icon color="white" size="16">mdi-rotate-right</v-icon>
+          </div>
+        </div>
+      </template>
+    </v-tooltip>
     <v-tooltip
       location="top"
       :text="surveyCrosshatch ? 'Disable 90° crosshatch re-fly' : 'Enable 90° crosshatch re-fly'"
@@ -78,7 +94,7 @@
           v-if="isCreatingSurvey && surveyPolygonVertexesPositions.length >= 3"
           v-bind="props"
           :style="confirmButtonStyle"
-          class="absolute mt-[72px] -ml-[150px] bg-transparent cursor-pointer elevation-4"
+          class="absolute mt-[72px] -ml-[165px] bg-transparent cursor-pointer elevation-4"
           variant="text"
           @click="setSurveyCrosshatch(!surveyCrosshatch)"
         >
@@ -88,6 +104,24 @@
           >
             <v-icon color="white" size="16">mdi-grid</v-icon>
           </div>
+        </div>
+      </template>
+    </v-tooltip>
+    <v-tooltip location="top" text="Crosshatch scan spacing">
+      <template #activator="{ props }">
+        <div
+          v-if="isCreatingSurvey && surveyCrosshatch && surveyPolygonVertexesPositions.length >= 3"
+          v-bind="props"
+          :style="confirmButtonStyle"
+          class="absolute mt-[120px] -ml-[160px] rounded-lg elevation-4"
+          variant="text"
+        >
+          <input
+            v-model.number="crosshatchDistanceBetweenLines"
+            class="rounded-lg bg-[#333333EE] text-white w-12 pl-2 pa-0"
+            type="number"
+            min="1"
+          />
         </div>
       </template>
     </v-tooltip>
@@ -297,18 +331,49 @@
             class="px-2 py-1 mt-1 mb-2 mx-5 rounded-sm bg-[#FFFFFF22]"
             type="number"
           />
-          <v-checkbox
-            :model-value="surveyCrosshatch"
-            label="Re-fly at 90° (crosshatch)"
-            theme="dark"
-            density="compact"
-            hide-details
-            class="mx-4"
-            @update:model-value="setSurveyCrosshatch"
-          />
-          <p class="mx-5 mb-2 text-[11px] opacity-70 text-slate-200">
-            Flies the area again at 90° for better photogrammetry coverage (≈doubles flight time).
-          </p>
+          <div class="flex items-center mx-4">
+            <v-checkbox
+              :model-value="surveyCrosshatch"
+              label="Re-fly at 90° (crosshatch)"
+              theme="dark"
+              density="compact"
+              hide-details
+              @update:model-value="setSurveyCrosshatch"
+            />
+            <v-tooltip
+              location="top"
+              max-width="260"
+              text="Flies the area again at 90° for better photogrammetry coverage (≈doubles flight time)."
+            >
+              <template #activator="{ props: crosshatchInfoProps }">
+                <v-icon v-bind="crosshatchInfoProps" size="18" class="ml-1 text-slate-300 cursor-help">
+                  mdi-information-outline
+                </v-icon>
+              </template>
+            </v-tooltip>
+          </div>
+          <template v-if="surveyCrosshatch">
+            <p class="m-1 overflow-visible text-sm text-slate-200">Crosshatch distance between lines (m)</p>
+            <input
+              v-model.number="crosshatchDistanceBetweenLines"
+              class="px-2 py-1 m-1 mx-5 rounded-sm bg-[#FFFFFF22]"
+              type="number"
+              min="1"
+            />
+          </template>
+          <div class="flex items-center justify-between mx-5 my-2">
+            <p class="overflow-visible text-sm text-slate-200">Entry point</p>
+            <v-btn
+              size="small"
+              variant="tonal"
+              theme="dark"
+              prepend-icon="mdi-rotate-right"
+              @click="rotateDraftSurveyEntryPoint"
+            >
+              Rotate
+            </v-btn>
+          </div>
+          <v-divider class="mb-1 mt-2" />
           <p class="m-1 overflow-visible text-sm text-slate-200">Altitude (m)</p>
           <input
             v-model.number="currentWaypointAltitude"
@@ -328,6 +393,7 @@
             variant="outlined"
             class="mx-5 my-1 text-sm"
           />
+          <v-divider class="mb-1 mt-2" />
           <button
             :class="{
               'bg-[#FFFFFF11] hover:bg-[#FFFFFF11] text-[#FFFFFF22] elevation-0':
@@ -569,7 +635,7 @@
     @set-home-position="setHomePositionFromContextMenu"
     @close="hideContextMenu"
     @delete-selected-survey="deleteSelectedSurvey"
-    @swap-survey-entry-exit="swapSurveyEntryExit"
+    @rotate-survey-entry-point="rotateSurveyEntryPoint"
     @toggle-survey="toggleSurvey"
     @toggle-simple-path="toggleSimplePath"
     @undo-generated-waypoints="undoGenerateWaypoints"
@@ -724,7 +790,7 @@ import {
   TargetFollower,
   WhoToFollow,
 } from '@/libs/map/utils-map'
-import { generateSurveyPath } from '@/libs/map/utils-map'
+import { orderedSurveyPath, surveyEndpointEdgeBearing, surveyEntryCornerCount } from '@/libs/map/utils-map'
 import {
   bearingBetween,
   centroidLatLng,
@@ -1005,7 +1071,6 @@ const surveysWithLiveWaypoints = computed<Survey[]>(() =>
 const undoIsInProgress = ref(false)
 const undoWaypointInsertIndex = ref<number | null>(null)
 const undoSurveyInsertIndex = ref<number | null>(null)
-const undoSurveyWasReversed = ref(false)
 let dragStartLatLng: L.LatLng | null = null
 let polygonLatLngsAtDragStart: L.LatLng[] = []
 const surveyPolygonUndoStack: L.LatLng[][] = []
@@ -1412,7 +1477,6 @@ const clearCurrentMission = (): void => {
   lastSelectedSurveyId.value = ''
   undoWaypointInsertIndex.value = null
   undoSurveyInsertIndex.value = null
-  undoSurveyWasReversed.value = false
   segmentSurveyInsertIndex.value = null
   clearSurveyPolygonUndoStack()
   interfaceStore.configPanelVisible = false
@@ -1456,6 +1520,19 @@ const enableUndoForCurrentSurvey = computed(() => {
 
 const selectedSurvey = computed(() => {
   return surveys.value.find((survey) => survey.id === selectedSurveyId.value)
+})
+
+// Entrance and exit waypoints of every survey, coloured green in their marker markup so the state survives
+// any icon re-render instead of being patched onto the DOM after the fact.
+const surveyEntryExitWaypointIds = computed(() => {
+  const ids = new Set<string>()
+  surveys.value.forEach((survey) => {
+    const first = survey.waypoints[0]
+    const last = survey.waypoints.at(-1)
+    if (first) ids.add(first.id)
+    if (last) ids.add(last.id)
+  })
+  return ids
 })
 
 const addSurvey = (survey: Survey): void => {
@@ -1566,7 +1643,7 @@ const updateConfirmButtonPosition = (): void => {
 
     const pos = pickBestPosition(
       [
-        { x: bounds.maxX + gap, y: cy - visualH / 2 },
+        { x: bounds.maxX + gap + 100, y: cy - visualH / 2 },
         { x: bounds.minX - gap - visualW, y: cy - visualH / 2 },
         { x: cx - visualW / 2, y: bounds.maxY + gap },
         { x: cx - visualW / 2, y: bounds.minY - gap - visualH },
@@ -2157,6 +2234,7 @@ const toggleSurvey = (): void => {
     return
   }
   logUserAction('Enabled mission survey tool')
+  surveyDraftEntryCorner.value = 0
   isCreatingSurvey.value = true
   isDrawingSurveyPolygon.value = true
   interfaceStore.configPanelVisible = true
@@ -2387,6 +2465,9 @@ const performUndo = (): void => {
     distanceBetweenSurveyLines.value = removedSurvey.distanceBetweenLines
     surveyLinesAngle.value = removedSurvey.surveyLinesAngle
     surveyCrosshatch.value = removedSurvey.crosshatch ?? false
+    crosshatchDistanceBetweenLines.value =
+      removedSurvey.crosshatchDistanceBetweenLines ?? removedSurvey.distanceBetweenLines
+    surveyDraftEntryCorner.value = removedSurvey.entryCorner ?? 0
 
     clearSurveyPolygonUndoStack()
     const coords = removedSurvey.polygonCoordinates
@@ -2582,32 +2663,16 @@ const deleteSelectedSurvey = (): void => {
   updateWaypointMarkers()
 }
 
-const swapSurveyEntryExit = (): void => {
-  const surveyId = selectedSurveyId.value
-  if (!surveyId) return
-
-  const survey = surveys.value.find((s) => s.id === surveyId)
+const rotateSurveyEntryPoint = (): void => {
+  const survey = selectedSurvey.value
   if (!survey || survey.waypoints.length < 2) return
 
-  logUserAction('Swapped survey entry/exit points')
+  const nextCorner = ((survey.entryCorner ?? 0) + 1) % surveyEntryCornerCount(survey.crosshatch)
+  logUserAction(`Rotated survey entry point to corner ${nextCorner + 1}`)
   missionStore.pushUndoSnapshot()
 
-  const firstWpId = survey.waypoints[0].id
-  const insertIndex = missionStore.currentPlanningWaypoints.findIndex((wp) => wp.id === firstWpId)
-  if (insertIndex === -1) return
-
-  survey.waypoints.forEach((wp) => {
-    const idx = missionStore.currentPlanningWaypoints.findIndex((w) => w.id === wp.id)
-    if (idx !== -1) missionStore.currentPlanningWaypoints.splice(idx, 1)
-  })
-
-  survey.waypoints.reverse()
-  missionStore.currentPlanningWaypoints.splice(insertIndex, 0, ...survey.waypoints)
-  updateSurvey(surveyId, { waypoints: survey.waypoints })
-
-  updateWaypointMarkers()
-  refreshSurveyEntryExitMarkers()
-  hideContextMenu()
+  survey.entryCorner = nextCorner
+  regenerateSelectedSurveyWaypoints()
 }
 
 const homeWaypointCursor =
@@ -2750,7 +2815,7 @@ const addWaypoint = (
   const currentMarkerSize = getMarkerSizeFromZoom(zoom.value)
   const iconDimensions = getIconDimensionsFromMarkerSize(currentMarkerSize)
   const markerIcon = L.divIcon({
-    html: createWaypointMarkerHtml(waypoint.commands.length, false),
+    html: createWaypointMarkerHtml(waypoint.commands.length, false, surveyEntryExitWaypointIds.value.has(waypoint.id)),
     className: 'waypoint-marker-icon',
     iconSize: iconDimensions.iconSize,
     iconAnchor: iconDimensions.iconAnchor,
@@ -2831,9 +2896,11 @@ const drawMissionOnTheMap = (waypoints: Waypoint[]): void => {
 
 const surveyPolygonVertexesMarkers = shallowRef<L.Marker[]>([])
 const rawDistanceBetweenSurveyLines = ref(10)
+const rawCrosshatchDistanceBetweenLines = ref(10)
 const rawSurveyLinesAngle = ref(0)
 const rawTurnaroundDistance = ref(0)
 const surveyCrosshatch = ref(false)
+const surveyDraftEntryCorner = ref(0)
 const existingWaypoints = ref<Waypoint[]>([])
 const surveyWaypoints = ref<Waypoint[]>([])
 
@@ -2841,6 +2908,12 @@ const surveyWaypoints = ref<Waypoint[]>([])
 const distanceBetweenSurveyLines = computed({
   get: () => Math.max(1, rawDistanceBetweenSurveyLines.value),
   set: (value) => (rawDistanceBetweenSurveyLines.value = Math.max(1, value)), // Ensure the distance is at least 1
+})
+
+// Distance between lines in the crosshatch second pass
+const crosshatchDistanceBetweenLines = computed({
+  get: () => Math.max(1, rawCrosshatchDistanceBetweenLines.value),
+  set: (value) => (rawCrosshatchDistanceBetweenLines.value = Math.max(1, value)),
 })
 
 const turnaroundDistance = computed({
@@ -2872,6 +2945,36 @@ const surveyCrosshatchPathLayer = shallowRef<L.Polyline | null>(null)
 const surveyTurnaroundLayers = shallowRef<L.Polyline[]>([])
 const surveyPolygonLayer = shallowRef<L.Polygon | null>(null)
 const surveyPreviewPath = shallowRef<SurveyPreview | null>(null)
+const surveyEndpointMarkers = shallowRef<L.Layer[]>([])
+
+const removeSurveyEndpointMarkers = (): void => {
+  surveyEndpointMarkers.value.forEach((marker) => planningMap.value?.removeLayer(marker as unknown as L.Layer))
+  surveyEndpointMarkers.value = []
+}
+
+// Small green chevron marking a survey entrance/exit, oriented perpendicular to the polygon edge it sits on:
+// it sits just outside the boundary and points inward for the entrance, outward for the exit.
+const createSurveyEndpointChevron = (position: L.LatLng, isEntrance: boolean): L.Marker => {
+  const outwardBearing = surveyEndpointEdgeBearing(surveyPolygonVertexesPositions.value, position)
+  // The endpoint sits at the box center (12, 20); the glyph sits above it (outward side) with its nearest edge
+  // 8px out, clearing the 5px circle by 3px. The entrance points down (inward), the exit up (outward).
+  const chevronPath = isEntrance ? 'M6 7 L12 12 L18 7' : 'M6 12 L12 7 L18 12'
+  const html =
+    `<div style="transform: rotate(${outwardBearing}deg);">` +
+    '<svg width="24" height="40" viewBox="0 0 24 40" fill="none" xmlns="http://www.w3.org/2000/svg">' +
+    `<path d="${chevronPath}" stroke="#FFFFFF" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>` +
+    `<path d="${chevronPath}" stroke="#034103" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>` +
+    '</svg></div>'
+  return L.marker(position, {
+    interactive: false,
+    icon: L.divIcon({
+      className: 'survey-endpoint-chevron',
+      html,
+      iconSize: [24, 40],
+      iconAnchor: [12, 20],
+    }),
+  })
+}
 
 const removeSurveyCrosshatchPathLayer = (): void => {
   if (surveyCrosshatchPathLayer.value) {
@@ -2892,6 +2995,7 @@ const clearSurveyPath = (): void => {
     surveyPathLayer.value = null
   }
   removeSurveyCrosshatchPathLayer()
+  removeSurveyEndpointMarkers()
   surveyTurnaroundLayers.value.forEach((layer) => planningMap.value?.removeLayer(layer as unknown as L.Layer))
   surveyTurnaroundLayers.value = []
   if (surveyPolygonLayer.value) {
@@ -2989,6 +3093,7 @@ const checkAndRemoveSurveyPath = (): void => {
   planningMap.value?.removeLayer(surveyPathLayer.value as unknown as L.Layer)
   surveyPathLayer.value = null
   removeSurveyCrosshatchPathLayer()
+  removeSurveyEndpointMarkers()
   surveyTurnaroundLayers.value.forEach((layer) => planningMap.value?.removeLayer(layer as unknown as L.Layer))
   surveyTurnaroundLayers.value = []
 }
@@ -3001,12 +3106,16 @@ const createSurveyPath = (): void => {
 
   try {
     const adjustedAngle = 90 - surveyLinesAngle.value
-    const result: SurveyPath = generateSurveyPath(
-      surveyPolygonVertexesPositions.value,
-      distanceBetweenSurveyLines.value,
-      adjustedAngle,
-      turnaroundDistance.value,
-      surveyCrosshatch.value
+    const result: SurveyPath = orderedSurveyPath(
+      {
+        polygonPoints: surveyPolygonVertexesPositions.value,
+        distanceBetweenLines: distanceBetweenSurveyLines.value,
+        linesAngle: adjustedAngle,
+        turnaroundDistance: turnaroundDistance.value,
+        crosshatch: surveyCrosshatch.value,
+        crosshatchDistanceBetweenLines: crosshatchDistanceBetweenLines.value,
+      },
+      surveyDraftEntryCorner.value
     )
 
     if (result.path.length === 0) {
@@ -3023,6 +3132,7 @@ const createSurveyPath = (): void => {
       planningMap.value?.removeLayer(surveyPathLayer.value as unknown as L.Layer)
     }
     removeSurveyCrosshatchPathLayer()
+    removeSurveyEndpointMarkers()
 
     surveyTurnaroundLayers.value.forEach((layer) => planningMap.value?.removeLayer(layer as unknown as L.Layer))
     surveyTurnaroundLayers.value = []
@@ -3063,6 +3173,27 @@ const createSurveyPath = (): void => {
         }).addTo(toRaw(planningMap.value)!)
       )
     }
+
+    // Mark the entrance (first point) and exit (last point) of the ordered path so the operator can
+    // see where the vehicle enters and leaves the survey while still editing it.
+    const entrance = result.path[0]
+    const exit = result.path[result.path.length - 1]
+    const map = toRaw(planningMap.value)!
+    const endpointCircle = (latLng: L.LatLng): L.CircleMarker =>
+      L.circleMarker(latLng, {
+        radius: 5,
+        color: '#ffffff99',
+        weight: 2,
+        fillColor: '#034103',
+        fillOpacity: 1,
+        className: 'survey-endpoint-marker',
+      }).addTo(map)
+    surveyEndpointMarkers.value = [
+      endpointCircle(entrance),
+      endpointCircle(exit),
+      createSurveyEndpointChevron(entrance, true).addTo(map),
+      createSurveyEndpointChevron(exit, false).addTo(map),
+    ]
   } catch (error) {
     surveyPreviewPath.value = null
     showDialog({
@@ -3086,7 +3217,17 @@ watch(
 )
 
 // Watch for changes in distanceBetweenSurveyLines, surveyLinesAngle, and turnaroundDistance
-watch([distanceBetweenSurveyLines, surveyLinesAngle, turnaroundDistance, surveyCrosshatch], () => createSurveyPath())
+watch(
+  [
+    distanceBetweenSurveyLines,
+    surveyLinesAngle,
+    turnaroundDistance,
+    surveyCrosshatch,
+    crosshatchDistanceBetweenLines,
+    surveyDraftEntryCorner,
+  ],
+  () => createSurveyPath()
+)
 
 const surveyEdgeAddMarkers: L.Marker[] = []
 
@@ -3196,30 +3337,6 @@ watch(isCreatingSurvey, (isCreatingNow) => {
   }
 })
 
-const refreshSurveyEntryExitMarkers = (): void => {
-  Object.values(waypointMarkers.value).forEach((marker) => {
-    marker.getElement()?.querySelector('.waypoint-main-marker')?.classList.remove('green-marker')
-  })
-
-  surveys.value.forEach((survey) => {
-    const firstWp = survey.waypoints[0]
-    const lastWp = survey.waypoints.at(-1)
-
-    if (firstWp) {
-      waypointMarkers.value[firstWp.id]
-        ?.getElement()
-        ?.querySelector('.waypoint-main-marker')
-        ?.classList.add('green-marker')
-    }
-    if (lastWp && lastWp !== firstWp) {
-      waypointMarkers.value[lastWp.id]
-        ?.getElement()
-        ?.querySelector('.waypoint-main-marker')
-        ?.classList.add('green-marker')
-    }
-  })
-}
-
 const generateWaypointsFromSurvey = (): void => {
   if (!surveyPathLayer.value) {
     showDialog({ variant: 'error', message: 'No survey path to generate waypoints from.', timer: 2000 })
@@ -3238,12 +3355,16 @@ const generateWaypointsFromSurvey = (): void => {
   ])
 
   const adjustedAngle = 90 - surveyLinesAngle.value
-  const { path: continuousPath } = generateSurveyPath(
-    surveyPolygonVertexesPositions.value,
-    distanceBetweenSurveyLines.value,
-    adjustedAngle,
-    turnaroundDistance.value,
-    surveyCrosshatch.value
+  const { path: continuousPath } = orderedSurveyPath(
+    {
+      polygonPoints: surveyPolygonVertexesPositions.value,
+      distanceBetweenLines: distanceBetweenSurveyLines.value,
+      linesAngle: adjustedAngle,
+      turnaroundDistance: turnaroundDistance.value,
+      crosshatch: surveyCrosshatch.value,
+      crosshatchDistanceBetweenLines: crosshatchDistanceBetweenLines.value,
+    },
+    surveyDraftEntryCorner.value
   )
 
   if (!continuousPath.length) {
@@ -3262,11 +3383,6 @@ const generateWaypointsFromSurvey = (): void => {
     altitudeReferenceType: currentWaypointAltitudeRefType.value,
     commands: makeDefaultNavCommands(),
   }))
-
-  if (undoSurveyWasReversed.value) {
-    newSurveyWaypoints.reverse()
-    undoSurveyWasReversed.value = false
-  }
 
   const segInsertIdx = segmentSurveyInsertIndex.value
   const waypointInsertIdx = undoWaypointInsertIndex.value
@@ -3289,6 +3405,8 @@ const generateWaypointsFromSurvey = (): void => {
     surveyLinesAngle: surveyLinesAngle.value,
     turnaroundDistance: turnaroundDistance.value,
     crosshatch: surveyCrosshatch.value,
+    crosshatchDistanceBetweenLines: crosshatchDistanceBetweenLines.value,
+    entryCorner: surveyDraftEntryCorner.value,
     waypoints: newSurveyWaypoints,
   }
 
@@ -3303,34 +3421,22 @@ const generateWaypointsFromSurvey = (): void => {
   isCreatingSurvey.value = false
   isDrawingSurveyPolygon.value = false
   updateWaypointMarkers()
-  refreshSurveyEntryExitMarkers()
-
-  const firstWaypoint = newSurveyWaypoints[0]
-  const lastWaypoint = newSurveyWaypoints[newSurveyWaypoints.length - 1]
-  const firstMarker = waypointMarkers.value[firstWaypoint.id]
-  const lastMarker = waypointMarkers.value[lastWaypoint.id]
-
-  if (firstMarker) {
-    firstMarker.getElement()?.querySelector('.waypoint-main-marker')?.classList.add('green-marker')
-  }
-  if (lastMarker && lastMarker !== firstMarker) {
-    lastMarker.getElement()?.querySelector('.waypoint-main-marker')?.classList.add('green-marker')
-  }
 
   openSnackbar({ variant: 'success', message: 'Waypoints generated from survey path.', duration: 1000 })
 }
 
 // Helper function to create waypoint marker HTML with command count indicator
-const createWaypointMarkerHtml = (commandCount: number, isSelected = false): string => {
+const createWaypointMarkerHtml = (commandCount: number, isSelected = false, isEntryExit = false): string => {
   const baseClass = isSelected ? 'selected-marker' : 'marker-icon'
   const size = getMarkerSizeFromZoom(zoom.value)
   const markerSizeClass = `wp-marker-${size}`
   const showSmallCommandCount = size !== 'md' && commandCount > 1
   const showCommandCount = size === 'md' && commandCount > 1
+  const entryExitClass = isEntryExit ? ' green-marker' : ''
 
   return `
     <div class="${markerSizeClass}">
-      <div class="${baseClass} waypoint-main-marker"></div>
+      <div class="${baseClass} waypoint-main-marker${entryExitClass}"></div>
       ${showCommandCount ? `<div class="command-count-indicator">${commandCount}</div>` : ''}
       ${showSmallCommandCount ? `<div class="command-count-indicator small">${commandCount}</div>` : ''}
     </div>
@@ -3353,7 +3459,7 @@ const updateWaypointMarkers = (): void => {
 
       marker.setIcon(
         L.divIcon({
-          html: createWaypointMarkerHtml(wp.commands.length, isSelected),
+          html: createWaypointMarkerHtml(wp.commands.length, isSelected, surveyEntryExitWaypointIds.value.has(wp.id)),
           className: 'waypoint-marker-icon',
           iconSize: dimensions.iconSize,
           iconAnchor: dimensions.iconAnchor,
@@ -3375,8 +3481,6 @@ const updateWaypointMarkers = (): void => {
       cumulativeCommandCount += wp.commands.length
     }
   })
-
-  refreshSurveyEntryExitMarkers()
 }
 
 // Toggles the crosshatch option while drawing a new survey. Bound to the button and checkbox so the
@@ -3385,6 +3489,14 @@ const setSurveyCrosshatch = (value: boolean | null): void => {
   const enabled = Boolean(value)
   logUserAction(`${enabled ? 'Enabled' : 'Disabled'} 90° crosshatch re-fly for survey`)
   surveyCrosshatch.value = enabled
+  // A crosshatch survey exposes 8 entry corners, a plain one only 4: keep the draft corner in range.
+  surveyDraftEntryCorner.value = surveyDraftEntryCorner.value % surveyEntryCornerCount(enabled)
+}
+
+const rotateDraftSurveyEntryPoint = (): void => {
+  const nextCorner = (surveyDraftEntryCorner.value + 1) % surveyEntryCornerCount(surveyCrosshatch.value)
+  logUserAction(`Rotated draft survey entry point to corner ${nextCorner + 1}`)
+  surveyDraftEntryCorner.value = nextCorner
 }
 
 const toggleSurveyCrosshatch = (): void => {
@@ -3395,6 +3507,9 @@ const toggleSurveyCrosshatch = (): void => {
   logUserAction(`${selectedSurvey.value.crosshatch ? 'Disabled' : 'Enabled'} 90° crosshatch on survey`)
   missionStore.pushUndoSnapshot()
   selectedSurvey.value.crosshatch = !selectedSurvey.value.crosshatch
+  // Keep the entry corner in range: a crosshatch survey exposes 8 corners, a plain one only 4.
+  selectedSurvey.value.entryCorner =
+    (selectedSurvey.value.entryCorner ?? 0) % surveyEntryCornerCount(selectedSurvey.value.crosshatch)
   regenerateSurveyWaypoints()
 }
 
@@ -3405,7 +3520,12 @@ const regenerateSurveyWaypoints = (angle?: number): void => {
   }
 
   logUserAction('Regenerated survey waypoints')
+  regenerateSelectedSurveyWaypoints(angle)
+}
 
+// Rebuilds the selected survey's waypoints from its polygon and current settings. Kept separate from the
+// logged handler so entry-point rotation can reuse it without logging a spurious "regenerated" action.
+const regenerateSelectedSurveyWaypoints = (angle?: number): void => {
   if (selectedSurvey.value) {
     selectedSurvey.value?.waypoints.forEach((waypoint) => {
       const marker = waypointMarkers.value[waypoint.id]
@@ -3416,12 +3536,17 @@ const regenerateSurveyWaypoints = (angle?: number): void => {
     })
 
     const adjustedAngle = 90 - (angle || selectedSurvey.value.surveyLinesAngle)
-    const { path: continuousPath } = generateSurveyPath(
-      selectedSurvey.value.polygonCoordinates.map((coord) => L.latLng(coord[0], coord[1])),
-      selectedSurvey.value.distanceBetweenLines,
-      adjustedAngle,
-      selectedSurvey.value.turnaroundDistance,
-      selectedSurvey.value.crosshatch
+    const { path: continuousPath } = orderedSurveyPath(
+      {
+        polygonPoints: selectedSurvey.value.polygonCoordinates.map((coord) => L.latLng(coord[0], coord[1])),
+        distanceBetweenLines: selectedSurvey.value.distanceBetweenLines,
+        linesAngle: adjustedAngle,
+        turnaroundDistance: selectedSurvey.value.turnaroundDistance,
+        crosshatch: selectedSurvey.value.crosshatch,
+        crosshatchDistanceBetweenLines:
+          selectedSurvey.value.crosshatchDistanceBetweenLines ?? selectedSurvey.value.distanceBetweenLines,
+      },
+      selectedSurvey.value.entryCorner ?? 0
     )
 
     if (!continuousPath.length) {
@@ -3466,18 +3591,6 @@ const regenerateSurveyWaypoints = (angle?: number): void => {
 
     newWaypoints.forEach((waypoint) => addWaypointMarker(waypoint))
     updateWaypointMarkers()
-    refreshSurveyEntryExitMarkers()
-
-    const firstWaypoint = newWaypoints[0]
-    const lastWaypoint = newWaypoints[newWaypoints.length - 1]
-    const firstMarker = waypointMarkers.value[firstWaypoint.id]
-    const lastMarker = waypointMarkers.value[lastWaypoint.id]
-    if (firstMarker) {
-      firstMarker.getElement()?.querySelector('.waypoint-main-marker')?.classList.add('green-marker')
-    }
-    if (lastMarker && lastMarker !== firstMarker) {
-      lastMarker.getElement()?.querySelector('.waypoint-main-marker')?.classList.add('green-marker')
-    }
   }
 }
 
@@ -3591,27 +3704,8 @@ const undoGenerateWaypoints = (): void => {
   distanceBetweenSurveyLines.value = survey.distanceBetweenLines
   surveyLinesAngle.value = survey.surveyLinesAngle
   surveyCrosshatch.value = survey.crosshatch ?? false
-
-  const firstWpCoords = survey.waypoints[0]?.coordinates
-  if (firstWpCoords && survey.polygonCoordinates.length >= 3) {
-    const adjustedAngle = 90 - survey.surveyLinesAngle
-    const { path: defaultPath } = generateSurveyPath(
-      surveyPolygonVertexesPositions.value,
-      survey.distanceBetweenLines,
-      adjustedAngle,
-      survey.turnaroundDistance,
-      survey.crosshatch
-    )
-    if (defaultPath.length >= 2) {
-      const first = defaultPath[0]
-      const last = defaultPath[defaultPath.length - 1]
-      const distToFirst = first.distanceTo(L.latLng(firstWpCoords[0], firstWpCoords[1]))
-      const distToLast = last.distanceTo(L.latLng(firstWpCoords[0], firstWpCoords[1]))
-      undoSurveyWasReversed.value = distToLast < distToFirst
-    }
-  } else {
-    undoSurveyWasReversed.value = false
-  }
+  crosshatchDistanceBetweenLines.value = survey.crosshatchDistanceBetweenLines ?? survey.distanceBetweenLines
+  surveyDraftEntryCorner.value = survey.entryCorner ?? 0
 
   isCreatingSurvey.value = true
   isDrawingSurveyPolygon.value = false
@@ -3679,7 +3773,7 @@ const addWaypointMarker = (waypoint: Waypoint): void => {
   const currentMarkerSize = getMarkerSizeFromZoom(zoom.value)
   const dimensions = getIconDimensionsFromMarkerSize(currentMarkerSize)
   const markerIcon = L.divIcon({
-    html: createWaypointMarkerHtml(waypoint.commands.length, false),
+    html: createWaypointMarkerHtml(waypoint.commands.length, false, surveyEntryExitWaypointIds.value.has(waypoint.id)),
     className: 'waypoint-marker-icon',
     iconSize: dimensions.iconSize,
     iconAnchor: dimensions.iconAnchor,
@@ -3727,7 +3821,11 @@ const applySelectedWaypointMarkerVisual = (newWaypointId?: string, oldWaypointId
       const dimensions = getIconDimensionsFromMarkerSize(markerSize)
       oldMarker.setIcon(
         L.divIcon({
-          html: createWaypointMarkerHtml(oldWp?.commands.length ?? 0, false),
+          html: createWaypointMarkerHtml(
+            oldWp?.commands.length ?? 0,
+            false,
+            surveyEntryExitWaypointIds.value.has(oldWaypointId)
+          ),
           className: 'waypoint-marker-icon',
           iconSize: dimensions.iconSize,
           iconAnchor: dimensions.iconAnchor,
@@ -3743,7 +3841,11 @@ const applySelectedWaypointMarkerVisual = (newWaypointId?: string, oldWaypointId
       const dimensions = getIconDimensionsFromMarkerSize(markerSize)
       newMarker.setIcon(
         L.divIcon({
-          html: createWaypointMarkerHtml(newWp?.commands.length ?? 0, true),
+          html: createWaypointMarkerHtml(
+            newWp?.commands.length ?? 0,
+            true,
+            surveyEntryExitWaypointIds.value.has(newWaypointId)
+          ),
           className: 'waypoint-marker-icon',
           iconSize: dimensions.iconSize,
           iconAnchor: dimensions.iconAnchor,
@@ -3751,8 +3853,6 @@ const applySelectedWaypointMarkerVisual = (newWaypointId?: string, oldWaypointId
       )
     }
   }
-
-  refreshSurveyEntryExitMarkers() // keep entry/exit green after selection updates
 }
 
 let homeRetryTimer: ReturnType<typeof setInterval> | null = null
@@ -3893,7 +3993,11 @@ const onMapClick = (e: L.LeafletMouseEvent): void => {
       const dimensions = getIconDimensionsFromMarkerSize(markerSize)
       oldMarker.setIcon(
         L.divIcon({
-          html: createWaypointMarkerHtml(oldWaypoint.commands.length, false),
+          html: createWaypointMarkerHtml(
+            oldWaypoint.commands.length,
+            false,
+            surveyEntryExitWaypointIds.value.has(oldWaypoint.id)
+          ),
           className: 'waypoint-marker-icon',
           iconSize: dimensions.iconSize,
           iconAnchor: dimensions.iconAnchor,


### PR DESCRIPTION
Requested recently by Tony White after field-testing the photogrammetry crosshatch feature.

- Crosshatch surveys can use a different line spacing for the perpendicular pass than the primary pass.
- The survey entry point can be rotated, so you choose which corner the vehicle starts from (replaces the old swap entry/exit button).
- New "always show waypoint numbers" button on the map and mission-planning toolbars keeps every waypoint numbered even when zoomed out.
- Direction arrows on the legs entering and leaving a survey show the travel direction. When no WP numbers are shown, its hard to tell at a glance.

Image 1 - Direction arrows now mark the survey legs: arrow (1) points at the arrow on the leg heading into the survey and (2) at the arrow on the leg heading out; (3) points at the new "always show waypoint numbers" button in the map toolbar.
![Survey entry and exit direction arrows](https://raw.githubusercontent.com/ArturoManzoli/cockpit/pr-assets/survey-entry-exit-arrows.png)

Image 2 - With the toolbar button enabled (1), every waypoint keeps its number visible even when zoomed out instead of collapsing to dots; (2) points at the new "rotate entry point" button in the survey radial menu, which cycles which corner the survey starts from.
![Always-visible waypoint numbers and rotate entry point](https://raw.githubusercontent.com/ArturoManzoli/cockpit/pr-assets/survey-waypoint-numbers-rotate-entry.png)

Image 3 - When crosshatch is enabled, a dedicated spacing field appears both in the survey configuration panel (2) and in the floating survey-creation menu (1), letting the crosshatch lines use a different spacing than the primary survey lines.
![Differential crosshatch spacing input](https://raw.githubusercontent.com/ArturoManzoli/cockpit/pr-assets/survey-crosshatch-spacing.png)

Closes #2837