### PR TITLE
edit-menu: fix inconsistent widget-card heights across palettes

### DIFF
--- a/src/components/EditMenu.vue
+++ b/src/components/EditMenu.vue
@@ -411,7 +411,7 @@
     <div
       v-show="widgetMode === 'Regular'"
       ref="availableWidgetsContainer"
-      class="flex items-center justify-between w-full h-full gap-3 overflow-x-auto text-white -mb-1 pr-2 cursor-pointer"
+      class="flex items-center justify-between w-full h-full gap-3 overflow-x-scroll overflow-y-hidden text-white -mb-1 pr-2 cursor-pointer"
     >
       <div
         v-for="widget in allAvailableWidgets"
@@ -436,10 +436,10 @@
             <div />
             <img v-bind="tooltipProps" :src="widget.icon" alt="widget-icon" class="p-4 max-h-[75%] max-w-[95%]" />
             <div
-              class="flex items-center justify-center w-full p-1 transition-all rounded-b-md text-white overflow-hidden"
+              class="flex items-center justify-center w-full py-1 px-2 transition-all rounded-b-md text-white"
               :class="{ 'bg-[#135da3]': widget.isExternal, 'bg-[#4fa483]': !widget.isExternal }"
             >
-              <span class="whitespace-normal text-center break-words leading-tight 2xl:text-sm text-xs px-1">{{
+              <span class="whitespace-normal text-center">{{
                 widget.name.replace(/([a-z])([A-Z])/g, '$1 $2').replace(/^./, (str) => str.toUpperCase())
               }}</span>
             </div>
@@ -454,7 +454,7 @@
     <div
       v-show="widgetMode === 'Mini'"
       ref="availableMiniWidgetsContainer"
-      class="flex items-center w-full h-full gap-3 overflow-auto pr-2"
+      class="flex items-center w-full h-full gap-3 overflow-x-scroll overflow-y-hidden pr-2"
     >
       <div
         v-for="miniWidget in availableMiniWidgetTypes"
@@ -483,13 +483,13 @@
     <div
       v-show="widgetMode === 'Input'"
       ref="availableCustomWidgetElementsContainer"
-      class="flex items-center w-full h-full gap-3 overflow-auto pr-2"
+      class="flex items-center w-full h-full gap-3 overflow-x-scroll overflow-y-hidden pr-2"
     >
       <div
         v-for="miniWidget in availableCustomWidgetElementsTypes"
         id="mini-widget-card"
         :key="miniWidget.hash"
-        class="flex flex-col items-center w-full justify-between rounded-md bg-[#273842] hover:brightness-125 h-[90%] aspect-square cursor-pointer elevation-4 overflow-clip"
+        class="flex flex-col items-center w-auto justify-between rounded-md bg-[#273842] hover:brightness-125 h-[90%] cursor-pointer elevation-4 overflow-visible"
         draggable="false"
       >
         <div />


### PR DESCRIPTION
### Problem

The widget cards in the **Regular**, **Mini** and **Input** palettes rendered at slightly different heights, and with different content/label proportions.

### Root cause

Two independent things:

1. The palette containers used `overflow-auto`. The horizontal scrollbar (`height: 0.5em` ≈ 8px, from `global.css`) only appeared in palettes whose cards overflowed (Regular/Mini), eating vertical space and shrinking their `h-[90%]` cards — while the non-overflowing Input palette kept the full height.
2. The Regular card's label used a smaller font + `leading-tight`, so its label was shorter than the Mini/Input labels. At equal total card height, that made its content region taller (the 226/28 vs 222/32 see-saw).

### Fix

- Reserve the scrollbar space in every palette with `overflow-x-scroll` (the track is always present and only becomes functional when the palette overflows), so `h-[90%]` resolves identically everywhere.
- Align the Input card's sizing classes and the Regular card's label styling with the Mini card.

### Before (heights annotated — Regular 226/28, Mini 222/32, Input 229/32)

<img width="708" height="255" alt="image" src="https://github.com/user-attachments/assets/512acfdc-ba0e-4966-b91c-7c37e3bb313a" />

<img width="420" height="256" alt="image" src="https://github.com/user-attachments/assets/bf487d4b-8aaf-4020-91e6-9d13f56123cb" />

<img width="602" height="263" alt="image" src="https://github.com/user-attachments/assets/485e81a2-e284-4a23-922f-ca0d99de54a9" />

<!-- drag the 3 "before" annotated screenshots here -->
### After (all palettes 222/32)

<img width="711" height="279" alt="image" src="https://github.com/user-attachments/assets/89e23943-6770-4c7b-8fa8-49013da3b159" />

<img width="442" height="277" alt="image" src="https://github.com/user-attachments/assets/f9c61463-df64-415c-b993-d39b64cbb24d" />
<img width="441" height="271" alt="image" src="https://github.com/user-attachments/assets/5e91801e-4b79-43b6-a2c2-8c39a963b5e2" />
