### PR TITLE
Mission Planning: Add direction arrows to survey lines

### DIFF
--- a/src/composables/map/useSurveyArrowOverlay.ts
+++ b/src/composables/map/useSurveyArrowOverlay.ts
@@ -1,0 +1,273 @@
+import L, { type Map as LeafletMap } from 'leaflet'
+import { type WatchStopHandle, watch } from 'vue'
+
+import {
+  type SurveyArrowAnchor,
+  computeSurveyArrowAnchors,
+  partitionArrowsByLength,
+  partitionArrowsByOrientation,
+} from '@/libs/map/survey-arrows'
+import type { Survey, WaypointCoordinates } from '@/types/mission'
+
+const ARROW_PANE = 'surveyArrowPane'
+const REFLY_PANE = 'surveyReflyPane'
+const PRIMARY_PANE = 'surveyPrimaryPane'
+
+// Preview legs match the dashed survey-path blue, crosshatch re-fly legs the purple crosshatch line, and
+// generated-survey legs the mission path blue.
+const previewArrowColor = '#2563eb'
+const crosshatchArrowColor = '#a855f7'
+const surveyArrowColor = '#3388ff'
+
+// Legs shorter than this on screen would render an arrow bigger than the leg itself, so they are skipped.
+const minArrowLegPixels = 44
+
+// Legs at least this fraction of the longest leg get a full-opacity arrow so the transect sweeps read clearly;
+// the shorter connector/turnaround legs still get an arrow, but faint, to avoid cluttering dense crosshatch grids.
+const transectLengthRatio = 0.3
+
+// Opacity of the arrows on the short connector legs (those below the transect-length threshold).
+const faintArrowOpacity = 0.6
+
+// A north-pointing arrowhead; CSS rotation aligns it with each leg's travel bearing and `currentColor` lets each
+// arrow adopt its source's blue.
+const arrowSvg = `<svg viewBox="0 0 14 14" width="24" height="24">
+  <path d="M7 1.5 L11.5 11 L7 8.4 L2.5 11 Z" fill="currentColor" />
+</svg>`
+
+// Full size at close zoom, shrinking as the survey and path shrink so the arrows stop dominating when zoomed
+// out, with a floor that keeps them legible. Kept gentler than the geometry's 2×-per-zoom scaling on purpose.
+const referenceZoom = 19
+const minArrowScale = 0.4
+const arrowScaleForZoom = (zoom: number): number =>
+  Math.min(1, Math.max(minArrowScale, 1 - Math.max(0, referenceZoom - zoom) * 0.15))
+
+/** The survey being drawn, split into its primary pass and its optional 90° crosshatch re-fly pass. */
+export interface SurveyPreview {
+  /** Coordinates of the primary survey pass. */
+  firstPass: WaypointCoordinates[]
+  /** Coordinates of the crosshatch re-fly pass, empty when crosshatch is disabled. */
+  crosshatch: WaypointCoordinates[]
+}
+
+/** Reactive sources the survey arrow overlay reads to decide which legs to decorate. */
+export interface SurveyArrowSources {
+  /** Ordered survey list; the legs between each survey's consecutive waypoints get arrows. */
+  surveys: () => Survey[]
+  /** The survey preview being drawn, or null when no survey preview is on the map. */
+  previewPath: () => SurveyPreview | null
+}
+
+/**
+ * Return type of {@link useSurveyArrowOverlay}.
+ */
+export interface UseSurveyArrowOverlayReturn {
+  /** Binds the overlay to a Leaflet map, creates its pane, and starts reacting to the sources. */
+  initArrowOverlay: (map: LeafletMap) => void
+  /** Removes every arrow, stops the watchers, and unbinds the map. */
+  destroyArrowOverlay: () => void
+}
+
+const metersPerPixel = (latitude: number, zoom: number): number =>
+  (40075016.686 * Math.cos((latitude * Math.PI) / 180)) / Math.pow(2, zoom + 8)
+
+/** An arrow anchor carrying the color and opacity of the leg it belongs to. */
+interface ColoredArrowAnchor extends SurveyArrowAnchor {
+  /** Hex color the arrow is drawn in. */
+  color: string
+  /** Opacity the arrow is drawn at (full for transect sweeps, faint for short connector legs). */
+  opacity: number
+}
+
+/** A survey transect to overlay as a solid line, as a `[start, end]` coordinate pair. */
+type LegSegment = [WaypointCoordinates, WaypointCoordinates]
+
+/** Everything a single render tick draws: the colored arrows and the survey transect line segments. */
+interface SurveyRenderData {
+  /** Colored direction arrows to draw. */
+  anchors: ColoredArrowAnchor[]
+  /** Crosshatch-pass transects to overlay as purple lines, below the primary transects. */
+  reflySegments: LegSegment[]
+  /** Primary-pass transects to overlay as blue lines, above the crosshatch ones so they win the crossings. */
+  primarySegments: LegSegment[]
+}
+
+/**
+ * Draws direction-of-travel arrows at the middle of each survey leg (the survey being drawn and the legs of every
+ * generated survey), never on plain waypoint-to-waypoint segments. For generated crosshatch surveys it also
+ * repaints the transects over the blue base line: the crosshatch re-fly pass in purple and the primary pass in
+ * blue on top, so the two passes read distinctly and the blue lines win every crossing. Owns its panes, watchers,
+ * and teardown so a view only wires an init/destroy pair. Renders are coalesced to one per animation frame so the
+ * overlay tracks the survey lines live during dial rotation and waypoint drags without redundant work.
+ * @param {SurveyArrowSources} sources - Reactive getters for the survey list and the live survey preview path.
+ * @returns {UseSurveyArrowOverlayReturn} Methods to initialize and tear down the overlay.
+ */
+export const useSurveyArrowOverlay = (sources: SurveyArrowSources): UseSurveyArrowOverlayReturn => {
+  let mapRef: LeafletMap | undefined
+  let markers: L.Marker[] = []
+  let arrowEls: (HTMLElement | null)[] = []
+  let reflyLines: L.Polyline[] = []
+  let primaryLines: L.Polyline[] = []
+  let stopWatch: WatchStopHandle | undefined
+  let rafId: number | null = null
+
+  const collectRenderData = (zoom: number): SurveyRenderData => {
+    const anchors: ColoredArrowAnchor[] = []
+    const reflySegments: LegSegment[] = []
+    const primarySegments: LegSegment[] = []
+
+    // Draws every leg of a single-color path: the long transect sweeps at full opacity, the short connector legs
+    // faint so they stay unobtrusive.
+    const addUniformArrows = (path: WaypointCoordinates[], color: string): void => {
+      const { long, short } = partitionArrowsByLength(computeSurveyArrowAnchors(path), transectLengthRatio)
+      long.forEach((anchor) => anchors.push({ ...anchor, color, opacity: 1 }))
+      short.forEach((anchor) => anchors.push({ ...anchor, color, opacity: faintArrowOpacity }))
+    }
+
+    // The preview knows its exact primary/crosshatch split, and the view draws the preview's own re-fly line, so
+    // only generated crosshatch surveys need their crosshatch legs both purple-arrowed and purple-lined here.
+    const preview = sources.previewPath()
+    if (preview) {
+      if (preview.firstPass.length >= 2) addUniformArrows(preview.firstPass, previewArrowColor)
+      if (preview.crosshatch.length >= 2) addUniformArrows(preview.crosshatch, crosshatchArrowColor)
+    }
+    sources.surveys().forEach((survey) => {
+      if (survey.waypoints.length < 2) return
+      const path = survey.waypoints.map((waypoint) => waypoint.coordinates)
+      if (!survey.crosshatch) {
+        addUniformArrows(path, surveyArrowColor)
+        return
+      }
+      // Classify the transect sweeps by pass to color them and draw the crosshatch re-fly lines; short connectors
+      // stay faint and uncolored-by-pass since they are not part of either sweep.
+      const { long, short } = partitionArrowsByLength(computeSurveyArrowAnchors(path), transectLengthRatio)
+      const crosshatchSweeps = new Set(partitionArrowsByOrientation(long).crosshatch)
+      long.forEach((anchor) => {
+        const isCrosshatch = crosshatchSweeps.has(anchor)
+        anchors.push({ ...anchor, color: isCrosshatch ? crosshatchArrowColor : surveyArrowColor, opacity: 1 })
+        ;(isCrosshatch ? reflySegments : primarySegments).push([anchor.start, anchor.end])
+      })
+      short.forEach((anchor) => anchors.push({ ...anchor, color: surveyArrowColor, opacity: faintArrowOpacity }))
+    })
+
+    return {
+      anchors: anchors.filter((a) => a.lengthMeters / metersPerPixel(a.position[0], zoom) >= minArrowLegPixels),
+      reflySegments,
+      primarySegments,
+    }
+  }
+
+  const render = (): void => {
+    if (!mapRef) return
+    const map = mapRef
+    const zoom = map.getZoom()
+    const scale = arrowScaleForZoom(zoom)
+    const { anchors, reflySegments, primarySegments } = collectRenderData(zoom)
+
+    while (markers.length > anchors.length) {
+      markers.pop()?.remove()
+      arrowEls.pop()
+    }
+
+    anchors.forEach((anchor, i) => {
+      const transform = `rotate(${anchor.bearing}deg) scale(${scale})`
+      if (markers[i]) {
+        markers[i].setLatLng(anchor.position)
+        const el = arrowEls[i]
+        if (el) {
+          el.style.transform = transform
+          el.style.color = anchor.color
+          el.style.opacity = String(anchor.opacity)
+        }
+      } else {
+        const icon = L.divIcon({
+          className: 'survey-arrow',
+          html: `<div class="survey-arrow-glyph" style="transform: ${transform}; color: ${anchor.color}; opacity: ${anchor.opacity}">${arrowSvg}</div>`,
+          iconSize: [24, 24],
+          iconAnchor: [12, 12],
+        })
+        const marker = L.marker(anchor.position, { icon, interactive: false, keyboard: false, pane: ARROW_PANE }).addTo(
+          map
+        )
+        markers[i] = marker
+        arrowEls[i] = marker.getElement()?.querySelector('.survey-arrow-glyph') ?? null
+      }
+    })
+
+    // Both passes are drawn at the mission polyline's width and full opacity so each fully hides the blue base line
+    // underneath it; the primary pane sits above the crosshatch pane so blue wins wherever the two passes cross.
+    const renderLines = (lines: L.Polyline[], segments: LegSegment[], color: string, pane: string): void => {
+      while (lines.length > segments.length) {
+        lines.pop()?.remove()
+      }
+      segments.forEach((segment, i) => {
+        const latLngs = [L.latLng(segment[0][0], segment[0][1]), L.latLng(segment[1][0], segment[1][1])]
+        if (lines[i]) {
+          lines[i].setLatLngs(latLngs)
+        } else {
+          lines[i] = L.polyline(latLngs, { color, weight: 3, opacity: 1, interactive: false, pane }).addTo(map)
+        }
+      })
+    }
+
+    renderLines(reflyLines, reflySegments, crosshatchArrowColor, REFLY_PANE)
+    renderLines(primaryLines, primarySegments, surveyArrowColor, PRIMARY_PANE)
+  }
+
+  // Coalesce bursts (dial rotation, waypoint drag) into one render on the next frame, so arrows repaint in step
+  // with the survey lines instead of lagging behind a debounce.
+  const scheduleRender = (): void => {
+    if (rafId !== null) return
+    rafId = requestAnimationFrame(() => {
+      rafId = null
+      render()
+    })
+  }
+
+  const initArrowOverlay = (map: LeafletMap): void => {
+    mapRef = map
+    if (!map.getPane(ARROW_PANE)) {
+      const pane = map.createPane(ARROW_PANE)
+      // Above the mission path (overlay pane, 400) but below the waypoint-number tooltips (650).
+      pane.style.zIndex = '620'
+      pane.style.pointerEvents = 'none'
+    }
+    if (!map.getPane(REFLY_PANE)) {
+      const pane = map.createPane(REFLY_PANE)
+      // Just above the mission path so the purple crosshatch lines sit on it, but below the waypoint markers (600).
+      pane.style.zIndex = '410'
+      pane.style.pointerEvents = 'none'
+    }
+    if (!map.getPane(PRIMARY_PANE)) {
+      const pane = map.createPane(PRIMARY_PANE)
+      // Above the crosshatch pane so the blue primary lines paint over the purple ones at every crossing.
+      pane.style.zIndex = '420'
+      pane.style.pointerEvents = 'none'
+    }
+
+    map.on('zoomend', scheduleRender)
+    stopWatch = watch([() => sources.previewPath(), () => sources.surveys()], () => scheduleRender(), {
+      immediate: true,
+    })
+  }
+
+  const destroyArrowOverlay = (): void => {
+    stopWatch?.()
+    stopWatch = undefined
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId)
+      rafId = null
+    }
+    mapRef?.off('zoomend', scheduleRender)
+    markers.forEach((marker) => marker.remove())
+    reflyLines.forEach((line) => line.remove())
+    primaryLines.forEach((line) => line.remove())
+    markers = []
+    arrowEls = []
+    reflyLines = []
+    primaryLines = []
+    mapRef = undefined
+  }
+
+  return { initArrowOverlay, destroyArrowOverlay }
+}

--- a/src/libs/map/survey-arrows.ts
+++ b/src/libs/map/survey-arrows.ts
@@ -1,0 +1,120 @@
+import { bearingBetween, calculateHaversineDistance } from '@/libs/mission/general-estimates'
+import type { Survey, Waypoint, WaypointCoordinates } from '@/types/mission'
+
+/** A direction arrow anchored at the middle of a survey leg. */
+export interface SurveyArrowAnchor {
+  /** Midpoint of the leg, where the arrow is drawn. */
+  position: WaypointCoordinates
+  /** Direction of travel along the leg, in degrees clockwise from north (0 = north). */
+  bearing: number
+  /** Great-circle length of the leg, in meters. */
+  lengthMeters: number
+  /** Start coordinate of the leg. */
+  start: WaypointCoordinates
+  /** End coordinate of the leg. */
+  end: WaypointCoordinates
+}
+
+/**
+ * Computes a direction-of-travel arrow anchor at the middle of each straight leg of an ordered path.
+ * Zero-length legs (repeated points) produce no anchor, so consecutive duplicates never yield a stray arrow.
+ * @param {WaypointCoordinates[]} path - Ordered coordinates describing the survey flight path.
+ * @returns {SurveyArrowAnchor[]} One anchor per non-degenerate leg, in path order.
+ */
+export const computeSurveyArrowAnchors = (path: WaypointCoordinates[]): SurveyArrowAnchor[] => {
+  const anchors: SurveyArrowAnchor[] = []
+
+  for (let i = 0; i < path.length - 1; i++) {
+    const start = path[i]
+    const end = path[i + 1]
+    const lengthMeters = calculateHaversineDistance(start, end)
+    if (lengthMeters === 0) continue
+
+    anchors.push({
+      // ponytail: arithmetic midpoint, accurate to sub-meter for survey-length legs but drifts from the true
+      // geodesic midpoint on very long legs at high latitude; swap in a geodesic midpoint if that ever matters.
+      position: [(start[0] + end[0]) / 2, (start[1] + end[1]) / 2],
+      bearing: bearingBetween(start, end),
+      lengthMeters,
+      start,
+      end,
+    })
+  }
+
+  return anchors
+}
+
+/** Arrows split by leg length relative to the longest leg in the set. */
+export interface LengthPartitionedArrows {
+  /** Legs at least `minLengthRatio` of the longest leg (the transect sweeps). */
+  long: SurveyArrowAnchor[]
+  /** Legs shorter than that fraction of the longest leg (the connector/turnaround legs). */
+  short: SurveyArrowAnchor[]
+}
+
+/**
+ * Splits arrows into the long transect sweeps and the short connector legs, comparing each leg's length against a
+ * fraction of the longest leg in the set.
+ * @param {SurveyArrowAnchor[]} anchors - Arrows in path order.
+ * @param {number} minLengthRatio - Fraction of the longest leg a leg must reach to count as long.
+ * @returns {LengthPartitionedArrows} The arrows grouped into long and short legs, each keeping path order.
+ */
+export const partitionArrowsByLength = (
+  anchors: SurveyArrowAnchor[],
+  minLengthRatio: number
+): LengthPartitionedArrows => {
+  const long: SurveyArrowAnchor[] = []
+  const short: SurveyArrowAnchor[] = []
+  if (anchors.length === 0) return { long, short }
+
+  const longestLeg = anchors.reduce((longest, anchor) => Math.max(longest, anchor.lengthMeters), 0)
+  const threshold = longestLeg * minLengthRatio
+  anchors.forEach((anchor) => (anchor.lengthMeters >= threshold ? long : short).push(anchor))
+  return { long, short }
+}
+
+/** Arrows of a survey grouped by which of the two perpendicular passes their leg belongs to. */
+export interface OrientedArrowGroups {
+  /** Arrows on the primary-pass sweeps. */
+  primary: SurveyArrowAnchor[]
+  /** Arrows on the perpendicular crosshatch re-fly sweeps. */
+  crosshatch: SurveyArrowAnchor[]
+}
+
+/**
+ * Splits a crosshatch survey's arrows into its two perpendicular sweep families, taking the first arrow's
+ * orientation as the primary reference (the primary pass comes first in the generated path). Orientation is
+ * taken modulo 180°, so the split is unaffected by which direction each leg is flown.
+ * @param {SurveyArrowAnchor[]} anchors - Arrows in path order.
+ * @returns {OrientedArrowGroups} The arrows grouped into the primary and crosshatch passes.
+ */
+export const partitionArrowsByOrientation = (anchors: SurveyArrowAnchor[]): OrientedArrowGroups => {
+  const primary: SurveyArrowAnchor[] = []
+  const crosshatch: SurveyArrowAnchor[] = []
+  if (anchors.length === 0) return { primary, crosshatch }
+
+  const reference = anchors[0].bearing % 180
+  anchors.forEach((anchor) => {
+    const foldedDiff = Math.abs((anchor.bearing % 180) - reference)
+    const orientationDiff = foldedDiff > 90 ? 180 - foldedDiff : foldedDiff
+    if (orientationDiff < 45) primary.push(anchor)
+    else crosshatch.push(anchor)
+  })
+  return { primary, crosshatch }
+}
+
+/**
+ * Rebuilds each survey's waypoint coordinates from the live mission waypoints, matched by id, so a dragged waypoint
+ * moves the survey path that owns it (a survey stores its own waypoint copies, which a drag would otherwise leave stale).
+ * @param {Survey[]} surveys - Surveys whose stored waypoint coordinates may be stale.
+ * @param {Waypoint[]} liveWaypoints - Current mission waypoints holding the up-to-date coordinates.
+ * @returns {Survey[]} The surveys with each waypoint's coordinates refreshed from its live counterpart.
+ */
+export const applyLiveWaypointCoordinates = (surveys: Survey[], liveWaypoints: Waypoint[]): Survey[] => {
+  const coordinatesById: Record<string, WaypointCoordinates> = {}
+  liveWaypoints.forEach((wp) => (coordinatesById[wp.id] = wp.coordinates))
+  return surveys.map((survey) => ({
+    ...survey,
+    waypoints: survey.waypoints.map((wp) => ({ ...wp, coordinates: coordinatesById[wp.id] ?? wp.coordinates })),
+  }))
+}

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -699,6 +699,7 @@ import { useMapOverlays } from '@/composables/map/useMapOverlays'
 import { useMapPoiMarkers } from '@/composables/map/useMapPoiMarkers'
 import { useMapTileLayers } from '@/composables/map/useMapTileLayers'
 import { useMapTileLayerSelection } from '@/composables/map/useMapTileLayerSelection'
+import { type SurveyPreview, useSurveyArrowOverlay } from '@/composables/map/useSurveyArrowOverlay'
 import { useVertexAngleOverlay } from '@/composables/map/useVertexAngleOverlay'
 import { useSnackbar } from '@/composables/snackbar'
 import {
@@ -712,6 +713,7 @@ import { MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import { MavCmd } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import type { NoiseTileOptions } from '@/libs/map/map-tile-fallback'
 import { attachTileNoiseFallback, refreshNoiseFallbackTiles } from '@/libs/map/map-tile-fallback'
+import { applyLiveWaypointCoordinates } from '@/libs/map/survey-arrows'
 import {
   createGridOverlay,
   fitMapToWaypoints,
@@ -761,6 +763,10 @@ const widgetStore = useWidgetManagerStore()
 const missionEstimates = useMissionEstimates()
 const angleOverlay = useVertexAngleOverlay()
 const dragMeasureOverlay = useDragMeasureOverlay(angleOverlay)
+const surveyArrowOverlay = useSurveyArrowOverlay({
+  surveys: () => surveysWithLiveWaypoints.value,
+  previewPath: () => surveyPreviewPath.value,
+})
 
 const { height: windowHeight } = useWindowSize()
 
@@ -989,6 +995,10 @@ const selectedSurveyId = ref<string>('')
 const surveyPolygonLayers = ref<{ [key: string]: Polygon }>({})
 const lastSelectedSurveyId = ref('')
 const surveys = computed(() => missionStore.currentPlanningSurveys)
+
+const surveysWithLiveWaypoints = computed<Survey[]>(() =>
+  applyLiveWaypointCoordinates(surveys.value, missionStore.currentPlanningWaypoints)
+)
 const undoIsInProgress = ref(false)
 const undoWaypointInsertIndex = ref<number | null>(null)
 const undoSurveyInsertIndex = ref<number | null>(null)
@@ -2858,6 +2868,7 @@ const surveyPathLayer = shallowRef<L.Polyline | null>(null)
 const surveyCrosshatchPathLayer = shallowRef<L.Polyline | null>(null)
 const surveyTurnaroundLayers = shallowRef<L.Polyline[]>([])
 const surveyPolygonLayer = shallowRef<L.Polygon | null>(null)
+const surveyPreviewPath = shallowRef<SurveyPreview | null>(null)
 
 const removeSurveyCrosshatchPathLayer = (): void => {
   if (surveyCrosshatchPathLayer.value) {
@@ -2872,6 +2883,7 @@ const clearSurveyPathByUser = (): void => {
 }
 
 const clearSurveyPath = (): void => {
+  surveyPreviewPath.value = null
   if (surveyPathLayer.value) {
     planningMap.value?.removeLayer(surveyPathLayer.value as unknown as L.Layer)
     surveyPathLayer.value = null
@@ -2970,6 +2982,7 @@ const updatePolygon = (): void => {
 
 const checkAndRemoveSurveyPath = (): void => {
   if (surveyPolygonVertexesPositions.value.length >= 4 || !surveyPathLayer.value) return
+  surveyPreviewPath.value = null
   planningMap.value?.removeLayer(surveyPathLayer.value as unknown as L.Layer)
   surveyPathLayer.value = null
   removeSurveyCrosshatchPathLayer()
@@ -2994,6 +3007,7 @@ const createSurveyPath = (): void => {
     )
 
     if (result.path.length === 0) {
+      surveyPreviewPath.value = null
       showDialog({
         variant: 'error',
         message: 'No valid path could be generated. Try adjusting the angle or distance between lines.',
@@ -3012,6 +3026,13 @@ const createSurveyPath = (): void => {
 
     const crosshatchStart = result.crosshatchStartIndex
     const firstPassPath = crosshatchStart !== undefined ? result.path.slice(0, crosshatchStart) : result.path
+    // Include the last point of the first pass so the transit leg into the second pass is drawn.
+    const crosshatchPath = crosshatchStart !== undefined ? result.path.slice(Math.max(0, crosshatchStart - 1)) : []
+
+    surveyPreviewPath.value = {
+      firstPass: firstPassPath.map((point) => [point.lat, point.lng]),
+      crosshatch: crosshatchPath.map((point) => [point.lat, point.lng]),
+    }
 
     surveyPathLayer.value = L.polyline(firstPassPath, {
       color: '#2563EB',
@@ -3021,11 +3042,10 @@ const createSurveyPath = (): void => {
     }).addTo(toRaw(planningMap.value)!)
 
     if (crosshatchStart !== undefined) {
-      // Include the last point of the first pass so the transit leg into the second pass is drawn.
-      surveyCrosshatchPathLayer.value = L.polyline(result.path.slice(Math.max(0, crosshatchStart - 1)), {
+      surveyCrosshatchPathLayer.value = L.polyline(crosshatchPath, {
         color: '#A855F7',
-        weight: 1,
-        opacity: 0.56,
+        weight: 1.5,
+        opacity: 0.8,
         className: 'survey-path-crosshatch',
       }).addTo(toRaw(planningMap.value)!)
     }
@@ -3041,6 +3061,7 @@ const createSurveyPath = (): void => {
       )
     }
   } catch (error) {
+    surveyPreviewPath.value = null
     showDialog({
       variant: 'error',
       message: `Failed to generate survey path: ${(error as Error).message}`,
@@ -3996,6 +4017,7 @@ onMounted(async () => {
   pane.style.zIndex = '640'
   pane.style.pointerEvents = 'none'
   angleOverlay.initAngleOverlay(planningMap.value!)
+  surveyArrowOverlay.initArrowOverlay(planningMap.value!)
   dragMeasureOverlay.initDragMeasureOverlay(planningMap.value!)
   measureLayer.value = L.layerGroup().addTo(planningMap.value!) as L.LayerGroup
 
@@ -4136,6 +4158,7 @@ onUnmounted(() => {
   clearLiveMeasure()
   dragMeasureOverlay.destroyDragMeasureOverlay()
   angleOverlay.destroyAngleOverlay()
+  surveyArrowOverlay.destroyArrowOverlay()
 
   detachTileFallbacks.forEach((detach) => detach())
   detachTileFallbacks = []
@@ -4600,6 +4623,10 @@ watch(
   pointer-events: none;
 }
 .measure-angle-tag {
+  background: transparent;
+  border: none;
+}
+.survey-arrow {
   background: transparent;
   border: none;
 }


### PR DESCRIPTION
- Survey lines now show direction-of-travel arrows, so you can tell at a glance which way the vehicle flies each sweep, both while drawing a survey and on already-generated ones.
- Arrows appear only on survey transects, never on plain waypoint-to-waypoint legs.
- Crosshatch (re-fly) surveys distinguish their two passes: the primary pass in blue and the perpendicular re-fly pass in purple, with the blue lines drawn on top where the two cross.

https://github.com/user-attachments/assets/16b6ca24-c824-4bcc-bb5e-2dd8507f58ed

Closes #2826