### PR TITLE
Video: Broadcast recording and snapshot actions over MAVLink

### DIFF
--- a/src/libs/vehicle/mavlink/types.ts
+++ b/src/libs/vehicle/mavlink/types.ts
@@ -6,7 +6,13 @@ import { round } from '@/libs/utils'
 import { AlertLevel } from '@/types/alert'
 import { type Waypoint, AltitudeReferenceType, MissionCommandType } from '@/types/mission'
 
-import { MavFrame, MAVLinkType, MavMissionType, MavSeverity } from '../../connection/m2r/messages/mavlink2rest-enum'
+import {
+  CameraMode,
+  MavFrame,
+  MAVLinkType,
+  MavMissionType,
+  MavSeverity,
+} from '../../connection/m2r/messages/mavlink2rest-enum'
 import type { VehicleConfigurationSettings } from '../types'
 
 const cockpitMavlinkFrameCorrespondency: [MavFrame, AltitudeReferenceType][] = [
@@ -135,6 +141,27 @@ export const alertLevelFromMavSeverity = {
   [MavSeverity.MAV_SEVERITY_INFO]: AlertLevel.Info,
   // Useful non-operational messages that can assist in debugging. These should not occur during normal operation.
   [MavSeverity.MAV_SEVERITY_DEBUG]: AlertLevel.Info,
+}
+
+// MAVLink2Rest exposes CAMERA_MODE as strings, but COMMAND_LONG params are numeric, so map them here.
+export const cameraModeCommandValue: Record<CameraMode, number> = {
+  [CameraMode.CAMERA_MODE_IMAGE]: 0,
+  [CameraMode.CAMERA_MODE_VIDEO]: 1,
+  [CameraMode.CAMERA_MODE_IMAGE_SURVEY]: 2,
+}
+
+/**
+ * Extra options for sending a COMMAND_LONG
+ */
+export interface SendCommandLongOptions {
+  /**
+   * MAVLink target component id (defaults to the autopilot)
+   */
+  targetComponent?: number
+  /**
+   * Whether to wait for a COMMAND_ACK; set false for fire-and-forget sends (defaults to true)
+   */
+  awaitAck?: boolean
 }
 
 /**

--- a/src/libs/vehicle/mavlink/types.ts
+++ b/src/libs/vehicle/mavlink/types.ts
@@ -138,6 +138,20 @@ export const alertLevelFromMavSeverity = {
 }
 
 /**
+ * Extra options for sending a COMMAND_LONG
+ */
+export interface SendCommandLongOptions {
+  /**
+   * MAVLink target component id (defaults to the autopilot)
+   */
+  targetComponent?: number
+  /**
+   * Whether to wait for a COMMAND_ACK; set false for fire-and-forget sends (defaults to true)
+   */
+  awaitAck?: boolean
+}
+
+/**
  * Data needed for setting a parameter on a ArduPilot vehicle
  */
 export interface MAVLinkParameterSetData extends VehicleConfigurationSettings {

--- a/src/libs/vehicle/mavlink/vehicle.ts
+++ b/src/libs/vehicle/mavlink/vehicle.ts
@@ -12,10 +12,12 @@ import { createTransformingFunction, getAllTransformingFunctions } from '@/libs/
 import { sendMavlinkMessage } from '@/libs/communication/mavlink'
 import type { MAVLinkMessageDictionary, Package, Type } from '@/libs/connection/m2r/messages/mavlink2rest'
 import {
+  CameraMode,
   getMAVLinkMessageId,
   GpsFixType,
   MavAutopilot,
   MavCmd,
+  MavComponent,
   MAVLinkType,
   MavMissionResult,
   MavMissionType,
@@ -34,7 +36,9 @@ import { defaultMessageIntervalsOptions } from '@/libs/vehicle/mavlink/defaults'
 import {
   type MAVLinkParameterSetData,
   type MessageIntervalOptions,
+  type SendCommandLongOptions,
   alertLevelFromMavSeverity,
+  cameraModeCommandValue,
   convertCockpitWaypointsToMavlink,
   convertMavlinkWaypointsToCockpit,
 } from '@/libs/vehicle/mavlink/types'
@@ -145,10 +149,13 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
   /**
    * Helper to send mavlink commands
    * @param {Message.CommandLong | Message.CommandInt} commandMessage
+   * @param {boolean} awaitAck - Whether to wait for a COMMAND_ACK. Set false for fire-and-forget sends (e.g. camera commands whose consumers may never ACK).
    * @returns {Promise<void>} A promise that resolves with the command acknowledgment.
    */
-  async sendCommand(commandMessage: Message.CommandLong | Message.CommandInt): Promise<void> {
+  async sendCommand(commandMessage: Message.CommandLong | Message.CommandInt, awaitAck = true): Promise<void> {
     sendMavlinkMessage(commandMessage)
+
+    if (!awaitAck) return
 
     // Monitor the acknowledgment of the command and throw an error if it fails or reaches a timeout
     let incomingAckCommand: CommandAck | undefined = undefined
@@ -202,6 +209,7 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
    * @param {number} param5
    * @param {number} param6
    * @param {number} param7
+   * @param {SendCommandLongOptions} options - Target component and acknowledgment behavior.
    * @returns {Promise<void>} A promise that resolves when the command is acknowledged.
    */
   async sendCommandLong(
@@ -212,8 +220,10 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
     param4 = 0,
     param5 = 0,
     param6 = 0,
-    param7 = 0
+    param7 = 0,
+    options: SendCommandLongOptions = {}
   ): Promise<void> {
+    const { targetComponent = MavComponent.MAV_COMP_ID_AUTOPILOT1, awaitAck = true } = options
     const commandMessage: Message.CommandLong = {
       type: MAVLinkType.COMMAND_LONG,
       param1: param1,
@@ -227,10 +237,10 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
         type: mav_command,
       },
       target_system: this.currentSystemId,
-      target_component: 1,
+      target_component: targetComponent,
       confirmation: 0,
     }
-    return this.sendCommand(commandMessage)
+    return this.sendCommand(commandMessage, awaitAck)
   }
 
   /**
@@ -275,6 +285,107 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
       autocontinue: 0,
     }
     return this.sendCommand(commandMessage)
+  }
+
+  /**
+   * Resolve the MAVLink target component and camera-id command param for a configured camera target.
+   * Follows the MAVLink camera-targeting convention: 0 broadcasts to all cameras, 1-6 addresses
+   * autopilot-connected cameras, and 7-255 addresses a dedicated MAVLink camera component.
+   * @param {number} cameraId - Target camera id as configured by the user (0-255).
+   * @returns {[targetComponent: number, cameraParam: number]} Target component and camera-id command param.
+   */
+  private resolveCameraTarget(cameraId: number): [targetComponent: number, cameraParam: number] {
+    if (cameraId >= 1 && cameraId <= 6) {
+      return [MavComponent.MAV_COMP_ID_AUTOPILOT1, cameraId]
+    }
+    if (cameraId >= 7 && cameraId <= 255) {
+      return [cameraId, cameraId]
+    }
+    return [MavComponent.MAV_COMP_ID_ALL, 0]
+  }
+
+  /**
+   * Send a fire-and-forget camera COMMAND_LONG, logging (but not surfacing) any send failure.
+   * @param {MavCmd} command - Camera command to send.
+   * @param {number} targetComponent - Resolved MAVLink target component.
+   * @param {number[]} params - COMMAND_LONG params 1-7 (missing trailing params default to 0).
+   * @returns {void}
+   */
+  private sendCameraCommand(command: MavCmd, targetComponent: number, params: number[]): void {
+    const [p1 = 0, p2 = 0, p3 = 0, p4 = 0, p5 = 0, p6 = 0, p7 = 0] = params
+    this.sendCommandLong(command, p1, p2, p3, p4, p5, p6, p7, { targetComponent, awaitAck: false }).catch((error) =>
+      console.debug(`Failed to send camera command ${command}: ${error}`)
+    )
+  }
+
+  /**
+   * Start video capture (recording) on the target camera.
+   * @param {number} cameraId - Target camera id (0 for all cameras).
+   * @param {number} streamId - Video stream id (0 for all streams).
+   * @param {number} statusFrequencyHz - Frequency for CAMERA_CAPTURE_STATUS messages while recording (0 to disable).
+   * @returns {void}
+   */
+  sendStartVideoCaptureCommand(cameraId = 0, streamId = 0, statusFrequencyHz = 0): void {
+    const [targetComponent, cameraParam] = this.resolveCameraTarget(cameraId)
+    this.sendCameraCommand(MavCmd.MAV_CMD_VIDEO_START_CAPTURE, targetComponent, [
+      streamId,
+      statusFrequencyHz,
+      cameraParam,
+    ])
+  }
+
+  /**
+   * Stop video capture (recording) on the target camera.
+   * @param {number} cameraId - Target camera id (0 for all cameras).
+   * @param {number} streamId - Video stream id (0 for all streams).
+   * @returns {void}
+   */
+  sendStopVideoCaptureCommand(cameraId = 0, streamId = 0): void {
+    const [targetComponent, cameraParam] = this.resolveCameraTarget(cameraId)
+    this.sendCameraCommand(MavCmd.MAV_CMD_VIDEO_STOP_CAPTURE, targetComponent, [streamId, cameraParam])
+  }
+
+  /**
+   * Start a single image capture on the target camera.
+   * @param {number} cameraId - Target camera id (0 for all cameras).
+   * @returns {void}
+   */
+  sendStartImageCaptureCommand(cameraId = 0): void {
+    const [targetComponent, cameraParam] = this.resolveCameraTarget(cameraId)
+    // Single capture: param2 interval 0, param3 total images 1, param4 sequence 1.
+    this.sendCameraCommand(MavCmd.MAV_CMD_IMAGE_START_CAPTURE, targetComponent, [cameraParam, 0, 1, 1])
+  }
+
+  /**
+   * Stop an ongoing image capture sequence on the target camera.
+   * @param {number} cameraId - Target camera id (0 for all cameras).
+   * @returns {void}
+   */
+  sendStopImageCaptureCommand(cameraId = 0): void {
+    const [targetComponent, cameraParam] = this.resolveCameraTarget(cameraId)
+    this.sendCameraCommand(MavCmd.MAV_CMD_IMAGE_STOP_CAPTURE, targetComponent, [cameraParam])
+  }
+
+  /**
+   * Set the running mode (image/video) of the target camera.
+   * @param {number} cameraId - Target camera id (0 for all cameras).
+   * @param {CameraMode} mode - Desired camera mode.
+   * @returns {void}
+   */
+  sendSetCameraModeCommand(cameraId: number, mode: CameraMode): void {
+    const [targetComponent, cameraParam] = this.resolveCameraTarget(cameraId)
+    this.sendCameraCommand(MavCmd.MAV_CMD_SET_CAMERA_MODE, targetComponent, [cameraParam, cameraModeCommandValue[mode]])
+  }
+
+  /**
+   * Request the target camera to emit its CAMERA_CAPTURE_STATUS.
+   * @param {number} cameraId - Target camera id (0 for all cameras).
+   * @returns {void}
+   */
+  sendRequestCameraCaptureStatusCommand(cameraId = 0): void {
+    const [targetComponent] = this.resolveCameraTarget(cameraId)
+    // param1 = 1 requests the capture status (MAV_BOOL_TRUE).
+    this.sendCameraCommand(MavCmd.MAV_CMD_REQUEST_CAMERA_CAPTURE_STATUS, targetComponent, [1])
   }
 
   /**

--- a/src/libs/vehicle/mavlink/vehicle.ts
+++ b/src/libs/vehicle/mavlink/vehicle.ts
@@ -16,6 +16,7 @@ import {
   GpsFixType,
   MavAutopilot,
   MavCmd,
+  MavComponent,
   MAVLinkType,
   MavMissionResult,
   MavMissionType,
@@ -34,6 +35,7 @@ import { defaultMessageIntervalsOptions } from '@/libs/vehicle/mavlink/defaults'
 import {
   type MAVLinkParameterSetData,
   type MessageIntervalOptions,
+  type SendCommandLongOptions,
   alertLevelFromMavSeverity,
   convertCockpitWaypointsToMavlink,
   convertMavlinkWaypointsToCockpit,
@@ -145,10 +147,13 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
   /**
    * Helper to send mavlink commands
    * @param {Message.CommandLong | Message.CommandInt} commandMessage
+   * @param {boolean} awaitAck - Whether to wait for a COMMAND_ACK. Set false for fire-and-forget sends (e.g. camera commands whose consumers may never ACK).
    * @returns {Promise<void>} A promise that resolves with the command acknowledgment.
    */
-  async sendCommand(commandMessage: Message.CommandLong | Message.CommandInt): Promise<void> {
+  async sendCommand(commandMessage: Message.CommandLong | Message.CommandInt, awaitAck = true): Promise<void> {
     sendMavlinkMessage(commandMessage)
+
+    if (!awaitAck) return
 
     // Monitor the acknowledgment of the command and throw an error if it fails or reaches a timeout
     let incomingAckCommand: CommandAck | undefined = undefined
@@ -202,6 +207,7 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
    * @param {number} param5
    * @param {number} param6
    * @param {number} param7
+   * @param {SendCommandLongOptions} options - Target component and acknowledgment behavior.
    * @returns {Promise<void>} A promise that resolves when the command is acknowledged.
    */
   async sendCommandLong(
@@ -212,8 +218,10 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
     param4 = 0,
     param5 = 0,
     param6 = 0,
-    param7 = 0
+    param7 = 0,
+    options: SendCommandLongOptions = {}
   ): Promise<void> {
+    const { targetComponent = MavComponent.MAV_COMP_ID_AUTOPILOT1, awaitAck = true } = options
     const commandMessage: Message.CommandLong = {
       type: MAVLinkType.COMMAND_LONG,
       param1: param1,
@@ -227,10 +235,10 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
         type: mav_command,
       },
       target_system: this.currentSystemId,
-      target_component: 1,
+      target_component: targetComponent,
       confirmation: 0,
     }
-    return this.sendCommand(commandMessage)
+    return this.sendCommand(commandMessage, awaitAck)
   }
 
   /**
@@ -275,6 +283,47 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
       autocontinue: 0,
     }
     return this.sendCommand(commandMessage)
+  }
+
+  /**
+   * Send a fire-and-forget camera COMMAND_LONG, logging (but not surfacing) any send failure.
+   * @param {MavCmd} command - Camera command to send.
+   * @param {number} targetComponent - Resolved MAVLink target component.
+   * @param {number[]} params - COMMAND_LONG params 1-7 (missing trailing params default to 0).
+   * @returns {void}
+   */
+  private sendCameraCommand(command: MavCmd, targetComponent: number, params: number[]): void {
+    const [p1 = 0, p2 = 0, p3 = 0, p4 = 0, p5 = 0, p6 = 0, p7 = 0] = params
+    this.sendCommandLong(command, p1, p2, p3, p4, p5, p6, p7, { targetComponent, awaitAck: false }).catch((error) =>
+      console.debug(`Failed to send camera command ${command}: ${error}`)
+    )
+  }
+
+  /**
+   * Broadcast a video capture (recording) start to all cameras on the vehicle.
+   * @returns {void}
+   */
+  sendStartVideoCaptureCommand(): void {
+    // Broadcast: stream id 0 (all streams), no periodic status, camera id 0 (all cameras).
+    this.sendCameraCommand(MavCmd.MAV_CMD_VIDEO_START_CAPTURE, MavComponent.MAV_COMP_ID_ALL, [0, 0, 0])
+  }
+
+  /**
+   * Broadcast a video capture (recording) stop to all cameras on the vehicle.
+   * @returns {void}
+   */
+  sendStopVideoCaptureCommand(): void {
+    // Broadcast: stream id 0 (all streams), camera id 0 (all cameras).
+    this.sendCameraCommand(MavCmd.MAV_CMD_VIDEO_STOP_CAPTURE, MavComponent.MAV_COMP_ID_ALL, [0, 0])
+  }
+
+  /**
+   * Broadcast a single image capture to all cameras on the vehicle.
+   * @returns {void}
+   */
+  sendStartImageCaptureCommand(): void {
+    // Broadcast single capture: camera id 0 (all), interval 0, total images 1, sequence 1.
+    this.sendCameraCommand(MavCmd.MAV_CMD_IMAGE_START_CAPTURE, MavComponent.MAV_COMP_ID_ALL, [0, 0, 1, 1])
   }
 
   /**

--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -22,7 +22,7 @@ import {
 import * as Connection from '@/libs/connection/connection'
 import { ConnectionManager } from '@/libs/connection/connection-manager'
 import type { Package } from '@/libs/connection/m2r/messages/mavlink2rest'
-import { MavAutopilot, MAVLinkType, MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
+import { CameraMode, MavAutopilot, MAVLinkType, MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import type { Message } from '@/libs/connection/m2r/messages/mavlink2rest-message'
 import eventTracker from '@/libs/external-telemetry/event-tracking'
 import { availableCockpitActions, registerActionCallback } from '@/libs/joystick/protocols/cockpit-actions'
@@ -1037,6 +1037,64 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     await mainVehicle.value.setCruiseSpeed(speedMps)
   }
 
+  /**
+   * Broadcast a video-capture (recording) start over MAVLink
+   * @param {number} cameraId - Target camera id (0 for all cameras)
+   * @param {number} streamId - Video stream id (0 for all streams)
+   * @param {number} statusFrequencyHz - Frequency for CAMERA_CAPTURE_STATUS messages while recording (0 to disable)
+   * @returns {void}
+   */
+  function sendStartVideoCaptureCommand(cameraId = 0, streamId = 0, statusFrequencyHz = 0): void {
+    mainVehicle.value?.sendStartVideoCaptureCommand(cameraId, streamId, statusFrequencyHz)
+  }
+
+  /**
+   * Broadcast a video-capture (recording) stop over MAVLink
+   * @param {number} cameraId - Target camera id (0 for all cameras)
+   * @param {number} streamId - Video stream id (0 for all streams)
+   * @returns {void}
+   */
+  function sendStopVideoCaptureCommand(cameraId = 0, streamId = 0): void {
+    mainVehicle.value?.sendStopVideoCaptureCommand(cameraId, streamId)
+  }
+
+  /**
+   * Broadcast a single image capture over MAVLink
+   * @param {number} cameraId - Target camera id (0 for all cameras)
+   * @returns {void}
+   */
+  function sendStartImageCaptureCommand(cameraId = 0): void {
+    mainVehicle.value?.sendStartImageCaptureCommand(cameraId)
+  }
+
+  /**
+   * Broadcast an image-capture sequence stop over MAVLink
+   * @param {number} cameraId - Target camera id (0 for all cameras)
+   * @returns {void}
+   */
+  function sendStopImageCaptureCommand(cameraId = 0): void {
+    mainVehicle.value?.sendStopImageCaptureCommand(cameraId)
+  }
+
+  /**
+   * Set the running mode (image/video) of the target camera over MAVLink
+   * @param {number} cameraId - Target camera id (0 for all cameras)
+   * @param {CameraMode} cameraMode - Desired camera mode
+   * @returns {void}
+   */
+  function sendSetCameraModeCommand(cameraId: number, cameraMode: CameraMode): void {
+    mainVehicle.value?.sendSetCameraModeCommand(cameraId, cameraMode)
+  }
+
+  /**
+   * Request the target camera to emit its CAMERA_CAPTURE_STATUS over MAVLink
+   * @param {number} cameraId - Target camera id (0 for all cameras)
+   * @returns {void}
+   */
+  function sendRequestCameraCaptureStatusCommand(cameraId = 0): void {
+    mainVehicle.value?.sendRequestCameraCaptureStatusCommand(cameraId)
+  }
+
   return {
     arm,
     takeoff,
@@ -1056,6 +1114,12 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     returnHome,
     setMissionCurrent,
     setCruiseSpeed,
+    sendStartVideoCaptureCommand,
+    sendStopVideoCaptureCommand,
+    sendStartImageCaptureCommand,
+    sendStopImageCaptureCommand,
+    sendSetCameraModeCommand,
+    sendRequestCameraCaptureStatusCommand,
     getCurrentVehicleName,
     mainVehicle,
     globalAddress,

--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -1098,6 +1098,30 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     await mainVehicle.value.setCruiseSpeed(speedMps)
   }
 
+  /**
+   * Broadcast a video-capture (recording) start to all cameras over MAVLink
+   * @returns {void}
+   */
+  function sendStartVideoCaptureCommand(): void {
+    mainVehicle.value?.sendStartVideoCaptureCommand()
+  }
+
+  /**
+   * Broadcast a video-capture (recording) stop to all cameras over MAVLink
+   * @returns {void}
+   */
+  function sendStopVideoCaptureCommand(): void {
+    mainVehicle.value?.sendStopVideoCaptureCommand()
+  }
+
+  /**
+   * Broadcast a single image capture to all cameras over MAVLink
+   * @returns {void}
+   */
+  function sendStartImageCaptureCommand(): void {
+    mainVehicle.value?.sendStartImageCaptureCommand()
+  }
+
   return {
     arm,
     takeoff,
@@ -1117,6 +1141,9 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     returnHome,
     setMissionCurrent,
     setCruiseSpeed,
+    sendStartVideoCaptureCommand,
+    sendStopVideoCaptureCommand,
+    sendStartImageCaptureCommand,
     getCurrentVehicleName,
     mainVehicle,
     globalAddress,

--- a/src/stores/snapshot.ts
+++ b/src/stores/snapshot.ts
@@ -7,6 +7,7 @@ import { defineStore } from 'pinia'
 
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { useBlueOsStorage } from '@/composables/settingsSyncer'
+import { CameraMode } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import { app_version } from '@/libs/cosmos'
 import { availableCockpitActions, registerActionCallback } from '@/libs/joystick/protocols/cockpit-actions'
 import { isElectron, sanitizeFilenameComponent } from '@/libs/utils'
@@ -279,6 +280,14 @@ export const useSnapshotStore = defineStore('snapshot', () => {
         console.error(`Failed to capture snapshot for stream '${streamName}':`, err)
         failed.push(streamName)
       }
+    }
+
+    // Best-effort MAVLink broadcast so systems like BlueOS can mirror the snapshot action.
+    if (videoStore.broadcastCameraActionsOverMavlink && succeeded.some((name) => streamNames.includes(name))) {
+      if (videoStore.setCameraModeOnCapture) {
+        vehicleStore.sendSetCameraModeCommand(videoStore.mavlinkCameraTargetId, CameraMode.CAMERA_MODE_IMAGE)
+      }
+      vehicleStore.sendStartImageCaptureCommand(videoStore.mavlinkCameraTargetId)
     }
 
     return { succeeded, failed }

--- a/src/stores/snapshot.ts
+++ b/src/stores/snapshot.ts
@@ -171,6 +171,11 @@ export const useSnapshotStore = defineStore('snapshot', () => {
       }
     }
 
+    // Best-effort MAVLink broadcast so systems like BlueOS can mirror the snapshot action.
+    if (succeeded.some((name) => streamNames.includes(name))) {
+      videoStore.broadcastSnapshotCapture()
+    }
+
     return { succeeded, failed }
   }
 

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -13,6 +13,7 @@ import { useBlueOsStorage } from '@/composables/settingsSyncer'
 import { useSnackbar } from '@/composables/snackbar'
 import { WebRTCManager } from '@/composables/webRTC'
 import { type ProcessedStreamInfo, getIpsInformationFromVehicle, getStreamInformationFromVehicle } from '@/libs/blueos'
+import { CameraMode } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import eventTracker from '@/libs/external-telemetry/event-tracking'
 import { availableCockpitActions, registerActionCallback } from '@/libs/joystick/protocols/cockpit-actions'
 import {
@@ -48,7 +49,15 @@ export const useVideoStore = defineStore('video', () => {
   const alertStore = useAlertStore()
   const { showDialog, closeDialog } = useInteractionDialog()
 
-  const { globalAddress, rtcConfiguration, webRTCSignallingURI } = useMainVehicleStore()
+  const {
+    globalAddress,
+    rtcConfiguration,
+    webRTCSignallingURI,
+    sendStartVideoCaptureCommand,
+    sendStopVideoCaptureCommand,
+    sendSetCameraModeCommand,
+    sendRequestCameraCaptureStatusCommand,
+  } = useMainVehicleStore()
   console.debug('[WebRTC] Using webrtc-adapter for', adapter.browserDetails)
 
   const streamsCorrespondency = useBlueOsStorage<VideoStreamCorrespondency[]>('cockpit-streams-correspondency', [])
@@ -69,6 +78,11 @@ export const useVideoStore = defineStore('video', () => {
   const userRestoredStreamIds = useBlueOsStorage<string[]>('cockpit-user-restored-stream-ids', [])
   const recordingMonitors: { [key: string]: ReturnType<typeof setInterval> | undefined } = {}
   const suppressNotGrowingDialogs = ref(false)
+  const broadcastCameraActionsOverMavlink = useBlueOsStorage('cockpit-broadcast-camera-actions-over-mavlink', false)
+  const mavlinkCameraTargetId = useBlueOsStorage('cockpit-mavlink-camera-target-id', 0)
+  const mavlinkVideoStreamId = useBlueOsStorage('cockpit-mavlink-video-stream-id', 0)
+  const setCameraModeOnCapture = useBlueOsStorage('cockpit-mavlink-set-camera-mode-on-capture', false)
+  const requestCaptureStatusOnCapture = useBlueOsStorage('cockpit-mavlink-request-capture-status', false)
 
   const streamInformation = ref<ProcessedStreamInfo[]>([])
   const go2rtcStreamInfo = ref<Record<string, Go2RTCStreamInfo>>({})
@@ -570,6 +584,26 @@ export const useVideoStore = defineStore('video', () => {
     )
   }
 
+  // Best-effort MAVLink broadcast of recording actions, so systems like BlueOS can mirror the recording state.
+  const broadcastRecordingStart = (): void => {
+    if (!broadcastCameraActionsOverMavlink.value) return
+    if (setCameraModeOnCapture.value) {
+      sendSetCameraModeCommand(mavlinkCameraTargetId.value, CameraMode.CAMERA_MODE_VIDEO)
+    }
+    sendStartVideoCaptureCommand(mavlinkCameraTargetId.value, mavlinkVideoStreamId.value)
+    if (requestCaptureStatusOnCapture.value) {
+      sendRequestCameraCaptureStatusCommand(mavlinkCameraTargetId.value)
+    }
+  }
+
+  const broadcastRecordingStop = (): void => {
+    if (!broadcastCameraActionsOverMavlink.value) return
+    sendStopVideoCaptureCommand(mavlinkCameraTargetId.value, mavlinkVideoStreamId.value)
+    if (requestCaptureStatusOnCapture.value) {
+      sendRequestCameraCaptureStatusCommand(mavlinkCameraTargetId.value)
+    }
+  }
+
   /**
    * Stop recording the stream
    * @param {string} streamName - Name of the stream
@@ -589,6 +623,8 @@ export const useVideoStore = defineStore('video', () => {
     activeStreams.value[streamName]!.timeRecordingStart = undefined
 
     activeStreams.value[streamName]!.mediaRecorder!.stop()
+
+    broadcastRecordingStop()
 
     alertStore.pushAlert(new Alert(AlertLevel.Success, `Stopped recording stream ${streamName}.`))
   }
@@ -744,6 +780,8 @@ export const useVideoStore = defineStore('video', () => {
     }
 
     activeStreams.value[streamName]!.mediaRecorder!.start(1000)
+
+    broadcastRecordingStart()
 
     // Initialize live processor if enabled and on Electron
     if (enableLiveProcessing.value && window.electronAPI) {
@@ -1317,5 +1355,10 @@ export const useVideoStore = defineStore('video', () => {
     addRtspStreamCorrespondency,
     enableLiveProcessing,
     keepRawVideoChunksAsBackup,
+    broadcastCameraActionsOverMavlink,
+    mavlinkCameraTargetId,
+    mavlinkVideoStreamId,
+    setCameraModeOnCapture,
+    requestCaptureStatusOnCapture,
   }
 })

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -54,7 +54,15 @@ export const useVideoStore = defineStore('video', () => {
   const alertStore = useAlertStore()
   const { showDialog, closeDialog } = useInteractionDialog()
 
-  const { globalAddress, rtcConfiguration, webRTCSignallingURI } = useMainVehicleStore()
+  const mainVehicleStore = useMainVehicleStore()
+  const {
+    globalAddress,
+    rtcConfiguration,
+    webRTCSignallingURI,
+    sendStartVideoCaptureCommand,
+    sendStopVideoCaptureCommand,
+    sendStartImageCaptureCommand,
+  } = mainVehicleStore
   console.debug('[WebRTC] Using webrtc-adapter for', adapter.browserDetails)
 
   const streamsCorrespondency = useBlueOsStorage<VideoStreamCorrespondency[]>('cockpit-streams-correspondency', [])
@@ -77,6 +85,10 @@ export const useVideoStore = defineStore('video', () => {
   const keepRawVideoChunksAsBackup = useBlueOsStorage('cockpit-keep-raw-video-chunks-as-backup', true)
   const userRestoredStreamIds = useBlueOsStorage<string[]>('cockpit-user-restored-stream-ids', [])
   const recordingMonitors: { [key: string]: ReturnType<typeof setInterval> | undefined } = {}
+  const broadcastCameraActionsOverMavlink = useBlueOsStorage('cockpit-broadcast-camera-actions-over-mavlink', false)
+  // Streams whose recording start we mirrored over MAVLink. The broadcast fires only on the 0->1 and 1->0
+  // transitions, so recording several streams at once does not repeat the same commands.
+  const mirroredRecordingStreams = new Set<string>()
   // Keyed by the warning message, so silencing one recording health warning doesn't silence the others.
   const suppressedRecordingHealthMessages = new Set<string>()
   type RecordingHealthWarning = {
@@ -778,6 +790,29 @@ export const useVideoStore = defineStore('video', () => {
     return getStreamData(streamName)?.mediaRecorder?.state === 'recording'
   }
 
+  // Best-effort MAVLink broadcast of recording actions, so systems like BlueOS can mirror the recording state.
+  const broadcastRecordingStart = (streamName: string): void => {
+    if (!broadcastCameraActionsOverMavlink.value) return
+    const alreadyMirroring = mirroredRecordingStreams.size > 0
+    mirroredRecordingStreams.add(streamName)
+    // Recording several streams still means one vehicle-side recording, so broadcast only on the first one.
+    if (alreadyMirroring) return
+    sendStartVideoCaptureCommand()
+  }
+
+  const broadcastRecordingStop = (streamName: string): void => {
+    // Only close a broadcast we actually opened; the toggle gates new broadcasts, not outstanding stops.
+    if (!mirroredRecordingStreams.delete(streamName)) return
+    if (mirroredRecordingStreams.size > 0) return
+    sendStopVideoCaptureCommand()
+  }
+
+  // Best-effort MAVLink broadcast of a snapshot capture, sharing the recording path's broadcast rules.
+  const broadcastSnapshotCapture = (): void => {
+    if (!broadcastCameraActionsOverMavlink.value) return
+    sendStartImageCaptureCommand()
+  }
+
   /**
    * Stop recording the stream
    * @param {string} streamName - Name of the stream
@@ -1090,6 +1125,10 @@ export const useVideoStore = defineStore('video', () => {
     }
 
     activeStreams.value[streamName]!.mediaRecorder!.onstop = async () => {
+      // Every way a recording ends reaches onstop (Stop button, stream teardown, dropped link), so mirror the stop
+      // here rather than in stopRecording, otherwise the vehicle keeps recording and mirroring stays wedged off.
+      broadcastRecordingStop(streamName)
+
       const info = unprocessedVideos.value[recordingHash]
       if (!info) {
         const errorMessage = `Failed to generate telemetry overlay: recording metadata for '${recordingHash}' not found.`
@@ -1144,6 +1183,10 @@ export const useVideoStore = defineStore('video', () => {
         console.warn(`Stream '${streamName}' was removed during video processing finalization.`)
       }
     }
+
+    // Mirror only after the recorder and its handlers are fully set up, so a start that throws (e.g. live-processing
+    // init failing) never leaves the stream marked as mirrored.
+    broadcastRecordingStart(streamName)
 
     alertStore.pushAlert(new Alert(AlertLevel.Success, `Started recording stream ${streamName}.`))
   }
@@ -1486,5 +1529,7 @@ export const useVideoStore = defineStore('video', () => {
     addRtspStreamCorrespondency,
     enableLiveProcessing,
     keepRawVideoChunksAsBackup,
+    broadcastCameraActionsOverMavlink,
+    broadcastSnapshotCapture,
   }
 })

--- a/src/views/ConfigurationVideoView.vue
+++ b/src/views/ConfigurationVideoView.vue
@@ -147,12 +147,95 @@
                 </template>
                 <template #bottom></template>
               </v-data-table>
-              <div class="flex items-center justify-start">
-                <v-checkbox v-model="showIgnoredStreams" label="Show ignored streams" hide-details class="text-sm" />
-                <span v-if="ignoredStreamExternalIds.length > 0" class="text-gray-400 text-sm ml-2">
-                  ({{ ignoredStreamExternalIds.length }} ignored)
-                </span>
+              <div class="flex items-center justify-between w-[95%]">
+                <div class="flex items-center justify-start">
+                  <v-checkbox v-model="showIgnoredStreams" label="Show ignored streams" hide-details class="text-sm" />
+                  <span v-if="ignoredStreamExternalIds.length > 0" class="text-gray-400 text-sm ml-2">
+                    ({{ ignoredStreamExternalIds.length }} ignored)
+                  </span>
+                </div>
+                <div class="flex items-center justify-end">
+                  <v-checkbox
+                    v-model="videoStore.broadcastCameraActionsOverMavlink"
+                    label="Broadcast camera actions over MAVLink"
+                    class="text-sm mx-2"
+                    hide-details
+                    @update:model-value="handleBroadcastCameraActionsUpdate"
+                  />
+                  <v-tooltip
+                    text="Send MAVLink camera commands when recording or taking a snapshot, so systems like BlueOS can mirror the action (e.g. start in-vehicle recording)"
+                  >
+                    <template #activator="{ props }">
+                      <v-icon v-bind="props" size="small" color="white" class="ml-2">mdi-information-outline</v-icon>
+                    </template>
+                  </v-tooltip>
+                </div>
               </div>
+
+              <template v-if="videoStore.broadcastCameraActionsOverMavlink">
+                <div class="flex items-center justify-start w-[50%] ml-2">
+                  <v-text-field
+                    v-model.number="videoStore.mavlinkCameraTargetId"
+                    label="Target camera ID"
+                    variant="filled"
+                    type="number"
+                    class="uri-input mt-4"
+                    theme="dark"
+                    density="compact"
+                    max="255"
+                    min="0"
+                    hint="0 for all cameras, 1-6 for autopilot-connected cameras, 7-255 for a MAVLink camera component"
+                    @update:focused="handleCameraTargetIdBlur"
+                  />
+                </div>
+                <div class="flex items-center justify-start w-[50%] ml-2">
+                  <v-text-field
+                    v-model.number="videoStore.mavlinkVideoStreamId"
+                    label="Video stream ID"
+                    variant="filled"
+                    type="number"
+                    class="uri-input mt-4"
+                    theme="dark"
+                    density="compact"
+                    min="0"
+                    hint="0 for all video streams"
+                    @update:focused="handleVideoStreamIdBlur"
+                  />
+                </div>
+                <div class="flex items-center justify-start w-[96%]">
+                  <v-checkbox
+                    v-model="videoStore.setCameraModeOnCapture"
+                    label="Set camera mode before capture"
+                    class="text-sm mx-2"
+                    hide-details
+                    @update:model-value="handleSetCameraModeOnCaptureUpdate"
+                  />
+                  <v-tooltip
+                    text="Send SET_CAMERA_MODE (video before recording, image before snapshots) before the capture command"
+                  >
+                    <template #activator="{ props }">
+                      <v-icon v-bind="props" size="small" color="white" class="ml-2">mdi-information-outline</v-icon>
+                    </template>
+                  </v-tooltip>
+                </div>
+                <div class="flex items-center justify-start w-[96%]">
+                  <v-checkbox
+                    v-model="videoStore.requestCaptureStatusOnCapture"
+                    label="Request capture status"
+                    class="text-sm mx-2"
+                    hide-details
+                    @update:model-value="handleRequestCaptureStatusUpdate"
+                  />
+                  <v-tooltip
+                    text="Request CAMERA_CAPTURE_STATUS after starting or stopping a recording, to reconcile the vehicle-side state"
+                  >
+                    <template #activator="{ props }">
+                      <v-icon v-bind="props" size="small" color="white" class="ml-2">mdi-information-outline</v-icon>
+                    </template>
+                  </v-tooltip>
+                </div>
+              </template>
+
               <div v-if="isElectron()" class="mt-4 mr-2 mb-2 w-[95%]">
                 <div class="text-sm text-gray-300 mb-2">Add direct RTSP stream (Standalone)</div>
                 <div class="flex items-end gap-2 w-full">
@@ -285,7 +368,70 @@
             </li>
           </template>
           <template #content>
-            <div class="flex items-center justify-end w-[96%] ml-2 mb-4">
+            <div class="flex items-start justify-between w-[96%] ml-2 mb-2">
+              <div class="flex flex-col">
+                <div class="flex items-center justify-start">
+                  <v-checkbox
+                    v-model="videoStore.enableLiveProcessing"
+                    label="Live video processing (Electron)"
+                    class="text-sm mx-2"
+                    hide-details
+                    :disabled="!isElectron()"
+                  />
+                  <v-tooltip
+                    :text="
+                      isElectron()
+                        ? 'Process videos in real-time during recording for instant availability when recording stops'
+                        : 'Live video processing is only available in the standalone version'
+                    "
+                  >
+                    <template #activator="{ props }">
+                      <v-icon v-bind="props" class="ml-2 text-slate-400">mdi-information-outline</v-icon>
+                    </template>
+                  </v-tooltip>
+                </div>
+
+                <div class="flex items-center justify-start">
+                  <v-checkbox
+                    v-model="videoStore.keepRawVideoChunksAsBackup"
+                    label="Save backup raw chunks"
+                    class="text-sm mx-2"
+                    :disabled="!isElectron()"
+                    hide-details
+                  />
+                  <v-tooltip max-width="400px">
+                    <template #activator="{ props }">
+                      <v-icon v-bind="props" class="ml-2 text-slate-400">mdi-information-outline</v-icon>
+                    </template>
+                    <div class="text-sm">
+                      <p class="mb-2">Save the raw video chunks alongside the final video file for backup purposes.</p>
+                      <p class="mb-2">
+                        <strong>Enabled:</strong> Raw chunks are preserved after recording. Videos use ~2x storage space
+                        but provide safety for reconstruction if the final video is corrupted.
+                      </p>
+                      <p>
+                        <strong>Disabled:</strong> Raw chunks are automatically deleted after successful processing,
+                        using minimal storage space.
+                      </p>
+                      <p class="mt-2 text-gray-300">
+                        You can always manually clean up backup chunks later using the "Temporary" tab in the Video
+                        Library.
+                      </p>
+                      <p class="mt-2 text-gray-300">For the browser version the chunks are always saved by default.</p>
+                    </div>
+                  </v-tooltip>
+                </div>
+
+                <div class="flex items-center justify-start">
+                  <v-checkbox
+                    v-model="snapshotStore.zipMultipleFiles"
+                    label="Zip multiple files"
+                    class="text-sm mx-2"
+                    hide-details
+                  />
+                </div>
+              </div>
+
               <v-btn variant="flat" class="bg-[#FFFFFF22] px-3 elevation-1" @click="openVideoLibrary">
                 <template #append>
                   <v-divider vertical></v-divider>
@@ -310,65 +456,6 @@
                   </p>
                 </div>
               </div>
-            </div>
-
-            <div class="flex items-center justify-start w-[96%] ml-2">
-              <v-checkbox
-                v-model="videoStore.enableLiveProcessing"
-                label="Live video processing (Electron)"
-                class="text-sm mx-2"
-                hide-details
-                :disabled="!isElectron()"
-              />
-              <v-tooltip
-                :text="
-                  isElectron()
-                    ? 'Process videos in real-time during recording for instant availability when recording stops'
-                    : 'Live video processing is only available in the standalone version'
-                "
-              >
-                <template #activator="{ props }">
-                  <v-icon v-bind="props" class="ml-2 text-slate-400">mdi-information-outline</v-icon>
-                </template>
-              </v-tooltip>
-            </div>
-
-            <div class="flex items-center justify-start w-[96%] ml-2">
-              <v-checkbox
-                v-model="videoStore.keepRawVideoChunksAsBackup"
-                label="Save backup raw chunks"
-                class="text-sm mx-2"
-                :disabled="!isElectron()"
-                hide-details
-              />
-              <v-tooltip max-width="400px">
-                <template #activator="{ props }">
-                  <v-icon v-bind="props" class="ml-2 text-slate-400">mdi-information-outline</v-icon>
-                </template>
-                <div class="text-sm">
-                  <p class="mb-2">Save the raw video chunks alongside the final video file for backup purposes.</p>
-                  <p class="mb-2">
-                    <strong>Enabled:</strong> Raw chunks are preserved after recording. Videos use ~2x storage space but
-                    provide safety for reconstruction if the final video is corrupted.
-                  </p>
-                  <p>
-                    <strong>Disabled:</strong> Raw chunks are automatically deleted after successful processing, using
-                    minimal storage space.
-                  </p>
-                  <p class="mt-2 text-gray-300">
-                    You can always manually clean up backup chunks later using the "Temporary" tab in the Video Library.
-                  </p>
-                  <p class="mt-2 text-gray-300">For the browser version the chunks are always saved by default.</p>
-                </div>
-              </v-tooltip>
-            </div>
-            <div class="flex items-center justify-start w-[50%] ml-2">
-              <v-checkbox
-                v-model="snapshotStore.zipMultipleFiles"
-                label="Zip multiple files"
-                class="text-sm mx-2"
-                hide-details
-              />
             </div>
           </template>
         </ExpansiblePanel>
@@ -675,6 +762,33 @@ function handleAllowedIpsUpdate(newValue: string[] | null): void {
 const openVideoLibrary = (): void => {
   logUserAction('Opened Video Library')
   interfaceStore.videoLibraryVisibility = true
+}
+
+const handleBroadcastCameraActionsUpdate = (value: boolean | null): void => {
+  logUserAction(`${value ? 'Enabled' : 'Disabled'} broadcasting camera actions over MAVLink`)
+}
+
+const clampToUint8 = (value: number): number =>
+  Number.isFinite(value) ? Math.min(255, Math.max(0, Math.round(value))) : 0
+
+const handleCameraTargetIdBlur = (focused: boolean): void => {
+  if (focused) return
+  videoStore.mavlinkCameraTargetId = clampToUint8(videoStore.mavlinkCameraTargetId)
+  logUserAction(`Set MAVLink target camera ID to '${videoStore.mavlinkCameraTargetId}'`)
+}
+
+const handleVideoStreamIdBlur = (focused: boolean): void => {
+  if (focused) return
+  videoStore.mavlinkVideoStreamId = clampToUint8(videoStore.mavlinkVideoStreamId)
+  logUserAction(`Set MAVLink video stream ID to '${videoStore.mavlinkVideoStreamId}'`)
+}
+
+const handleSetCameraModeOnCaptureUpdate = (value: boolean | null): void => {
+  logUserAction(`${value ? 'Enabled' : 'Disabled'} setting camera mode before capture over MAVLink`)
+}
+
+const handleRequestCaptureStatusUpdate = (value: boolean | null): void => {
+  logUserAction(`${value ? 'Enabled' : 'Disabled'} requesting camera capture status over MAVLink`)
 }
 
 /**

--- a/src/views/ConfigurationVideoView.vue
+++ b/src/views/ConfigurationVideoView.vue
@@ -147,12 +147,31 @@
                 </template>
                 <template #bottom></template>
               </v-data-table>
-              <div class="flex items-center justify-start">
-                <v-checkbox v-model="showIgnoredStreams" label="Show ignored streams" hide-details class="text-sm" />
-                <span v-if="ignoredStreamExternalIds.length > 0" class="text-gray-400 text-sm ml-2">
-                  ({{ ignoredStreamExternalIds.length }} ignored)
-                </span>
+              <div class="flex items-center justify-between w-[95%]">
+                <div class="flex items-center justify-start">
+                  <v-checkbox v-model="showIgnoredStreams" label="Show ignored streams" hide-details class="text-sm" />
+                  <span v-if="ignoredStreamExternalIds.length > 0" class="text-gray-400 text-sm ml-2">
+                    ({{ ignoredStreamExternalIds.length }} ignored)
+                  </span>
+                </div>
+                <div class="flex items-center justify-end">
+                  <v-checkbox
+                    v-model="videoStore.broadcastCameraActionsOverMavlink"
+                    label="Broadcast camera actions over MAVLink"
+                    class="text-sm mx-2"
+                    hide-details
+                    @update:model-value="handleBroadcastCameraActionsUpdate"
+                  />
+                  <v-tooltip
+                    text="Send MAVLink camera commands when recording or taking a snapshot, so systems like BlueOS can mirror the action (e.g. start in-vehicle recording)"
+                  >
+                    <template #activator="{ props }">
+                      <v-icon v-bind="props" size="small" color="white" class="ml-2">mdi-information-outline</v-icon>
+                    </template>
+                  </v-tooltip>
+                </div>
               </div>
+
               <div v-if="isElectron()" class="mt-4 mr-2 mb-2 w-[95%]">
                 <div class="text-sm text-gray-300 mb-2">Add direct RTSP stream (standalone)</div>
                 <div class="flex items-end gap-2 w-full">
@@ -285,7 +304,70 @@
             </li>
           </template>
           <template #content>
-            <div class="flex items-center justify-end w-[96%] ml-2 mb-4">
+            <div class="flex items-start justify-between w-[96%] ml-2 mb-2">
+              <div class="flex flex-col">
+                <div class="flex items-center justify-start">
+                  <v-checkbox
+                    v-model="videoStore.enableLiveProcessing"
+                    label="Live video processing (standalone)"
+                    class="text-sm mx-2"
+                    hide-details
+                    :disabled="!isElectron()"
+                  />
+                  <v-tooltip
+                    :text="
+                      isElectron()
+                        ? 'Process videos in real-time during recording for instant availability when recording stops'
+                        : 'Live video processing is only available in Cockpit standalone'
+                    "
+                  >
+                    <template #activator="{ props }">
+                      <v-icon v-bind="props" class="ml-2 text-slate-400">mdi-information-outline</v-icon>
+                    </template>
+                  </v-tooltip>
+                </div>
+
+                <div class="flex items-center justify-start">
+                  <v-checkbox
+                    v-model="videoStore.keepRawVideoChunksAsBackup"
+                    label="Save backup raw chunks"
+                    class="text-sm mx-2"
+                    :disabled="!isElectron()"
+                    hide-details
+                  />
+                  <v-tooltip max-width="400px">
+                    <template #activator="{ props }">
+                      <v-icon v-bind="props" class="ml-2 text-slate-400">mdi-information-outline</v-icon>
+                    </template>
+                    <div class="text-sm">
+                      <p class="mb-2">Save the raw video chunks alongside the final video file for backup purposes.</p>
+                      <p class="mb-2">
+                        <strong>Enabled:</strong> Raw chunks are preserved after recording. Videos use ~2x storage space
+                        but provide safety for reconstruction if the final video is corrupted.
+                      </p>
+                      <p>
+                        <strong>Disabled:</strong> Raw chunks are automatically deleted after successful processing,
+                        using minimal storage space.
+                      </p>
+                      <p class="mt-2 text-gray-300">
+                        You can always manually clean up backup chunks later using the "Temporary" tab in the Video
+                        Library.
+                      </p>
+                      <p class="mt-2 text-gray-300">In Cockpit Lite the chunks are always saved by default.</p>
+                    </div>
+                  </v-tooltip>
+                </div>
+
+                <div class="flex items-center justify-start">
+                  <v-checkbox
+                    v-model="snapshotStore.zipMultipleFiles"
+                    label="Zip multiple files"
+                    class="text-sm mx-2"
+                    hide-details
+                  />
+                </div>
+              </div>
+
               <v-btn variant="flat" class="bg-[#FFFFFF22] px-3 elevation-1" @click="openVideoLibrary">
                 <template #append>
                   <v-divider vertical></v-divider>
@@ -310,65 +392,6 @@
                   </p>
                 </div>
               </div>
-            </div>
-
-            <div class="flex items-center justify-start w-[96%] ml-2">
-              <v-checkbox
-                v-model="videoStore.enableLiveProcessing"
-                label="Live video processing (standalone)"
-                class="text-sm mx-2"
-                hide-details
-                :disabled="!isElectron()"
-              />
-              <v-tooltip
-                :text="
-                  isElectron()
-                    ? 'Process videos in real-time during recording for instant availability when recording stops'
-                    : 'Live video processing is only available in Cockpit standalone'
-                "
-              >
-                <template #activator="{ props }">
-                  <v-icon v-bind="props" class="ml-2 text-slate-400">mdi-information-outline</v-icon>
-                </template>
-              </v-tooltip>
-            </div>
-
-            <div class="flex items-center justify-start w-[96%] ml-2">
-              <v-checkbox
-                v-model="videoStore.keepRawVideoChunksAsBackup"
-                label="Save backup raw chunks"
-                class="text-sm mx-2"
-                :disabled="!isElectron()"
-                hide-details
-              />
-              <v-tooltip max-width="400px">
-                <template #activator="{ props }">
-                  <v-icon v-bind="props" class="ml-2 text-slate-400">mdi-information-outline</v-icon>
-                </template>
-                <div class="text-sm">
-                  <p class="mb-2">Save the raw video chunks alongside the final video file for backup purposes.</p>
-                  <p class="mb-2">
-                    <strong>Enabled:</strong> Raw chunks are preserved after recording. Videos use ~2x storage space but
-                    provide safety for reconstruction if the final video is corrupted.
-                  </p>
-                  <p>
-                    <strong>Disabled:</strong> Raw chunks are automatically deleted after successful processing, using
-                    minimal storage space.
-                  </p>
-                  <p class="mt-2 text-gray-300">
-                    You can always manually clean up backup chunks later using the "Temporary" tab in the Video Library.
-                  </p>
-                  <p class="mt-2 text-gray-300">In Cockpit Lite the chunks are always saved by default.</p>
-                </div>
-              </v-tooltip>
-            </div>
-            <div class="flex items-center justify-start w-[50%] ml-2">
-              <v-checkbox
-                v-model="snapshotStore.zipMultipleFiles"
-                label="Zip multiple files"
-                class="text-sm mx-2"
-                hide-details
-              />
             </div>
           </template>
         </ExpansiblePanel>
@@ -675,6 +698,10 @@ function handleAllowedIpsUpdate(newValue: string[] | null): void {
 const openVideoLibrary = (): void => {
   logUserAction('Opened Video Library')
   interfaceStore.videoLibraryVisibility = true
+}
+
+const handleBroadcastCameraActionsUpdate = (value: boolean | null): void => {
+  logUserAction(`${value ? 'Enabled' : 'Disabled'} broadcasting camera actions over MAVLink`)
 }
 
 /**


### PR DESCRIPTION
- `sendCommandLong` gains a trailing options object (`targetComponent`, `awaitAck`), so a command can address a component other than the autopilot and skip the `COMMAND_ACK` wait that only the autopilot answers.
- `MAVLinkVehicle` gains fire-and-forget `VIDEO_START_CAPTURE`, `VIDEO_STOP_CAPTURE` and `IMAGE_START_CAPTURE` senders.
- Those commands are broadcast (component id 0, camera id 0, stream id 0) instead of addressed to a camera the user picks, so any listener on the vehicle can mirror the action without Cockpit having to know the camera layout.
- Broadcasting means no feedback: nothing is addressed, so nothing can be attributed back, and the configurable target-camera id, the `CAMERA_CAPTURE_STATUS`/`CAMERA_INFORMATION` parsing and the recorder-widget badge that earlier revisions of this PR carried are not part of it.
- Main-vehicle store exposes thin wrappers over the three senders, so the video and snapshot stores never reach into the vehicle instance.
- Video store mirrors recording start/stop and snapshot captures behind the off-by-default `cockpit-broadcast-camera-actions-over-mavlink` setting; recording several streams collapses to a single start/stop pair, and the stop fires from the recorder's `onstop` so every recording-end path (manual stop, teardown, dropped link) is covered.
- Video configuration panel adds the opt-in checkbox with an explanatory tooltip, logged through `logUserAction`, and stacks the video library options in a column beside the library button to reclaim vertical space.

Closes #2695
