### PR TITLE
Snapshots: Add capture datetime to EXIF metadata

### DIFF
--- a/src/components/VideoLibraryModal.vue
+++ b/src/components/VideoLibraryModal.vue
@@ -722,6 +722,7 @@ import { computed, markRaw, nextTick, onBeforeUnmount, onMounted, reactive, ref,
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { useSnackbar } from '@/composables/snackbar'
 import { useVideoChunkManager } from '@/composables/videoChunkManager'
+import { createThumbnail } from '@/libs/snapshot'
 import { formatBytes, formatDate, isElectron } from '@/libs/utils'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useSnapshotStore } from '@/stores/snapshot'
@@ -1159,7 +1160,7 @@ const fetchPictures = async (): Promise<void> => {
           const fullBlob = (await snapshotStore.snapshotStorage.getItem(filename)) as Blob | null
           if (fullBlob) {
             try {
-              thumbBlob = await snapshotStore.createThumbnail(fullBlob, 200, 113)
+              thumbBlob = await createThumbnail(fullBlob, 200, 113)
               await snapshotStore.snapshotThumbStorage.setItem(thumbKey, thumbBlob)
             } catch (err) {
               console.error(`Failed to create thumbnail for "${filename}"`, err)

--- a/src/libs/snapshot.ts
+++ b/src/libs/snapshot.ts
@@ -1,4 +1,9 @@
 import { format } from 'date-fns'
+import piexif from 'piexifjs'
+
+import { app_version } from '@/libs/cosmos'
+import { sanitizeFilenameComponent } from '@/libs/utils'
+import { EIXFType, SnapshotExif } from '@/types/snapshot'
 
 /**
  * Formats a date as EXIF ASCII local DateTime (`YYYY:MM:DD HH:MM:SS`).
@@ -33,4 +38,154 @@ export const toExifGpsTimeStamp = (date: Date): [number, number][] => {
     [minutes, 1],
     [seconds, 1],
   ]
+}
+
+const blobToDataURL = (blob: Blob): Promise<string> =>
+  new Promise((res, rej) => {
+    const r = new FileReader()
+    r.onload = () => res(r.result as string)
+    r.onerror = () => rej(r.error ?? new Error('FileReader failed to read blob'))
+    r.readAsDataURL(blob)
+  })
+
+const dataURLToBlob = (dataURL: string): Blob => {
+  const [meta, b64] = dataURL.split(',')
+  const bin = atob(b64)
+  const arr = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i)
+  const mime = /data:(.*);base64/.exec(meta)?.[1] ?? 'image/jpeg'
+  return new Blob([arr], { type: mime })
+}
+
+const toDMS = (deg: number): [number, number][] => {
+  const d = Math.floor(Math.abs(deg))
+  const mFloat = (Math.abs(deg) - d) * 60
+  const m = Math.floor(mFloat)
+  const s = Math.round((mFloat - m) * 6000)
+  return [
+    [d, 1],
+    [m, 1],
+    [s, 100],
+  ]
+}
+
+/**
+ * Builds the EXIF payload embedded into a captured snapshot JPEG.
+ * @param {EIXFType} opts
+ * @returns {SnapshotExif}
+ */
+export const buildExif = (opts: EIXFType): SnapshotExif => {
+  const { latitude, longitude, capturedAt, yaw, pitch, roll, width, height } = opts
+  const dateTime = formatExifDateTime(capturedAt)
+
+  const jsonComment = {
+    vehicle_attitude: {
+      yaw: yaw ?? 0,
+      pitch: pitch ?? 0,
+      roll: roll ?? 0,
+    },
+  }
+
+  return {
+    '0th': {
+      [piexif.ImageIFD.Software]: `Cockpit ${app_version.version} - Blue Robotics`,
+      [piexif.ImageIFD.DateTime]: dateTime,
+    },
+    'Exif': {
+      [piexif.ExifIFD.UserComment]: JSON.stringify(jsonComment),
+      [piexif.ExifIFD.PixelXDimension]: width,
+      [piexif.ExifIFD.PixelYDimension]: height,
+      [piexif.ExifIFD.DateTimeOriginal]: dateTime,
+      [piexif.ExifIFD.DateTimeDigitized]: dateTime,
+    },
+    'GPS': {
+      [piexif.GPSIFD.GPSLatitudeRef]: latitude >= 0 ? 'N' : 'S',
+      [piexif.GPSIFD.GPSLongitudeRef]: longitude >= 0 ? 'E' : 'W',
+      [piexif.GPSIFD.GPSLatitude]: toDMS(Math.abs(latitude)),
+      [piexif.GPSIFD.GPSLongitude]: toDMS(Math.abs(longitude)),
+      [piexif.GPSIFD.GPSDateStamp]: formatExifGpsDateStamp(capturedAt),
+      [piexif.GPSIFD.GPSTimeStamp]: toExifGpsTimeStamp(capturedAt),
+    },
+  }
+}
+
+const embedExif = async (blob: Blob, exifObj: piexif.Ifd): Promise<Blob> => {
+  const dataURL = await blobToDataURL(blob)
+  const exifStr = piexif.dump(exifObj)
+  const updated = piexif.insert(exifStr, dataURL)
+  return dataURLToBlob(updated)
+}
+
+/**
+ * Embeds EXIF into a JPEG blob, returning the original blob on failure or non-JPEG input.
+ * @param {Blob} blob
+ * @param {piexif.Ifd} exif
+ * @returns {Promise<Blob>}
+ */
+export const maybeEmbedExif = async (blob: Blob, exif: piexif.Ifd): Promise<Blob> => {
+  if (blob.type !== 'image/jpeg') return blob
+  try {
+    return await embedExif(blob, exif)
+  } catch (err) {
+    console.error('EXIF embed failed – storing image without metadata', err)
+    return blob
+  }
+}
+
+/**
+ * Builds a sanitized snapshot filename for the given stream and mission.
+ * @param {string} streamName
+ * @param {string} missionName
+ * @param {Date} capturedAt
+ * @returns {string}
+ */
+export const snapshotFilename = (streamName: string, missionName = 'Cockpit', capturedAt: Date): string => {
+  // Sanitize because the `O` timezone token emits a real colon for non-integer UTC offsets (e.g. `GMT+5:30`), which is illegal on Windows and yields a 0KB file.
+  const timeString = sanitizeFilenameComponent(format(capturedAt, 'LLL dd, yyyy - HH꞉mm꞉ss.SSS O'))
+  const safeMissionName = sanitizeFilenameComponent(missionName) || 'Cockpit'
+  const safeStreamName = sanitizeFilenameComponent(streamName) || 'workspace'
+  return `${safeMissionName} (${timeString}) #${safeStreamName}.jpeg`
+}
+
+/**
+ * Creates a JPEG thumbnail of the given image blob.
+ * @param {Blob} blob
+ * @param {number} width
+ * @param {number} height
+ * @returns {Promise<Blob>}
+ */
+export const createThumbnail = (blob: Blob, width: number, height: number): Promise<Blob> => {
+  const img = document.createElement('img')
+  const objectUrl = URL.createObjectURL(blob)
+  img.src = objectUrl
+  img.width = width
+  img.height = height
+
+  const canvas = document.createElement('canvas')
+  canvas.width = width
+  canvas.height = height
+  const ctx = canvas.getContext('2d')
+  if (!ctx) throw new Error('Could not get 2D context')
+
+  return new Promise<Blob>((resolve, reject) => {
+    img.onload = () => {
+      ctx.drawImage(img, 0, 0, width, height)
+      canvas.toBlob(
+        (thumbnailBlob) => {
+          URL.revokeObjectURL(objectUrl)
+          if (thumbnailBlob) {
+            resolve(thumbnailBlob)
+          } else {
+            reject(new Error('Canvas toBlob failed'))
+          }
+        },
+        'image/jpeg',
+        0.9
+      )
+    }
+    img.onerror = () => {
+      URL.revokeObjectURL(objectUrl)
+      reject(new Error('Image load failed'))
+    }
+  })
 }

--- a/src/libs/snapshot.ts
+++ b/src/libs/snapshot.ts
@@ -1,0 +1,36 @@
+import { format } from 'date-fns'
+
+/**
+ * Formats a date as EXIF ASCII local DateTime (`YYYY:MM:DD HH:MM:SS`).
+ * @param {Date} date
+ * @returns {string}
+ */
+export const formatExifDateTime = (date: Date): string => format(date, 'yyyy:MM:dd HH:mm:ss')
+
+/**
+ * Formats a date as EXIF GPSDateStamp in UTC (`YYYY:MM:DD`).
+ * @param {Date} date
+ * @returns {string}
+ */
+export const formatExifGpsDateStamp = (date: Date): string => {
+  const year = date.getUTCFullYear()
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0')
+  const day = String(date.getUTCDate()).padStart(2, '0')
+  return `${year}:${month}:${day}`
+}
+
+/**
+ * Builds an EXIF GPSTimeStamp rational triplet from the UTC time of a date.
+ * @param {Date} date
+ * @returns {[number, number][]}
+ */
+export const toExifGpsTimeStamp = (date: Date): [number, number][] => {
+  const hours = date.getUTCHours()
+  const minutes = date.getUTCMinutes()
+  const seconds = date.getUTCSeconds()
+  return [
+    [hours, 1],
+    [minutes, 1],
+    [seconds, 1],
+  ]
+}

--- a/src/stores/snapshot.ts
+++ b/src/stores/snapshot.ts
@@ -1,20 +1,17 @@
 import { useThrottleFn } from '@vueuse/core'
 import { BlobReader, BlobWriter, ZipWriter } from '@zip.js/zip.js'
-import { format } from 'date-fns'
 import saveAs from 'file-saver'
-import piexif from 'piexifjs'
 import { defineStore } from 'pinia'
 
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { useBlueOsStorage } from '@/composables/settingsSyncer'
-import { app_version } from '@/libs/cosmos'
 import { availableCockpitActions, registerActionCallback } from '@/libs/joystick/protocols/cockpit-actions'
-import { formatExifDateTime, formatExifGpsDateStamp, toExifGpsTimeStamp } from '@/libs/snapshot'
-import { isElectron, sanitizeFilenameComponent } from '@/libs/utils'
+import { buildExif, createThumbnail, maybeEmbedExif, snapshotFilename } from '@/libs/snapshot'
+import { isElectron } from '@/libs/utils'
 import { snapshotStorage, snapshotThumbStorage } from '@/libs/videoStorage'
 import { useMissionStore } from '@/stores/mission'
 import { StorageDB } from '@/types/general'
-import { EIXFType, SnapshotExif, SnapshotFileDescriptor, SnapshotResult } from '@/types/snapshot'
+import { SnapshotFileDescriptor, SnapshotResult } from '@/types/snapshot'
 import { DownloadProgressCallback, FileDescriptor } from '@/types/video'
 
 import { useMainVehicleStore } from './mainVehicle'
@@ -27,86 +24,6 @@ export const useSnapshotStore = defineStore('snapshot', () => {
   const { showDialog } = useInteractionDialog()
 
   const zipMultipleFiles = useBlueOsStorage('cockpit-zip-multiple-video-files', false)
-
-  const blobToDataURL = (blob: Blob): Promise<string> =>
-    new Promise((res) => {
-      const r = new FileReader()
-      r.onload = () => res(r.result as string)
-      r.readAsDataURL(blob)
-    })
-
-  const dataURLToBlob = (dataURL: string): Blob => {
-    const [meta, b64] = dataURL.split(',')
-    const bin = atob(b64)
-    const arr = new Uint8Array(bin.length)
-    for (let i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i)
-    const mime = /data:(.*);base64/.exec(meta)?.[1] ?? 'image/jpeg'
-    return new Blob([arr], { type: mime })
-  }
-
-  const toDMS = (deg: number): [number, number][] => {
-    const d = Math.floor(Math.abs(deg))
-    const mFloat = (Math.abs(deg) - d) * 60
-    const m = Math.floor(mFloat)
-    const s = Math.round((mFloat - m) * 6000)
-    return [
-      [d, 1],
-      [m, 1],
-      [s, 100],
-    ]
-  }
-
-  const buildExif = (opts: EIXFType): SnapshotExif => {
-    const { latitude, longitude, capturedAt, yaw, pitch, roll, width, height } = opts
-    const dateTime = formatExifDateTime(capturedAt)
-
-    const jsonComment = {
-      vehicle_attitude: {
-        yaw: yaw ?? 0,
-        pitch: pitch ?? 0,
-        roll: roll ?? 0,
-      },
-    }
-
-    return {
-      '0th': {
-        [piexif.ImageIFD.Software]: `Cockpit ${app_version.version} - Blue Robotics`,
-        [piexif.ImageIFD.DateTime]: dateTime,
-      },
-      'Exif': {
-        [piexif.ExifIFD.UserComment]: JSON.stringify(jsonComment),
-        [piexif.ExifIFD.PixelXDimension]: width,
-        [piexif.ExifIFD.PixelYDimension]: height,
-        [piexif.ExifIFD.DateTimeOriginal]: dateTime,
-        [piexif.ExifIFD.DateTimeDigitized]: dateTime,
-      },
-      'GPS': {
-        [piexif.GPSIFD.GPSLatitudeRef]: latitude >= 0 ? 'N' : 'S',
-        [piexif.GPSIFD.GPSLongitudeRef]: longitude >= 0 ? 'E' : 'W',
-        [piexif.GPSIFD.GPSLatitude]: toDMS(Math.abs(latitude)),
-        [piexif.GPSIFD.GPSLongitude]: toDMS(Math.abs(longitude)),
-        [piexif.GPSIFD.GPSDateStamp]: formatExifGpsDateStamp(capturedAt),
-        [piexif.GPSIFD.GPSTimeStamp]: toExifGpsTimeStamp(capturedAt),
-      },
-    }
-  }
-
-  const embedExif = async (blob: Blob, exifObj: piexif.Ifd): Promise<Blob> => {
-    const dataURL = await blobToDataURL(blob)
-    const exifStr = piexif.dump(exifObj)
-    const updated = piexif.insert(exifStr, dataURL)
-    return dataURLToBlob(updated)
-  }
-
-  const maybeEmbedExif = async (b: Blob, exif: piexif.Ifd): Promise<Blob> => {
-    if (b.type !== 'image/jpeg') return b
-    try {
-      return await embedExif(b, exif)
-    } catch (err) {
-      console.error('EXIF embed failed – storing image without metadata', err)
-      return b
-    }
-  }
 
   const captureStreamFrame = async (streamName: string): Promise<Blob> => {
     if (!streamName) {
@@ -183,50 +100,6 @@ export const useSnapshotStore = defineStore('snapshot', () => {
     return new Blob([jpegBuffer], { type: 'image/jpeg' })
   }
 
-  const snapshotFilename = (streamName: string, missionName = 'Cockpit'): string => {
-    // Sanitize because the `O` timezone token emits a real colon for non-integer UTC offsets (e.g. `GMT+5:30`), which is illegal on Windows and yields a 0KB file.
-    const timeString = sanitizeFilenameComponent(format(new Date(), 'LLL dd, yyyy - HH꞉mm꞉ss.SSS O'))
-    const safeMissionName = sanitizeFilenameComponent(missionName) || 'Cockpit'
-    const safeStreamName = sanitizeFilenameComponent(streamName) || 'workspace'
-    return `${safeMissionName} (${timeString}) #${safeStreamName}.jpeg`
-  }
-
-  const createThumbnail = (blob: Blob, width: number, height: number): Promise<Blob> => {
-    const img = document.createElement('img')
-    const objectUrl = URL.createObjectURL(blob)
-    img.src = objectUrl
-    img.width = width
-    img.height = height
-
-    const canvas = document.createElement('canvas')
-    canvas.width = width
-    canvas.height = height
-    const ctx = canvas.getContext('2d')
-    if (!ctx) throw new Error('Could not get 2D context')
-
-    return new Promise<Blob>((resolve, reject) => {
-      img.onload = () => {
-        ctx.drawImage(img, 0, 0, width, height)
-        canvas.toBlob(
-          (thumbnailBlob) => {
-            URL.revokeObjectURL(objectUrl)
-            if (thumbnailBlob) {
-              resolve(thumbnailBlob)
-            } else {
-              reject(new Error('Canvas toBlob failed'))
-            }
-          },
-          'image/jpeg',
-          0.9
-        )
-      }
-      img.onerror = () => {
-        URL.revokeObjectURL(objectUrl)
-        reject(new Error('Image load failed'))
-      }
-    })
-  }
-
   /**
    * Captures snapshots from the given streams and optionally the workspace.
    * @param {string[]} streamNames - Names of the video streams to capture
@@ -258,7 +131,7 @@ export const useSnapshotStore = defineStore('snapshot', () => {
           })
           wsBlob = await maybeEmbedExif(wsBlob, wsExif)
           const thumbBlob = await createThumbnail(wsBlob, 200, 113)
-          const filename = snapshotFilename('workspace', missionName)
+          const filename = snapshotFilename('workspace', missionName, capturedAt)
           const thumbFilename = filename + '-thumb'
           await snapshotStorage.setItem(filename, wsBlob)
           await snapshotThumbStorage.setItem(thumbFilename, thumbBlob)
@@ -278,7 +151,7 @@ export const useSnapshotStore = defineStore('snapshot', () => {
         const stExif = buildExif({ latitude, longitude, capturedAt, yaw, pitch, roll, width, height })
         stBlob = await maybeEmbedExif(stBlob, stExif)
         const internalStreamName = videoStore.internalStreamNameFromExternal(streamName) ?? streamName
-        const filename = snapshotFilename(internalStreamName, missionName)
+        const filename = snapshotFilename(internalStreamName, missionName, capturedAt)
         const thumbFilename = filename + '-thumb'
 
         await snapshotStorage.setItem(filename, stBlob)
@@ -374,9 +247,7 @@ export const useSnapshotStore = defineStore('snapshot', () => {
   return {
     snapshotStorage,
     snapshotThumbStorage,
-    createThumbnail,
     downloadFilesFromSnapshotDB,
-    snapshotFilename,
     takeSnapshot,
     deleteSnapshotFiles,
     zipMultipleFiles,

--- a/src/stores/snapshot.ts
+++ b/src/stores/snapshot.ts
@@ -9,6 +9,7 @@ import { useInteractionDialog } from '@/composables/interactionDialog'
 import { useBlueOsStorage } from '@/composables/settingsSyncer'
 import { app_version } from '@/libs/cosmos'
 import { availableCockpitActions, registerActionCallback } from '@/libs/joystick/protocols/cockpit-actions'
+import { formatExifDateTime, formatExifGpsDateStamp, toExifGpsTimeStamp } from '@/libs/snapshot'
 import { isElectron, sanitizeFilenameComponent } from '@/libs/utils'
 import { snapshotStorage, snapshotThumbStorage } from '@/libs/videoStorage'
 import { useMissionStore } from '@/stores/mission'
@@ -56,7 +57,8 @@ export const useSnapshotStore = defineStore('snapshot', () => {
   }
 
   const buildExif = (opts: EIXFType): SnapshotExif => {
-    const { latitude, longitude, yaw, pitch, roll, width, height } = opts
+    const { latitude, longitude, capturedAt, yaw, pitch, roll, width, height } = opts
+    const dateTime = formatExifDateTime(capturedAt)
 
     const jsonComment = {
       vehicle_attitude: {
@@ -69,17 +71,22 @@ export const useSnapshotStore = defineStore('snapshot', () => {
     return {
       '0th': {
         [piexif.ImageIFD.Software]: `Cockpit ${app_version.version} - Blue Robotics`,
+        [piexif.ImageIFD.DateTime]: dateTime,
       },
       'Exif': {
         [piexif.ExifIFD.UserComment]: JSON.stringify(jsonComment),
         [piexif.ExifIFD.PixelXDimension]: width,
         [piexif.ExifIFD.PixelYDimension]: height,
+        [piexif.ExifIFD.DateTimeOriginal]: dateTime,
+        [piexif.ExifIFD.DateTimeDigitized]: dateTime,
       },
       'GPS': {
         [piexif.GPSIFD.GPSLatitudeRef]: latitude >= 0 ? 'N' : 'S',
         [piexif.GPSIFD.GPSLongitudeRef]: longitude >= 0 ? 'E' : 'W',
         [piexif.GPSIFD.GPSLatitude]: toDMS(Math.abs(latitude)),
         [piexif.GPSIFD.GPSLongitude]: toDMS(Math.abs(longitude)),
+        [piexif.GPSIFD.GPSDateStamp]: formatExifGpsDateStamp(capturedAt),
+        [piexif.GPSIFD.GPSTimeStamp]: toExifGpsTimeStamp(capturedAt),
       },
     }
   }
@@ -230,6 +237,7 @@ export const useSnapshotStore = defineStore('snapshot', () => {
     const { yaw, pitch, roll } = vehicleStore.attitude
     const { latitude, longitude } = vehicleStore.coordinates
     const missionName = missionStore.missionName || 'Cockpit'
+    const capturedAt = new Date()
 
     const succeeded: string[] = []
     const failed: string[] = []
@@ -241,6 +249,7 @@ export const useSnapshotStore = defineStore('snapshot', () => {
           const wsExif = buildExif({
             latitude,
             longitude,
+            capturedAt,
             yaw,
             pitch,
             roll,
@@ -266,7 +275,7 @@ export const useSnapshotStore = defineStore('snapshot', () => {
         let stBlob = await captureStreamFrame(streamName)
         const thumbBlob = await createThumbnail(stBlob, 200, 113)
         const { width, height } = videoStore.getMediaStream(streamName)?.getVideoTracks()[0].getSettings() || {}
-        const stExif = buildExif({ latitude, longitude, yaw, pitch, roll, width, height })
+        const stExif = buildExif({ latitude, longitude, capturedAt, yaw, pitch, roll, width, height })
         stBlob = await maybeEmbedExif(stBlob, stExif)
         const internalStreamName = videoStore.internalStreamNameFromExternal(streamName) ?? streamName
         const filename = snapshotFilename(internalStreamName, missionName)

--- a/src/types/snapshot.ts
+++ b/src/types/snapshot.ts
@@ -47,6 +47,10 @@ export interface EIXFType {
    */
   longitude: number
   /**
+   * Instant the snapshot was captured
+   */
+  capturedAt: Date
+  /**
    * Yaw angle of the vehicle during the snapshot
    */
   yaw?: number


### PR DESCRIPTION
* Add src/libs/snapshot.ts with formatters: formatExifDateTime, formatExifGpsDateStamp, and toExifGpsTimeStamp.
* Extend EIXFType with required capturedAt and stamp DateTime, DateTimeOriginal, DateTimeDigitized, GPSDateStamp, and GPSTimeStamp in buildExif.
* Move buildExif, maybeEmbedExif, snapshotFilename, and createThumbnail into the snapshot lib; the Pinia store keeps capture, storage, and download orchestration only.

Closes #2593