### PR TITLE
feat: Add BlueOS Cloud login/authentication support

### DIFF
--- a/src/components/MainMenu.vue
+++ b/src/components/MainMenu.vue
@@ -202,6 +202,7 @@ import { useWidgetManagerStore } from '@/stores/widgetManager'
 import { SubMenuComponent } from '@/types/general'
 import ConfigurationActionsView from '@/views/ConfigurationActionsView.vue'
 import ConfigurationAlertsView from '@/views/ConfigurationAlertsView.vue'
+import ConfigurationCloudView from '@/views/ConfigurationCloudView.vue'
 import ConfigurationDevelopmentView from '@/views/ConfigurationDevelopmentView.vue'
 import ConfigurationGeneralView from '@/views/ConfigurationGeneralView.vue'
 import ConfigurationJoystickView from '@/views/ConfigurationJoystickView.vue'
@@ -401,6 +402,12 @@ const configMenu = computed(() => {
       title: 'MAVLink',
       componentName: SubMenuComponentName.SettingsMAVLink,
       component: markRaw(ConfigurationMAVLinkView) as SubMenuComponent,
+    })
+    menusToShow.push({
+      icon: 'mdi-cloud-outline',
+      title: 'Cloud',
+      componentName: SubMenuComponentName.SettingsCloud,
+      component: markRaw(ConfigurationCloudView) as SubMenuComponent,
     })
   }
   return menusToShow

--- a/src/components/blueos-cloud/BlueOsCloudLoginDialog.vue
+++ b/src/components/blueos-cloud/BlueOsCloudLoginDialog.vue
@@ -1,0 +1,194 @@
+<template>
+  <v-dialog
+    :model-value="modelValue"
+    width="540"
+    persistent
+    @update:model-value="(value) => emit('update:modelValue', value)"
+  >
+    <v-card class="relative pa-4 text-white rounded-lg" :style="interfaceStore.globalGlassMenuStyles">
+      <v-card-title class="flex justify-center items-center text-lg font-medium">BlueOS Cloud login</v-card-title>
+      <v-btn icon="mdi-close" variant="text" size="small" class="absolute right-2 top-2" @click="closeDialog" />
+      <v-card-text class="px-2 py-4">
+        <div v-if="step === 'intro'" class="flex flex-col gap-3">
+          <p class="text-sm leading-snug">
+            Connect Cockpit to your BlueOS Cloud account to create missions and upload recorded videos directly from
+            this app.
+          </p>
+          <ol class="text-sm list-decimal list-inside opacity-90 space-y-1">
+            <li>Click <span class="font-semibold">Start login</span> below.</li>
+            <li>A short verification code will be displayed.</li>
+            <li>Open the link, sign in to BlueOS Cloud and confirm the code.</li>
+            <li>Cockpit will detect the authorization automatically.</li>
+          </ol>
+          <p v-if="errorMessage" class="text-sm text-red-300 break-words">{{ errorMessage }}</p>
+        </div>
+
+        <div v-else-if="step === 'awaiting'" class="flex flex-col items-center gap-4 text-center">
+          <p class="text-sm leading-snug">
+            Open the link below in your browser, sign in and confirm the verification code:
+          </p>
+          <div class="flex flex-col items-center gap-2">
+            <span class="text-xs uppercase tracking-wider opacity-70">Verification code</span>
+            <span class="font-mono text-3xl font-semibold tracking-[0.2em]">{{ deviceAuthorization?.user_code }}</span>
+          </div>
+          <v-btn
+            v-if="deviceAuthorization?.verification_uri_complete"
+            class="bg-[#FFFFFF22]"
+            variant="flat"
+            prepend-icon="mdi-open-in-new"
+            @click="openVerificationUrl"
+          >
+            Open BlueOS Cloud login page
+          </v-btn>
+          <p class="text-xs opacity-70 break-all">{{ deviceAuthorization?.verification_uri_complete }}</p>
+          <div class="flex items-center gap-2 mt-2">
+            <v-progress-circular indeterminate size="18" width="2" color="white" />
+            <span class="text-sm">Waiting for authorization...</span>
+          </div>
+          <p v-if="errorMessage" class="text-sm text-red-300 break-words">{{ errorMessage }}</p>
+        </div>
+
+        <div v-else-if="step === 'success'" class="flex flex-col items-center gap-3 text-center">
+          <v-icon color="green" size="44">mdi-check-circle</v-icon>
+          <p class="text-base font-medium">You're connected!</p>
+          <div v-if="cloudStore.user" class="flex items-center gap-3 px-4 py-2 rounded bg-[#FFFFFF11]">
+            <v-avatar size="40">
+              <img
+                v-if="cloudStore.user.picture"
+                :src="cloudStore.user.picture"
+                alt="BlueOS Cloud profile picture"
+                referrerpolicy="no-referrer"
+                class="w-full h-full object-cover"
+              />
+              <v-icon v-else>mdi-account</v-icon>
+            </v-avatar>
+            <div class="flex flex-col items-start">
+              <span class="font-medium">{{ cloudStore.displayName }}</span>
+              <span v-if="cloudStore.user.email" class="text-xs opacity-80">{{ cloudStore.user.email }}</span>
+            </div>
+          </div>
+        </div>
+      </v-card-text>
+      <v-divider class="opacity-20 mx-4 mb-3 mt-1" />
+      <v-card-actions class="px-4 py-2">
+        <template v-if="step === 'success'">
+          <v-spacer />
+          <v-btn variant="text" @click="closeDialog">Done</v-btn>
+        </template>
+        <template v-else>
+          <v-btn variant="text" @click="closeDialog">Cancel</v-btn>
+          <v-spacer />
+          <v-btn
+            v-if="step === 'intro'"
+            variant="flat"
+            class="bg-[#FFFFFF33] text-white"
+            :loading="isStartingLogin"
+            @click="startLogin"
+          >
+            Start login
+          </v-btn>
+        </template>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+
+import {
+  DeviceAuthorizationCancelled,
+  pollForDeviceAuthorizationToken,
+  requestDeviceAuthorization,
+} from '@/libs/blueos-cloud/auth'
+import { DeviceAuthorizationResponse } from '@/libs/blueos-cloud/types'
+import { useAppInterfaceStore } from '@/stores/appInterface'
+import { useBlueOsCloudStore } from '@/stores/blueOsCloud'
+
+type WizardStep = 'intro' | 'awaiting' | 'success'
+
+const props = defineProps<{
+  /**
+   * Controls whether the wizard dialog is visible.
+   */
+  modelValue: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void
+}>()
+
+const interfaceStore = useAppInterfaceStore()
+const cloudStore = useBlueOsCloudStore()
+
+const step = ref<WizardStep>('intro')
+const isStartingLogin = ref(false)
+const errorMessage = ref<string | null>(null)
+const deviceAuthorization = ref<DeviceAuthorizationResponse | null>(null)
+let pollAbortController: AbortController | null = null
+
+const resetState = (): void => {
+  step.value = cloudStore.isAuthenticated ? 'success' : 'intro'
+  errorMessage.value = null
+  isStartingLogin.value = false
+  deviceAuthorization.value = null
+  pollAbortController?.abort()
+  pollAbortController = null
+}
+
+const closeDialog = (): void => {
+  logUserAction('Closed the BlueOS Cloud login dialog')
+  pollAbortController?.abort()
+  pollAbortController = null
+  emit('update:modelValue', false)
+}
+
+const openVerificationUrl = (): void => {
+  if (!deviceAuthorization.value) return
+  logUserAction('Opened the BlueOS Cloud verification page')
+  window.open(deviceAuthorization.value.verification_uri_complete, '_blank', 'noopener,noreferrer')
+}
+
+const startLogin = async (): Promise<void> => {
+  logUserAction('Started BlueOS Cloud login')
+  errorMessage.value = null
+  isStartingLogin.value = true
+  try {
+    const authorization = await requestDeviceAuthorization()
+    deviceAuthorization.value = authorization
+    step.value = 'awaiting'
+    isStartingLogin.value = false
+
+    pollAbortController?.abort()
+    pollAbortController = new AbortController()
+
+    const tokens = await pollForDeviceAuthorizationToken(authorization, pollAbortController.signal)
+    await cloudStore.persistSession(tokens)
+    cloudStore.isIntegrationEnabled = true
+    step.value = 'success'
+    logUserAction('Signed in to BlueOS Cloud')
+  } catch (error) {
+    if (error instanceof DeviceAuthorizationCancelled) {
+      step.value = 'intro'
+      isStartingLogin.value = false
+      return
+    }
+    errorMessage.value = (error as Error).message
+    step.value = 'intro'
+    isStartingLogin.value = false
+  }
+}
+
+watch(
+  () => props.modelValue,
+  (visible) => {
+    if (visible) {
+      resetState()
+    } else {
+      pollAbortController?.abort()
+      pollAbortController = null
+    }
+  },
+  { immediate: true }
+)
+</script>

--- a/src/libs/blueos-cloud/auth.ts
+++ b/src/libs/blueos-cloud/auth.ts
@@ -1,0 +1,213 @@
+import { BlueOsCloudTokens, BlueOsCloudUser, DeviceAuthorizationResponse, TokenResponse } from './types'
+
+export const BLUEOS_CLOUD_AUTH0_DOMAIN = 'bcloud-prod.us.auth0.com'
+export const BLUEOS_CLOUD_AUTH0_CLIENT_ID = '0zWm0LYYxwIzFKXsv84mElKoo601QG4S'
+export const BLUEOS_CLOUD_AUTH0_AUDIENCE = 'https://app.blueos.cloud/api/v1'
+export const BLUEOS_CLOUD_AUTH0_SCOPE = 'openid profile email offline_access'
+
+const TOKEN_REFRESH_SAFETY_MARGIN_MS = 60_000
+
+/**
+ * Custom error thrown when the user explicitly cancels or rejects the device authorization request.
+ *
+ * Use it to differentiate user-driven aborts from generic network failures in the wizard UI.
+ */
+export class DeviceAuthorizationCancelled extends Error {
+  /**
+   * Creates a new DeviceAuthorizationCancelled error.
+   * @param {string} message - Human readable description of why the flow was cancelled.
+   */
+  constructor(message = 'Device authorization cancelled') {
+    super(message)
+    this.name = 'DeviceAuthorizationCancelled'
+  }
+}
+
+/**
+ * Starts the Auth0 Device Authorization Flow by requesting a device & user code pair.
+ *
+ * The returned `verification_uri_complete` URL must be opened by the user in a browser to authorize the application.
+ * Once the user finishes the browser flow, call {@link pollForDeviceAuthorizationToken} with the returned `device_code`
+ * to exchange it for an access token.
+ * @returns {Promise<DeviceAuthorizationResponse>} The device authorization payload returned by Auth0.
+ */
+export const requestDeviceAuthorization = async (): Promise<DeviceAuthorizationResponse> => {
+  const body = new URLSearchParams({
+    client_id: BLUEOS_CLOUD_AUTH0_CLIENT_ID,
+    scope: BLUEOS_CLOUD_AUTH0_SCOPE,
+    audience: BLUEOS_CLOUD_AUTH0_AUDIENCE,
+  })
+
+  const res = await fetch(`https://${BLUEOS_CLOUD_AUTH0_DOMAIN}/oauth/device/code`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  })
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`Failed to start BlueOS Cloud login: ${res.status} ${text || res.statusText}`)
+  }
+
+  return res.json()
+}
+
+/**
+ * Normalizes an Auth0 token response into the locally-persisted token bundle.
+ *
+ * Auth0 only issues a new refresh token on the initial exchange, so `fallbackRefreshToken` preserves the previous one
+ * during refreshes when the response omits it.
+ * @param {TokenResponse} response - Raw token payload returned by the Auth0 token endpoint.
+ * @param {string | null | undefined} fallbackRefreshToken - Refresh token to keep when the response does not include one.
+ * @returns {BlueOsCloudTokens} Token bundle ready to be persisted.
+ */
+const buildTokensFromResponse = (
+  response: TokenResponse,
+  fallbackRefreshToken: string | null | undefined
+): BlueOsCloudTokens => ({
+  accessToken: response.access_token,
+  refreshToken: response.refresh_token ?? fallbackRefreshToken ?? null,
+  expiresAt: Date.now() + response.expires_in * 1000,
+})
+
+/**
+ * Polls the Auth0 token endpoint until the user completes the browser-side authorization flow.
+ *
+ * The polling cadence respects the `interval` returned by Auth0, automatically slowing down when the server responds
+ * with `slow_down`, and stops after `expires_in` seconds with a clear error.
+ * @param {DeviceAuthorizationResponse} authorization - Payload returned by {@link requestDeviceAuthorization}.
+ * @param {AbortSignal} [signal] - Optional signal that allows cancelling the polling loop (e.g. when the user closes
+ *   the wizard dialog).
+ * @returns {Promise<BlueOsCloudTokens>} Tokens obtained once the user authorizes the application.
+ */
+export const pollForDeviceAuthorizationToken = async (
+  authorization: DeviceAuthorizationResponse,
+  signal?: AbortSignal
+): Promise<BlueOsCloudTokens> => {
+  let intervalSeconds = authorization.interval > 0 ? authorization.interval : 5
+  const expiresAt = Date.now() + authorization.expires_in * 1000
+
+  while (Date.now() < expiresAt) {
+    if (signal?.aborted) throw new DeviceAuthorizationCancelled('Login wizard was closed')
+
+    await new Promise<void>((resolve, reject) => {
+      const onAbort = (): void => {
+        clearTimeout(timeoutId)
+        reject(new DeviceAuthorizationCancelled('Login wizard was closed'))
+      }
+      const timeoutId = setTimeout(() => {
+        signal?.removeEventListener('abort', onAbort)
+        resolve()
+      }, intervalSeconds * 1000)
+      signal?.addEventListener('abort', onAbort, { once: true })
+    })
+
+    const body = new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+      device_code: authorization.device_code,
+      client_id: BLUEOS_CLOUD_AUTH0_CLIENT_ID,
+    })
+    const res = await fetch(`https://${BLUEOS_CLOUD_AUTH0_DOMAIN}/oauth/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    })
+
+    if (res.ok) {
+      const data: TokenResponse = await res.json()
+      return buildTokensFromResponse(data, null)
+    }
+
+    const errorPayload = (await res.json().catch(() => ({}))) as {
+      /**
+       * Auth0 error code (e.g. `authorization_pending`, `slow_down`, `access_denied`, `expired_token`).
+       */
+      error?: string
+      /**
+       * Human-readable description of the Auth0 error.
+       */
+      error_description?: string
+    }
+
+    if (errorPayload.error === 'authorization_pending') continue
+    if (errorPayload.error === 'slow_down') {
+      intervalSeconds += 5
+      continue
+    }
+    if (errorPayload.error === 'access_denied') {
+      throw new DeviceAuthorizationCancelled('Authorization was denied on the BlueOS Cloud login page')
+    }
+    if (errorPayload.error === 'expired_token') {
+      throw new Error('BlueOS Cloud login code expired. Please try again.')
+    }
+
+    throw new Error(`BlueOS Cloud login failed: ${errorPayload.error_description || errorPayload.error || res.status}`)
+  }
+
+  throw new Error('BlueOS Cloud login timed out. Please try again.')
+}
+
+/**
+ * Refreshes the access token using a previously issued refresh token.
+ * @param {string} refreshToken - Refresh token returned during the original device flow.
+ * @returns {Promise<BlueOsCloudTokens>} New token bundle reusing the input refresh token when a new one is not issued.
+ */
+export const refreshAccessToken = async (refreshToken: string): Promise<BlueOsCloudTokens> => {
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    client_id: BLUEOS_CLOUD_AUTH0_CLIENT_ID,
+    refresh_token: refreshToken,
+  })
+
+  const res = await fetch(`https://${BLUEOS_CLOUD_AUTH0_DOMAIN}/oauth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  })
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`Failed to refresh BlueOS Cloud session: ${res.status} ${text || res.statusText}`)
+  }
+
+  const data: TokenResponse = await res.json()
+  return buildTokensFromResponse(data, refreshToken)
+}
+
+/**
+ * Determines whether a token bundle is still valid.
+ *
+ * A small safety margin is subtracted from the absolute expiration time so callers don't try to use a token that is
+ * about to expire mid-flight.
+ * @param {BlueOsCloudTokens | null} tokens - Token bundle to check, or `null` when no user is logged in.
+ * @returns {boolean} `true` when the access token is present and not within the safety margin of expiring.
+ */
+export const isTokenValid = (tokens: BlueOsCloudTokens | null): boolean => {
+  if (!tokens?.accessToken) return false
+  return Date.now() < tokens.expiresAt - TOKEN_REFRESH_SAFETY_MARGIN_MS
+}
+
+/**
+ * Fetches the authenticated user profile from Auth0.
+ * @param {string} accessToken - Valid Auth0 access token.
+ * @returns {Promise<BlueOsCloudUser>} Profile data describing the authenticated user.
+ */
+export const fetchAuthenticatedUser = async (accessToken: string): Promise<BlueOsCloudUser> => {
+  const res = await fetch(`https://${BLUEOS_CLOUD_AUTH0_DOMAIN}/userinfo`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  })
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`Failed to fetch BlueOS Cloud user info: ${res.status} ${text || res.statusText}`)
+  }
+
+  const profile = (await res.json()) as Record<string, unknown>
+  return {
+    sub: String(profile.sub ?? ''),
+    name: typeof profile.name === 'string' ? profile.name : undefined,
+    email: typeof profile.email === 'string' ? profile.email : undefined,
+    picture: typeof profile.picture === 'string' ? profile.picture : undefined,
+    nickname: typeof profile.nickname === 'string' ? profile.nickname : undefined,
+  }
+}

--- a/src/libs/blueos-cloud/types.ts
+++ b/src/libs/blueos-cloud/types.ts
@@ -1,0 +1,99 @@
+/**
+ * Authenticated BlueOS Cloud user, derived from the Auth0 `/userinfo` endpoint.
+ */
+export interface BlueOsCloudUser {
+  /**
+   * Auth0 subject identifier (e.g. `auth0|abc123`).
+   */
+  sub: string
+  /**
+   * Display name returned by Auth0.
+   */
+  name?: string
+  /**
+   * E-mail address returned by Auth0.
+   */
+  email?: string
+  /**
+   * Profile picture URL returned by Auth0.
+   */
+  picture?: string
+  /**
+   * Auth0 nickname / username.
+   */
+  nickname?: string
+}
+
+/**
+ * Token bundle persisted locally after a successful login.
+ */
+export interface BlueOsCloudTokens {
+  /**
+   * Auth0 access token used to call the BlueOS Cloud API.
+   */
+  accessToken: string
+  /**
+   * Optional refresh token used to obtain a new access token when it expires.
+   */
+  refreshToken: string | null
+  /**
+   * Epoch milliseconds at which the access token expires.
+   */
+  expiresAt: number
+}
+
+/**
+ * Successful response payload from `POST /oauth/device/code` (Auth0 Device Authorization Flow).
+ */
+export interface DeviceAuthorizationResponse {
+  /**
+   * Opaque code that the application uses to poll the token endpoint.
+   */
+  device_code: string
+  /**
+   * Short, human-readable code that the user must enter on the verification page.
+   */
+  user_code: string
+  /**
+   * Base verification URL (without the `user_code` query parameter).
+   */
+  verification_uri: string
+  /**
+   * Verification URL that already contains the `user_code` query parameter.
+   */
+  verification_uri_complete: string
+  /**
+   * Seconds before the device code expires.
+   */
+  expires_in: number
+  /**
+   * Recommended polling interval in seconds.
+   */
+  interval: number
+}
+
+/**
+ * Successful response payload from `POST /oauth/token` (Auth0 token exchange).
+ */
+export interface TokenResponse {
+  /**
+   * Access token used to authenticate API calls.
+   */
+  access_token: string
+  /**
+   * Refresh token (only returned when the `offline_access` scope is requested).
+   */
+  refresh_token?: string
+  /**
+   * OpenID Connect ID token (JWT) describing the authenticated user.
+   */
+  id_token?: string
+  /**
+   * Token type returned by the authorization server (typically `Bearer`).
+   */
+  token_type: string
+  /**
+   * Seconds until the access token expires.
+   */
+  expires_in: number
+}

--- a/src/stores/appInterface.ts
+++ b/src/stores/appInterface.ts
@@ -27,6 +27,7 @@ export enum SubMenuComponentName {
   SettingsTelemetry = 'settings-telemetry',
   SettingsAlerts = 'settings-alerts',
   SettingsDev = 'settings-dev',
+  SettingsCloud = 'settings-cloud',
   SettingsMission = 'settings-mission',
   SettingsActions = 'settings-actions',
   SettingsSources = 'settings-sources',

--- a/src/stores/blueOsCloud.ts
+++ b/src/stores/blueOsCloud.ts
@@ -1,0 +1,94 @@
+import { StorageSerializers, useStorage } from '@vueuse/core'
+import { defineStore } from 'pinia'
+import { computed } from 'vue'
+
+import { useBlueOsStorage } from '@/composables/settingsSyncer'
+import { fetchAuthenticatedUser, isTokenValid, refreshAccessToken } from '@/libs/blueos-cloud/auth'
+import { BlueOsCloudTokens, BlueOsCloudUser } from '@/libs/blueos-cloud/types'
+
+export const useBlueOsCloudStore = defineStore('blueOsCloud', () => {
+  const isIntegrationEnabled = useBlueOsStorage<boolean>('cockpit-blueos-cloud-enabled', false)
+  const tokens = useStorage<BlueOsCloudTokens | null>('cockpit-blueos-cloud-tokens', null, undefined, {
+    serializer: StorageSerializers.object,
+  })
+  const user = useStorage<BlueOsCloudUser | null>('cockpit-blueos-cloud-user', null, undefined, {
+    serializer: StorageSerializers.object,
+  })
+
+  const isAuthenticated = computed(() => !!tokens.value && !!user.value)
+
+  const displayName = computed(() => {
+    const currentUser = user.value
+    if (!currentUser) return ''
+    return currentUser.name || currentUser.nickname || currentUser.email || currentUser.sub
+  })
+
+  /**
+   * Clears persisted tokens and the cached user profile, effectively logging the user out locally.
+   */
+  const clearSession = (): void => {
+    tokens.value = null
+    user.value = null
+  }
+
+  /**
+   * Stores a freshly issued token bundle and refreshes the cached user profile from Auth0.
+   *
+   * Used both at the end of the device-flow login wizard and after a successful refresh-token exchange.
+   * @param {BlueOsCloudTokens} newTokens - Token bundle to persist.
+   */
+  const persistSession = async (newTokens: BlueOsCloudTokens): Promise<void> => {
+    tokens.value = newTokens
+    user.value = await fetchAuthenticatedUser(newTokens.accessToken)
+  }
+
+  // Shared in-flight refresh so concurrent callers exchange the refresh token only once.
+  let refreshPromise: Promise<string> | null = null
+
+  /**
+   * Returns a valid access token, refreshing it on the fly when it has expired.
+   *
+   * Concurrent callers share a single in-flight refresh, so the refresh token is never exchanged more than once.
+   * Throws when there is no active session or when the refresh attempt fails, so callers can show a re-login prompt.
+   * @returns {Promise<string>} An access token guaranteed to be valid for the next API call.
+   */
+  const ensureValidAccessToken = async (): Promise<string> => {
+    if (!tokens.value) throw new Error('Not signed in to BlueOS Cloud')
+
+    if (isTokenValid(tokens.value)) return tokens.value.accessToken
+
+    const refreshToken = tokens.value.refreshToken
+    if (!refreshToken) {
+      clearSession()
+      throw new Error('BlueOS Cloud session expired. Please sign in again.')
+    }
+
+    if (!refreshPromise) {
+      refreshPromise = refreshAccessToken(refreshToken)
+        .then(async (refreshed) => {
+          await persistSession(refreshed)
+          return refreshed.accessToken
+        })
+        .catch((error) => {
+          clearSession()
+          throw error
+        })
+        .finally(() => {
+          refreshPromise = null
+        })
+    }
+
+    return refreshPromise
+  }
+
+  return {
+    isIntegrationEnabled,
+    tokens,
+    user,
+    isAuthenticated,
+    displayName,
+    persistSession,
+    clearSession,
+    ensureValidAccessToken,
+  }
+})

--- a/src/views/ConfigurationCloudView.vue
+++ b/src/views/ConfigurationCloudView.vue
@@ -1,0 +1,127 @@
+<template>
+  <BaseConfigurationView>
+    <template #title>Cloud configuration</template>
+    <template #content>
+      <div
+        class="flex-col h-full overflow-y-auto ml-[10px] pr-3 -mr-[10px]"
+        :class="interfaceStore.isOnSmallScreen ? 'max-w-[80vw] max-h-[90vh]' : 'max-w-[650px] max-h-[85vh]'"
+      >
+        <ExpansiblePanel no-top-divider no-bottom-divider :is-expanded="!interfaceStore.isOnPhoneScreen">
+          <template #title>BlueOS Cloud integration</template>
+          <template #subtitle>
+            <span v-if="cloudStore.isAuthenticated">Signed in as {{ cloudStore.displayName }}</span>
+            <span v-else>Not connected</span>
+          </template>
+          <template #info>
+            <p class="w-full">
+              Connect Cockpit to your BlueOS Cloud account to create missions and upload recorded videos directly from
+              the app. After enabling the integration you will be guided through a quick login wizard.
+            </p>
+          </template>
+          <template #content>
+            <div class="flex flex-col w-full py-2 gap-3">
+              <div class="flex items-center justify-between">
+                <div class="flex items-center gap-3">
+                  <v-switch
+                    v-model="cloudStore.isIntegrationEnabled"
+                    color="white"
+                    hide-details
+                    base-color="#FFFFFF33"
+                    class="mt-0"
+                    @update:model-value="onCloudIntegrationToggle"
+                  />
+                  <span class="text-sm">Enable BlueOS Cloud integration</span>
+                </div>
+                <v-btn
+                  v-if="cloudStore.isAuthenticated"
+                  size="x-small"
+                  variant="flat"
+                  class="bg-[#FFFFFF22] shadow-1"
+                  @click="signOutFromCloud"
+                >
+                  Sign out
+                </v-btn>
+                <v-btn
+                  v-else-if="cloudStore.isIntegrationEnabled"
+                  size="x-small"
+                  variant="flat"
+                  class="bg-[#FFFFFF22] shadow-1"
+                  @click="openLoginDialog"
+                >
+                  Sign in
+                </v-btn>
+              </div>
+              <div v-if="cloudStore.isAuthenticated" class="flex items-center gap-3 px-3 py-2 rounded bg-[#FFFFFF11]">
+                <v-avatar size="36">
+                  <img
+                    v-if="cloudStore.user?.picture"
+                    :src="cloudStore.user.picture"
+                    alt="BlueOS Cloud profile picture"
+                    referrerpolicy="no-referrer"
+                    class="w-full h-full object-cover"
+                  />
+                  <v-icon v-else>mdi-account</v-icon>
+                </v-avatar>
+                <div class="flex flex-col">
+                  <span class="font-medium">{{ cloudStore.displayName }}</span>
+                  <span v-if="cloudStore.user?.email" class="text-xs opacity-80">{{ cloudStore.user.email }}</span>
+                </div>
+              </div>
+            </div>
+          </template>
+        </ExpansiblePanel>
+      </div>
+    </template>
+  </BaseConfigurationView>
+  <BlueOsCloudLoginDialog v-model="showCloudLoginDialog" />
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+
+import BlueOsCloudLoginDialog from '@/components/blueos-cloud/BlueOsCloudLoginDialog.vue'
+import ExpansiblePanel from '@/components/ExpansiblePanel.vue'
+import { useSnackbar } from '@/composables/snackbar'
+import { useAppInterfaceStore } from '@/stores/appInterface'
+import { useBlueOsCloudStore } from '@/stores/blueOsCloud'
+
+import BaseConfigurationView from './BaseConfigurationView.vue'
+
+const interfaceStore = useAppInterfaceStore()
+const cloudStore = useBlueOsCloudStore()
+const { openSnackbar } = useSnackbar()
+
+const showCloudLoginDialog = ref(false)
+
+// Revert the toggle when the login wizard is dismissed without a completed sign-in.
+watch(showCloudLoginDialog, (isOpen) => {
+  if (!isOpen && !cloudStore.isAuthenticated) {
+    cloudStore.isIntegrationEnabled = false
+  }
+})
+
+const openLoginDialog = (): void => {
+  logUserAction('Opened the BlueOS Cloud login dialog')
+  showCloudLoginDialog.value = true
+}
+
+const onCloudIntegrationToggle = (value: boolean | null): void => {
+  const enabled = value ?? false
+  logUserAction(`${enabled ? 'Enabled' : 'Disabled'} BlueOS Cloud integration`)
+  if (enabled && !cloudStore.isAuthenticated) {
+    openLoginDialog()
+  }
+}
+
+const signOutFromCloud = (): void => {
+  logUserAction('Signed out from BlueOS Cloud')
+  cloudStore.clearSession()
+  cloudStore.isIntegrationEnabled = false
+  openSnackbar({
+    message: 'Signed out from BlueOS Cloud.',
+    duration: 3000,
+    variant: 'info',
+    closeButton: true,
+  })
+}
+</script>


### PR DESCRIPTION
### Description

Adds the login/authentication foundation for BlueOS Cloud integration in Cockpit. This is the auth-only slice — it establishes and persists a BlueOS Cloud session so later work (missions, uploads) can build on top of it.

The flow uses the **Auth0 Device Authorization Flow**: the user starts the login, gets a short verification code + link, authorizes in the browser, and Cockpit polls for the token automatically. Tokens and the user profile are persisted locally and the access token is transparently refreshed when it expires.

https://github.com/user-attachments/assets/a3548d2d-dd28-40c3-bc3c-71c42d28ef3d


### Notes

- **Login-only scope:** no mission/upload UI is included in this PR — just the session foundation.
- The Cloud settings menu only appears in **pirate mode** for now.

### How to test

1. Enable pirate mode, open **Settings → Cloud**, toggle the integration on and complete the login wizard.
2. Confirm the profile (name, email, avatar) shows and persists across reloads.

Closes #2707
