### PR TITLE
Allow tracking Points of Interest in the maps

### DIFF
--- a/src/components/MapCenterControl.vue
+++ b/src/components/MapCenterControl.vue
@@ -1,0 +1,172 @@
+<template>
+  <v-speed-dial
+    v-model="speedDialOpen"
+    location="top center"
+    transition="slide-y-reverse-transition"
+    content-class="speed-dial-glow"
+  >
+    <template #activator="{ props: activatorProps }">
+      <v-tooltip location="top center" :text="centerActivatorTooltipText" :disabled="speedDialOpen">
+        <template #activator="{ props: tooltipProps }">
+          <v-btn
+            v-bind="{ ...activatorProps, ...tooltipProps }"
+            class="absolute right-[44px] m-3 rounded-sm shadow-sm bg-slate-50 text-[14px]"
+            :style="[interfaceStore.globalGlassMenuStyles, { zIndex: 1002 }, activatorStyle ?? {}]"
+            :color="followerTarget !== undefined ? 'red' : ''"
+            elevation="2"
+            icon="mdi-crosshairs-gps"
+            size="x-small"
+          />
+        </template>
+      </v-tooltip>
+    </template>
+
+    <v-tooltip location="left" :text="centerMissionButtonTooltipText">
+      <template #activator="{ props: tooltipProps }">
+        <v-btn
+          key="mission"
+          v-bind="tooltipProps"
+          :class="[targetButtonClass, !hasMissionWaypoints ? 'active-events-on-disabled' : '']"
+          :style="[interfaceStore.globalGlassMenuStyles, !hasMissionWaypoints ? { color: disabledButtonColor } : {}]"
+          elevation="2"
+          icon="mdi-map-marker-path"
+          size="x-small"
+          :disabled="!hasMissionWaypoints"
+          @click.stop="emit('centerOnMission')"
+        />
+      </template>
+    </v-tooltip>
+
+    <v-tooltip location="left" :text="centerHomeButtonTooltipText">
+      <template #activator="{ props: tooltipProps }">
+        <v-btn
+          key="home"
+          v-bind="tooltipProps"
+          :class="[targetButtonClass, !home ? 'active-events-on-disabled' : '']"
+          :style="[interfaceStore.globalGlassMenuStyles, !home ? { color: disabledButtonColor } : {}]"
+          :color="followerTarget === WhoToFollow.HOME ? 'red' : ''"
+          elevation="2"
+          icon="mdi-home-search"
+          size="x-small"
+          :disabled="!home"
+          @click.stop="targetFollower.goToTarget(WhoToFollow.HOME, true)"
+          @dblclick.stop="targetFollower.follow(WhoToFollow.HOME)"
+        />
+      </template>
+    </v-tooltip>
+
+    <v-tooltip location="left" :text="centerVehicleButtonTooltipText">
+      <template #activator="{ props: tooltipProps }">
+        <v-btn
+          key="vehicle"
+          v-bind="tooltipProps"
+          :class="[targetButtonClass, !vehiclePosition ? 'active-events-on-disabled' : '']"
+          :style="[interfaceStore.globalGlassMenuStyles, !vehiclePosition ? { color: disabledButtonColor } : {}]"
+          :color="followerTarget === WhoToFollow.VEHICLE ? 'red' : ''"
+          elevation="2"
+          icon="mdi-airplane-marker"
+          size="x-small"
+          :disabled="!vehiclePosition"
+          @click.stop="targetFollower.goToTarget(WhoToFollow.VEHICLE, true)"
+          @dblclick.stop="targetFollower.follow(WhoToFollow.VEHICLE)"
+        />
+      </template>
+    </v-tooltip>
+  </v-speed-dial>
+</template>
+
+<script setup lang="ts">
+import { type StyleValue, computed, defineModel } from 'vue'
+
+import { TargetFollower, WhoToFollow } from '@/libs/map/utils-map'
+import { useAppInterfaceStore } from '@/stores/appInterface'
+import type { WaypointCoordinates } from '@/types/mission'
+
+const props = withDefaults(
+  defineProps<{
+    /** Target follower controlling home/vehicle tracking */
+    targetFollower: TargetFollower
+    /** Currently tracked target, if any */
+    followerTarget?: WhoToFollow
+    /** Home coordinates, when available */
+    home?: WaypointCoordinates
+    /** Vehicle coordinates, when available */
+    vehiclePosition?: WaypointCoordinates
+    /** Whether the vehicle is currently online */
+    isVehicleOnline: boolean
+    /** Whether the current mission has any waypoints to center on */
+    hasMissionWaypoints: boolean
+    /** Inline style positioning the activator button (e.g. its bottom offset) */
+    activatorStyle?: StyleValue
+  }>(),
+  {
+    followerTarget: undefined,
+    home: undefined,
+    vehiclePosition: undefined,
+    activatorStyle: undefined,
+  }
+)
+
+const emit = defineEmits<{
+  /** Requests the parent to center the map on the current mission */
+  (e: 'centerOnMission'): void
+}>()
+
+const interfaceStore = useAppInterfaceStore()
+
+// Two-way bound open state, so parents can react to the dial opening/closing.
+const speedDialOpen = defineModel<boolean>('open', { default: false })
+
+const targetButtonClass = 'rounded-sm shadow-sm bg-slate-50 text-[14px]'
+const disabledButtonColor = '#FFFFFF44'
+
+const centerActivatorTooltipText = computed(() => {
+  if (props.followerTarget === WhoToFollow.HOME) return 'Tracking home position. Open to change target.'
+  if (props.followerTarget === WhoToFollow.VEHICLE) return 'Tracking vehicle position. Open to change target.'
+  return 'Center map on home, vehicle or mission.'
+})
+
+const centerMissionButtonTooltipText = computed(() => {
+  if (!props.hasMissionWaypoints) return 'Cannot center map on mission (no waypoints available).'
+  return 'Click to center the map on the current mission.'
+})
+
+const centerHomeButtonTooltipText = computed(() => {
+  if (props.home === undefined) return 'Cannot center map on home (home position undefined).'
+  if (props.followerTarget === WhoToFollow.HOME) return 'Tracking home position. Click to stop tracking.'
+  return 'Click once to center on home or twice to track it.'
+})
+
+const centerVehicleButtonTooltipText = computed(() => {
+  if (!props.isVehicleOnline) return 'Cannot center map on vehicle (vehicle offline).'
+  if (props.vehiclePosition === undefined) return 'Cannot center map on vehicle (vehicle position undefined).'
+  if (props.followerTarget === WhoToFollow.VEHICLE) return 'Tracking vehicle position. Click to stop tracking.'
+  return 'Click once to center on vehicle or twice to track it.'
+})
+</script>
+
+<style scoped>
+.active-events-on-disabled {
+  pointer-events: all;
+}
+</style>
+
+<!-- Unscoped: the speed-dial content is teleported to <body>, so a scoped selector would not reach it. -->
+<style>
+.speed-dial-glow {
+  isolation: isolate;
+}
+
+.speed-dial-glow::before {
+  content: '';
+  position: absolute;
+  inset: -8px -10px -7px -10px;
+  border-radius: 4px;
+  background: rgba(30, 30, 30, 0.15);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+  -webkit-backdrop-filter: blur(14px);
+  backdrop-filter: blur(14px);
+  pointer-events: none;
+  z-index: -1;
+}
+</style>

--- a/src/components/MapCenterControl.vue
+++ b/src/components/MapCenterControl.vue
@@ -1,9 +1,10 @@
 <template>
   <v-speed-dial
-    v-model="speedDialOpen"
+    :model-value="speedDialOpen"
     location="top center"
     transition="slide-y-reverse-transition"
     content-class="speed-dial-glow"
+    @update:model-value="onSpeedDialToggle"
   >
     <template #activator="{ props: activatorProps }">
       <v-tooltip location="top center" :text="centerActivatorTooltipText" :disabled="speedDialOpen">
@@ -32,7 +33,7 @@
           icon="mdi-map-marker-path"
           size="x-small"
           :disabled="!hasMissionWaypoints"
-          @click.stop="emit('centerOnMission')"
+          @click.stop="centerOnMission"
         />
       </template>
     </v-tooltip>
@@ -49,8 +50,8 @@
           icon="mdi-home-search"
           size="x-small"
           :disabled="!home"
-          @click.stop="targetFollower.goToTarget(WhoToFollow.HOME, true)"
-          @dblclick.stop="targetFollower.follow(WhoToFollow.HOME)"
+          @click.stop="goToHome"
+          @dblclick.stop="trackHome"
         />
       </template>
     </v-tooltip>
@@ -67,27 +68,69 @@
           icon="mdi-airplane-marker"
           size="x-small"
           :disabled="!vehiclePosition"
-          @click.stop="targetFollower.goToTarget(WhoToFollow.VEHICLE, true)"
-          @dblclick.stop="targetFollower.follow(WhoToFollow.VEHICLE)"
+          @click.stop="goToVehicle"
+          @dblclick.stop="trackVehicle"
         />
       </template>
     </v-tooltip>
+
+    <v-menu location="start" :close-on-content-click="false">
+      <template #activator="{ props: menuProps }">
+        <v-tooltip location="left" :text="centerPoiButtonTooltipText">
+          <template #activator="{ props: tooltipProps }">
+            <v-btn
+              key="pois"
+              v-bind="{ ...menuProps, ...tooltipProps }"
+              :class="[targetButtonClass, pois.length === 0 ? 'active-events-on-disabled' : '']"
+              :style="[interfaceStore.globalGlassMenuStyles, pois.length === 0 ? { color: disabledButtonColor } : {}]"
+              :color="isTrackingAnyPoi ? 'red' : ''"
+              elevation="2"
+              icon="mdi-map-marker-radius"
+              size="x-small"
+              :disabled="pois.length === 0"
+            />
+          </template>
+        </v-tooltip>
+      </template>
+      <v-list
+        density="compact"
+        class="rounded-lg mr-2 py-0"
+        :style="[interfaceStore.globalGlassMenuStyles, { maxHeight: '300px', overflowY: 'auto' }]"
+      >
+        <template v-for="(poi, index) in pois" :key="poi.id">
+          <v-tooltip location="left" text="Click to center, double-click to track">
+            <template #activator="{ props: itemProps }">
+              <v-list-item
+                v-bind="itemProps"
+                :title="poi.name"
+                :active="isTrackingPoi(poi)"
+                class="poi-name-item"
+                @click="goToPoi(poi)"
+                @dblclick="trackPoi(poi)"
+              />
+            </template>
+          </v-tooltip>
+          <v-divider v-if="index < pois.length - 1" />
+        </template>
+      </v-list>
+    </v-menu>
   </v-speed-dial>
 </template>
 
 <script setup lang="ts">
 import { type StyleValue, computed, defineModel } from 'vue'
 
+import { usePointsOfInterest } from '@/composables/usePointsOfInterest'
 import { TargetFollower, WhoToFollow } from '@/libs/map/utils-map'
 import { useAppInterfaceStore } from '@/stores/appInterface'
-import type { WaypointCoordinates } from '@/types/mission'
+import type { ResolvedPointOfInterest, WaypointCoordinates } from '@/types/mission'
 
 const props = withDefaults(
   defineProps<{
     /** Target follower controlling home/vehicle tracking */
     targetFollower: TargetFollower
-    /** Currently tracked target, if any */
-    followerTarget?: WhoToFollow
+    /** Currently tracked target id, if any (a WhoToFollow value or a POI target key) */
+    followerTarget?: string
     /** Home coordinates, when available */
     home?: WaypointCoordinates
     /** Vehicle coordinates, when available */
@@ -113,14 +156,74 @@ const emit = defineEmits<{
 }>()
 
 const interfaceStore = useAppInterfaceStore()
+const { resolvedPointsOfInterest: pois } = usePointsOfInterest()
+
+const poiTargetKey = (poiId: string): string => `poi:${poiId}`
+
+const ensurePoiTrackable = (poi: ResolvedPointOfInterest): void => {
+  props.targetFollower.setTrackableTarget(
+    poiTargetKey(poi.id),
+    () => pois.value.find((candidate) => candidate.id === poi.id)?.coordinates
+  )
+}
+
+const isTrackingPoi = (poi: ResolvedPointOfInterest): boolean => props.followerTarget === poiTargetKey(poi.id)
+
+const isTrackingAnyPoi = computed(() => props.followerTarget?.startsWith('poi:') ?? false)
+
+const goToPoi = (poi: ResolvedPointOfInterest): void => {
+  logUserAction(`Centered the map on the "${poi.name}" point of interest`)
+  ensurePoiTrackable(poi)
+  props.targetFollower.goToTarget(poiTargetKey(poi.id), true)
+}
+
+const trackPoi = (poi: ResolvedPointOfInterest): void => {
+  logUserAction(`Started tracking the "${poi.name}" point of interest on the map`)
+  ensurePoiTrackable(poi)
+  props.targetFollower.follow(poiTargetKey(poi.id))
+}
+
+const centerOnMission = (): void => {
+  logUserAction('Centered the map on the mission')
+  emit('centerOnMission')
+}
+
+const goToHome = (): void => {
+  logUserAction('Centered the map on the home position')
+  props.targetFollower.goToTarget(WhoToFollow.HOME, true)
+}
+
+const trackHome = (): void => {
+  logUserAction('Started tracking the home position on the map')
+  props.targetFollower.follow(WhoToFollow.HOME)
+}
+
+const goToVehicle = (): void => {
+  logUserAction('Centered the map on the vehicle')
+  props.targetFollower.goToTarget(WhoToFollow.VEHICLE, true)
+}
+
+const trackVehicle = (): void => {
+  logUserAction('Started tracking the vehicle on the map')
+  props.targetFollower.follow(WhoToFollow.VEHICLE)
+}
 
 // Two-way bound open state, so parents can react to the dial opening/closing.
 const speedDialOpen = defineModel<boolean>('open', { default: false })
+
+const onSpeedDialToggle = (open: boolean): void => {
+  speedDialOpen.value = open
+  logUserAction(open ? 'Opened the map center-on menu' : 'Closed the map center-on menu')
+}
 
 const targetButtonClass = 'rounded-sm shadow-sm bg-slate-50 text-[14px]'
 const disabledButtonColor = '#FFFFFF44'
 
 const centerActivatorTooltipText = computed(() => {
+  if (isTrackingAnyPoi.value) {
+    const tracked = pois.value.find((poi) => poiTargetKey(poi.id) === props.followerTarget)
+    return `Tracking "${tracked?.name ?? 'a point of interest'}". Open to change target.`
+  }
   if (props.followerTarget === WhoToFollow.HOME) return 'Tracking home position. Open to change target.'
   if (props.followerTarget === WhoToFollow.VEHICLE) return 'Tracking vehicle position. Open to change target.'
   return 'Center map on home, vehicle or mission.'
@@ -143,11 +246,33 @@ const centerVehicleButtonTooltipText = computed(() => {
   if (props.followerTarget === WhoToFollow.VEHICLE) return 'Tracking vehicle position. Click to stop tracking.'
   return 'Click once to center on vehicle or twice to track it.'
 })
+
+const centerPoiButtonTooltipText = computed(() => {
+  if (pois.value.length === 0) return 'No points of interest to center on.'
+  return 'Center on a point of interest.'
+})
 </script>
 
 <style scoped>
 .active-events-on-disabled {
   pointer-events: all;
+}
+
+.poi-name-item :deep(.v-list-item-title) {
+  font-weight: 600;
+  user-select: none;
+}
+
+.poi-name-item.v-list-item--active {
+  background-color: #f44336;
+}
+
+.poi-name-item.v-list-item--active :deep(.v-list-item__overlay) {
+  opacity: 0;
+}
+
+.poi-name-item.v-list-item--active :deep(.v-list-item-title) {
+  color: #ffffff;
 }
 </style>
 

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -1132,9 +1132,9 @@ watch(props.widget, () => {
 })
 
 // Allow following a given target
-const followerTarget = ref<WhoToFollow | undefined>(undefined)
+const followerTarget = ref<string | undefined>(undefined)
 const targetFollower = new TargetFollower(
-  (newTarget: WhoToFollow | undefined) => (followerTarget.value = newTarget),
+  (newTarget: string | undefined) => (followerTarget.value = newTarget),
   (newCenter: WaypointCoordinates) => (mapCenter.value = newCenter)
 )
 targetFollower.setTrackableTarget(WhoToFollow.VEHICLE, () => vehiclePosition.value)

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -50,85 +50,18 @@
           />
         </template>
       </v-tooltip>
-      <v-speed-dial
-        v-model="speedDialOpen"
-        location="top center"
-        transition="slide-y-reverse-transition"
-        content-class="speed-dial-glow"
-      >
-        <template #activator="{ props: activatorProps }">
-          <v-tooltip location="top" :text="centerActivatorTooltipText" :disabled="speedDialOpen">
-            <template #activator="{ props: tooltipProps }">
-              <v-btn
-                v-if="showButtons"
-                v-bind="{ ...activatorProps, ...tooltipProps }"
-                class="absolute right-[44px] m-3 bottom-button bg-slate-50 text-[14px]"
-                :style="interfaceStore.globalGlassMenuStyles"
-                :color="followerTarget !== undefined ? 'red' : ''"
-                elevation="2"
-                style="z-index: 1002; border-radius: 0px"
-                icon="mdi-crosshairs-gps"
-                size="x-small"
-              />
-            </template>
-          </v-tooltip>
-        </template>
-        <v-tooltip location="left" :text="centerMissionButtonTooltipText">
-          <template #activator="{ props: tooltipProps }">
-            <v-btn
-              key="mission"
-              v-bind="tooltipProps"
-              class="bg-slate-50 text-[14px]"
-              :style="[interfaceStore.globalGlassMenuStyles, !hasMissionWaypoints ? { color: '#FFFFFF33' } : {}]"
-              :class="!hasMissionWaypoints ? 'active-events-on-disabled' : ''"
-              elevation="2"
-              style="border-radius: 0px"
-              icon="mdi-map-marker-path"
-              size="x-small"
-              :disabled="!hasMissionWaypoints"
-              @click.stop="centerOnMission"
-            />
-          </template>
-        </v-tooltip>
-        <v-tooltip location="left" :text="centerHomeButtonTooltipText">
-          <template #activator="{ props: tooltipProps }">
-            <v-btn
-              key="home"
-              v-bind="tooltipProps"
-              class="bg-slate-50 text-[14px]"
-              :style="[interfaceStore.globalGlassMenuStyles, !home ? { color: '#FFFFFF33' } : {}]"
-              :class="!home ? 'active-events-on-disabled' : ''"
-              :color="followerTarget == WhoToFollow.HOME ? 'red' : ''"
-              elevation="2"
-              style="border-radius: 0px"
-              icon="mdi-home-search"
-              size="x-small"
-              :disabled="!home"
-              @click.stop="centerOnHome"
-              @dblclick.stop="followHome"
-            />
-          </template>
-        </v-tooltip>
-        <v-tooltip location="left" :text="centerVehicleButtonTooltipText">
-          <template #activator="{ props: tooltipProps }">
-            <v-btn
-              key="vehicle"
-              v-bind="tooltipProps"
-              class="bg-slate-50 text-[14px]"
-              :style="[interfaceStore.globalGlassMenuStyles, !vehiclePosition ? { color: '#FFFFFF33' } : {}]"
-              :class="!vehiclePosition ? 'active-events-on-disabled' : ''"
-              :color="followerTarget == WhoToFollow.VEHICLE ? 'red' : ''"
-              elevation="2"
-              style="border-radius: 0px"
-              icon="mdi-airplane-marker"
-              size="x-small"
-              :disabled="!vehiclePosition"
-              @click.stop="centerOnVehicle"
-              @dblclick.stop="followVehicle"
-            />
-          </template>
-        </v-tooltip>
-      </v-speed-dial>
+      <MapCenterControl
+        v-if="showButtons"
+        v-model:open="speedDialOpen"
+        :target-follower="targetFollower"
+        :follower-target="followerTarget"
+        :home="home"
+        :vehicle-position="vehiclePosition"
+        :is-vehicle-online="vehicleStore.isVehicleOnline"
+        :has-mission-waypoints="hasMissionWaypoints"
+        :activator-style="{ bottom: bottomButtonsDisplacement }"
+        @center-on-mission="centerOnMission"
+      />
       <MapNorthIndicator class="north-indicator" />
       <PoiMapArrows
         :map-ready="mapReady"
@@ -295,6 +228,7 @@ import ExpansiblePanel from '@/components/ExpansiblePanel.vue'
 import GlobalOriginDialog from '@/components/GlobalOriginDialog.vue'
 import MapNorthIndicator from '@/components/map/MapNorthIndicator.vue'
 import MapOverlaysDialog from '@/components/map/MapOverlaysDialog.vue'
+import MapCenterControl from '@/components/MapCenterControl.vue'
 import MissionChecklist from '@/components/MissionChecklist.vue'
 import PoiActionPopup from '@/components/poi/PoiActionPopup.vue'
 import PoiManager from '@/components/poi/PoiManager.vue'
@@ -368,6 +302,7 @@ const map = shallowRef<Map | undefined>()
 const zoom = ref(missionStore.userLastMapZoom ?? missionStore.defaultMapZoom)
 const mapCenter = ref<WaypointCoordinates>(missionStore.userLastMapCenter ?? missionStore.defaultMapCenter)
 const mapId = computed(() => `map-${widget.value.hash}`)
+const speedDialOpen = ref(false)
 const showButtons = computed(
   () => isMouseOver.value || downloadMenuOpen.value || speedDialOpen.value || widgetStore.isFullScreen(widget.value)
 )
@@ -382,7 +317,6 @@ let esriSaveBtn: HTMLAnchorElement | undefined
 let osmSaveBtn: HTMLAnchorElement | undefined
 let seamarksSaveBtn: HTMLAnchorElement | undefined
 const downloadMenuOpen = ref(false)
-const speedDialOpen = ref(false)
 const missionItemsInVehicle = ref<Waypoint[]>([])
 const missionSeqToMarkerSeq = shallowRef<Record<number, number>>({})
 
@@ -1868,29 +1802,6 @@ const topProgressBarDisplacement = computed(() => {
   return `${Math.max(-widgetStore.widgetClearanceForVisibleArea(widget.value).top, 0)}px`
 })
 
-const centerHomeButtonTooltipText = computed(() => {
-  if (home.value === undefined) {
-    return 'Cannot center map on home (home position undefined).'
-  }
-  if (followerTarget.value === WhoToFollow.HOME) {
-    return 'Tracking home position. Click to stop tracking.'
-  }
-  return 'Click once to center on home or twice to track it.'
-})
-
-const centerVehicleButtonTooltipText = computed(() => {
-  if (!vehicleStore.isVehicleOnline) {
-    return 'Cannot center map on vehicle (vehicle offline).'
-  }
-  if (vehiclePosition.value === undefined) {
-    return 'Cannot center map on vehicle (vehicle position undefined).'
-  }
-  if (followerTarget.value === WhoToFollow.VEHICLE) {
-    return 'Tracking vehicle position. Click to stop tracking.'
-  }
-  return 'Click once to center on vehicle or twice to track it.'
-})
-
 const missionFitCoordinates = computed<WaypointCoordinates[]>(() => {
   const drawn = mapWaypoints.value.map((wp) => wp.coordinates)
   if (drawn.length > 0) return drawn
@@ -1899,42 +1810,9 @@ const missionFitCoordinates = computed<WaypointCoordinates[]>(() => {
 
 const hasMissionWaypoints = computed(() => missionFitCoordinates.value.length > 0)
 
-const centerMissionButtonTooltipText = computed(() => {
-  if (!hasMissionWaypoints.value) {
-    return 'Cannot center map on mission (no waypoints loaded).'
-  }
-  return 'Click to center the map on the current mission.'
-})
-
-const centerActivatorTooltipText = computed(() => {
-  if (followerTarget.value === WhoToFollow.HOME) return 'Tracking home position. Open to change target.'
-  if (followerTarget.value === WhoToFollow.VEHICLE) return 'Tracking vehicle position. Open to change target.'
-  return 'Center map on home, vehicle or mission.'
-})
-
 const navigateToMissionPlanning = (): void => {
   logUserAction('Navigated to Mission Planning from map widget')
   router.push('/mission-planning')
-}
-
-const centerOnHome = (): void => {
-  logUserAction('Centered map on home')
-  targetFollower.goToTarget(WhoToFollow.HOME, true)
-}
-
-const followHome = (): void => {
-  logUserAction('Started following home on map')
-  targetFollower.follow(WhoToFollow.HOME)
-}
-
-const centerOnVehicle = (): void => {
-  logUserAction('Centered map on vehicle')
-  targetFollower.goToTarget(WhoToFollow.VEHICLE, true)
-}
-
-const followVehicle = (): void => {
-  logUserAction('Started following vehicle on map')
-  targetFollower.follow(WhoToFollow.VEHICLE)
 }
 
 const centerOnMission = (): void => {
@@ -2238,33 +2116,6 @@ const centerOnMission = (): void => {
   }
   50% {
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 0 0 3px rgba(255, 255, 255, 0);
-  }
-}
-
-.speed-dial-glow {
-  isolation: isolate;
-}
-
-.speed-dial-glow::before {
-  content: '';
-  position: absolute;
-  inset: -8px -10px -7px -10px;
-  border-radius: 4px;
-  background: rgba(30, 30, 30, 0.15);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
-  -webkit-backdrop-filter: blur(14px);
-  backdrop-filter: blur(14px);
-  pointer-events: none;
-  z-index: -1;
-  animation: speed-dial-glow-in 180ms ease-out;
-}
-
-@keyframes speed-dial-glow-in {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
   }
 }
 </style>

--- a/src/libs/map/utils-map.ts
+++ b/src/libs/map/utils-map.ts
@@ -58,13 +58,13 @@ export class TargetFollower {
   /**
    * Sets current target to the component observing this follower.
    */
-  private onTargetChange: (newTarget: WhoToFollow | undefined) => void
+  private onTargetChange: (newTarget: string | undefined) => void
 
   /**
-   * Current target ref to follow.
-   * @type {WhoToFollow | undefined}
+   * Current target ref to follow. A well-known {@link WhoToFollow} value or any registered target id.
+   * @type {string | undefined}
    */
-  private target: WhoToFollow | undefined
+  private target: string | undefined
 
   /**
    * Targets available to be followed
@@ -83,11 +83,11 @@ export class TargetFollower {
 
   /**
    * Constructor for the TargetFollower class.
-   * @param {(newTarget: WhoToFollow | undefined) => void} onTargetChange - Sets current target to the component observing this follower.
+   * @param {(newTarget: string | undefined) => void} onTargetChange - Sets current target to the component observing this follower.
    * @param {(newCenter: WaypointCoordinates) => void} onCenterChange - Sets current center for the map coupled to this follower.
    */
   constructor(
-    onTargetChange: (newTarget: WhoToFollow | undefined) => void,
+    onTargetChange: (newTarget: string | undefined) => void,
     onCenterChange: (newCenter: WaypointCoordinates) => void
   ) {
     this.onTargetChange = onTargetChange
@@ -96,10 +96,10 @@ export class TargetFollower {
 
   /**
    * Sets coupled map center to a given target.
-   * @param {WhoToFollow} target - The target to follow.
+   * @param {string | undefined} target - The target to follow (a {@link WhoToFollow} value or a registered target id).
    * @returns {void}
    */
-  private setCenter(target: WhoToFollow | undefined): void {
+  private setCenter(target: string | undefined): void {
     if (!target) return
 
     const updateOnValid = (newCenter: WaypointCoordinates | undefined): void => {
@@ -113,12 +113,12 @@ export class TargetFollower {
 
   /**
    * Stops to follow current target and goes to a given target.
-   * @param {WhoToFollow} target - The target to follow.
+   * @param {string} target - The target to follow (a {@link WhoToFollow} value or a registered target id).
    * @param {boolean} toggleSameTarget - If should stop following current selected
    * target if the same target is selected again.
    * @returns {void}
    */
-  public goToTarget(target: WhoToFollow, toggleSameTarget = false): void {
+  public goToTarget(target: string, toggleSameTarget = false): void {
     // Saves a copy of target because unFollow will set it to undefined
     const oldTarget = this.target
     this.unFollow()
@@ -132,12 +132,12 @@ export class TargetFollower {
 
   /**
    * Sets a source of data for a given target to follow.
-   * @param {WhoToFollow} target - The target that will receive this data
+   * @param {string} target - The target that will receive this data (a {@link WhoToFollow} value or a target id)
    * @param {() => WaypointCoordinates | undefined} compute - The function to compute the target data
    * coordinates.
    * @returns {void}
    */
-  public setTrackableTarget(target: WhoToFollow, compute: () => WaypointCoordinates | undefined): void {
+  public setTrackableTarget(target: string, compute: () => WaypointCoordinates | undefined): void {
     this.trackables[target] = compute
   }
 
@@ -169,11 +169,11 @@ export class TargetFollower {
 
   /**
    * Set the current target ref to follow.
-   * @param {WhoToFollow} target - The target to follow.
+   * @param {string} target - The target to follow (a {@link WhoToFollow} value or a registered target id).
    * @param {boolean} navigateNow - If should navigate to the target now.
    * @returns {void}
    */
-  public follow(target: WhoToFollow, navigateNow = true): void {
+  public follow(target: string, navigateNow = true): void {
     this.target = target
     this.onTargetChange(this.target)
 
@@ -230,9 +230,9 @@ export class TargetFollower {
 
   /**
    * Returns the current target ref to follow.
-   * @returns {WhoToFollow | undefined} The current target ref to follow.
+   * @returns {string | undefined} The current target ref to follow.
    */
-  public getCurrentTarget(): WhoToFollow | undefined {
+  public getCurrentTarget(): string | undefined {
     return this.target
   }
 }

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -525,71 +525,17 @@
         </v-menu>
       </template>
     </v-tooltip>
-    <v-speed-dial v-model="speedDialOpen" location="top center" transition="slide-y-reverse-transition">
-      <template #activator="{ props: activatorProps }">
-        <v-tooltip location="top center" :text="centerActivatorTooltipText" :disabled="speedDialOpen">
-          <template #activator="{ props: tooltipProps }">
-            <v-btn
-              v-bind="{ ...activatorProps, ...tooltipProps }"
-              class="absolute m-3 rounded-sm shadow-sm bottom-12 right-[44px] bg-slate-50 text-[14px]"
-              :style="interfaceStore.globalGlassMenuStyles"
-              :color="followerTarget !== undefined ? 'red' : ''"
-              icon="mdi-crosshairs-gps"
-              size="x-small"
-            />
-          </template>
-        </v-tooltip>
-      </template>
-      <v-tooltip location="left" :text="centerMissionButtonTooltipText">
-        <template #activator="{ props: tooltipProps }">
-          <v-btn
-            key="mission"
-            v-bind="tooltipProps"
-            class="rounded-sm shadow-sm bg-slate-50 text-[14px]"
-            :style="[interfaceStore.globalGlassMenuStyles, !hasMissionWaypoints ? { color: '#FFFFFF44' } : {}]"
-            :class="[!hasMissionWaypoints ? 'active-events-on-disabled' : '']"
-            icon="mdi-map-marker-path"
-            size="x-small"
-            :disabled="!hasMissionWaypoints"
-            @click.stop="centerOnMission"
-          />
-        </template>
-      </v-tooltip>
-      <v-tooltip location="left" :text="centerHomeButtonTooltipText">
-        <template #activator="{ props: tooltipProps }">
-          <v-btn
-            key="home"
-            v-bind="tooltipProps"
-            class="rounded-sm shadow-sm bg-slate-50 text-[14px]"
-            :style="[interfaceStore.globalGlassMenuStyles, !home ? { color: '#FFFFFF44' } : {}]"
-            :class="[!home ? 'active-events-on-disabled' : '']"
-            :color="followerTarget == WhoToFollow.HOME ? 'red' : ''"
-            icon="mdi-home-search"
-            size="x-small"
-            :disabled="!home"
-            @click.stop="targetFollower.goToTarget(WhoToFollow.HOME, true)"
-            @dblclick.stop="targetFollower.follow(WhoToFollow.HOME)"
-          />
-        </template>
-      </v-tooltip>
-      <v-tooltip location="left" :text="centerVehicleButtonTooltipText">
-        <template #activator="{ props: tooltipProps }">
-          <v-btn
-            key="vehicle"
-            v-bind="tooltipProps"
-            class="rounded-sm shadow-sm bg-slate-50 text-[14px]"
-            :style="[interfaceStore.globalGlassMenuStyles, !vehiclePosition ? { color: '#FFFFFF44' } : {}]"
-            :class="[!vehiclePosition ? 'active-events-on-disabled' : '']"
-            :color="followerTarget == WhoToFollow.VEHICLE ? 'red' : ''"
-            icon="mdi-airplane-marker"
-            size="x-small"
-            :disabled="!vehiclePosition"
-            @click.stop="targetFollower.goToTarget(WhoToFollow.VEHICLE, true)"
-            @dblclick.stop="targetFollower.follow(WhoToFollow.VEHICLE)"
-          />
-        </template>
-      </v-tooltip>
-    </v-speed-dial>
+    <MapCenterControl
+      v-model:open="speedDialOpen"
+      :target-follower="targetFollower"
+      :follower-target="followerTarget"
+      :home="home"
+      :vehicle-position="vehiclePosition"
+      :is-vehicle-online="vehicleStore.isVehicleOnline"
+      :has-mission-waypoints="hasMissionWaypoints"
+      :activator-style="{ bottom: '3rem' }"
+      @center-on-mission="centerOnMission"
+    />
     <MapNorthIndicator class="north-indicator" />
     <v-progress-linear
       v-if="uploadingMission"
@@ -734,6 +680,7 @@ import brov2MarkerImage from '@/assets/brov2-marker.avif'
 import genericVehicleMarkerImage from '@/assets/generic-vehicle-marker.avif'
 import MapNorthIndicator from '@/components/map/MapNorthIndicator.vue'
 import MapOverlaysDialog from '@/components/map/MapOverlaysDialog.vue'
+import MapCenterControl from '@/components/MapCenterControl.vue'
 import ContextMenu from '@/components/mission-planning/ContextMenu.vue'
 import HomePositionSettingHelp from '@/components/mission-planning/HomePositionSettingHelp.vue'
 import MissionEstimatesPanel from '@/components/mission-planning/MissionEstimates.vue'
@@ -4464,29 +4411,6 @@ watch(
   }
 )
 
-const centerHomeButtonTooltipText = computed(() => {
-  if (home.value === undefined) {
-    return 'Cannot center map on home (home position undefined).'
-  }
-  if (followerTarget.value === WhoToFollow.HOME) {
-    return 'Tracking home position. Click to stop tracking.'
-  }
-  return 'Click once to center on home or twice to track it.'
-})
-
-const centerVehicleButtonTooltipText = computed(() => {
-  if (!vehicleStore.isVehicleOnline) {
-    return 'Cannot center map on vehicle (vehicle offline).'
-  }
-  if (vehiclePosition.value === undefined) {
-    return 'Cannot center map on vehicle (vehicle position undefined).'
-  }
-  if (followerTarget.value === WhoToFollow.VEHICLE) {
-    return 'Tracking vehicle position. Click to stop tracking.'
-  }
-  return 'Click once to center on vehicle or twice to track it.'
-})
-
 const missionFitCoordinates = computed<WaypointCoordinates[]>(() => {
   const waypointCoords = missionStore.currentPlanningWaypoints.map((wp) => wp.coordinates)
   const surveyCoords = missionStore.currentPlanningSurveys.flatMap((survey) => [
@@ -4497,19 +4421,6 @@ const missionFitCoordinates = computed<WaypointCoordinates[]>(() => {
 })
 
 const hasMissionWaypoints = computed(() => missionFitCoordinates.value.length > 0)
-
-const centerMissionButtonTooltipText = computed(() => {
-  if (!hasMissionWaypoints.value) {
-    return 'Cannot center map on mission (no waypoints defined).'
-  }
-  return 'Click to center the map on the current mission.'
-})
-
-const centerActivatorTooltipText = computed(() => {
-  if (followerTarget.value === WhoToFollow.HOME) return 'Tracking home position. Open to change target.'
-  if (followerTarget.value === WhoToFollow.VEHICLE) return 'Tracking vehicle position. Open to change target.'
-  return 'Center map on home, vehicle or mission.'
-})
 
 const centerOnMission = (): void => {
   if (!planningMap.value || !hasMissionWaypoints.value) return

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -964,7 +964,7 @@ watch(
 
 const mapCenter = ref<WaypointCoordinates>(missionStore.userLastMapCenter ?? missionStore.defaultMapCenter)
 const zoom = ref(missionStore.userLastMapZoom ?? missionStore.defaultMapZoom)
-const followerTarget = ref<WhoToFollow | undefined>(undefined)
+const followerTarget = ref<string | undefined>(undefined)
 const currentWaypointAltitude = ref(0)
 const currentWaypointAltitudeRefType = ref<AltitudeReferenceType>(AltitudeReferenceType.RELATIVE_TO_HOME)
 const availableFrames = Object.values(AltitudeReferenceType).map((value: AltitudeReferenceType) => ({
@@ -2151,7 +2151,7 @@ const toggleSurvey = (): void => {
 }
 
 const targetFollower = new TargetFollower(
-  (newTarget: WhoToFollow | undefined) => (followerTarget.value = newTarget),
+  (newTarget: string | undefined) => (followerTarget.value = newTarget),
   (newCenter: WaypointCoordinates) => (mapCenter.value = newCenter)
 )
 targetFollower.setTrackableTarget(WhoToFollow.VEHICLE, () => vehiclePosition.value)


### PR DESCRIPTION
## Summary

<img width="255" height="221" alt="image" src="https://github.com/user-attachments/assets/f2a35240-8fda-43c2-9cfd-18c56dcb1df4" />


Extracts the map "center on" speed dial into a shared component and lets users **center on** or **continuously track** any target — home, vehicle, mission, and points of interest — from both the flight Map widget and the Mission Planning map.

Builds on the live-tracked Points of Interest feature (#1945, merged).

## What this introduces

- **Shared `MapCenterControl` component** — the center-on speed dial, previously duplicated between the Map widget and the Mission Planning view, is now a single reusable component consumed by both.
- **Generalized `TargetFollower`** — the follow target is now an arbitrary string id instead of only the built-in `WhoToFollow` values, so any registered target (including POIs) can be centered or tracked.
- **Center vs. track from the dial** — single-click a target to center the map on it once; double-click to keep following it. Applies to home, vehicle and each POI. Mission centering fits the map to the mission's waypoints (handled by the parent view).
- **POI submenu** — lists every point of interest; the currently tracked one is highlighted, and clicking again stops tracking.

## Key design choices

- A single `MapCenterControl.vue` used by both `Map.vue` and `MissionPlanningView.vue`, removing the duplicated speed-dial markup and logic; parents only supply their differences (e.g. activator offset and the mission fit-to-waypoints handler).
- POIs register as `poi:<id>` trackables whose coordinates are read live from `usePointsOfInterest`, so tracking a POI follows its live position.

## Test plan

- [ ] The center-on dial appears on both the Map widget and the Mission Planning map.
- [ ] Single-click home / vehicle → map recenters once; double-click → map follows it (button turns red / tooltip reflects tracking).
- [ ] With POIs defined, open the POI submenu: single-click centers, double-click tracks, and the tracked POI is highlighted.
- [ ] "Center on mission" fits the map to the current mission's waypoints.
- [ ] Both maps behave identically (no duplicated/divergent center-dial behavior).