### PR TITLE
Frontend: Remove Electron references from the interface

### DIFF
--- a/src/components/VideoLibraryModal.vue
+++ b/src/components/VideoLibraryModal.vue
@@ -371,7 +371,7 @@
                           class="flex items-center gap-2 cursor-pointer"
                           @click="isInstructionsExpanded = !isInstructionsExpanded"
                         >
-                          <span class="text-sm text-white/70">Browser Version Instructions</span>
+                          <span class="text-sm text-white/70">Cockpit Lite Instructions</span>
                           <v-icon
                             class="text-white/70 transition-transform duration-200"
                             :class="{ 'rotate-180': isInstructionsExpanded }"
@@ -391,8 +391,7 @@
                             <div class="text-white/80 text-sm space-y-1">
                               <p>
                                 These are raw video chunks that need to be processed. The processing can be done
-                                exclusively in the standalone version of Cockpit. The browser version can only record
-                                the video chunks.
+                                exclusively in Cockpit Standalone. Cockpit Lite can only record the video chunks.
                               </p>
                               <div>
                                 <p class="font-medium mb-2">To process your videos:</p>
@@ -403,7 +402,7 @@
                                   </li>
                                   <li class="flex items-start gap-2">
                                     <span class="text-white font-bold">2.</span>
-                                    <span>Open the standalone version of Cockpit (desktop app)</span>
+                                    <span>Open Cockpit Standalone</span>
                                   </li>
                                   <li class="flex items-start gap-2">
                                     <span class="text-white font-bold">3.</span>
@@ -627,7 +626,7 @@
                           <ol class="text-white/80 text-sm space-y-2">
                             <li class="flex items-start gap-2">
                               <span class="text-white font-bold">1.</span>
-                              <span>Download raw video chunks from the browser version's "Raw" tab</span>
+                              <span>Download raw video chunks from Cockpit Lite's "Raw" tab</span>
                             </li>
                             <li class="flex items-start gap-2">
                               <span class="text-white font-bold">2.</span>
@@ -831,7 +830,7 @@ const videoSubTabs = [
     label: 'Processed',
     icon: 'mdi-video',
     disabled: !isElectron(),
-    tooltip: isElectron() ? '' : 'Only available in standalone version',
+    tooltip: isElectron() ? '' : 'Only available in Cockpit Standalone',
   },
   {
     name: 'raw',
@@ -845,7 +844,7 @@ const videoSubTabs = [
     label: 'Processing',
     icon: 'mdi-cog-outline',
     disabled: !isElectron(),
-    tooltip: isElectron() ? 'Process ZIP files with raw video chunks' : 'Only available in standalone version',
+    tooltip: isElectron() ? 'Process ZIP files with raw video chunks' : 'Only available in Cockpit Standalone',
   },
 ]
 
@@ -854,7 +853,7 @@ const openElectronFolder = (opener: () => void): void => {
     opener()
   } else {
     openSnackbar({
-      message: 'This feature is only available in the desktop version of Cockpit.',
+      message: 'This feature is only available in Cockpit Standalone.',
       duration: 3000,
       variant: 'error',
       closeButton: true,
@@ -876,7 +875,7 @@ const playVideoInDefaultPlayer = (fileName: string): void => {
   if (isElectron() && window.electronAPI) {
     window.electronAPI?.openVideoFile(fileName)
   } else {
-    openSnackbar({ message: 'This feature is only available in the desktop version of Cockpit.', variant: 'error' })
+    openSnackbar({ message: 'This feature is only available in Cockpit Standalone.', variant: 'error' })
   }
 }
 

--- a/src/components/configuration/HttpRequestActionConfig.vue
+++ b/src/components/configuration/HttpRequestActionConfig.vue
@@ -171,8 +171,8 @@
             class="mt-2"
           >
             <div class="text-body-2">
-              <strong>Note:</strong> Specifying the User-Agent header only works in the standalone Electron version of
-              the application, not in the browser/extension version.
+              <strong>Note:</strong> Specifying the User-Agent header only works in Cockpit Standalone, not in Cockpit
+              Lite.
             </div>
           </v-alert>
         </v-form>

--- a/src/components/map/MapOverlaysDialog.vue
+++ b/src/components/map/MapOverlaysDialog.vue
@@ -11,9 +11,8 @@
           >
             <v-icon icon="mdi-information-outline" size="16" class="mt-[2px]" />
             <span>
-              In the browser (Lite) version, overlays are stored in limited browser storage that the browser may clear,
-              so very large surveys may fail to save or not persist. For large datasets or reliable storage, use the
-              Standalone (desktop) app.
+              In Cockpit Lite, overlays are stored in limited browser storage that the browser may clear, so very large
+              surveys may fail to save or not persist. For large datasets or reliable storage, use Cockpit Standalone.
             </span>
           </div>
 

--- a/src/components/mini-widgets/SnapshotTool.vue
+++ b/src/components/mini-widgets/SnapshotTool.vue
@@ -77,7 +77,7 @@
             />
           </template>
 
-          <span> Some features like “Capturing Cockpit work area” are only available in the Electron version. </span>
+          <span> Some features like “Capturing Cockpit work area” are only available in Cockpit Standalone. </span>
         </v-tooltip>
       </div>
       <div class="flex items-center justify-start w-[90%] -mb-2">
@@ -154,7 +154,7 @@
           @update:model-value="(val) => (miniWidget.options.captureWorkspace = val)"
         />
         <p class="ml-[4px] -mb-[2px] text-sm" :class="{ 'opacity-20 pointer-events-none': !isElectronEnv }">
-          Capture Cockpit work area (Desktop-only feature)
+          Capture Cockpit work area (Standalone-only feature)
         </p>
       </div>
       <v-text-field

--- a/src/composables/videoChunkManager.ts
+++ b/src/composables/videoChunkManager.ts
@@ -581,7 +581,7 @@ export const useVideoChunkManager = (): {
    */
   const processChunkGroup = async (group: ChunkGroup): Promise<void> => {
     if (!isElectron() || !window.electronAPI) {
-      openSnackbar({ message: 'Manual processing is only available in Electron', variant: 'error' })
+      openSnackbar({ message: 'Manual processing is only available in Cockpit Standalone', variant: 'error' })
       return
     }
 

--- a/src/libs/connection/electron-connection.ts
+++ b/src/libs/connection/electron-connection.ts
@@ -34,7 +34,7 @@ class ElectronConnectionIPC {
    */
   async initialize(): Promise<void> {
     if (!window.electronAPI) {
-      throw new Error('This connection is only available in desktop version')
+      throw new Error('This connection is only available in Cockpit Standalone')
     }
 
     this._isOpen = await window.electronAPI.linkOpen(this.path)

--- a/src/libs/electron/vehicle-discovery.ts
+++ b/src/libs/electron/vehicle-discovery.ts
@@ -264,7 +264,7 @@ class VehicleDiscover {
     signal?: AbortSignal
   ): Promise<NetworkVehicle[]> {
     if (!isElectron()) {
-      throw new Error('For technical reasons, finding vehicles is only available in Electron.')
+      throw new Error('For technical reasons, finding vehicles is only available in Cockpit Standalone.')
     }
 
     if (this.currentSearch !== undefined) {
@@ -282,7 +282,8 @@ class VehicleDiscover {
 
       try {
         if (!window.electronAPI?.getInfoOnSubnets) {
-          const msg = 'For technical reasons, getting information about the local subnet is only available in Electron.'
+          const msg =
+            'For technical reasons, getting information about the local subnet is only available in Cockpit Standalone.'
           throw new Error(msg)
         }
 

--- a/src/libs/live-video-processor.ts
+++ b/src/libs/live-video-processor.ts
@@ -71,7 +71,7 @@ export class LiveVideoProcessor {
    */
   async startProcessing(): Promise<void> {
     if (!isElectron()) {
-      throw new Error('Live video processing is only available in Electron')
+      throw new Error('Live video processing is only available in Cockpit Standalone')
     }
 
     this.isProcessing = true
@@ -232,7 +232,7 @@ export class LiveVideoProcessor {
     onProgress?: (progress: number, message: string) => void
   ): Promise<string> {
     if (!isElectron() || !window.electronAPI) {
-      throw new Error('ZIP processing is only available in Electron')
+      throw new Error('ZIP processing is only available in Cockpit Standalone')
     }
 
     if (!zipFilePaths || zipFilePaths.length === 0) {

--- a/src/libs/map/overlay-import.ts
+++ b/src/libs/map/overlay-import.ts
@@ -78,7 +78,7 @@ export const importGeoTiffFile = async (file: File): Promise<MapOverlayMeta> => 
   const available = await getOverlayStorageBytesAvailable()
   if (available !== undefined && file.size > available) {
     throw new OverlayStorageQuotaError(
-      `Not enough browser storage to save "${file.name}". Free up space or use the Standalone (desktop) app.`
+      `Not enough browser storage to save "${file.name}". Free up space or use Cockpit Standalone.`
     )
   }
 
@@ -90,7 +90,7 @@ export const importGeoTiffFile = async (file: File): Promise<MapOverlayMeta> => 
   } catch (error) {
     if (error instanceof DOMException && error.name === 'QuotaExceededError') {
       throw new OverlayStorageQuotaError(
-        `Browser storage is full, so "${file.name}" could not be saved. Free up space or use the Standalone app.`
+        `Browser storage is full, so "${file.name}" could not be saved. Free up space or use Cockpit Standalone.`
       )
     }
     throw error

--- a/src/libs/sensors/gnss.ts
+++ b/src/libs/sensors/gnss.ts
@@ -455,7 +455,7 @@ export const stopGnssDevice = async (deviceId: string): Promise<void> => {
  */
 export const startGnssDevice = async (device: GnssDeviceInfo, publish = true): Promise<void> => {
   if (!isElectron() || !window.electronAPI) {
-    throw new Error('GNSS reading is only available in the desktop version of Cockpit.')
+    throw new Error('GNSS reading is only available in Cockpit Standalone.')
   }
 
   await stopGnssDevice(device.id)
@@ -517,7 +517,7 @@ export const autodetectBaud = async (
   perBaudMs = 1500
 ): Promise<number | null> => {
   if (!isElectron() || !window.electronAPI) {
-    throw new Error('GNSS reading is only available in the desktop version of Cockpit.')
+    throw new Error('GNSS reading is only available in Cockpit Standalone.')
   }
 
   await stopDevicesOnPort(port)

--- a/src/stores/omniscientLogger.ts
+++ b/src/stores/omniscientLogger.ts
@@ -39,38 +39,38 @@ export const useOmniscientLoggerStore = defineStore('omniscient-logger', () => {
     // Separate memory metrics for different process types
     cockpitMainMemoryVariable = {
       id: 'cockpit-main-memory',
-      name: 'Cockpit Main Memory (Electron)',
+      name: 'Cockpit Main Memory (Standalone)',
       type: 'number',
       description:
-        'The memory usage of the main process in the standalone Cockpit application, in MB. This value is updated every 100ms. Only available in Electron.',
+        'The memory usage of the main process in Cockpit Standalone, in MB. This value is updated every 100ms. Only available in Cockpit Standalone.',
     } as DataLakeVariable
     createDataLakeVariable(cockpitMainMemoryVariable)
 
     cockpitRenderersMemoryVariable = {
       id: 'cockpit-renderers-memory',
-      name: 'Cockpit Renderers Memory (Electron)',
+      name: 'Cockpit Renderers Memory (Standalone)',
       type: 'number',
       description:
-        'The total memory usage of the renderer processes in the standalone Cockpit application, in MB. This value is updated every 100ms. Only available in Electron.',
+        'The total memory usage of the renderer processes in Cockpit Standalone, in MB. This value is updated every 100ms. Only available in Cockpit Standalone.',
     } as DataLakeVariable
     createDataLakeVariable(cockpitRenderersMemoryVariable)
 
     cockpitGpuMemoryVariable = {
       id: 'cockpit-gpu-memory',
-      name: 'Cockpit GPU Memory (Electron)',
+      name: 'Cockpit GPU Memory (Standalone)',
       type: 'number',
       description:
-        'The memory usage of the GPU in the standalone Cockpit application, in MB. This value is updated every 100ms. Only available in Electron.',
+        'The memory usage of the GPU in Cockpit Standalone, in MB. This value is updated every 100ms. Only available in Cockpit Standalone.',
     } as DataLakeVariable
     createDataLakeVariable(cockpitGpuMemoryVariable)
 
     // CPU usage tracking
     cockpitCpuUsageVariable = {
       id: 'cockpit-cpu-usage',
-      name: 'Cockpit CPU Usage (Electron)',
+      name: 'Cockpit CPU Usage (Standalone)',
       type: 'number',
       description:
-        'The CPU usage of the standalone Cockpit application as a percentage. This value is updated every 100ms. Only available in Electron.',
+        'The CPU usage of Cockpit Standalone as a percentage. This value is updated every 100ms. Only available in Cockpit Standalone.',
     } as DataLakeVariable
     createDataLakeVariable(cockpitCpuUsageVariable)
   }

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -1225,7 +1225,7 @@ export const useVideoStore = defineStore('video', () => {
    */
   const addRtspStreamCorrespondency = (rtspUrl: string): VideoStreamCorrespondency => {
     if (!window.electronAPI) {
-      throw new Error('RTSP streams are only available in the standalone version.')
+      throw new Error('RTSP streams are only available in Cockpit Standalone.')
     }
 
     let parsedUrl: URL

--- a/src/views/ConfigurationGeneralView.vue
+++ b/src/views/ConfigurationGeneralView.vue
@@ -1002,7 +1002,7 @@ const openCockpitFolder = (): void => {
     window.electronAPI?.openCockpitFolder()
   } else {
     openSnackbar({
-      message: 'This feature is only available in the desktop version of Cockpit.',
+      message: 'This feature is only available in Cockpit Standalone.',
       duration: 3000,
       variant: 'error',
       closeButton: true,

--- a/src/views/ConfigurationSourcesView.vue
+++ b/src/views/ConfigurationSourcesView.vue
@@ -26,11 +26,10 @@
                 <div class="flex items-start gap-3">
                   <v-icon color="amber" class="mt-1">mdi-information</v-icon>
                   <div>
-                    <h4 class="text-amber-200 font-medium mb-2">Browser Version</h4>
+                    <h4 class="text-amber-200 font-medium mb-2">Cockpit Lite</h4>
                     <p class="text-amber-100 text-sm">
-                      Reading external serial GNSS receivers is only available in the standalone (desktop) version of
-                      Cockpit. Browsers cannot access serial devices outside of a secure context, so this feature is
-                      disabled here.
+                      Reading external serial GNSS receivers is only available in Cockpit Standalone. Browsers cannot
+                      access serial devices outside of a secure context, so this feature is disabled here.
                     </p>
                   </div>
                 </div>

--- a/src/views/ConfigurationVideoView.vue
+++ b/src/views/ConfigurationVideoView.vue
@@ -271,7 +271,7 @@
           <template #info>
             <li>
               Configure live video processing to process videos in real-time during recording for instant availability
-              when recording stops. This is only available in the Electron (desktop) version.
+              when recording stops. This is only available in Cockpit Standalone.
             </li>
             <li>
               Choose whether to save backup raw chunks alongside the final video file. This provides safety for video
@@ -303,10 +303,10 @@
               <div class="flex items-start gap-3">
                 <v-icon color="amber" class="mt-1">mdi-information</v-icon>
                 <div>
-                  <h4 class="text-amber-200 font-medium mb-2">Browser Version</h4>
+                  <h4 class="text-amber-200 font-medium mb-2">Cockpit Lite</h4>
                   <p class="text-amber-100 text-sm">
-                    Video processing is not available in the browser version. Your recordings will be saved as raw
-                    chunks that can be downloaded and processed using the standalone version of Cockpit.
+                    Video processing is not available in Cockpit Lite. Your recordings will be saved as raw chunks that
+                    can be downloaded and processed using Cockpit Standalone.
                   </p>
                 </div>
               </div>
@@ -315,7 +315,7 @@
             <div class="flex items-center justify-start w-[96%] ml-2">
               <v-checkbox
                 v-model="videoStore.enableLiveProcessing"
-                label="Live video processing (Electron)"
+                label="Live video processing (Standalone)"
                 class="text-sm mx-2"
                 hide-details
                 :disabled="!isElectron()"
@@ -324,7 +324,7 @@
                 :text="
                   isElectron()
                     ? 'Process videos in real-time during recording for instant availability when recording stops'
-                    : 'Live video processing is only available in the standalone version'
+                    : 'Live video processing is only available in Cockpit Standalone'
                 "
               >
                 <template #activator="{ props }">
@@ -358,7 +358,7 @@
                   <p class="mt-2 text-gray-300">
                     You can always manually clean up backup chunks later using the "Temporary" tab in the Video Library.
                   </p>
-                  <p class="mt-2 text-gray-300">For the browser version the chunks are always saved by default.</p>
+                  <p class="mt-2 text-gray-300">In Cockpit Lite the chunks are always saved by default.</p>
                 </div>
               </v-tooltip>
             </div>


### PR DESCRIPTION
- User-facing snackbars, tooltips, dialogs, alerts and data-lake variables no longer mention "Electron", an implementation detail users are not expected to know.
- The desktop edition is now consistently called "Cockpit Standalone" and the web edition "Cockpit Lite", replacing the previous mix of "Electron", "Desktop" and "standalone".
- "Standalone" is capitalized because it names an edition, exactly like "Lite" in "Cockpit Lite": both are branded product editions (proper nouns), not plain adjectives describing a build.
- Internal code (runtime guards, identifiers, comments) keeps the Electron name.

Closes #2627