### PR TITLE
Mission Planning: Prevent removing the primary NAV_WAYPOINT command

### DIFF
--- a/src/components/mission-planning/CommandInputForm.vue
+++ b/src/components/mission-planning/CommandInputForm.vue
@@ -10,6 +10,7 @@
           item-title="name"
           item-value="value"
           hide-details
+          :disabled="lockCommandSelection"
           class="spaced-number w-full"
           density="compact"
           theme="dark"
@@ -27,12 +28,16 @@
           item-title="name"
           item-value="value"
           hide-details
+          :disabled="lockCommandSelection"
           class="spaced-number w-full"
           density="compact"
           theme="dark"
           variant="plain"
           @update:model-value="onMavCommandChange"
         ></v-select>
+        <p v-if="lockCommandSelection" class="w-full text-center text-[10px] opacity-75 mt-1">
+          The primary MAV_CMD_NAV_WAYPOINT command cannot be changed.
+        </p>
       </div>
 
       <!-- Parameter Inputs -->
@@ -117,6 +122,10 @@ const props = defineProps<{
    * Whether this is an edit operation
    */
   isEditing?: boolean
+  /**
+   * Locks the type and command selects so the primary MAV_CMD_NAV_WAYPOINT cannot be changed away.
+   */
+  lockCommandSelection?: boolean
 }>()
 
 const emit = defineEmits<{

--- a/src/components/mission-planning/WaypointConfigPanel.vue
+++ b/src/components/mission-planning/WaypointConfigPanel.vue
@@ -128,13 +128,27 @@
                     class="!h-[24px] !w-[24px] !min-w-[24px]"
                     @click="editCommand(index)"
                   />
-                  <v-btn
-                    size="x-small"
-                    variant="outlined"
-                    icon="mdi-delete"
-                    class="!h-[24px] !w-[24px] !min-w-[24px]"
-                    @click="removeCommand(index)"
-                  />
+                  <v-tooltip
+                    location="top"
+                    :text="
+                      isProtectedNavWaypoint(command)
+                        ? 'A waypoint must keep a MAV_CMD_NAV_WAYPOINT command'
+                        : 'Delete command'
+                    "
+                  >
+                    <template #activator="{ props: deleteTooltipProps }">
+                      <div v-bind="deleteTooltipProps">
+                        <v-btn
+                          size="x-small"
+                          variant="outlined"
+                          icon="mdi-delete"
+                          class="!h-[24px] !w-[24px] !min-w-[24px]"
+                          :disabled="isProtectedNavWaypoint(command)"
+                          @click="removeCommand(index)"
+                        />
+                      </div>
+                    </template>
+                  </v-tooltip>
                 </div>
               </div>
             </div>
@@ -157,6 +171,7 @@
             v-if="showCommandForm"
             :existing-command="editingCommand"
             :is-editing="editingCommandIndex !== -1"
+            :lock-command-selection="isEditingProtectedNavWaypoint"
             @command-ready="handleCommandReady"
             @cancel="handleCommandCancel"
           />
@@ -186,6 +201,8 @@ import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMissionStore } from '@/stores/mission'
 import {
   AltitudeReferenceType,
+  countNavWaypointCommands,
+  isNavWaypointCommand,
   MissionCommand,
   MissionCommandType,
   Waypoint,
@@ -300,6 +317,14 @@ const handleCommandCancel = (): void => {
   editingCommandIndex.value = -1
   emit('shouldUpdateWaypoints')
 }
+
+const isProtectedNavWaypoint = (command: MissionCommand): boolean =>
+  isNavWaypointCommand(command) && countNavWaypointCommands(waypointOnMissionStore.value?.commands ?? []) <= 1
+
+const isEditingProtectedNavWaypoint = computed(
+  () =>
+    editingCommand.value !== undefined && editingCommandIndex.value >= 0 && isProtectedNavWaypoint(editingCommand.value)
+)
 
 const editCommand = (index: number): void => {
   if (!waypointOnMissionStore.value?.commands) return

--- a/src/stores/mission.ts
+++ b/src/stores/mission.ts
@@ -15,6 +15,8 @@ import { eventCategoriesDefaultMapping } from '@/libs/slide-to-confirm'
 import {
   AltitudeReferenceType,
   CockpitMission,
+  countNavWaypointCommands,
+  isNavWaypointCommand,
   MapOverlayMeta,
   MapTileProvider,
   MapTileProviderPreference,
@@ -414,6 +416,10 @@ export const useMissionStore = defineStore('mission', () => {
     if (commandIndex < 0 || commandIndex >= waypoint.commands.length) {
       throw Error(`Invalid command index ${commandIndex} for waypoint ${waypointId}.`)
     }
+    // A waypoint must always keep at least one MAV_CMD_NAV_WAYPOINT, otherwise it is dropped on upload.
+    if (isNavWaypointCommand(waypoint.commands[commandIndex]) && countNavWaypointCommands(waypoint.commands) <= 1) {
+      throw Error(`Cannot remove the last MAV_CMD_NAV_WAYPOINT command from waypoint ${waypointId}.`)
+    }
     waypoint.commands.splice(commandIndex, 1)
   }
 
@@ -424,6 +430,13 @@ export const useMissionStore = defineStore('mission', () => {
     }
     if (commandIndex < 0 || commandIndex >= waypoint.commands.length) {
       throw Error(`Invalid command index ${commandIndex} for waypoint ${waypointId}.`)
+    }
+    const removesLastNavWaypoint =
+      isNavWaypointCommand(waypoint.commands[commandIndex]) &&
+      !isNavWaypointCommand(updatedCommand) &&
+      countNavWaypointCommands(waypoint.commands) <= 1
+    if (removesLastNavWaypoint) {
+      throw Error(`Cannot remove the last MAV_CMD_NAV_WAYPOINT command from waypoint ${waypointId}.`)
     }
     waypoint.commands[commandIndex] = updatedCommand
   }

--- a/src/types/mission.ts
+++ b/src/types/mission.ts
@@ -78,6 +78,22 @@ export type MavlinkNonNavCommand = {
 export type MissionCommand = MavlinkNavCommand | MavlinkNonNavCommand
 
 /**
+ * Whether a command is the primary navigation command that carries a waypoint's map position.
+ * @param {MissionCommand} command Command to check.
+ * @returns {command is MavlinkNavCommand} True when the command is a MAV_CMD_NAV_WAYPOINT navigation command.
+ */
+export const isNavWaypointCommand = (command: MissionCommand): command is MavlinkNavCommand =>
+  command.type === MissionCommandType.MAVLINK_NAV_COMMAND && command.command === MavCmd.MAV_CMD_NAV_WAYPOINT
+
+/**
+ * Counts how many MAV_CMD_NAV_WAYPOINT commands a waypoint holds.
+ * @param {MissionCommand[]} commands Commands of the waypoint.
+ * @returns {number} Number of MAV_CMD_NAV_WAYPOINT commands.
+ */
+export const countNavWaypointCommands = (commands: MissionCommand[]): number =>
+  commands.filter(isNavWaypointCommand).length
+
+/**
  * Possible types for waypoints. Usually used to decide what function should the waypoint perform.
  */
 export enum AltitudeReferenceType {


### PR DESCRIPTION
- A waypoint's sole MAV_CMD_NAV_WAYPOINT could be deleted (or edited into a different command), so that waypoint vanished on upload and every later mission item ID shifted.
- The delete button is now disabled when it would remove the last MAV_CMD_NAV_WAYPOINT, with a tooltip explaining why.
- Editing that protected command locks the type/command selectors so only its parameters can change; a short hint explains the lock.
- The mission store also refuses remove/update mutations that would leave a waypoint without a MAV_CMD_NAV_WAYPOINT.

Image 1 - The trash button next to the sole MAV_CMD_NAV_WAYPOINT (1) is now disabled.
![Delete button on sole NAV_WAYPOINT](https://raw.githubusercontent.com/ArturoManzoli/cockpit/pr-assets/prevent-removing-nav-waypoint.png)

Closes #2642