### PR TITLE
docs: add lazy-senior-dev minimalism rules to agent + review guidelines

### DIFF
--- a/.github/claude-review/review-guidelines.md
+++ b/.github/claude-review/review-guidelines.md
@@ -11,6 +11,7 @@ exactly.
 - Senior Cockpit developer with deep expertise in TypeScript, Vue 3, and marine robotics / MAVLink.
 - You write clean, minimal code and follow existing patterns. You never over-engineer.
 - When uncertain, you prefer searching the codebase over guessing.
+- The best code is the code never written. You value deletion over addition, boring over clever, and the shortest working diff. You reward PRs that reuse existing helpers, the standard library, native platform features, or already-installed dependencies over ones that add new abstractions, dependencies, or boilerplate nobody asked for.
 
 ## Environment & security
 
@@ -50,12 +51,14 @@ Use these exact headings, in this order, and never omit a section — sections w
 - Storage prefix: flag any new local-storage key (via `settings-management.ts` or `useBlueOsStorage`) that does not start with `cockpit-`.
 - Default-options merging: flag new widgets, or added/removed widget Options entries, that do not merge a defaults object with the persisted one (the `src/components/widgets/Plotter.vue` pattern), since users' existing widgets would miss the new entries.
 - Optional chaining: flag added TypeScript that uses `x && x.y` / nested guards where `x?.y` (optional chaining) is the cleaner, AGENTS.md-preferred form.
+- Root cause vs symptom: when a PR fixes a bug by patching one call site, check whether the defect actually lives in a shared function that other callers still hit. Flag symptom-only fixes (`major`) and point at the shared function that should be fixed once.
 
 ### 2. AGENTS.md Adherence
 - Cite the specific rule in `AGENTS.md` for each finding.
 - Especially check: use of existing dependencies before adding new ones, alphabetical dependency ordering in `package.json`, `yarn` (not `npm`/`npx`), JSDoc completeness for added/changed public functions, comment policy (explain "why" not "what"), optional chaining usage in TS, Lite (web) vs Standalone (electron) feature-parity notes, `cockpit-` prefix for new local-storage keys, widget options default-merging pattern.
 - Scope discipline: flag renames, declaration/import/hook reorders, `const`/`let`/`var` swaps, helper moves between files, and formatter-only reflows that are unrelated to the stated purpose of the PR.
 - Empty/filler JSDoc: flag (as `major`) any added `/** */` block whose summary or `@param`/`@returns` body is empty, whitespace-only, or filler text.
+- Minimalism (per the AGENTS.md "Before writing code" ladder): flag over-engineering, unrequested abstractions, boilerplate, and net additions that a smaller diff, an existing helper/util/composable, the standard library, a native platform feature, or an already-installed dependency could have covered. Reward deletion. Confirm deliberate corner-cuts with a known ceiling are marked with a `ponytail:` comment naming the ceiling and upgrade path.
 
 ### 3. Security
 Sub-check ALL of the following, but only write out the ones that produce a finding. If none of them produce a finding, collapse the whole section to the one-line check-mark form (do not list the clean sub-checks):
@@ -98,6 +101,7 @@ Sub-check ALL of the following, but only write out the ones that produce a findi
 
 ### 8. Tests
 - Missing coverage for new logic, brittle tests, tests that were removed/weakened, testability concerns.
+- Non-trivial logic should leave behind at least ONE runnable check (an assert-based self-check or a small test) that fails if the logic breaks. Flag non-trivial additions that ship with no such check. Trivial one-liners need none.
 
 ### 9. Documentation
 - README updates when a feature differs between Lite and Standalone (per AGENTS.md), in-code JSDoc, user-facing docs, changelog-worthy items.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,28 @@ When explaining:
 - Reference specific files with line numbers when relevant
 - Show code examples from the actual codebase when possible
 
+## Before writing code (minimalism)
+
+The best code is the code never written. Understand the problem first — read the task and the code it touches, trace the real flow end to end — *then* climb this ladder and stop at the first rung that holds:
+
+1. Does this need to be built at all? (YAGNI)
+2. Does it already exist in this codebase? Reuse the existing helper, util, composable, or component (see "Reuse before reinventing").
+3. Does the language / standard library already do this? Use it.
+4. Does a native browser or platform feature cover it? Use it.
+5. Does an already-installed dependency solve it? Use it (see Critical Rule #1).
+6. Can this be one line? Make it one line.
+7. Only then: write the minimum code that works.
+
+Prefer deletion over addition, boring over clever, and the shortest working diff that you fully understand. Question complex requests ("Do you actually need X, or does Y cover it?") instead of silently building them.
+
+**Fix the root cause, not the symptom.** A bug report names a symptom. When you touch a function, grep its callers and fix the shared function once — one guard there is a smaller, safer diff than one guard per call site, and patching only the path the ticket names leaves sibling callers broken.
+
+**Do not be lazy about:** understanding the problem, input validation at trust boundaries, error handling that prevents data loss, security, accessibility, and the calibration real hardware needs (clocks drift, sensors read off — the vehicle is never the spec ideal).
+
+**Leave one runnable check.** Non-trivial logic must leave behind at least ONE runnable check — the smallest thing that fails if the logic breaks (an assert-based self-check or one small test; no new frameworks or fixtures). Trivial one-liners need none.
+
+**Mark deliberate corner-cuts.** When you knowingly cut a real corner with a known ceiling (global lock, O(n²) scan, naive heuristic), leave a `ponytail:` comment naming the ceiling and the upgrade path.
+
 ## Scope discipline
 
 Touch only the lines required for the change you were asked to make. The following are forbidden unless the user explicitly requested them:


### PR DESCRIPTION
## Why

Distills the most important principles from the "lazy senior developer" (ponytail) philosophy — *lazy means efficient, not careless* — and folds them into our agent instructions and the automated PR reviewer. `AGENTS.md` already covered reuse, scope discipline, and comment/JSDoc rules; this adds the pieces that were still missing.

## `AGENTS.md` — new "Before writing code (minimalism)" section
- The **decision ladder**: YAGNI → reuse in-codebase → stdlib → native platform feature → installed dep → one line → minimum code, gated on understanding the problem and tracing the real flow first.
- **Fix the root cause, not the symptom** — grep callers and fix the shared function once.
- **What NOT to be lazy about**: trust-boundary validation, data-loss-preventing error handling, security, accessibility, real-hardware calibration — plus **one runnable check** for non-trivial logic.
- The **`ponytail:` comment** convention for deliberate corner-cuts with a named ceiling/upgrade path.
- deletion over addition, boring over clever, shortest working diff you understand.

## `.github/claude-review/review-guidelines.md` — matching reviewer checks
- Persona now values reuse/deletion over new abstractions and deps.
- §1: flag symptom-only bug fixes; point at the shared function.
- §2: flag over-engineering/unrequested abstractions a smaller diff or existing helper/stdlib/platform/dep would cover; verify `ponytail:` markers.
- §8: require at least one runnable check for non-trivial logic.

Docs-only change; no runtime impact.