### PR TITLE
Add support for BlueOS Cloud missions

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -103,6 +103,7 @@
   <BaseStationConfigPanel :is-mission-planning-context="route.name === 'Mission planning'" />
   <BaseStationContextPopup />
   <SnackbarContainer />
+  <BlueOsCloudMissionStartupHost />
   <FloatingWrapper v-model="devStore.showConsole" title="Console">
     <ConsoleViewer
       :disabled="!devStore.enableSystemLogging"
@@ -130,6 +131,7 @@ import { useRoute } from 'vue-router'
 import ArchitectureWarning from '@/components/ArchitectureWarning.vue'
 import BaseStationConfigPanel from '@/components/BaseStationConfigPanel.vue'
 import BaseStationContextPopup from '@/components/BaseStationContextPopup.vue'
+import BlueOsCloudMissionStartupHost from '@/components/blueos-cloud/BlueOsCloudMissionStartupHost.vue'
 import CameraReplacementDialog from '@/components/CameraReplacementDialog.vue'
 import ConsoleViewer from '@/components/ConsoleViewer.vue'
 import DataPrivacyModal from '@/components/DataPrivacyModal.vue'

--- a/src/components/blueos-cloud/BlueOsCloudLocationPicker.vue
+++ b/src/components/blueos-cloud/BlueOsCloudLocationPicker.vue
@@ -1,0 +1,265 @@
+<template>
+  <div class="flex flex-col gap-2">
+    <div class="flex items-center justify-between">
+      <span class="text-subtitle-2 font-weight-bold">Mission location</span>
+      <div class="flex gap-1">
+        <v-btn
+          v-if="hasVehiclePosition"
+          variant="text"
+          size="x-small"
+          prepend-icon="mdi-crosshairs-gps"
+          @click="centerOnVehicle"
+        >
+          Vehicle
+        </v-btn>
+        <v-btn
+          variant="text"
+          size="x-small"
+          prepend-icon="mdi-map-marker"
+          :disabled="!coordinates"
+          @click="clearLocation"
+        >
+          Clear
+        </v-btn>
+      </div>
+    </div>
+    <div class="w-full h-[200px] rounded-lg overflow-hidden border border-[#FFFFFF1F] relative">
+      <div ref="mapContainer" class="absolute inset-0" />
+    </div>
+    <div class="grid grid-cols-2 gap-3 pt-2">
+      <v-text-field
+        :model-value="latitudeInput"
+        label="Latitude"
+        type="number"
+        step="0.000001"
+        variant="outlined"
+        density="compact"
+        theme="dark"
+        hide-details
+        @update:model-value="onLatitudeInput"
+      />
+      <v-text-field
+        :model-value="longitudeInput"
+        label="Longitude"
+        type="number"
+        step="0.000001"
+        variant="outlined"
+        density="compact"
+        theme="dark"
+        hide-details
+        @update:model-value="onLongitudeInput"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import 'leaflet/dist/leaflet.css'
+
+import * as L from 'leaflet'
+import markerIcon from 'leaflet/dist/images/marker-icon.png'
+import markerIcon2x from 'leaflet/dist/images/marker-icon-2x.png'
+import markerShadow from 'leaflet/dist/images/marker-shadow.png'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+
+import { useMapTileLayers } from '@/composables/map/useMapTileLayers'
+import { useMainVehicleStore } from '@/stores/mainVehicle'
+import { useMissionStore } from '@/stores/mission'
+import { WaypointCoordinates } from '@/types/mission'
+
+const leafletDefaultIcon = L.icon({
+  iconUrl: markerIcon,
+  iconRetinaUrl: markerIcon2x,
+  shadowUrl: markerShadow,
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+  tooltipAnchor: [16, -28],
+  shadowSize: [41, 41],
+})
+
+const props = defineProps<{
+  /**
+   * Currently selected coordinates (`null` while the user has not picked anything yet).
+   */
+  modelValue: WaypointCoordinates | null
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: WaypointCoordinates | null): void
+}>()
+
+const missionStore = useMissionStore()
+const vehicleStore = useMainVehicleStore()
+
+const mapContainer = ref<HTMLDivElement | null>(null)
+let map: L.Map | null = null
+let baseLayer: L.TileLayer | null = null
+let centerMarker: L.Marker | null = null
+
+const hasVehiclePosition = computed(() => !!vehicleStore.coordinates.latitude && !!vehicleStore.coordinates.longitude)
+const latitudeInput = ref('')
+const longitudeInput = ref('')
+
+// Typing a coordinate pans the map, whose `moveend` reports the new center back: echoing that into the field being
+// typed in would rewrite it with a six-decimal value, so only that field is held back while its handler runs.
+let fieldBeingEdited: 'latitude' | 'longitude' | null = null
+
+const formatCoord = (value: number): string => value.toFixed(6)
+
+const updateInputs = (coords: WaypointCoordinates | null): void => {
+  if (fieldBeingEdited !== 'latitude') latitudeInput.value = coords ? formatCoord(coords[0]) : ''
+  if (fieldBeingEdited !== 'longitude') longitudeInput.value = coords ? formatCoord(coords[1]) : ''
+}
+
+const coordinates = ref<WaypointCoordinates | null>(props.modelValue)
+
+const setCoordinates = (
+  coords: WaypointCoordinates | null,
+  options: {
+    /**
+     * Whether to recenter the map on the new coordinates.
+     */
+    panMap?: boolean
+  } = {}
+): void => {
+  coordinates.value = coords
+  updateInputs(coords)
+  emit('update:modelValue', coords)
+  if (options.panMap && coords && map) {
+    map.setView(coords as L.LatLngTuple, map.getZoom(), { animate: false })
+  }
+}
+
+// A half-typed or emptied field is not a request to drop the location, or backspacing the latitude would throw the
+// longitude away too. Clearing the location is what the Clear button is for.
+const onLatitudeInput = (raw: string | number): void => {
+  fieldBeingEdited = 'latitude'
+  latitudeInput.value = String(raw)
+  const lat = typeof raw === 'number' ? raw : parseFloat(raw)
+  if (Number.isFinite(lat)) {
+    const lng = coordinates.value?.[1] ?? map?.getCenter().lng ?? 0
+    setCoordinates([lat, lng], { panMap: true })
+  }
+  fieldBeingEdited = null
+}
+
+const onLongitudeInput = (raw: string | number): void => {
+  fieldBeingEdited = 'longitude'
+  longitudeInput.value = String(raw)
+  const lng = typeof raw === 'number' ? raw : parseFloat(raw)
+  if (Number.isFinite(lng)) {
+    const lat = coordinates.value?.[0] ?? map?.getCenter().lat ?? 0
+    setCoordinates([lat, lng], { panMap: true })
+  }
+  fieldBeingEdited = null
+}
+
+const clearLocation = (): void => {
+  logUserAction('Cleared the BlueOS Cloud mission location')
+  setCoordinates(null)
+}
+
+const centerOnVehicle = (): void => {
+  if (!vehicleStore.coordinates.latitude || !vehicleStore.coordinates.longitude) return
+  logUserAction('Centered the BlueOS Cloud mission location on the vehicle')
+  setCoordinates([vehicleStore.coordinates.latitude, vehicleStore.coordinates.longitude], { panMap: true })
+}
+
+const initialCenter = (): {
+  /**
+   * Coordinates the map should open centered on.
+   */
+  center: WaypointCoordinates
+  /**
+   * Initial zoom level for the map.
+   */
+  zoom: number
+  /**
+   * Whether `center` should also be emitted as the selected value.
+   */
+  useAsValue: boolean
+} => {
+  if (props.modelValue) {
+    return { center: props.modelValue, zoom: missionStore.userLastMapZoom || 15, useAsValue: true }
+  }
+  if (vehicleStore.coordinates.latitude && vehicleStore.coordinates.longitude) {
+    return {
+      center: [vehicleStore.coordinates.latitude, vehicleStore.coordinates.longitude],
+      zoom: missionStore.userLastMapZoom || 15,
+      useAsValue: true,
+    }
+  }
+  return {
+    center: missionStore.userLastMapCenter,
+    zoom: missionStore.userLastMapZoom,
+    useAsValue: false,
+  }
+}
+
+onMounted(() => {
+  if (!mapContainer.value) return
+
+  const start = initialCenter()
+  // Shared tile layers, so the picker serves the tiles the user already cached for the other map surfaces.
+  baseLayer = useMapTileLayers().baseMaps[missionStore.userLastMapTileProvider]
+  map = L.map(mapContainer.value, {
+    center: start.center as L.LatLngTuple,
+    zoom: start.zoom,
+    zoomControl: false,
+    attributionControl: false,
+    layers: [baseLayer],
+  })
+
+  centerMarker = L.marker(map.getCenter(), {
+    icon: leafletDefaultIcon,
+    interactive: false,
+    keyboard: false,
+  }).addTo(map)
+  map.on('move', () => {
+    if (!map || !centerMarker) return
+    centerMarker.setLatLng(map.getCenter())
+  })
+  map.on('moveend', () => {
+    if (!map) return
+    const { lat, lng } = map.getCenter()
+    setCoordinates([lat, lng])
+  })
+
+  if (start.useAsValue) {
+    setCoordinates(start.center)
+  } else {
+    updateInputs(props.modelValue)
+  }
+
+  setTimeout(() => map?.invalidateSize(), 50)
+})
+
+onBeforeUnmount(() => {
+  centerMarker = null
+  baseLayer = null
+  map?.remove()
+  map = null
+})
+
+watch(
+  () => props.modelValue,
+  (incoming) => {
+    if (!incoming) {
+      coordinates.value = null
+      updateInputs(null)
+      return
+    }
+    if (
+      coordinates.value &&
+      Math.abs(coordinates.value[0] - incoming[0]) < 1e-7 &&
+      Math.abs(coordinates.value[1] - incoming[1]) < 1e-7
+    ) {
+      return
+    }
+    coordinates.value = incoming
+    updateInputs(incoming)
+    if (map) map.setView(incoming as L.LatLngTuple, map.getZoom(), { animate: false })
+  }
+)
+</script>

--- a/src/components/blueos-cloud/BlueOsCloudMissionDecisionOptions.vue
+++ b/src/components/blueos-cloud/BlueOsCloudMissionDecisionOptions.vue
@@ -1,0 +1,85 @@
+<template>
+  <div class="flex flex-col gap-3 w-full">
+    <v-btn v-if="previousMission" variant="flat" class="bg-[#FFFFFF22] h-auto py-3" @click="onContinuePrevious">
+      <div class="flex flex-col items-start gap-1 w-full text-left normal-case">
+        <div class="flex items-center gap-2">
+          <v-icon size="20">mdi-history</v-icon>
+          <span class="font-medium">Continue previous mission</span>
+        </div>
+        <span class="text-caption opacity-80 font-normal whitespace-normal">
+          {{ previousMissionSummary }}
+        </span>
+      </div>
+    </v-btn>
+
+    <v-btn variant="flat" class="bg-[#FFFFFF22]" prepend-icon="mdi-folder-open-outline" @click="onSelectExisting">
+      Select existing mission
+    </v-btn>
+
+    <v-btn variant="flat" class="bg-[#FFFFFF22]" prepend-icon="mdi-plus" @click="onCreateNew">
+      Create a new mission
+    </v-btn>
+
+    <v-btn v-if="showSkip" variant="text" class="mt-1" @click="onSkip"> Continue without a mission </v-btn>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import type { BlueOsCloudMission } from '@/libs/blueos-cloud/types'
+
+const props = withDefaults(
+  defineProps<{
+    /**
+     * Last linked cloud mission, when one is available to continue.
+     */
+    previousMission?: BlueOsCloudMission | null
+    /**
+     * Whether to show the "continue without a mission" action (startup dialog).
+     */
+    showSkip?: boolean
+  }>(),
+  { previousMission: null, showSkip: false }
+)
+
+const emit = defineEmits<{
+  (e: 'continue-previous'): void
+  (e: 'select-existing'): void
+  (e: 'create-new'): void
+  (e: 'skip'): void
+}>()
+
+const previousMissionSummary = computed(() => {
+  const mission = props.previousMission
+  if (!mission) return ''
+  const parts = [mission.title?.trim() || 'Untitled mission']
+  if (mission.description?.trim()) parts.push(mission.description.trim())
+  if (mission.start_latitude && mission.start_longitude) {
+    const lat = parseFloat(mission.start_latitude)
+    const lng = parseFloat(mission.start_longitude)
+    if (Number.isFinite(lat) && Number.isFinite(lng)) parts.push(`${lat.toFixed(4)}, ${lng.toFixed(4)}`)
+  }
+  return parts.join(' · ')
+})
+
+const onContinuePrevious = (): void => {
+  logUserAction('Chose to continue the previous BlueOS Cloud mission')
+  emit('continue-previous')
+}
+
+const onSelectExisting = (): void => {
+  logUserAction('Chose to select an existing BlueOS Cloud mission')
+  emit('select-existing')
+}
+
+const onCreateNew = (): void => {
+  logUserAction('Chose to create a new BlueOS Cloud mission')
+  emit('create-new')
+}
+
+const onSkip = (): void => {
+  logUserAction('Chose to continue without a BlueOS Cloud mission')
+  emit('skip')
+}
+</script>

--- a/src/components/blueos-cloud/BlueOsCloudMissionForm.vue
+++ b/src/components/blueos-cloud/BlueOsCloudMissionForm.vue
@@ -65,27 +65,10 @@
 import { ref, watch } from 'vue'
 
 import BlueOsCloudLocationPicker from '@/components/blueos-cloud/BlueOsCloudLocationPicker.vue'
+import type { MissionFormSubmitPayload } from '@/composables/blueos-cloud/useBlueOsCloudMission'
 import { generateAutomaticMissionName } from '@/libs/mission/automatic-name'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import type { WaypointCoordinates } from '@/types/mission'
-
-/**
- * Payload emitted when the user submits the create/edit mission form.
- */
-type MissionFormSubmitPayload = {
-  /**
-   * Mission title.
-   */
-  name: string
-  /**
-   * Mission description.
-   */
-  description: string
-  /**
-   * Mission start location, or `null` when unset.
-   */
-  location: WaypointCoordinates | null
-}
 
 const props = withDefaults(
   defineProps<{

--- a/src/components/blueos-cloud/BlueOsCloudMissionForm.vue
+++ b/src/components/blueos-cloud/BlueOsCloudMissionForm.vue
@@ -1,0 +1,154 @@
+<template>
+  <v-dialog
+    :model-value="modelValue"
+    width="560"
+    persistent
+    @update:model-value="(value) => emit('update:modelValue', value)"
+  >
+    <v-card class="relative text-white rounded-lg" :style="interfaceStore.globalGlassMenuStyles">
+      <v-card-title class="text-h6 font-weight-bold py-4 text-center">
+        {{ mode === 'edit' ? 'Edit mission' : 'Create a new mission' }}
+      </v-card-title>
+      <v-btn icon variant="text" size="small" aria-label="Close" class="absolute top-4 right-4" @click="close">
+        <v-icon size="22">mdi-close</v-icon>
+      </v-btn>
+      <v-card-text class="px-8 flex flex-col gap-4">
+        <div>
+          <p class="text-subtitle-2 font-weight-bold mb-1">Mission name</p>
+          <v-text-field
+            v-model="name"
+            placeholder="Mission name"
+            variant="outlined"
+            density="compact"
+            theme="dark"
+            hide-details
+          />
+          <div class="flex justify-end mt-1">
+            <v-btn variant="text" size="small" class="px-0 text-white" @click="generateName">Generate name</v-btn>
+          </div>
+        </div>
+        <div>
+          <p class="text-subtitle-2 font-weight-bold mb-1">Description</p>
+          <v-textarea
+            v-model="description"
+            placeholder="Optional description"
+            variant="outlined"
+            density="compact"
+            theme="dark"
+            rows="2"
+            auto-grow
+            hide-details
+          />
+        </div>
+        <BlueOsCloudLocationPicker v-model="location" />
+      </v-card-text>
+      <v-divider class="mx-10" />
+      <v-card-actions>
+        <div class="flex justify-between items-center pa-2 w-full h-full">
+          <v-btn variant="text" @click="close">Cancel</v-btn>
+          <v-btn
+            variant="flat"
+            theme="dark"
+            class="bg-[#FFFFFF33] text-white disabled:opacity-40"
+            :disabled="!name.trim()"
+            @click="submit"
+          >
+            {{ mode === 'edit' ? 'Save changes' : 'Create mission' }}
+          </v-btn>
+        </div>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+
+import BlueOsCloudLocationPicker from '@/components/blueos-cloud/BlueOsCloudLocationPicker.vue'
+import { generateAutomaticMissionName } from '@/libs/mission/automatic-name'
+import { useAppInterfaceStore } from '@/stores/appInterface'
+import type { WaypointCoordinates } from '@/types/mission'
+
+/**
+ * Payload emitted when the user submits the create/edit mission form.
+ */
+type MissionFormSubmitPayload = {
+  /**
+   * Mission title.
+   */
+  name: string
+  /**
+   * Mission description.
+   */
+  description: string
+  /**
+   * Mission start location, or `null` when unset.
+   */
+  location: WaypointCoordinates | null
+}
+
+const props = withDefaults(
+  defineProps<{
+    /**
+     * Controls dialog visibility.
+     */
+    modelValue: boolean
+    /**
+     * Whether the form creates a new mission or edits an existing one.
+     */
+    mode?: 'create' | 'edit'
+    /**
+     * Mission name to prefill (used in edit mode).
+     */
+    initialName?: string
+    /**
+     * Mission description to prefill (used in edit mode).
+     */
+    initialDescription?: string
+    /**
+     * Mission start location to prefill (used in edit mode).
+     */
+    initialLocation?: WaypointCoordinates | null
+  }>(),
+  { mode: 'create', initialName: '', initialDescription: '', initialLocation: null }
+)
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void
+  (e: 'submit', payload: MissionFormSubmitPayload): void
+}>()
+
+const interfaceStore = useAppInterfaceStore()
+
+const name = ref('')
+const description = ref('')
+const location = ref<WaypointCoordinates | null>(null)
+
+watch(
+  () => props.modelValue,
+  (visible) => {
+    if (!visible) return
+    name.value = props.initialName
+    description.value = props.initialDescription
+    location.value = props.initialLocation
+  },
+  { immediate: true }
+)
+
+const generateName = (): void => {
+  logUserAction(`Generated a mission name in the ${props.mode} form`)
+  name.value = generateAutomaticMissionName()
+}
+
+const close = (): void => {
+  logUserAction(`Closed the mission ${props.mode} form without saving`)
+  emit('update:modelValue', false)
+}
+
+const submit = (): void => {
+  const trimmedName = name.value.trim()
+  if (!trimmedName) return
+  emit('submit', { name: trimmedName, description: description.value.trim(), location: location.value })
+  emit('update:modelValue', false)
+}
+</script>

--- a/src/components/blueos-cloud/BlueOsCloudMissionPicker.vue
+++ b/src/components/blueos-cloud/BlueOsCloudMissionPicker.vue
@@ -1,0 +1,243 @@
+<template>
+  <v-dialog
+    :model-value="modelValue"
+    width="560"
+    persistent
+    @update:model-value="(value) => emit('update:modelValue', value)"
+  >
+    <v-card class="relative text-white rounded-lg" :style="interfaceStore.globalGlassMenuStyles">
+      <v-card-title class="text-h6 font-weight-bold py-4 text-center">{{ title }}</v-card-title>
+      <v-btn icon variant="text" size="small" aria-label="Close" class="absolute top-4 right-4" @click="closeDialog">
+        <v-icon size="22">mdi-close</v-icon>
+      </v-btn>
+      <v-card-text class="px-8 flex flex-col gap-3">
+        <p v-if="description" class="text-body-2 opacity-90 ma-0">{{ description }}</p>
+
+        <div class="flex items-center gap-2">
+          <v-text-field
+            v-model="searchQuery"
+            placeholder="Search by name, description, date or location"
+            prepend-inner-icon="mdi-magnify"
+            variant="outlined"
+            density="compact"
+            theme="dark"
+            hide-details
+            clearable
+            class="flex-1"
+          />
+          <v-select
+            v-model="sortKey"
+            :items="sortOptions"
+            variant="outlined"
+            density="compact"
+            theme="dark"
+            hide-details
+            class="w-[160px]"
+            @update:model-value="onSortChange"
+          />
+          <v-btn icon variant="text" size="small" aria-label="Refresh the mission list" @click="onRefreshRequested">
+            <v-tooltip activator="parent" location="top" open-delay="300">Refresh the mission list</v-tooltip>
+            <v-icon size="20">mdi-refresh</v-icon>
+          </v-btn>
+        </div>
+
+        <div v-if="cloudStore.isLoadingMissions" class="flex justify-center py-6">
+          <v-progress-circular indeterminate color="white" />
+        </div>
+        <div v-else>
+          <div v-if="visibleMissions.length === 0" class="flex flex-col items-center gap-2 py-6 opacity-70">
+            <v-icon size="28">{{ cloudStore.missions.length === 0 ? 'mdi-cloud-off-outline' : 'mdi-magnify' }}</v-icon>
+            <span class="text-body-2">{{ emptyListMessage }}</span>
+          </div>
+          <div v-else class="max-h-[40vh] overflow-y-auto pr-1">
+            <template v-if="pinnedMission">
+              <div
+                :key="pinnedMission.id"
+                class="w-full flex items-center gap-2 px-3 py-2 rounded mb-1 transition-colors cursor-pointer border"
+                :class="getMissionRowClasses(pinnedMission.id)"
+                @click="chooseMission(pinnedMission)"
+              >
+                <div class="flex-1 min-w-0">
+                  <div class="font-medium truncate flex items-center gap-2">
+                    {{ pinnedMission.title || 'Untitled mission' }}
+                    <span
+                      class="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-sky-400/20 text-sky-200 border border-sky-300/40"
+                    >
+                      Active
+                    </span>
+                  </div>
+                  <div class="text-xs opacity-70 truncate">
+                    {{ formatMissionMeta(pinnedMission) }}
+                  </div>
+                </div>
+                <a
+                  :href="buildBlueOsCloudMissionUrl(pinnedMission.id)"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="opacity-70 hover:opacity-100"
+                  @click.stop
+                >
+                  <v-tooltip activator="parent" location="top" open-delay="300">View on BlueOS Cloud</v-tooltip>
+                  <v-icon size="16">mdi-open-in-new</v-icon>
+                </a>
+              </div>
+              <div v-if="otherMissions.length > 0" class="flex items-center gap-2 my-2 px-1 opacity-60">
+                <v-divider class="flex-1 opacity-40" />
+                <span class="text-[10px] uppercase tracking-wider">Other missions</span>
+                <v-divider class="flex-1 opacity-40" />
+              </div>
+            </template>
+            <div
+              v-for="mission in otherMissions"
+              :key="mission.id"
+              class="w-full flex items-center gap-2 px-3 py-2 rounded mb-1 transition-colors cursor-pointer border"
+              :class="getMissionRowClasses(mission.id)"
+              @click="chooseMission(mission)"
+            >
+              <div class="flex-1 min-w-0">
+                <div class="font-medium truncate">{{ mission.title || 'Untitled mission' }}</div>
+                <div class="text-xs opacity-70 truncate">
+                  {{ formatMissionMeta(mission) }}
+                </div>
+              </div>
+              <a
+                :href="buildBlueOsCloudMissionUrl(mission.id)"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="opacity-70 hover:opacity-100"
+                @click.stop
+              >
+                <v-tooltip activator="parent" location="top" open-delay="300">View on BlueOS Cloud</v-tooltip>
+                <v-icon size="16">mdi-open-in-new</v-icon>
+              </a>
+            </div>
+          </div>
+        </div>
+
+        <p v-if="cloudStore.lastError" class="text-body-2 text-red-300 ma-0">{{ cloudStore.lastError }}</p>
+      </v-card-text>
+      <v-divider class="mx-10" />
+      <v-card-actions>
+        <div class="flex justify-between items-center pa-2 w-full h-full">
+          <v-spacer />
+          <v-btn variant="text" @click="closeDialog">Cancel</v-btn>
+        </div>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+
+import { useSnackbar } from '@/composables/snackbar'
+import { buildBlueOsCloudMissionUrl } from '@/libs/blueos-cloud/api'
+import { type MissionSortKey, filterAndSortMissions, formatMissionMeta } from '@/libs/blueos-cloud/mission-list'
+import { BlueOsCloudMission } from '@/libs/blueos-cloud/types'
+import { useAppInterfaceStore } from '@/stores/appInterface'
+import { useBlueOsCloudStore } from '@/stores/blueOsCloud'
+
+const props = withDefaults(
+  defineProps<{
+    /**
+     * Controls dialog visibility.
+     */
+    modelValue: boolean
+    /**
+     * Dialog title shown in the header.
+     */
+    title?: string
+    /**
+     * Optional description displayed above the mission list.
+     */
+    description?: string
+  }>(),
+  {
+    title: 'Select a BlueOS Cloud mission',
+    description: '',
+  }
+)
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void
+  (e: 'selected', mission: BlueOsCloudMission): void
+}>()
+
+const interfaceStore = useAppInterfaceStore()
+const cloudStore = useBlueOsCloudStore()
+const { openSnackbar } = useSnackbar()
+
+const sortOptions = [
+  { title: 'Newest first', value: 'newest' },
+  { title: 'Oldest first', value: 'oldest' },
+  { title: 'Name (A-Z)', value: 'name' },
+]
+
+// Vuetify's clearable button writes `null` back into the model, so the query is nullable on purpose.
+const searchQuery = ref<string | null>('')
+const sortKey = ref<MissionSortKey>('newest')
+
+const visibleMissions = computed(() =>
+  filterAndSortMissions(cloudStore.missions, searchQuery.value ?? '', sortKey.value)
+)
+
+const pinnedMission = computed(
+  () => visibleMissions.value.find((mission) => mission.id === cloudStore.linkedMissionId) ?? null
+)
+
+const otherMissions = computed(() =>
+  visibleMissions.value.filter((mission) => mission.id !== cloudStore.linkedMissionId)
+)
+
+const emptyListMessage = computed(() =>
+  cloudStore.missions.length === 0 ? 'No missions yet on your BlueOS Cloud account.' : 'No missions match your search.'
+)
+
+const onSortChange = (value: MissionSortKey): void => {
+  logUserAction(`Sorted the BlueOS Cloud mission list by '${value}'`)
+}
+
+const getMissionRowClasses = (missionId: string): string => {
+  const isActive = cloudStore.linkedMissionId === missionId
+  if (isActive) return 'bg-sky-500/10 border-sky-300/40 hover:bg-sky-500/15'
+  return 'bg-[#FFFFFF11] border-transparent hover:bg-[#FFFFFF1A]'
+}
+
+const loadMissions = async (): Promise<void> => {
+  try {
+    await cloudStore.refreshMissions()
+  } catch (error) {
+    openSnackbar({
+      message: `Failed to load BlueOS Cloud missions: ${(error as Error).message}`,
+      variant: 'error',
+      duration: 4000,
+      closeButton: true,
+    })
+  }
+}
+
+const onRefreshRequested = (): void => {
+  logUserAction('Refreshed the BlueOS Cloud mission list')
+  void loadMissions()
+}
+
+const chooseMission = (mission: BlueOsCloudMission): void => {
+  logUserAction(`Selected BlueOS Cloud mission '${mission.title}'`)
+  emit('selected', mission)
+  emit('update:modelValue', false)
+}
+
+const closeDialog = (): void => {
+  logUserAction('Closed the BlueOS Cloud mission picker without selecting')
+  emit('update:modelValue', false)
+}
+
+watch(
+  () => props.modelValue,
+  async (visible) => {
+    if (!visible) return
+    if (cloudStore.isAuthenticated) await loadMissions()
+  },
+  { immediate: true }
+)
+</script>

--- a/src/components/blueos-cloud/BlueOsCloudMissionStartupDialog.vue
+++ b/src/components/blueos-cloud/BlueOsCloudMissionStartupDialog.vue
@@ -1,0 +1,50 @@
+<template>
+  <v-dialog :model-value="modelValue" width="560" persistent>
+    <v-card class="relative text-white rounded-lg" :style="interfaceStore.globalGlassMenuStyles">
+      <v-card-title class="text-h6 font-weight-bold py-4 text-center">BlueOS Cloud mission</v-card-title>
+      <v-btn icon variant="text" size="small" aria-label="Close" class="absolute top-4 right-4" @click="emit('close')">
+        <v-icon size="22">mdi-close</v-icon>
+      </v-btn>
+      <v-card-text class="px-8 pb-6 flex flex-col gap-4">
+        <p class="text-sm opacity-80 text-center ma-0">
+          Choose how you want to work with BlueOS Cloud missions for this session.
+        </p>
+        <BlueOsCloudMissionDecisionOptions
+          :previous-mission="previousMission"
+          show-skip
+          @continue-previous="emit('continue-previous')"
+          @select-existing="emit('select-existing')"
+          @create-new="emit('create-new')"
+          @skip="emit('skip')"
+        />
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+import BlueOsCloudMissionDecisionOptions from '@/components/blueos-cloud/BlueOsCloudMissionDecisionOptions.vue'
+import type { BlueOsCloudMission } from '@/libs/blueos-cloud/types'
+import { useAppInterfaceStore } from '@/stores/appInterface'
+
+defineProps<{
+  /**
+   * Controls dialog visibility.
+   */
+  modelValue: boolean
+  /**
+   * Last linked cloud mission, when one is available to continue.
+   */
+  previousMission: BlueOsCloudMission | null
+}>()
+
+const emit = defineEmits<{
+  (e: 'continue-previous'): void
+  (e: 'select-existing'): void
+  (e: 'create-new'): void
+  (e: 'skip'): void
+  (e: 'close'): void
+}>()
+
+const interfaceStore = useAppInterfaceStore()
+</script>

--- a/src/components/blueos-cloud/BlueOsCloudMissionStartupHost.vue
+++ b/src/components/blueos-cloud/BlueOsCloudMissionStartupHost.vue
@@ -1,0 +1,39 @@
+<template>
+  <BlueOsCloudMissionStartupDialog
+    :model-value="showDecisionDialog"
+    :previous-mission="previousMission"
+    @continue-previous="continuePreviousMission"
+    @select-existing="openMissionPicker"
+    @create-new="openCreateMissionForm"
+    @skip="skipMission"
+    @close="dismissDecisionDialog"
+  />
+  <BlueOsCloudMissionPicker
+    v-model="showMissionPicker"
+    title="Select a BlueOS Cloud mission"
+    description="Pick a mission to continue logging to."
+    @selected="onMissionSelected"
+  />
+  <BlueOsCloudMissionForm v-model="showMissionForm" mode="create" @submit="onMissionFormSubmit" />
+</template>
+
+<script setup lang="ts">
+import BlueOsCloudMissionForm from '@/components/blueos-cloud/BlueOsCloudMissionForm.vue'
+import BlueOsCloudMissionPicker from '@/components/blueos-cloud/BlueOsCloudMissionPicker.vue'
+import BlueOsCloudMissionStartupDialog from '@/components/blueos-cloud/BlueOsCloudMissionStartupDialog.vue'
+import { useBlueOsCloudMissionStartupDialog } from '@/composables/blueos-cloud/useBlueOsCloudMissionStartupDialog'
+
+const {
+  showDecisionDialog,
+  showMissionPicker,
+  showMissionForm,
+  previousMission,
+  continuePreviousMission,
+  openMissionPicker,
+  openCreateMissionForm,
+  skipMission,
+  dismissDecisionDialog,
+  onMissionSelected,
+  onMissionFormSubmit,
+} = useBlueOsCloudMissionStartupDialog()
+</script>

--- a/src/components/mini-widgets/MissionIdentifier.vue
+++ b/src/components/mini-widgets/MissionIdentifier.vue
@@ -21,24 +21,19 @@
     <v-dialog v-model="configMenuOpen" max-width="624px">
       <v-card class="rounded-lg relative" :style="interfaceStore.globalGlassMenuStyles">
         <v-card-title class="text-h6 font-weight-bold py-4 text-center">Mission configuration</v-card-title>
-        <v-btn icon variant="text" size="small" class="absolute top-4 right-4" @click="cancel">
+        <v-btn icon variant="text" size="small" aria-label="Close" class="absolute top-4 right-4" @click="cancel">
           <v-icon size="22">mdi-close</v-icon>
         </v-btn>
         <v-card-text class="px-8">
-          <template v-if="cloudActive">
-            <!-- No mission associated with this cycle yet: choose to select an existing one or create a new one. -->
-            <div v-if="!hasMissionThisCycle" class="flex justify-center gap-4 py-6">
-              <v-btn
-                variant="flat"
-                class="bg-[#FFFFFF22]"
-                prepend-icon="mdi-folder-open-outline"
-                @click="openExistingMissionPicker"
-              >
-                Select existing mission
-              </v-btn>
-              <v-btn variant="flat" class="bg-[#FFFFFF22]" prepend-icon="mdi-plus" @click="openCreateMissionForm">
-                Create a new mission
-              </v-btn>
+          <template v-if="isCloudActive">
+            <!-- No mission associated with this cycle yet: choose continue / select / create. -->
+            <div v-if="!hasMissionThisCycle" class="py-2">
+              <BlueOsCloudMissionDecisionOptions
+                :previous-mission="previousCloudMission"
+                @continue-previous="continuePreviousMission"
+                @select-existing="openExistingMissionPicker"
+                @create-new="openCreateMissionForm"
+              />
             </div>
 
             <!-- A mission is associated: show its details (read-only) and its cloud sync status. -->
@@ -50,14 +45,18 @@
                     {{ linkedCloudMission?.title || 'Untitled mission' }}
                   </p>
                 </div>
-                <v-btn variant="text" size="small" class="text-white" @click="openEditMissionForm">Edit mission</v-btn>
-              </div>
-              <div class="flex items-center gap-4">
-                <div class="flex-1 min-w-0">
-                  <p class="text-caption opacity-70 mb-1">Description</p>
-                  <p class="text-body-2 ma-0">{{ linkedCloudMission?.description || 'Not set' }}</p>
+                <div class="flex items-center gap-1 shrink-0">
+                  <v-btn variant="text" size="small" class="text-white" @click="openEditMissionForm"
+                    >Edit mission</v-btn
+                  >
+                  <v-btn variant="text" size="small" class="text-white" @click="finishCloudMission">
+                    Reset mission
+                  </v-btn>
                 </div>
-                <v-btn variant="text" size="small" class="text-white" @click="finishCloudMission">Reset mission</v-btn>
+              </div>
+              <div class="min-w-0">
+                <p class="text-caption opacity-70 mb-1">Description</p>
+                <p class="text-body-2 ma-0">{{ linkedCloudMission?.description || 'Not set' }}</p>
               </div>
               <div class="flex items-center gap-4">
                 <div class="flex-1 min-w-0">
@@ -119,11 +118,7 @@
         <v-divider class="mt-2 mx-10" />
         <v-card-actions>
           <div class="flex justify-between items-center pa-2 w-full h-full">
-            <template v-if="cloudActive && hasMissionThisCycle">
-              <v-spacer />
-              <v-btn variant="text" @click="cancel">Cancel</v-btn>
-            </template>
-            <template v-else-if="cloudActive">
+            <template v-if="isCloudActive">
               <v-spacer />
               <v-btn variant="text" @click="cancel">Close</v-btn>
             </template>
@@ -148,14 +143,14 @@
       v-model="showExistingMissionPicker"
       title="Select a BlueOS Cloud mission"
       description="Pick a mission to continue logging to."
-      @selected="onExistingMissionSelected"
+      @selected="selectExistingMission"
     />
     <BlueOsCloudMissionForm
       v-model="showMissionForm"
-      :mode="missionFormMode"
-      :initial-name="missionFormInitialName"
-      :initial-description="missionFormInitialDescription"
-      :initial-location="missionFormInitialLocation"
+      :mode="missionForm.mode"
+      :initial-name="missionForm.name"
+      :initial-description="missionForm.description"
+      :initial-location="missionForm.location"
       @submit="onMissionFormSubmit"
     />
   </teleport>
@@ -164,12 +159,12 @@
 <script setup lang="ts">
 import { computed, ref, toRefs, watch } from 'vue'
 
+import BlueOsCloudMissionDecisionOptions from '@/components/blueos-cloud/BlueOsCloudMissionDecisionOptions.vue'
 import BlueOsCloudMissionForm from '@/components/blueos-cloud/BlueOsCloudMissionForm.vue'
 import BlueOsCloudMissionPicker from '@/components/blueos-cloud/BlueOsCloudMissionPicker.vue'
+import { type MissionFormSubmitPayload, useBlueOsCloudMission } from '@/composables/blueos-cloud/useBlueOsCloudMission'
 import { useInteractionDialog } from '@/composables/interactionDialog'
-import { useSnackbar } from '@/composables/snackbar'
 import { buildBlueOsCloudMissionUrl } from '@/libs/blueos-cloud/api'
-import { BlueOsCloudMission } from '@/libs/blueos-cloud/types'
 import { generateAutomaticMissionName } from '@/libs/mission/automatic-name'
 import { SubMenuComponentName, SubMenuName, useAppInterfaceStore } from '@/stores/appInterface'
 import { useBlueOsCloudStore } from '@/stores/blueOsCloud'
@@ -194,7 +189,16 @@ const widgetStore = useWidgetManagerStore()
 const interfaceStore = useAppInterfaceStore()
 const cloudStore = useBlueOsCloudStore()
 const { showDialog, closeDialog } = useInteractionDialog()
-const { openSnackbar } = useSnackbar()
+const {
+  isCloudActive,
+  hasMissionThisCycle,
+  previousMission: previousCloudMission,
+  ensureLinkedMissionLoaded,
+  continuePreviousMission,
+  selectExistingMission,
+  createMission,
+  editLinkedMission,
+} = useBlueOsCloudMission()
 
 const configMenuOpen = computed({
   get: () => widgetStore.miniWidgetManagerVars(miniWidget.value.hash).configMenuOpen,
@@ -206,20 +210,26 @@ const stagedIsAutomatic = ref(true)
 const isHovered = ref(false)
 const showExistingMissionPicker = ref(false)
 const showMissionForm = ref(false)
-const missionFormMode = ref<'create' | 'edit'>('create')
-const missionFormInitialName = ref('')
-const missionFormInitialDescription = ref('')
-const missionFormInitialLocation = ref<WaypointCoordinates | null>(null)
 
-// BlueOS Cloud missions are an advanced feature, gated behind pirate mode like the Cloud settings menu.
-const cloudActive = computed(() => interfaceStore.pirateMode && cloudStore.isAuthenticated)
-
-// Stamp that ties a cloud mission link to the current mission cycle (renewed after 6h idle / a new day).
-const currentCycleId = computed(() => new Date(store.missionStartTime).getTime())
-
-const hasMissionThisCycle = computed(
-  () => !!cloudStore.linkedMissionId && cloudStore.linkedMissionCycleId === currentCycleId.value
-)
+// Grouped so opening the form in either mode always sets every field it prefills.
+const missionForm = ref<{
+  /**
+   * Whether the form creates a new mission or edits the linked one.
+   */
+  mode: 'create' | 'edit'
+  /**
+   * Mission name to prefill.
+   */
+  name: string
+  /**
+   * Mission description to prefill.
+   */
+  description: string
+  /**
+   * Mission start location to prefill.
+   */
+  location: WaypointCoordinates | null
+}>({ mode: 'create', name: '', description: '', location: null })
 
 const linkedCloudMission = computed(() => cloudStore.linkedMission)
 
@@ -255,6 +265,7 @@ watch(configMenuOpen, (open) => {
   logUserAction('Opened the mission configuration menu')
   stagedName.value = store.missionName
   stagedIsAutomatic.value = store.missionNameIsAutomatic
+  if (isCloudActive.value) void ensureLinkedMissionLoaded()
 })
 
 const onNameInput = (value: string): void => {
@@ -352,81 +363,34 @@ const save = (): void => {
   saveLocalMissionName(name, stagedIsAutomatic.value)
 }
 
-const openExistingMissionPicker = async (): Promise<void> => {
+const openExistingMissionPicker = (): void => {
   logUserAction('Opened the BlueOS Cloud mission picker')
   showExistingMissionPicker.value = true
-  try {
-    if (cloudStore.missions.length === 0) await cloudStore.refreshMissions()
-  } catch {
-    // Errors are surfaced inside the picker via `cloudStore.lastError`.
-  }
-}
-
-const onExistingMissionSelected = (mission: BlueOsCloudMission): void => {
-  logUserAction(`Opened BlueOS Cloud mission '${mission.title}'`)
-  store.applyMissionName(mission.title, { isAutomatic: false, startNewMission: false })
-  cloudStore.linkExistingMission(mission.id, currentCycleId.value)
-  openSnackbar({
-    message: `Now logging to BlueOS Cloud mission "${mission.title}".`,
-    variant: 'success',
-    duration: 3000,
-    closeButton: true,
-  })
 }
 
 const openCreateMissionForm = (): void => {
   logUserAction('Opened the BlueOS Cloud mission creation form')
-  missionFormMode.value = 'create'
-  missionFormInitialName.value = ''
-  missionFormInitialDescription.value = ''
-  missionFormInitialLocation.value = null
+  missionForm.value = { mode: 'create', name: '', description: '', location: null }
   showMissionForm.value = true
 }
 
 const openEditMissionForm = (): void => {
   logUserAction('Opened the BlueOS Cloud mission edit form')
-  missionFormMode.value = 'edit'
-  missionFormInitialName.value = linkedCloudMission.value?.title ?? ''
-  missionFormInitialDescription.value = linkedCloudMission.value?.description ?? ''
-  missionFormInitialLocation.value = linkedMissionLocation.value
+  missionForm.value = {
+    mode: 'edit',
+    name: linkedCloudMission.value?.title ?? '',
+    description: linkedCloudMission.value?.description ?? '',
+    location: linkedMissionLocation.value,
+  }
   showMissionForm.value = true
 }
 
-const onMissionFormSubmit = (payload: {
-  /**
-   * Mission title.
-   */
-  name: string
-  /**
-   * Mission description.
-   */
-  description: string
-  /**
-   * Mission start location.
-   */
-  location: WaypointCoordinates | null
-}): void => {
-  const { name, description, location } = payload
-  const latitude = location?.[0] ?? null
-  const longitude = location?.[1] ?? null
-
-  if (missionFormMode.value === 'edit') {
-    store.applyMissionName(name, { isAutomatic: false, startNewMission: false })
-    cloudStore.updateLinkedMission({ name, description, latitude, longitude })
-    logUserAction('Edited the linked BlueOS Cloud mission')
-    openSnackbar({ message: `Mission "${name}" updated.`, variant: 'success', duration: 3000, closeButton: true })
-    return
+const onMissionFormSubmit = (payload: MissionFormSubmitPayload): void => {
+  if (missionForm.value.mode === 'edit') {
+    editLinkedMission(payload)
+  } else {
+    createMission(payload)
   }
-
-  store.applyMissionName(name, { isAutomatic: false, startNewMission: true })
-  cloudStore.startCloudMission({ name, description, latitude, longitude }, currentCycleId.value)
-  logUserAction(`Created BlueOS Cloud mission '${name}'`)
-  openSnackbar({
-    message: `Mission "${name}" saved. It will sync to BlueOS Cloud when online.`,
-    variant: 'success',
-    duration: 3000,
-    closeButton: true,
-  })
 }
 
 const finishCloudMission = (): void => {

--- a/src/components/mini-widgets/MissionIdentifier.vue
+++ b/src/components/mini-widgets/MissionIdentifier.vue
@@ -21,19 +21,23 @@
     <v-dialog v-model="configMenuOpen" max-width="624px">
       <v-card class="rounded-lg relative" :style="interfaceStore.globalGlassMenuStyles">
         <v-card-title class="text-h6 font-weight-bold py-4 text-center">Mission configuration</v-card-title>
+        <v-btn icon variant="text" size="small" class="absolute top-4 right-4" @click="cancel">
+          <v-icon size="22">mdi-close</v-icon>
+        </v-btn>
         <v-card-text class="px-8">
           <p class="text-subtitle-1 font-weight-bold mb-2">Mission Name</p>
           <v-text-field
             :model-value="stagedName"
-            append-inner-icon="mdi-close"
             variant="outlined"
             density="compact"
             theme="dark"
             hide-details
             @update:model-value="onNameInput"
-            @click:append-inner="restoreLastMissionName"
           />
-          <div class="flex justify-end mt-2">
+          <div class="flex justify-between items-center mt-2">
+            <v-btn variant="text" size="small" class="px-0 text-white" @click="finishCurrentMission">
+              Reset current mission
+            </v-btn>
             <v-btn variant="text" size="small" class="px-0 text-white" @click="generateNewName">
               Generate new name
             </v-btn>
@@ -43,7 +47,7 @@
         <v-card-actions>
           <div class="flex justify-between items-center pa-2 w-full h-full">
             <v-btn variant="text" @click="cancel">Cancel</v-btn>
-            <v-btn :disabled="!hasChanges" @click="save">Save</v-btn>
+            <v-btn :disabled="!canSave" @click="save">Save</v-btn>
           </div>
         </v-card-actions>
       </v-card>
@@ -85,7 +89,7 @@ const configMenuOpen = computed({
 const stagedName = ref('')
 const stagedIsAutomatic = ref(true)
 
-const hasChanges = computed(() => {
+const canSave = computed(() => {
   const name = stagedName.value.trim()
   return !!name && name !== store.missionName
 })
@@ -102,16 +106,45 @@ const onNameInput = (value: string): void => {
   stagedIsAutomatic.value = false
 }
 
-const restoreLastMissionName = (): void => {
-  logUserAction('Restored the last used mission name')
-  stagedName.value = store.lastMissionName
-  stagedIsAutomatic.value = false
-}
-
 const generateNewName = (): void => {
   logUserAction('Generated a new automatic mission name')
   stagedName.value = generateAutomaticMissionName()
   stagedIsAutomatic.value = true
+}
+
+// Resetting closes the running mission and starts a new cycle, which cannot be undone, so it always asks first.
+const confirmMissionReset = (reset: () => void): void => {
+  showDialog({
+    title: 'Reset mission?',
+    message: 'The current mission will be closed and a new one started with a new automatic name.',
+    variant: 'warning',
+    actions: [
+      {
+        text: 'Cancel',
+        action: () => {
+          logUserAction('Cancelled the mission reset')
+          closeDialog()
+        },
+      },
+      {
+        text: 'Reset mission',
+        action: () => {
+          closeDialog()
+          reset()
+        },
+      },
+    ],
+  })
+}
+
+const finishCurrentMission = (): void => {
+  confirmMissionReset(() => {
+    logUserAction('Reset the current mission')
+    const newName = generateAutomaticMissionName()
+    store.applyMissionName(newName, { isAutomatic: true, startNewMission: true })
+    stagedName.value = newName
+    stagedIsAutomatic.value = true
+  })
 }
 
 const cancel = (): void => {
@@ -119,13 +152,7 @@ const cancel = (): void => {
   configMenuOpen.value = false
 }
 
-const save = (): void => {
-  const name = stagedName.value.trim()
-  if (!name || name === store.missionName) {
-    configMenuOpen.value = false
-    return
-  }
-  const isAutomatic = stagedIsAutomatic.value
+const saveLocalMissionName = (name: string, isAutomatic: boolean): void => {
   showDialog({
     title: 'New mission?',
     message: 'Do you want to start a new mission with this name, or just rename the current mission?',
@@ -158,5 +185,14 @@ const save = (): void => {
       },
     ],
   })
+}
+
+const save = (): void => {
+  const name = stagedName.value.trim()
+  if (!name || name === store.missionName) {
+    configMenuOpen.value = false
+    return
+  }
+  saveLocalMissionName(name, stagedIsAutomatic.value)
 }
 </script>

--- a/src/components/mini-widgets/MissionIdentifier.vue
+++ b/src/components/mini-widgets/MissionIdentifier.vue
@@ -1,19 +1,19 @@
 <template>
   <div
-    class="flex items-center justify-start h-full px-4 mr-1 transition-all cursor-pointer hover:bg-slate-200/30 min-w-[20%] select-none"
+    class="flex items-center justify-start h-full px-4 mr-1 cursor-pointer min-w-[20%] select-none"
     :class="widgetStore.editingMode ? 'pointer-events-none' : 'pointer-events-auto'"
     @click="configMenuOpen = true"
+    @mouseenter="isHovered = true"
+    @mouseleave="isHovered = false"
   >
     <div class="flex items-center overflow-hidden text-lg font-medium text-white whitespace-nowrap">
-      <p class="overflow-x-hidden text-ellipsis">
-        {{ store.missionName }}
-        <FontAwesomeIcon
-          v-if="store.missionNameIsAutomatic"
-          icon="fa-pen-to-square"
-          size="1x"
-          class="ml-2 text-slate-200/30"
-        />
-      </p>
+      <p class="min-w-0 overflow-x-hidden text-ellipsis">{{ store.missionName }}</p>
+      <FontAwesomeIcon
+        icon="fa-pen-to-square"
+        size="1x"
+        class="ml-2 shrink-0 text-slate-200/30 mb-1"
+        :class="isHovered ? 'opacity-100' : 'opacity-0'"
+      />
     </div>
   </div>
 
@@ -203,6 +203,7 @@ const configMenuOpen = computed({
 
 const stagedName = ref('')
 const stagedIsAutomatic = ref(true)
+const isHovered = ref(false)
 const showExistingMissionPicker = ref(false)
 const showMissionForm = ref(false)
 const missionFormMode = ref<'create' | 'edit'>('create')

--- a/src/components/mini-widgets/MissionIdentifier.vue
+++ b/src/components/mini-widgets/MissionIdentifier.vue
@@ -25,44 +25,157 @@
           <v-icon size="22">mdi-close</v-icon>
         </v-btn>
         <v-card-text class="px-8">
-          <p class="text-subtitle-1 font-weight-bold mb-2">Mission Name</p>
-          <v-text-field
-            :model-value="stagedName"
-            variant="outlined"
-            density="compact"
-            theme="dark"
-            hide-details
-            @update:model-value="onNameInput"
-          />
-          <div class="flex justify-between items-center mt-2">
-            <v-btn variant="text" size="small" class="px-0 text-white" @click="finishCurrentMission">
-              Reset current mission
+          <template v-if="cloudActive">
+            <!-- No mission associated with this cycle yet: choose to select an existing one or create a new one. -->
+            <div v-if="!hasMissionThisCycle" class="flex justify-center gap-4 py-6">
+              <v-btn
+                variant="flat"
+                class="bg-[#FFFFFF22]"
+                prepend-icon="mdi-folder-open-outline"
+                @click="openExistingMissionPicker"
+              >
+                Select existing mission
+              </v-btn>
+              <v-btn variant="flat" class="bg-[#FFFFFF22]" prepend-icon="mdi-plus" @click="openCreateMissionForm">
+                Create a new mission
+              </v-btn>
+            </div>
+
+            <!-- A mission is associated: show its details (read-only) and its cloud sync status. -->
+            <div v-else class="flex flex-col gap-4">
+              <div class="flex items-center gap-4">
+                <div class="flex-1 min-w-0">
+                  <p class="text-caption opacity-70 mb-1">Name</p>
+                  <p class="text-body-1 font-weight-medium ma-0 truncate">
+                    {{ linkedCloudMission?.title || 'Untitled mission' }}
+                  </p>
+                </div>
+                <v-btn variant="text" size="small" class="text-white" @click="openEditMissionForm">Edit mission</v-btn>
+              </div>
+              <div class="flex items-center gap-4">
+                <div class="flex-1 min-w-0">
+                  <p class="text-caption opacity-70 mb-1">Description</p>
+                  <p class="text-body-2 ma-0">{{ linkedCloudMission?.description || 'Not set' }}</p>
+                </div>
+                <v-btn variant="text" size="small" class="text-white" @click="finishCloudMission">Reset mission</v-btn>
+              </div>
+              <div class="flex items-center gap-4">
+                <div class="flex-1 min-w-0">
+                  <p class="text-caption opacity-70 mb-1">Location</p>
+                  <p class="text-body-2 ma-0">{{ linkedMissionLocationText }}</p>
+                </div>
+                <div class="flex items-center gap-2 shrink-0">
+                  <v-icon size="18" color="light-blue-lighten-2">{{ cloudIndicatorIcon }}</v-icon>
+                  <span class="text-body-2">
+                    <template v-if="cloudStore.isLinkedMissionSynced">
+                      Synced with BlueOS Cloud ·
+                      <a
+                        :href="linkedCloudMissionUrl"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="text-light-blue-lighten-2 hover:underline"
+                      >
+                        View mission
+                      </a>
+                    </template>
+                    <template v-else>Saved locally · will upload when online.</template>
+                  </span>
+                </div>
+              </div>
+            </div>
+          </template>
+
+          <!-- Not signed in to BlueOS Cloud (or not in pirate mode): the classic local mission behavior. -->
+          <template v-else>
+            <p class="text-subtitle-1 font-weight-bold mb-2">Mission Name</p>
+            <v-text-field
+              :model-value="stagedName"
+              variant="outlined"
+              density="compact"
+              theme="dark"
+              hide-details
+              @update:model-value="onNameInput"
+            />
+            <div class="flex justify-between items-center mt-2">
+              <v-btn variant="text" size="small" class="px-0 text-white" @click="finishCurrentMission">
+                Reset current mission
+              </v-btn>
+              <v-btn variant="text" size="small" class="px-0 text-white" @click="generateNewName">
+                Generate new name
+              </v-btn>
+            </div>
+            <v-btn
+              v-if="interfaceStore.pirateMode"
+              variant="text"
+              size="small"
+              class="px-0 mt-4 text-white"
+              prepend-icon="mdi-cloud-outline"
+              @click="openCloudSettings"
+            >
+              <span class="text-caption normal-case"> Log in to BlueOS Cloud to manage and sync your missions </span>
             </v-btn>
-            <v-btn variant="text" size="small" class="px-0 text-white" @click="generateNewName">
-              Generate new name
-            </v-btn>
-          </div>
+          </template>
         </v-card-text>
         <v-divider class="mt-2 mx-10" />
         <v-card-actions>
           <div class="flex justify-between items-center pa-2 w-full h-full">
-            <v-btn variant="text" @click="cancel">Cancel</v-btn>
-            <v-btn :disabled="!canSave" @click="save">Save</v-btn>
+            <template v-if="cloudActive && hasMissionThisCycle">
+              <v-spacer />
+              <v-btn variant="text" @click="cancel">Cancel</v-btn>
+            </template>
+            <template v-else-if="cloudActive">
+              <v-spacer />
+              <v-btn variant="text" @click="cancel">Close</v-btn>
+            </template>
+            <template v-else>
+              <v-btn variant="text" @click="cancel">Cancel</v-btn>
+              <v-btn
+                variant="flat"
+                theme="dark"
+                class="bg-[#FFFFFF33] text-white disabled:opacity-40"
+                :disabled="!canSaveNonCloud"
+                @click="save"
+              >
+                Save
+              </v-btn>
+            </template>
           </div>
         </v-card-actions>
       </v-card>
     </v-dialog>
+
+    <BlueOsCloudMissionPicker
+      v-model="showExistingMissionPicker"
+      title="Select a BlueOS Cloud mission"
+      description="Pick a mission to continue logging to."
+      @selected="onExistingMissionSelected"
+    />
+    <BlueOsCloudMissionForm
+      v-model="showMissionForm"
+      :mode="missionFormMode"
+      :initial-name="missionFormInitialName"
+      :initial-description="missionFormInitialDescription"
+      :initial-location="missionFormInitialLocation"
+      @submit="onMissionFormSubmit"
+    />
   </teleport>
 </template>
 
 <script setup lang="ts">
 import { computed, ref, toRefs, watch } from 'vue'
 
+import BlueOsCloudMissionForm from '@/components/blueos-cloud/BlueOsCloudMissionForm.vue'
+import BlueOsCloudMissionPicker from '@/components/blueos-cloud/BlueOsCloudMissionPicker.vue'
 import { useInteractionDialog } from '@/composables/interactionDialog'
+import { useSnackbar } from '@/composables/snackbar'
+import { buildBlueOsCloudMissionUrl } from '@/libs/blueos-cloud/api'
+import { BlueOsCloudMission } from '@/libs/blueos-cloud/types'
 import { generateAutomaticMissionName } from '@/libs/mission/automatic-name'
-import { useAppInterfaceStore } from '@/stores/appInterface'
+import { SubMenuComponentName, SubMenuName, useAppInterfaceStore } from '@/stores/appInterface'
+import { useBlueOsCloudStore } from '@/stores/blueOsCloud'
 import { useMissionStore } from '@/stores/mission'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
+import type { WaypointCoordinates } from '@/types/mission'
 import type { MiniWidget } from '@/types/widgets'
 
 /**
@@ -79,7 +192,9 @@ const miniWidget = toRefs(props).miniWidget
 const store = useMissionStore()
 const widgetStore = useWidgetManagerStore()
 const interfaceStore = useAppInterfaceStore()
+const cloudStore = useBlueOsCloudStore()
 const { showDialog, closeDialog } = useInteractionDialog()
+const { openSnackbar } = useSnackbar()
 
 const configMenuOpen = computed({
   get: () => widgetStore.miniWidgetManagerVars(miniWidget.value.hash).configMenuOpen,
@@ -88,8 +203,48 @@ const configMenuOpen = computed({
 
 const stagedName = ref('')
 const stagedIsAutomatic = ref(true)
+const showExistingMissionPicker = ref(false)
+const showMissionForm = ref(false)
+const missionFormMode = ref<'create' | 'edit'>('create')
+const missionFormInitialName = ref('')
+const missionFormInitialDescription = ref('')
+const missionFormInitialLocation = ref<WaypointCoordinates | null>(null)
 
-const canSave = computed(() => {
+// BlueOS Cloud missions are an advanced feature, gated behind pirate mode like the Cloud settings menu.
+const cloudActive = computed(() => interfaceStore.pirateMode && cloudStore.isAuthenticated)
+
+// Stamp that ties a cloud mission link to the current mission cycle (renewed after 6h idle / a new day).
+const currentCycleId = computed(() => new Date(store.missionStartTime).getTime())
+
+const hasMissionThisCycle = computed(
+  () => !!cloudStore.linkedMissionId && cloudStore.linkedMissionCycleId === currentCycleId.value
+)
+
+const linkedCloudMission = computed(() => cloudStore.linkedMission)
+
+const linkedCloudMissionUrl = computed(() =>
+  linkedCloudMission.value ? buildBlueOsCloudMissionUrl(linkedCloudMission.value.id) : ''
+)
+
+const linkedMissionLocation = computed<WaypointCoordinates | null>(() => {
+  const mission = linkedCloudMission.value
+  if (!mission?.start_latitude || !mission?.start_longitude) return null
+  const lat = parseFloat(mission.start_latitude)
+  const lng = parseFloat(mission.start_longitude)
+  return Number.isFinite(lat) && Number.isFinite(lng) ? [lat, lng] : null
+})
+
+const linkedMissionLocationText = computed(() => {
+  const location = linkedMissionLocation.value
+  if (!location) return 'Not set'
+  return `${location[0].toFixed(6)}, ${location[1].toFixed(6)}`
+})
+
+const cloudIndicatorIcon = computed(() =>
+  cloudStore.isLinkedMissionSynced ? 'mdi-cloud-check-outline' : 'mdi-cloud-clock-outline'
+)
+
+const canSaveNonCloud = computed(() => {
   const name = stagedName.value.trim()
   return !!name && name !== store.missionName
 })
@@ -194,5 +349,99 @@ const save = (): void => {
     return
   }
   saveLocalMissionName(name, stagedIsAutomatic.value)
+}
+
+const openExistingMissionPicker = async (): Promise<void> => {
+  logUserAction('Opened the BlueOS Cloud mission picker')
+  showExistingMissionPicker.value = true
+  try {
+    if (cloudStore.missions.length === 0) await cloudStore.refreshMissions()
+  } catch {
+    // Errors are surfaced inside the picker via `cloudStore.lastError`.
+  }
+}
+
+const onExistingMissionSelected = (mission: BlueOsCloudMission): void => {
+  logUserAction(`Opened BlueOS Cloud mission '${mission.title}'`)
+  store.applyMissionName(mission.title, { isAutomatic: false, startNewMission: false })
+  cloudStore.linkExistingMission(mission.id, currentCycleId.value)
+  openSnackbar({
+    message: `Now logging to BlueOS Cloud mission "${mission.title}".`,
+    variant: 'success',
+    duration: 3000,
+    closeButton: true,
+  })
+}
+
+const openCreateMissionForm = (): void => {
+  logUserAction('Opened the BlueOS Cloud mission creation form')
+  missionFormMode.value = 'create'
+  missionFormInitialName.value = ''
+  missionFormInitialDescription.value = ''
+  missionFormInitialLocation.value = null
+  showMissionForm.value = true
+}
+
+const openEditMissionForm = (): void => {
+  logUserAction('Opened the BlueOS Cloud mission edit form')
+  missionFormMode.value = 'edit'
+  missionFormInitialName.value = linkedCloudMission.value?.title ?? ''
+  missionFormInitialDescription.value = linkedCloudMission.value?.description ?? ''
+  missionFormInitialLocation.value = linkedMissionLocation.value
+  showMissionForm.value = true
+}
+
+const onMissionFormSubmit = (payload: {
+  /**
+   * Mission title.
+   */
+  name: string
+  /**
+   * Mission description.
+   */
+  description: string
+  /**
+   * Mission start location.
+   */
+  location: WaypointCoordinates | null
+}): void => {
+  const { name, description, location } = payload
+  const latitude = location?.[0] ?? null
+  const longitude = location?.[1] ?? null
+
+  if (missionFormMode.value === 'edit') {
+    store.applyMissionName(name, { isAutomatic: false, startNewMission: false })
+    cloudStore.updateLinkedMission({ name, description, latitude, longitude })
+    logUserAction('Edited the linked BlueOS Cloud mission')
+    openSnackbar({ message: `Mission "${name}" updated.`, variant: 'success', duration: 3000, closeButton: true })
+    return
+  }
+
+  store.applyMissionName(name, { isAutomatic: false, startNewMission: true })
+  cloudStore.startCloudMission({ name, description, latitude, longitude }, currentCycleId.value)
+  logUserAction(`Created BlueOS Cloud mission '${name}'`)
+  openSnackbar({
+    message: `Mission "${name}" saved. It will sync to BlueOS Cloud when online.`,
+    variant: 'success',
+    duration: 3000,
+    closeButton: true,
+  })
+}
+
+const finishCloudMission = (): void => {
+  confirmMissionReset(() => {
+    logUserAction('Reset the BlueOS Cloud mission')
+    store.applyMissionName(generateAutomaticMissionName(), { isAutomatic: true, startNewMission: true })
+    cloudStore.finishMission()
+  })
+}
+
+const openCloudSettings = (): void => {
+  logUserAction('Opened the Cloud settings from the mission configuration menu')
+  configMenuOpen.value = false
+  interfaceStore.isMainMenuVisible = true
+  interfaceStore.mainMenuCurrentStep = 2
+  interfaceStore.currentSubMenuName = SubMenuName.settings
+  interfaceStore.currentSubMenuComponentName = SubMenuComponentName.SettingsCloud
 }
 </script>

--- a/src/composables/blueos-cloud/useBlueOsCloudMission.ts
+++ b/src/composables/blueos-cloud/useBlueOsCloudMission.ts
@@ -1,0 +1,167 @@
+import { type ComputedRef, computed } from 'vue'
+
+import { openSnackbar } from '@/composables/snackbar'
+import type { BlueOsCloudMission } from '@/libs/blueos-cloud/types'
+import { generateAutomaticMissionName } from '@/libs/mission/automatic-name'
+import { useAppInterfaceStore } from '@/stores/appInterface'
+import { useBlueOsCloudStore } from '@/stores/blueOsCloud'
+import { useMissionStore } from '@/stores/mission'
+import type { WaypointCoordinates } from '@/types/mission'
+
+/**
+ * Payload emitted by the BlueOS Cloud mission form.
+ */
+export type MissionFormSubmitPayload = {
+  /**
+   * Mission title.
+   */
+  name: string
+  /**
+   * Mission description.
+   */
+  description: string
+  /**
+   * Mission start location, or `null` when the user left it unset.
+   */
+  location: WaypointCoordinates | null
+}
+
+/**
+ * Public API of {@link useBlueOsCloudMission}.
+ */
+type BlueOsCloudMissionApi = {
+  /**
+   * Whether cloud missions are available, which requires pirate mode and an authenticated user.
+   */
+  isCloudActive: ComputedRef<boolean>
+  /**
+   * Whether a cloud mission is already linked to the current mission cycle.
+   */
+  hasMissionThisCycle: ComputedRef<boolean>
+  /**
+   * Mission offered as "continue previous", or `null` when one is already linked to this cycle.
+   */
+  previousMission: ComputedRef<BlueOsCloudMission | null>
+  /**
+   * Fetches the mission list when it holds no record of the linked mission, so its details are revalidated.
+   */
+  ensureLinkedMissionLoaded: () => Promise<void>
+  /**
+   * Relinks the previously linked mission to the current cycle.
+   */
+  continuePreviousMission: () => void
+  /**
+   * Links a mission chosen from the picker to the current cycle.
+   * @param {BlueOsCloudMission} mission - Selected cloud mission.
+   */
+  selectExistingMission: (mission: BlueOsCloudMission) => void
+  /**
+   * Creates a mission from the form payload and links it to a brand-new mission cycle.
+   * @param {MissionFormSubmitPayload} payload - New mission fields.
+   */
+  createMission: (payload: MissionFormSubmitPayload) => void
+  /**
+   * Applies the form payload to the mission already linked to this cycle.
+   * @param {MissionFormSubmitPayload} payload - Updated mission fields.
+   */
+  editLinkedMission: (payload: MissionFormSubmitPayload) => void
+}
+
+/**
+ * Mission-cycle awareness and the linking actions (continue, select, create, edit) shared by the startup decision
+ * dialog and the mission configuration dialog, so both entry points behave identically.
+ * @returns {BlueOsCloudMissionApi} Cycle state and mission linking actions.
+ */
+export const useBlueOsCloudMission = (): BlueOsCloudMissionApi => {
+  const interfaceStore = useAppInterfaceStore()
+  const cloudStore = useBlueOsCloudStore()
+  const missionStore = useMissionStore()
+
+  // BlueOS Cloud missions are an advanced feature, gated behind pirate mode like the Cloud settings menu.
+  const isCloudActive = computed(() => interfaceStore.pirateMode && cloudStore.isAuthenticated)
+
+  // Stamp that ties a cloud mission link to the current mission cycle (renewed after 6h idle / a new day).
+  const currentCycleId = computed(() => new Date(missionStore.missionStartTime).getTime())
+
+  const hasMissionThisCycle = computed(
+    () => !!cloudStore.linkedMissionId && cloudStore.linkedMissionCycleId === currentCycleId.value
+  )
+
+  // Last linked mission id is kept even after skip/cycle mismatch, so "continue previous" stays available.
+  const previousMission = computed(() => (hasMissionThisCycle.value ? null : cloudStore.linkedMission))
+
+  const notify = (message: string): void => {
+    openSnackbar({ message, variant: 'success', duration: 3000, closeButton: true })
+  }
+
+  const ensureLinkedMissionLoaded = async (): Promise<void> => {
+    const missionRef = cloudStore.linkedMissionId
+    // Also fetches while the mission is linked to this cycle, where only the cache would answer: the remembered
+    // details would otherwise never notice an edit made on the cloud, and an edit from Cockpit would revert it.
+    if (!missionRef || !cloudStore.isLinkedMissionSynced) return
+    if (cloudStore.missions.some((mission) => mission.id === missionRef)) return
+    try {
+      await cloudStore.refreshMissions()
+    } catch {
+      // Offline — continue-previous stays hidden until the missions can be loaded.
+    }
+  }
+
+  const continuePreviousMission = (): void => {
+    const mission = previousMission.value
+    if (!mission) return
+    const title = mission.title?.trim()
+    missionStore.applyMissionName(title || generateAutomaticMissionName(), {
+      isAutomatic: !title,
+      startNewMission: false,
+    })
+    cloudStore.linkExistingMission(mission.id, currentCycleId.value)
+    notify(`Continuing BlueOS Cloud mission "${title || 'Untitled mission'}".`)
+  }
+
+  const selectExistingMission = (mission: BlueOsCloudMission): void => {
+    logUserAction(`Opened BlueOS Cloud mission '${mission.title}'`)
+    const title = mission.title?.trim()
+    missionStore.applyMissionName(title || generateAutomaticMissionName(), {
+      isAutomatic: !title,
+      startNewMission: false,
+    })
+    cloudStore.linkExistingMission(mission.id, currentCycleId.value)
+    notify(`Now logging to BlueOS Cloud mission "${title || 'Untitled mission'}".`)
+  }
+
+  const createMission = (payload: MissionFormSubmitPayload): void => {
+    const { name, description, location } = payload
+    logUserAction(`Created BlueOS Cloud mission '${name}'`)
+    missionStore.applyMissionName(name, { isAutomatic: false, startNewMission: true })
+    cloudStore.startCloudMission(
+      { name, description, latitude: location?.[0] ?? null, longitude: location?.[1] ?? null },
+      currentCycleId.value
+    )
+    notify(`Mission "${name}" saved. It will sync to BlueOS Cloud when online.`)
+  }
+
+  const editLinkedMission = (payload: MissionFormSubmitPayload): void => {
+    const { name, description, location } = payload
+    logUserAction('Edited the linked BlueOS Cloud mission')
+    missionStore.applyMissionName(name, { isAutomatic: false, startNewMission: false })
+    cloudStore.updateLinkedMission({
+      name,
+      description,
+      latitude: location?.[0] ?? null,
+      longitude: location?.[1] ?? null,
+    })
+    notify(`Mission "${name}" updated.`)
+  }
+
+  return {
+    isCloudActive,
+    hasMissionThisCycle,
+    previousMission,
+    ensureLinkedMissionLoaded,
+    continuePreviousMission,
+    selectExistingMission,
+    createMission,
+    editLinkedMission,
+  }
+}

--- a/src/composables/blueos-cloud/useBlueOsCloudMissionStartupDialog.ts
+++ b/src/composables/blueos-cloud/useBlueOsCloudMissionStartupDialog.ts
@@ -1,0 +1,161 @@
+import { type ComputedRef, type Ref, onMounted, ref, watch } from 'vue'
+
+import { type MissionFormSubmitPayload, useBlueOsCloudMission } from '@/composables/blueos-cloud/useBlueOsCloudMission'
+import type { BlueOsCloudMission } from '@/libs/blueos-cloud/types'
+import { useBlueOsCloudStore } from '@/stores/blueOsCloud'
+
+/**
+ * Public API of {@link useBlueOsCloudMissionStartupDialog}.
+ */
+type BlueOsCloudMissionStartupDialogApi = {
+  /**
+   * Whether the initial decision dialog is open.
+   */
+  showDecisionDialog: Ref<boolean>
+  /**
+   * Whether the existing-mission picker is open.
+   */
+  showMissionPicker: Ref<boolean>
+  /**
+   * Whether the create-mission form is open.
+   */
+  showMissionForm: Ref<boolean>
+  /**
+   * Previous linked mission offered as "continue", when known.
+   */
+  previousMission: ComputedRef<BlueOsCloudMission | null>
+  /**
+   * Relink the previous mission to the current cycle.
+   */
+  continuePreviousMission: () => void
+  /**
+   * Open the existing-mission picker from the decision dialog.
+   */
+  openMissionPicker: () => void
+  /**
+   * Open the create-mission form from the decision dialog.
+   */
+  openCreateMissionForm: () => void
+  /**
+   * Skip cloud missions for this cycle while keeping the previous mission id.
+   */
+  skipMission: () => void
+  /**
+   * Dismiss the decision dialog without choosing anything.
+   */
+  dismissDecisionDialog: () => void
+  /**
+   * Link a mission chosen from the picker.
+   * @param {BlueOsCloudMission} mission - Selected cloud mission.
+   */
+  onMissionSelected: (mission: BlueOsCloudMission) => void
+  /**
+   * Create a mission from the form submit payload.
+   * @param {MissionFormSubmitPayload} payload - New mission fields.
+   */
+  onMissionFormSubmit: (payload: MissionFormSubmitPayload) => void
+}
+
+/**
+ * State and handlers for the BlueOS Cloud mission decision dialog shown when Cockpit starts.
+ * @returns {BlueOsCloudMissionStartupDialogApi} Dialog visibility flags and action handlers.
+ */
+export const useBlueOsCloudMissionStartupDialog = (): BlueOsCloudMissionStartupDialogApi => {
+  const cloudStore = useBlueOsCloudStore()
+  const {
+    isCloudActive,
+    hasMissionThisCycle,
+    previousMission,
+    ensureLinkedMissionLoaded,
+    continuePreviousMission,
+    selectExistingMission,
+    createMission,
+  } = useBlueOsCloudMission()
+
+  const showDecisionDialog = ref(false)
+  const showMissionPicker = ref(false)
+  const showMissionForm = ref(false)
+
+  const closeDecisionDialog = (): void => {
+    showDecisionDialog.value = false
+  }
+
+  const dismissDecisionDialog = (): void => {
+    logUserAction('Dismissed the BlueOS Cloud mission question without choosing')
+    closeDecisionDialog()
+  }
+
+  const onContinuePreviousMission = (): void => {
+    continuePreviousMission()
+    closeDecisionDialog()
+  }
+
+  const openMissionPicker = (): void => {
+    closeDecisionDialog()
+    showMissionPicker.value = true
+  }
+
+  const openCreateMissionForm = (): void => {
+    closeDecisionDialog()
+    showMissionForm.value = true
+  }
+
+  const skipMission = (): void => {
+    cloudStore.clearMissionCycleLink()
+    closeDecisionDialog()
+  }
+
+  // The picker and the form replace the decision dialog, so closing one without choosing has to bring the question
+  // back: nothing else would reopen it for the rest of the session.
+  let isChoiceMade = false
+
+  const onSurfaceVisibilityChange = (isOpen: boolean): void => {
+    if (isOpen || isChoiceMade) return
+    showDecisionDialog.value = true
+  }
+
+  watch(showMissionPicker, onSurfaceVisibilityChange)
+  watch(showMissionForm, onSurfaceVisibilityChange)
+
+  const openIfEligible = async (): Promise<void> => {
+    // A mission already linked to this cycle means the session is just being resumed, so there is nothing to decide.
+    if (!isCloudActive.value || hasMissionThisCycle.value) return
+    // Never stack the question on top of a surface the user is already answering it with.
+    if (showDecisionDialog.value || showMissionPicker.value || showMissionForm.value) return
+    await ensureLinkedMissionLoaded()
+    isChoiceMade = false
+    showDecisionDialog.value = true
+  }
+
+  onMounted(() => {
+    void openIfEligible()
+  })
+
+  watch(isCloudActive, (active, wasActive) => {
+    if (active && !wasActive) void openIfEligible()
+  })
+
+  const onMissionSelected = (mission: BlueOsCloudMission): void => {
+    isChoiceMade = true
+    selectExistingMission(mission)
+  }
+
+  const onMissionFormSubmit = (payload: MissionFormSubmitPayload): void => {
+    isChoiceMade = true
+    createMission(payload)
+  }
+
+  return {
+    showDecisionDialog,
+    showMissionPicker,
+    showMissionForm,
+    previousMission,
+    continuePreviousMission: onContinuePreviousMission,
+    openMissionPicker,
+    openCreateMissionForm,
+    skipMission,
+    dismissDecisionDialog,
+    onMissionSelected,
+    onMissionFormSubmit,
+  }
+}

--- a/src/libs/blueos-cloud/api.ts
+++ b/src/libs/blueos-cloud/api.ts
@@ -1,0 +1,209 @@
+import { BlueOsCloudMission, BlueOsCloudPaginatedResponse } from './types'
+
+export const BLUEOS_CLOUD_API_BASE = 'https://app.blueos.cloud/api/v1'
+export const BLUEOS_CLOUD_APP_BASE = 'https://app.blueos.cloud'
+
+/**
+ * Error carrying the HTTP status of a failed BlueOS Cloud API call, so callers can react to specific cases
+ * (e.g. a `404` meaning the mission was deleted on the cloud).
+ */
+export class BlueOsCloudApiError extends Error {
+  /**
+   * HTTP status code returned by the BlueOS Cloud API.
+   */
+  status: number
+
+  /**
+   * Creates a new BlueOsCloudApiError.
+   * @param {string} message - Human readable description of the failure.
+   * @param {number} status - HTTP status code returned by the API.
+   */
+  constructor(message: string, status: number) {
+    super(message)
+    this.name = 'BlueOsCloudApiError'
+    this.status = status
+  }
+}
+
+/**
+ * Whether a request was definitively refused by the server, as opposed to never having reached it (offline, so
+ * nothing was thrown by the API at all) or having hit a transient condition that a retry can clear.
+ * @param {unknown} error - Error thrown by an API call.
+ * @returns {boolean} `true` when the server answered with a status that a retry will not change.
+ */
+export const isPermanentApiError = (error: unknown): boolean =>
+  error instanceof BlueOsCloudApiError &&
+  error.status >= 400 &&
+  error.status < 500 &&
+  error.status !== 408 &&
+  error.status !== 429
+
+/**
+ * Returns the public URL where a BlueOS Cloud mission can be viewed in the user's browser.
+ * @param {string} missionId - Identifier of the mission as returned by the API.
+ * @returns {string} Fully-qualified URL pointing at the mission detail page.
+ */
+export const buildBlueOsCloudMissionUrl = (missionId: string): string =>
+  `${BLUEOS_CLOUD_APP_BASE}/v2/missions/${missionId}`
+
+// The BlueOS Cloud API takes the Auth0 access token raw, without the `Bearer` scheme Auth0's own endpoints use.
+const authHeaders = (accessToken: string): Record<string, string> => ({
+  Authorization: accessToken,
+})
+
+const authJsonHeaders = (accessToken: string): Record<string, string> => ({
+  'Authorization': accessToken,
+  'Content-Type': 'application/json',
+})
+
+const fetchAllPages = async <T>(initialUrl: string, accessToken: string): Promise<T[]> => {
+  const all: T[] = []
+  let nextUrl: string | null = initialUrl
+
+  while (nextUrl) {
+    const res = await fetch(nextUrl, { headers: authHeaders(accessToken) })
+    if (!res.ok) {
+      const text = await res.text().catch(() => '')
+      throw new BlueOsCloudApiError(`BlueOS Cloud API error: ${res.status} ${text || res.statusText}`, res.status)
+    }
+    const data = (await res.json()) as BlueOsCloudPaginatedResponse<T> | T[]
+    if (Array.isArray(data)) {
+      all.push(...data)
+      nextUrl = null
+    } else {
+      all.push(...data.results)
+      nextUrl = data.next
+    }
+  }
+
+  return all
+}
+
+/**
+ * Fetches every mission visible to the authenticated user, automatically following pagination.
+ * @param {string} accessToken - Valid BlueOS Cloud access token.
+ * @returns {Promise<BlueOsCloudMission[]>} List of missions sorted as returned by the API.
+ */
+export const fetchMissions = async (accessToken: string): Promise<BlueOsCloudMission[]> => {
+  return fetchAllPages<BlueOsCloudMission>(`${BLUEOS_CLOUD_API_BASE}/missions/`, accessToken)
+}
+
+/**
+ * Creates a new mission in BlueOS Cloud.
+ *
+ * Latitude and longitude are formatted to 6 decimal places to satisfy the API contract.
+ * @param {object} input - Data describing the new mission.
+ * @param {string} input.name - Human-readable mission title.
+ * @param {string} [input.description] - Optional mission description.
+ * @param {number | null} [input.latitude] - Optional starting latitude in decimal degrees.
+ * @param {number | null} [input.longitude] - Optional starting longitude in decimal degrees.
+ * @param {number} [input.startTime] - Epoch of the moment the mission started; defaults to now.
+ * @param {string} accessToken - Valid BlueOS Cloud access token.
+ * @returns {Promise<BlueOsCloudMission>} Newly created mission as returned by the API.
+ */
+export const createMission = async (
+  input: {
+    /**
+     * Human-readable mission title.
+     */
+    name: string
+    /**
+     * Optional mission description.
+     */
+    description?: string
+    /**
+     * Optional starting latitude in decimal degrees.
+     */
+    latitude?: number | null
+    /**
+     * Optional starting longitude in decimal degrees.
+     */
+    longitude?: number | null
+    /**
+     * Epoch of the moment the mission started; defaults to now.
+     */
+    startTime?: number
+  },
+  accessToken: string
+): Promise<BlueOsCloudMission> => {
+  // Taken from the caller rather than from the clock, since a mission created offline is only posted hours later.
+  const body: Record<string, unknown> = {
+    title: input.name,
+    start_time: new Date(input.startTime ?? Date.now()).toISOString(),
+  }
+  if (input.description) body.description = input.description
+  if (input.latitude != null) body.start_latitude = input.latitude.toFixed(6)
+  if (input.longitude != null) body.start_longitude = input.longitude.toFixed(6)
+
+  const res = await fetch(`${BLUEOS_CLOUD_API_BASE}/missions/`, {
+    method: 'POST',
+    headers: authJsonHeaders(accessToken),
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new BlueOsCloudApiError(
+      `Failed to create BlueOS Cloud mission: ${res.status} ${text || res.statusText}`,
+      res.status
+    )
+  }
+
+  return res.json()
+}
+
+/**
+ * Updates an existing mission in BlueOS Cloud (e.g. to rename it or move its start location).
+ *
+ * Only the provided fields are sent, so a rename is a `PATCH` carrying just the new title.
+ * @param {string} id - Identifier of the mission to update.
+ * @param {object} input - Fields to change.
+ * @param {string} [input.name] - New mission title.
+ * @param {string} [input.description] - New mission description.
+ * @param {number | null} [input.latitude] - New starting latitude in decimal degrees.
+ * @param {number | null} [input.longitude] - New starting longitude in decimal degrees.
+ * @param {string} accessToken - Valid BlueOS Cloud access token.
+ * @returns {Promise<BlueOsCloudMission>} The updated mission as returned by the API.
+ */
+export const updateMission = async (
+  id: string,
+  input: {
+    /**
+     * New mission title.
+     */
+    name?: string
+    /**
+     * New mission description.
+     */
+    description?: string
+    /**
+     * New starting latitude in decimal degrees.
+     */
+    latitude?: number | null
+    /**
+     * New starting longitude in decimal degrees.
+     */
+    longitude?: number | null
+  },
+  accessToken: string
+): Promise<BlueOsCloudMission> => {
+  const body: Record<string, unknown> = {}
+  if (input.name !== undefined) body.title = input.name
+  if (input.description !== undefined) body.description = input.description
+  if (input.latitude !== undefined) body.start_latitude = input.latitude != null ? input.latitude.toFixed(6) : null
+  if (input.longitude !== undefined) body.start_longitude = input.longitude != null ? input.longitude.toFixed(6) : null
+
+  const res = await fetch(`${BLUEOS_CLOUD_API_BASE}/missions/${id}/`, {
+    method: 'PATCH',
+    headers: authJsonHeaders(accessToken),
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new BlueOsCloudApiError(
+      `Failed to update BlueOS Cloud mission: ${res.status} ${text || res.statusText}`,
+      res.status
+    )
+  }
+
+  return res.json()
+}

--- a/src/libs/blueos-cloud/auth.ts
+++ b/src/libs/blueos-cloud/auth.ts
@@ -1,3 +1,4 @@
+import { BlueOsCloudApiError } from './api'
 import { BlueOsCloudTokens, BlueOsCloudUser, DeviceAuthorizationResponse, TokenResponse } from './types'
 
 export const BLUEOS_CLOUD_AUTH0_DOMAIN = 'bcloud-prod.us.auth0.com'
@@ -149,6 +150,9 @@ export const pollForDeviceAuthorizationToken = async (
 
 /**
  * Refreshes the access token using a previously issued refresh token.
+ *
+ * Throws a {@link BlueOsCloudApiError} when the server answered and refused the exchange, and whatever `fetch`
+ * threw when it could not be reached at all, so callers can tell a dead session from a missing connection.
  * @param {string} refreshToken - Refresh token returned during the original device flow.
  * @returns {Promise<BlueOsCloudTokens>} New token bundle reusing the input refresh token when a new one is not issued.
  */
@@ -167,7 +171,10 @@ export const refreshAccessToken = async (refreshToken: string): Promise<BlueOsCl
 
   if (!res.ok) {
     const text = await res.text().catch(() => '')
-    throw new Error(`Failed to refresh BlueOS Cloud session: ${res.status} ${text || res.statusText}`)
+    throw new BlueOsCloudApiError(
+      `Failed to refresh BlueOS Cloud session: ${res.status} ${text || res.statusText}`,
+      res.status
+    )
   }
 
   const data: TokenResponse = await res.json()

--- a/src/libs/blueos-cloud/mission-list.ts
+++ b/src/libs/blueos-cloud/mission-list.ts
@@ -1,0 +1,67 @@
+import type { BlueOsCloudMission } from './types'
+
+/**
+ * Orders offered by the BlueOS Cloud mission picker.
+ */
+export type MissionSortKey = 'newest' | 'oldest' | 'name'
+
+const startTimeOf = (mission: BlueOsCloudMission): number | null => {
+  const time = mission.start_time ? new Date(mission.start_time).getTime() : NaN
+  return Number.isFinite(time) ? time : null
+}
+
+const locationTextOf = (mission: BlueOsCloudMission): string | null => {
+  if (!mission.start_latitude || !mission.start_longitude) return null
+  const lat = parseFloat(mission.start_latitude)
+  const lng = parseFloat(mission.start_longitude)
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null
+  return `${lat.toFixed(4)}, ${lng.toFixed(4)}`
+}
+
+const metaPartsOf = (mission: BlueOsCloudMission): string[] => {
+  const parts: string[] = []
+  const startTime = startTimeOf(mission)
+  if (startTime !== null) parts.push(new Date(startTime).toLocaleString())
+  const location = locationTextOf(mission)
+  if (location) parts.push(location)
+  return parts
+}
+
+/**
+ * Start time and start coordinates of a mission, as shown under its name on the picker rows.
+ * @param {BlueOsCloudMission} mission - Mission to describe.
+ * @returns {string} Formatted metadata, or a placeholder when the mission carries none.
+ */
+export const formatMissionMeta = (mission: BlueOsCloudMission): string =>
+  metaPartsOf(mission).join(' • ') || 'No metadata'
+
+/**
+ * Filters missions by a free-text query and sorts what is left.
+ *
+ * The query is matched against the same text the picker displays (name, description, date and coordinates), so
+ * searching for a date or a coordinate prefix narrows the list just like searching for a name does.
+ * @param {BlueOsCloudMission[]} missions - Missions to narrow down.
+ * @param {string} query - Free-text search, matched case-insensitively against every word the user typed.
+ * @param {MissionSortKey} sortKey - Order to apply to the remaining missions.
+ * @returns {BlueOsCloudMission[]} New array with the matching missions in the requested order.
+ */
+export const filterAndSortMissions = (
+  missions: BlueOsCloudMission[],
+  query: string,
+  sortKey: MissionSortKey
+): BlueOsCloudMission[] => {
+  const terms = query.toLowerCase().split(/\s+/).filter(Boolean)
+
+  const matching = missions.filter((mission) => {
+    if (terms.length === 0) return true
+    const searchable = [mission.title, mission.description, ...metaPartsOf(mission)].join(' ').toLowerCase()
+    return terms.every((term) => searchable.includes(term))
+  })
+
+  // Missions with no usable start time are treated as the oldest ones, so they never push dated missions down.
+  return matching.sort((a, b) => {
+    if (sortKey === 'name') return (a.title || '').localeCompare(b.title || '')
+    const [first, second] = [startTimeOf(a) ?? 0, startTimeOf(b) ?? 0]
+    return sortKey === 'oldest' ? first - second : second - first
+  })
+}

--- a/src/libs/blueos-cloud/mission-sync-queue.ts
+++ b/src/libs/blueos-cloud/mission-sync-queue.ts
@@ -1,0 +1,219 @@
+// Cockpit usually runs offline in the field, so BlueOS Cloud mission mutations (create, rename, relocate)
+// can't be sent right away. They are kept in a persistent queue and replayed once the internet is reachable.
+//
+// The queue is keyed by a stable client id rather than the cloud id, because a mission created offline has no
+// cloud id yet. A later rename of that same mission coalesces into the pending create, so an offline
+// "create then rename" flushes as a single create carrying the final title.
+
+/**
+ * A mission whose desired state still needs to be pushed to BlueOS Cloud.
+ */
+export interface PendingCloudMission {
+  /**
+   * Stable client-generated id, used as the mission reference until the cloud id is known.
+   */
+  clientId: string
+  /**
+   * Real BlueOS Cloud id once the mission has been created there; `null` while creation is still pending.
+   */
+  cloudId: string | null
+  /**
+   * Desired mission title, or `undefined` when this field should be left untouched on update.
+   */
+  title?: string
+  /**
+   * Desired mission description, or `undefined` when it should be left untouched.
+   */
+  description?: string
+  /**
+   * Desired start latitude in decimal degrees, or `undefined` when it should be left untouched.
+   */
+  latitude?: number | null
+  /**
+   * Desired start longitude in decimal degrees, or `undefined` when it should be left untouched.
+   */
+  longitude?: number | null
+  /**
+   * Epoch of the moment the mission started, captured when the create was queued so a mission created offline
+   * isn't dated to whenever it reached the cloud. Absent on entries that only carry an update.
+   */
+  startTime?: number
+  /**
+   * Number of failed flush attempts, used to drop operations that can never succeed.
+   */
+  attempts: number
+  /**
+   * Bumped on every enqueue, so a flush can tell whether the entry it pushed was edited while in flight.
+   */
+  revision: number
+}
+
+/**
+ * Persistent queue of missions awaiting synchronization, keyed by client id.
+ */
+export type PendingMissionQueue = Record<string, PendingCloudMission>
+
+/**
+ * Data for queuing the creation of a new mission.
+ */
+export interface EnqueueCreateParams {
+  /**
+   * Stable client id to key the mission by.
+   */
+  clientId: string
+  /**
+   * Mission title.
+   */
+  title: string
+  /**
+   * Optional mission description.
+   */
+  description?: string
+  /**
+   * Start latitude in decimal degrees, or null.
+   */
+  latitude: number | null
+  /**
+   * Start longitude in decimal degrees, or null.
+   */
+  longitude: number | null
+  /**
+   * Epoch of the moment the mission started.
+   */
+  startTime: number
+}
+
+/**
+ * Fields to change on a queued mission; omit a field to leave it untouched.
+ */
+export interface MissionPatch {
+  /**
+   * New title.
+   */
+  title?: string
+  /**
+   * New description.
+   */
+  description?: string
+  /**
+   * New start latitude in decimal degrees.
+   */
+  latitude?: number | null
+  /**
+   * New start longitude in decimal degrees.
+   */
+  longitude?: number | null
+}
+
+/**
+ * Finds a pending mission by its client id or by its already-known cloud id.
+ * @param {PendingMissionQueue} queue - Current queue.
+ * @param {string} ref - Client id or cloud id to look up.
+ * @returns {PendingCloudMission | undefined} The matching pending mission, if any.
+ */
+export const findPending = (queue: PendingMissionQueue, ref: string): PendingCloudMission | undefined =>
+  queue[ref] ?? Object.values(queue).find((mission) => mission.cloudId === ref)
+
+/**
+ * Queues the creation of a brand-new mission.
+ * @param {PendingMissionQueue} queue - Current queue.
+ * @param {EnqueueCreateParams} params - New mission data.
+ * @returns {PendingMissionQueue} The queue with the create operation added.
+ */
+export const enqueueCreate = (queue: PendingMissionQueue, params: EnqueueCreateParams): PendingMissionQueue => ({
+  ...queue,
+  [params.clientId]: {
+    clientId: params.clientId,
+    cloudId: null,
+    title: params.title,
+    description: params.description,
+    latitude: params.latitude,
+    longitude: params.longitude,
+    startTime: params.startTime,
+    attempts: 0,
+    revision: 0,
+  },
+})
+
+/**
+ * Queues an update (rename and/or relocate), coalescing into an existing pending entry when present so a
+ * create-then-rename collapses into a single create and repeated renames don't stack.
+ * @param {PendingMissionQueue} queue - Current queue.
+ * @param {string} ref - Client id or cloud id of the mission to update.
+ * @param {MissionPatch} patch - Fields to change; omit a field to leave it untouched.
+ * @returns {PendingMissionQueue} The queue with the update coalesced in.
+ */
+export const enqueueUpdate = (queue: PendingMissionQueue, ref: string, patch: MissionPatch): PendingMissionQueue => {
+  const existing = findPending(queue, ref)
+  // A mission that was already synced (or a selected existing cloud mission) is tracked by its cloud id.
+  const base: PendingCloudMission = existing ?? { clientId: ref, cloudId: ref, attempts: 0, revision: 0 }
+  const merged: PendingCloudMission = {
+    ...base,
+    ...(patch.title !== undefined ? { title: patch.title } : {}),
+    ...(patch.description !== undefined ? { description: patch.description } : {}),
+    ...(patch.latitude !== undefined ? { latitude: patch.latitude } : {}),
+    ...(patch.longitude !== undefined ? { longitude: patch.longitude } : {}),
+    attempts: 0,
+    revision: base.revision + 1,
+  }
+  return { ...queue, [base.clientId]: merged }
+}
+
+/**
+ * Removes a mission from the queue once it is fully synced (or abandoned).
+ * @param {PendingMissionQueue} queue - Current queue.
+ * @param {string} clientId - Client id of the entry to remove.
+ * @returns {PendingMissionQueue} The queue without that entry.
+ */
+const removePending = (queue: PendingMissionQueue, clientId: string): PendingMissionQueue => {
+  if (!(clientId in queue)) return queue
+  const next = { ...queue }
+  delete next[clientId]
+  return next
+}
+
+/**
+ * Drops an entry that has just been pushed, unless the user edited it while the request was in flight: that newer
+ * edit stays queued, retargeted at the cloud id the mission holds now, so it is flushed as an update rather than
+ * being deleted unsent or created a second time.
+ * @param {PendingMissionQueue} queue - Current queue.
+ * @param {PendingCloudMission} pushed - The entry as it was when the request was built.
+ * @param {string} cloudId - Cloud id the mission holds now that the push succeeded.
+ * @returns {PendingMissionQueue} The queue without the entry, or with the newer edit retargeted.
+ */
+export const settlePending = (
+  queue: PendingMissionQueue,
+  pushed: PendingCloudMission,
+  cloudId: string
+): PendingMissionQueue => {
+  const stored = queue[pushed.clientId]
+  if (!stored || stored.revision === pushed.revision) return removePending(queue, pushed.clientId)
+  return { ...queue, [pushed.clientId]: { ...stored, cloudId } }
+}
+
+/**
+ * Records a failed flush attempt, dropping the entry once it has failed `maxAttempts` times so a permanently
+ * rejected operation can't wedge the queue forever.
+ * @param {PendingMissionQueue} queue - Current queue.
+ * @param {string} clientId - Client id of the entry that failed.
+ * @param {number} maxAttempts - Attempt count at which the entry is dropped.
+ * @returns {PendingMissionQueue} The queue with the attempt counted or the entry dropped.
+ */
+export const registerFailedAttempt = (
+  queue: PendingMissionQueue,
+  clientId: string,
+  maxAttempts: number
+): PendingMissionQueue => {
+  const existing = queue[clientId]
+  if (!existing) return queue
+  const attempts = existing.attempts + 1
+  if (attempts >= maxAttempts) return removePending(queue, clientId)
+  return { ...queue, [clientId]: { ...existing, attempts } }
+}
+
+/**
+ * Lists the missions still awaiting synchronization.
+ * @param {PendingMissionQueue} queue - Current queue.
+ * @returns {PendingCloudMission[]} The pending missions.
+ */
+export const pendingMissions = (queue: PendingMissionQueue): PendingCloudMission[] => Object.values(queue)

--- a/src/libs/blueos-cloud/types.ts
+++ b/src/libs/blueos-cloud/types.ts
@@ -97,3 +97,63 @@ export interface TokenResponse {
    */
   expires_in: number
 }
+
+/**
+ * Mission representation as returned by the BlueOS Cloud API.
+ */
+export interface BlueOsCloudMission {
+  /**
+   * Unique mission identifier.
+   */
+  id: string
+  /**
+   * Mission title shown on the cloud UI.
+   */
+  title: string
+  /**
+   * Optional mission description.
+   */
+  description: string
+  /**
+   * ISO timestamp of when the mission started.
+   */
+  start_time: string | null
+  /**
+   * ISO timestamp of when the mission ended.
+   */
+  end_time: string | null
+  /**
+   * Identifier of the user that created the mission.
+   */
+  created_by: number | null
+  /**
+   * Decimal latitude of the mission start (string to preserve precision).
+   */
+  start_latitude: string | null
+  /**
+   * Decimal longitude of the mission start (string to preserve precision).
+   */
+  start_longitude: string | null
+}
+
+/**
+ * Generic paginated payload used by the BlueOS Cloud API.
+ */
+export interface BlueOsCloudPaginatedResponse<T> {
+  /**
+   * Total number of items across all pages.
+   */
+  count: number
+  /**
+   * URL of the next page, or `null` when there are no more pages.
+   */
+  next: string | null
+  /**
+   * URL of the previous page, or `null` when on the first page.
+   */
+  previous: string | null
+  /**
+   * Items contained in the current page.
+   */
+  results: T[]
+}

--- a/src/stores/blueOsCloud.ts
+++ b/src/stores/blueOsCloud.ts
@@ -1,10 +1,80 @@
 import { StorageSerializers, useStorage } from '@vueuse/core'
 import { defineStore } from 'pinia'
-import { computed } from 'vue'
+import { v4 as uuid } from 'uuid'
+import { computed, onScopeDispose, ref, watch } from 'vue'
 
 import { useBlueOsStorage } from '@/composables/settingsSyncer'
+import { openSnackbar } from '@/composables/snackbar'
+import {
+  BlueOsCloudApiError,
+  createMission,
+  fetchMissions,
+  isPermanentApiError,
+  updateMission,
+} from '@/libs/blueos-cloud/api'
 import { fetchAuthenticatedUser, isTokenValid, refreshAccessToken } from '@/libs/blueos-cloud/auth'
-import { BlueOsCloudTokens, BlueOsCloudUser } from '@/libs/blueos-cloud/types'
+import {
+  type PendingCloudMission,
+  type PendingMissionQueue,
+  enqueueCreate,
+  enqueueUpdate,
+  findPending,
+  pendingMissions,
+  registerFailedAttempt,
+  settlePending,
+} from '@/libs/blueos-cloud/mission-sync-queue'
+import { BlueOsCloudMission, BlueOsCloudTokens, BlueOsCloudUser } from '@/libs/blueos-cloud/types'
+
+// Drop a mission sync operation after this many rejections by the server so a permanently rejected op can't wedge
+// the queue. Failures that never reached the server (offline) don't count, or field work would be thrown away.
+const MAX_MISSION_SYNC_ATTEMPTS = 5
+
+// Backoff before retrying the queue after a failed flush (e.g. still offline).
+const MISSION_SYNC_RETRY_MS = 30_000
+
+/**
+ * Fields for creating a new BlueOS Cloud mission from the session.
+ */
+interface StartCloudMissionInput {
+  /**
+   * Mission title.
+   */
+  name: string
+  /**
+   * Optional mission description.
+   */
+  description?: string
+  /**
+   * Start latitude in decimal degrees.
+   */
+  latitude?: number | null
+  /**
+   * Start longitude in decimal degrees.
+   */
+  longitude?: number | null
+}
+
+/**
+ * Fields to change on the currently linked BlueOS Cloud mission.
+ */
+interface UpdateLinkedMissionInput {
+  /**
+   * New mission title.
+   */
+  name?: string
+  /**
+   * New mission description.
+   */
+  description?: string
+  /**
+   * New start latitude in decimal degrees.
+   */
+  latitude?: number | null
+  /**
+   * New start longitude in decimal degrees.
+   */
+  longitude?: number | null
+}
 
 export const useBlueOsCloudStore = defineStore('blueOsCloud', () => {
   const isIntegrationEnabled = useBlueOsStorage<boolean>('cockpit-blueos-cloud-enabled', false)
@@ -15,7 +85,82 @@ export const useBlueOsCloudStore = defineStore('blueOsCloud', () => {
     serializer: StorageSerializers.object,
   })
 
+  const missions = ref<BlueOsCloudMission[]>([])
+  const isLoadingMissions = ref(false)
+  const lastError = ref<string | null>(null)
+
+  /**
+   * Identifier of the cloud mission currently linked to the active Cockpit session, set from the mission
+   * configuration dialog. Upload pickers read this to auto-select the right mission by default.
+   */
+  const linkedMissionId = useStorage<string | null>('cockpit-blueos-cloud-linked-mission-id', null, undefined, {
+    serializer: StorageSerializers.object,
+  })
+
+  // Persistent queue of mission mutations awaiting internet, so offline field work is replayed once online.
+  const missionSyncQueue = useStorage<PendingMissionQueue>('cockpit-blueos-cloud-mission-queue-v1', {}, undefined, {
+    serializer: StorageSerializers.object,
+  })
+
+  // Mission-cycle stamp (the mission start-time epoch) captured when the cloud mission was linked, so the link
+  // is considered active only during that cycle; a new cycle (6h idle / new day) prompts a fresh select/create.
+  const linkedMissionCycleId = useStorage<number | null>('cockpit-blueos-cloud-linked-mission-cycle', null, undefined, {
+    serializer: StorageSerializers.object,
+  })
+
+  // Last known details of the linked mission. The mission list is fetched, so it is empty until something asks for
+  // it: without this, a reload would show the linked mission as untitled and unlocated, and editing it from there
+  // would erase its description and start position on the cloud.
+  const cachedLinkedMission = useStorage<BlueOsCloudMission | null>(
+    'cockpit-blueos-cloud-linked-mission-v1',
+    null,
+    undefined,
+    { serializer: StorageSerializers.object }
+  )
+
+  const fetchedLinkedMission = computed<BlueOsCloudMission | null>(() => {
+    const missionRef = linkedMissionId.value
+    if (!missionRef) return null
+    return missions.value.find((mission) => mission.id === missionRef) ?? null
+  })
+
+  watch(fetchedLinkedMission, (mission) => {
+    if (mission) cachedLinkedMission.value = mission
+  })
+
+  const patchedCoordinate = (patched: number | null | undefined, base: string | null): string | null => {
+    if (patched === undefined) return base
+    return patched === null ? null : String(patched)
+  }
+
+  // A queued mutation is newer than both the fetched list and the cache, so it is overlaid on whichever of them
+  // answered instead of replacing it: a patch carries only the fields the user changed.
+  const linkedMission = computed<BlueOsCloudMission | null>(() => {
+    const missionRef = linkedMissionId.value
+    if (!missionRef) return null
+    const cached = cachedLinkedMission.value?.id === missionRef ? cachedLinkedMission.value : null
+    const base = fetchedLinkedMission.value ?? cached
+    const pending = findPending(missionSyncQueue.value, missionRef)
+    if (!pending) return base
+    return {
+      id: base?.id ?? pending.clientId,
+      title: pending.title ?? base?.title ?? '',
+      description: pending.description ?? base?.description ?? '',
+      start_time: base?.start_time ?? null,
+      end_time: base?.end_time ?? null,
+      created_by: base?.created_by ?? null,
+      start_latitude: patchedCoordinate(pending.latitude, base?.start_latitude ?? null),
+      start_longitude: patchedCoordinate(pending.longitude, base?.start_longitude ?? null),
+    }
+  })
+
   const isAuthenticated = computed(() => !!tokens.value && !!user.value)
+
+  // Whether the linked mission already exists on BlueOS Cloud (vs. a locally-created one still awaiting sync).
+  // Read from the queue rather than from the fetched list, so it stays right before any list is loaded.
+  const isLinkedMissionSynced = computed(
+    () => !!linkedMissionId.value && !findPending(missionSyncQueue.value, linkedMissionId.value)
+  )
 
   const displayName = computed(() => {
     const currentUser = user.value
@@ -23,23 +168,36 @@ export const useBlueOsCloudStore = defineStore('blueOsCloud', () => {
     return currentUser.name || currentUser.nickname || currentUser.email || currentUser.sub
   })
 
+  let retryTimer: ReturnType<typeof setTimeout> | null = null
+
   /**
    * Clears persisted tokens and the cached user profile, effectively logging the user out locally.
    */
   const clearSession = (): void => {
+    if (retryTimer) {
+      clearTimeout(retryTimer)
+      retryTimer = null
+    }
     tokens.value = null
     user.value = null
+    missions.value = []
+    linkedMissionId.value = null
+    linkedMissionCycleId.value = null
+    cachedLinkedMission.value = null
+    // The sync queue is deliberately kept: it holds work the user was told was saved, and it is replayed on sign-in.
   }
 
   /**
    * Stores a freshly issued token bundle and refreshes the cached user profile from Auth0.
    *
-   * Used both at the end of the device-flow login wizard and after a successful refresh-token exchange.
+   * Used both at the end of the device-flow login wizard and after a successful refresh-token exchange, so it is
+   * also where anything left queued by a previous session gets its first chance to be uploaded.
    * @param {BlueOsCloudTokens} newTokens - Token bundle to persist.
    */
   const persistSession = async (newTokens: BlueOsCloudTokens): Promise<void> => {
     tokens.value = newTokens
     user.value = await fetchAuthenticatedUser(newTokens.accessToken)
+    void flushMissionSyncQueue()
   }
 
   // Shared in-flight refresh so concurrent callers exchange the refresh token only once.
@@ -70,7 +228,9 @@ export const useBlueOsCloudStore = defineStore('blueOsCloud', () => {
           return refreshed.accessToken
         })
         .catch((error) => {
-          clearSession()
+          // Only a refusal from Auth0 means the session is really over; a refresh that couldn't be attempted (no
+          // internet) must keep the user signed in, or field work is logged out for being offline.
+          if (isPermanentApiError(error)) clearSession()
           throw error
         })
         .finally(() => {
@@ -81,14 +241,266 @@ export const useBlueOsCloudStore = defineStore('blueOsCloud', () => {
     return refreshPromise
   }
 
+  /**
+   * Refreshes the cached list of cloud missions.
+   *
+   * Mutates `missions`, `isLoadingMissions` and `lastError` so the UI can react to the load lifecycle.
+   * @returns {Promise<BlueOsCloudMission[]>} The updated list of missions.
+   */
+  const refreshMissions = async (): Promise<BlueOsCloudMission[]> => {
+    isLoadingMissions.value = true
+    lastError.value = null
+    try {
+      const accessToken = await ensureValidAccessToken()
+      const fetched = await fetchMissions(accessToken)
+      missions.value = fetched
+      return fetched
+    } catch (error) {
+      lastError.value = (error as Error).message
+      throw error
+    } finally {
+      isLoadingMissions.value = false
+    }
+  }
+
+  let isFlushingQueue = false
+
+  const scheduleQueueRetry = (): void => {
+    if (retryTimer) return
+    retryTimer = setTimeout(() => {
+      retryTimer = null
+      void flushMissionSyncQueue()
+    }, MISSION_SYNC_RETRY_MS)
+  }
+
+  // Inserts rather than only replacing: the list is empty until something fetches it, so a flush right after a
+  // restart would otherwise drop the record the server just returned, along with the cache written from it.
+  const upsertMission = (mission: BlueOsCloudMission): void => {
+    missions.value = [mission, ...missions.value.filter((existing) => existing.id !== mission.id)]
+  }
+
+  // An edit saved mid-request survives the push that was already in flight, but the running flush walks a snapshot
+  // taken before it, so the entry it leaves behind needs a retry of its own to ever be uploaded.
+  const settleSyncedMission = (mission: PendingCloudMission, cloudId: string): void => {
+    missionSyncQueue.value = settlePending(missionSyncQueue.value, mission, cloudId)
+    if (mission.clientId in missionSyncQueue.value) scheduleQueueRetry()
+  }
+
+  /**
+   * Creates a queued mission on the cloud and reconciles the local state with the id the server assigned: the
+   * created mission enters the list, a session link pointing at the local id follows it, and the entry leaves
+   * the queue.
+   * @param {PendingCloudMission} mission - Queued mission to create.
+   * @param {string} accessToken - Valid BlueOS Cloud access token.
+   */
+  const createAndReconcile = async (mission: PendingCloudMission, accessToken: string): Promise<void> => {
+    const created = await createMission(
+      {
+        name: mission.title ?? '',
+        description: mission.description,
+        latitude: mission.latitude ?? null,
+        longitude: mission.longitude ?? null,
+        startTime: mission.startTime,
+      },
+      accessToken
+    )
+    upsertMission(created)
+    if (linkedMissionId.value === mission.clientId) linkedMissionId.value = created.id
+    settleSyncedMission(mission, created.id)
+  }
+
+  /**
+   * Tells the user a queued operation was given up on, and clears the link when it was the mission's own creation
+   * that was refused, so the dialog stops offering a mission that will never be uploaded. A refused update names a
+   * mission the cloud is still serving, so that one keeps its link and loses only the edit.
+   * @param {PendingCloudMission} mission - Mission that was dropped from the queue.
+   */
+  const announceDroppedMission = (mission: PendingCloudMission): void => {
+    const wasNeverUploaded = mission.cloudId === null
+    if (wasNeverUploaded && linkedMissionId.value === mission.clientId) linkedMissionId.value = null
+    const missionName = mission.title ?? mission.clientId
+    const rejected = wasNeverUploaded
+      ? `mission "${missionName}", so it will not be uploaded`
+      : `the changes to mission "${missionName}", which stays linked but keeps its previous details`
+    openSnackbar({
+      message: `BlueOS Cloud rejected ${rejected}.`,
+      variant: 'error',
+      duration: 6000,
+      closeButton: true,
+    })
+  }
+
+  /**
+   * Pushes a single queued mission to BlueOS Cloud, counting a server refusal against its attempt budget.
+   * @param {PendingCloudMission} mission - Queued mission to push.
+   * @param {string} accessToken - Valid BlueOS Cloud access token.
+   * @returns {Promise<'synced' | 'retry' | 'dropped'>} Whether the mission is now on the cloud, should be retried
+   * later, or exhausted its attempts and left the queue unsent.
+   */
+  const syncPendingMission = async (
+    mission: PendingCloudMission,
+    accessToken: string
+  ): Promise<'synced' | 'retry' | 'dropped'> => {
+    const missionName = mission.title ?? mission.clientId
+    try {
+      if (mission.cloudId === null) {
+        await createAndReconcile(mission, accessToken)
+      } else {
+        const updated = await updateMission(
+          mission.cloudId,
+          {
+            name: mission.title,
+            description: mission.description,
+            latitude: mission.latitude,
+            longitude: mission.longitude,
+          },
+          accessToken
+        )
+        upsertMission(updated)
+        settleSyncedMission(mission, mission.cloudId)
+      }
+      return 'synced'
+    } catch (opError) {
+      // The mission was deleted on the cloud since we linked it: re-create it so the local mission is restored.
+      const missionWasDeleted =
+        mission.cloudId !== null && opError instanceof BlueOsCloudApiError && opError.status === 404
+      if (missionWasDeleted) {
+        try {
+          await createAndReconcile(mission, accessToken)
+          console.warn(`[BlueOsCloud] Mission '${missionName}' no longer existed on the cloud and was re-created.`)
+          return 'synced'
+        } catch (recreateError) {
+          // Deliberately falls through to the accounting below, which judges the original 404: a mission the server
+          // says is gone and then refuses to re-create is a refusal, and should spend an attempt like any other.
+          console.error(`[BlueOsCloud] Failed to re-create missing BlueOS Cloud mission. ${recreateError}`)
+        }
+      } else {
+        console.error(`[BlueOsCloud] Failed to sync mission '${missionName}'. ${opError}`)
+      }
+      if (!isPermanentApiError(opError)) return 'retry'
+      const remaining = registerFailedAttempt(missionSyncQueue.value, mission.clientId, MAX_MISSION_SYNC_ATTEMPTS)
+      const wasDropped = !(mission.clientId in remaining)
+      missionSyncQueue.value = remaining
+      return wasDropped ? 'dropped' : 'retry'
+    }
+  }
+
+  /**
+   * Replays queued mission mutations against BlueOS Cloud, reconciling locally-created missions with the ids the
+   * server assigns. Safe to call repeatedly; it no-ops while offline, unauthenticated, or already flushing, and
+   * schedules a retry when an operation fails so field work eventually syncs once the internet is reachable.
+   * @returns {Promise<void>} Resolves once a flush pass finishes (successfully or by deferring for retry).
+   */
+  const flushMissionSyncQueue = async (): Promise<void> => {
+    if (isFlushingQueue || !isAuthenticated.value) return
+    if (pendingMissions(missionSyncQueue.value).length === 0) return
+    isFlushingQueue = true
+    try {
+      const accessToken = await ensureValidAccessToken()
+      for (const mission of pendingMissions(missionSyncQueue.value)) {
+        const outcome = await syncPendingMission(mission, accessToken)
+        if (outcome === 'synced') continue
+        if (outcome === 'dropped') announceDroppedMission(mission)
+        // ponytail: abort the flush after the first failure; later queue entries wait for the scheduled retry.
+        // Upgrade: keep walking the remaining missions in this pass and collect failures.
+        scheduleQueueRetry()
+        return
+      }
+    } catch {
+      // Could not obtain a valid token (offline or session expired); keep the queue and retry later.
+      scheduleQueueRetry()
+    } finally {
+      isFlushingQueue = false
+    }
+  }
+
+  /**
+   * Starts a brand-new mission on BlueOS Cloud and links it to the session. Works offline: the mission is queued
+   * with a local id and created on the cloud once the internet is reachable.
+   * @param {StartCloudMissionInput} input - New mission data.
+   * @param {number} cycleId - Mission-cycle stamp (mission start-time epoch) to associate the link with, and the
+   * start time the mission is created with on the cloud.
+   * @returns {string} The local client id now linked to the session.
+   */
+  const startCloudMission = (input: StartCloudMissionInput, cycleId: number): string => {
+    const clientId = uuid()
+    missionSyncQueue.value = enqueueCreate(missionSyncQueue.value, {
+      clientId,
+      title: input.name,
+      description: input.description,
+      latitude: input.latitude ?? null,
+      longitude: input.longitude ?? null,
+      startTime: cycleId,
+    })
+    linkedMissionId.value = clientId
+    linkedMissionCycleId.value = cycleId
+    void flushMissionSyncQueue()
+    return clientId
+  }
+
+  /**
+   * Links an already-existing cloud mission to the current session cycle.
+   * @param {string} missionId - Cloud mission id to link.
+   * @param {number} cycleId - Mission-cycle stamp (mission start-time epoch) to associate the link with.
+   */
+  const linkExistingMission = (missionId: string, cycleId: number): void => {
+    linkedMissionId.value = missionId
+    linkedMissionCycleId.value = cycleId
+  }
+
+  /**
+   * Unlinks the current cloud mission so the next session starts fresh (used when finishing a mission).
+   */
+  const finishMission = (): void => {
+    linkedMissionId.value = null
+    linkedMissionCycleId.value = null
+  }
+
+  /**
+   * Queues an update (rename, relocate and/or re-describe) for the currently linked mission, coalescing with any
+   * pending create/update for it. Works offline.
+   * @param {UpdateLinkedMissionInput} input - Fields to change.
+   */
+  const updateLinkedMission = (input: UpdateLinkedMissionInput): void => {
+    const missionRef = linkedMissionId.value
+    if (!missionRef) return
+    missionSyncQueue.value = enqueueUpdate(missionSyncQueue.value, missionRef, {
+      // Always carry the title so a later re-create (if the cloud mission was deleted) keeps the mission name.
+      title: input.name ?? linkedMission.value?.title,
+      description: input.description,
+      latitude: input.latitude,
+      longitude: input.longitude,
+    })
+    void flushMissionSyncQueue()
+  }
+
+  // Replay the queue whenever the browser regains connectivity, and once now for anything left from a past session.
+  const replayQueueOnReconnection = (): void => void flushMissionSyncQueue()
+  window.addEventListener('online', replayQueueOnReconnection)
+  onScopeDispose(() => window.removeEventListener('online', replayQueueOnReconnection))
+  void flushMissionSyncQueue()
+
   return {
     isIntegrationEnabled,
     tokens,
     user,
+    missions,
+    isLoadingMissions,
+    lastError,
+    linkedMissionId,
+    linkedMissionCycleId,
+    linkedMission,
+    isLinkedMissionSynced,
     isAuthenticated,
     displayName,
     persistSession,
     clearSession,
     ensureValidAccessToken,
+    refreshMissions,
+    startCloudMission,
+    linkExistingMission,
+    finishMission,
+    updateLinkedMission,
+    flushMissionSyncQueue,
   }
 })

--- a/src/stores/blueOsCloud.ts
+++ b/src/stores/blueOsCloud.ts
@@ -457,6 +457,14 @@ export const useBlueOsCloudStore = defineStore('blueOsCloud', () => {
   }
 
   /**
+   * Clears only the cycle link so this session has no active cloud mission, while keeping the last mission id
+   * available for "continue previous".
+   */
+  const clearMissionCycleLink = (): void => {
+    linkedMissionCycleId.value = null
+  }
+
+  /**
    * Queues an update (rename, relocate and/or re-describe) for the currently linked mission, coalescing with any
    * pending create/update for it. Works offline.
    * @param {UpdateLinkedMissionInput} input - Fields to change.
@@ -500,6 +508,7 @@ export const useBlueOsCloudStore = defineStore('blueOsCloud', () => {
     startCloudMission,
     linkExistingMission,
     finishMission,
+    clearMissionCycleLink,
     updateLinkedMission,
     flushMissionSyncQueue,
   }

--- a/src/stores/mission.ts
+++ b/src/stores/mission.ts
@@ -58,7 +58,6 @@ export const useMissionStore = defineStore('mission', () => {
     'cockpit-slide-events-categories-required',
     eventCategoriesDefaultMapping
   )
-  const lastMissionName = useStorage('cockpit-last-mission-name', '')
   const missionStartTime = useStorage('cockpit-mission-start-time', new Date())
   const defaultMapCenter = useBlueOsStorage<WaypointCoordinates>('cockpit-default-map-center', DEFAULT_MAP_CENTER)
   const defaultMapZoom = useBlueOsStorage<number>('cockpit-default-map-zoom', DEFAULT_MAP_ZOOM)
@@ -184,11 +183,6 @@ export const useMissionStore = defineStore('mission', () => {
   // Id of the custom provider the user last selected as the map's base layer, so the choice is restored on reload
   // (built-in base maps are tracked separately by `userLastMapTileProvider`). Null when a built-in map is active.
   const userLastCustomMapProviderId = useBlueOsStorage<string | null>('cockpit-user-last-custom-map-provider-id', null)
-
-  // Only remember user-typed names so the mission-name restore button never brings back an automatic name.
-  watch(missionName, () => {
-    if (!missionNameIsAutomatic.value) lastMissionName.value = missionName.value
-  })
 
   const applyMissionName = (
     name: string,
@@ -869,7 +863,6 @@ export const useMissionStore = defineStore('mission', () => {
     missionName,
     missionNameIsAutomatic,
     applyMissionName,
-    lastMissionName,
     missionStartTime,
     currentPlanningWaypoints,
     currentPlanningSurveys,

--- a/src/tests/libs/blueos-cloud/mission-list.test.ts
+++ b/src/tests/libs/blueos-cloud/mission-list.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+
+import { filterAndSortMissions, formatMissionMeta } from '@/libs/blueos-cloud/mission-list'
+import type { BlueOsCloudMission } from '@/libs/blueos-cloud/types'
+
+const mission = (overrides: Partial<BlueOsCloudMission>): BlueOsCloudMission => ({
+  id: 'id',
+  title: 'Untitled mission',
+  description: '',
+  start_time: null,
+  end_time: null,
+  created_by: null,
+  start_latitude: null,
+  start_longitude: null,
+  ...overrides,
+})
+
+const reefSurvey = mission({
+  id: 'reef',
+  title: 'Reef survey',
+  description: 'Testing Cockpit/Cloud integration',
+  start_time: '2026-08-04T12:00:00Z',
+  start_latitude: '19.641100',
+  start_longitude: '-156.007600',
+})
+
+const hullInspection = mission({
+  id: 'hull',
+  title: 'Hull inspection',
+  start_time: '2026-07-29T12:00:00Z',
+})
+
+const undated = mission({ id: 'undated', title: 'Auto upload check', start_time: 'not a date' })
+
+describe('BlueOS Cloud mission list', () => {
+  it('sorts by start time, treating missions without a usable one as the oldest', () => {
+    const missions = [hullInspection, undated, reefSurvey]
+
+    expect(filterAndSortMissions(missions, '', 'newest').map((m) => m.id)).toEqual(['reef', 'hull', 'undated'])
+    expect(filterAndSortMissions(missions, '', 'oldest').map((m) => m.id)).toEqual(['undated', 'hull', 'reef'])
+  })
+
+  it('sorts by name', () => {
+    expect(filterAndSortMissions([reefSurvey, hullInspection], '', 'name').map((m) => m.id)).toEqual(['hull', 'reef'])
+  })
+
+  it('matches the query against name, description and location', () => {
+    const missions = [reefSurvey, hullInspection]
+
+    expect(filterAndSortMissions(missions, 'reef', 'newest').map((m) => m.id)).toEqual(['reef'])
+    expect(filterAndSortMissions(missions, 'integration', 'newest').map((m) => m.id)).toEqual(['reef'])
+    expect(filterAndSortMissions(missions, '-156.00', 'newest').map((m) => m.id)).toEqual(['reef'])
+    expect(filterAndSortMissions(missions, 'HULL', 'newest').map((m) => m.id)).toEqual(['hull'])
+    expect(filterAndSortMissions(missions, 'reef hull', 'newest')).toEqual([])
+  })
+
+  it('matches the query against the start date as it is displayed', () => {
+    const displayedDate = new Date(reefSurvey.start_time as string).toLocaleString()
+
+    expect(filterAndSortMissions([reefSurvey, hullInspection], displayedDate, 'newest').map((m) => m.id)).toEqual([
+      'reef',
+    ])
+  })
+
+  it('keeps the whole list when the query is empty and never mutates the input', () => {
+    const missions = [hullInspection, reefSurvey]
+
+    expect(filterAndSortMissions(missions, '   ', 'newest')).toHaveLength(2)
+    expect(missions.map((m) => m.id)).toEqual(['hull', 'reef'])
+  })
+
+  it('formats the metadata shown on a row, falling back when there is none', () => {
+    expect(formatMissionMeta(reefSurvey)).toContain('19.6411, -156.0076')
+    expect(formatMissionMeta(mission({}))).toBe('No metadata')
+    expect(formatMissionMeta(mission({ start_latitude: 'unknown', start_longitude: '1.0' }))).toBe('No metadata')
+  })
+})

--- a/src/tests/libs/blueos-cloud/mission-sync-queue.test.ts
+++ b/src/tests/libs/blueos-cloud/mission-sync-queue.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { BlueOsCloudApiError, isPermanentApiError } from '@/libs/blueos-cloud/api'
+import {
+  type PendingMissionQueue,
+  enqueueCreate,
+  enqueueUpdate,
+  registerFailedAttempt,
+  settlePending,
+} from '@/libs/blueos-cloud/mission-sync-queue'
+
+const queueWithOneCreate = (): PendingMissionQueue =>
+  enqueueCreate({}, { clientId: 'local-1', title: 'Reef survey', latitude: null, longitude: null, startTime: 1 })
+
+describe('BlueOS Cloud mission sync queue', () => {
+  it('only treats a server refusal as permanent, so offline failures never spend the attempt budget', () => {
+    expect(isPermanentApiError(new BlueOsCloudApiError('bad request', 400))).toBe(true)
+    expect(isPermanentApiError(new BlueOsCloudApiError('not found', 404))).toBe(true)
+    expect(isPermanentApiError(new BlueOsCloudApiError('timeout', 408))).toBe(false)
+    expect(isPermanentApiError(new BlueOsCloudApiError('too many requests', 429))).toBe(false)
+    expect(isPermanentApiError(new BlueOsCloudApiError('server error', 500))).toBe(false)
+    expect(isPermanentApiError(new TypeError('Failed to fetch'))).toBe(false)
+  })
+
+  it('counts attempts and drops the entry only once the budget is spent', () => {
+    let queue = queueWithOneCreate()
+
+    queue = registerFailedAttempt(queue, 'local-1', 3)
+    expect(queue['local-1'].attempts).toBe(1)
+
+    queue = registerFailedAttempt(queue, 'local-1', 3)
+    expect(queue['local-1'].attempts).toBe(2)
+
+    queue = registerFailedAttempt(queue, 'local-1', 3)
+    expect(queue['local-1']).toBeUndefined()
+  })
+
+  it('ignores an attempt on an entry that is no longer queued', () => {
+    expect(registerFailedAttempt({}, 'gone', 3)).toEqual({})
+  })
+
+  it('keeps an edit saved while the entry was being pushed, retargeted at the new cloud id', () => {
+    const pushed = queueWithOneCreate()['local-1']
+    const editedMidFlight = enqueueUpdate(queueWithOneCreate(), 'local-1', { title: 'Reef survey, south wall' })
+
+    const settled = settlePending(editedMidFlight, pushed, 'cloud-1')
+    expect(settled['local-1'].title).toBe('Reef survey, south wall')
+    // Without the cloud id the next flush would create the mission a second time instead of updating it.
+    expect(settled['local-1'].cloudId).toBe('cloud-1')
+
+    expect(settlePending(queueWithOneCreate(), pushed, 'cloud-1')).toEqual({})
+  })
+})

--- a/src/tests/stores/blueOsCloud.test.ts
+++ b/src/tests/stores/blueOsCloud.test.ts
@@ -1,0 +1,154 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
+
+import { BlueOsCloudApiError, createMission, updateMission } from '@/libs/blueos-cloud/api'
+import type { BlueOsCloudMission } from '@/libs/blueos-cloud/types'
+import { useBlueOsCloudStore } from '@/stores/blueOsCloud'
+
+// The vehicle-synced settings backend is not what these tests are about, and it needs a live BlueOS to initialize.
+vi.mock('@/composables/settingsSyncer', () => ({ useBlueOsStorage: (_key: string, value: unknown) => ref(value) }))
+
+vi.mock('@/libs/blueos-cloud/api', async () => ({
+  ...(await vi.importActual<typeof import('@/libs/blueos-cloud/api')>('@/libs/blueos-cloud/api')),
+  createMission: vi.fn(),
+  updateMission: vi.fn(),
+}))
+
+// Recent Node versions expose a localStorage global that jsdom does not replace and that throws on use, so the
+// tests bring their own.
+const entries = new Map<string, string>()
+Object.defineProperty(window, 'localStorage', {
+  configurable: true,
+  value: {
+    getItem: (key: string) => entries.get(key) ?? null,
+    setItem: (key: string, value: string) => entries.set(key, value),
+    removeItem: (key: string) => entries.delete(key),
+    clear: () => entries.clear(),
+  },
+})
+
+const cloudMission: BlueOsCloudMission = {
+  id: 'cloud-1',
+  title: 'Reef survey',
+  description: 'North wall',
+  start_time: null,
+  end_time: null,
+  created_by: null,
+  start_latitude: '-27.5',
+  start_longitude: '-48.5',
+}
+
+// A reload keeps only what is in local storage, so the mission list starts empty again.
+const reloadStore = (): ReturnType<typeof useBlueOsCloudStore> => {
+  setActivePinia(createPinia())
+  return useBlueOsCloudStore()
+}
+
+const signIn = (store: ReturnType<typeof useBlueOsCloudStore>): void => {
+  store.tokens = { accessToken: 'token', refreshToken: null, expiresAt: Date.now() + 3_600_000 }
+  store.user = { sub: 'auth0|user' }
+}
+
+describe('BlueOS Cloud linked mission', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('still knows the linked mission after a reload, with no list fetched', async () => {
+    const store = useBlueOsCloudStore()
+    store.missions = [cloudMission]
+    store.linkExistingMission(cloudMission.id, 1)
+    await nextTick()
+
+    const reloaded = reloadStore()
+    expect(reloaded.missions).toEqual([])
+    expect(reloaded.linkedMission).toEqual(cloudMission)
+    expect(reloaded.isLinkedMissionSynced).toBe(true)
+  })
+
+  it('does not offer the remembered mission once another one is linked', async () => {
+    const store = useBlueOsCloudStore()
+    store.missions = [cloudMission]
+    store.linkExistingMission(cloudMission.id, 1)
+    await nextTick()
+
+    const reloaded = reloadStore()
+    reloaded.linkExistingMission('cloud-2', 1)
+    expect(reloaded.linkedMission).toBeNull()
+  })
+
+  it('shows a queued offline edit rather than the stale fetched mission', () => {
+    const store = useBlueOsCloudStore()
+    store.missions = [cloudMission]
+    store.linkExistingMission(cloudMission.id, 1)
+
+    store.updateLinkedMission({ name: 'Reef survey, south wall' })
+
+    expect(store.linkedMission?.title).toBe('Reef survey, south wall')
+    // Fields the edit never carried keep the values the cloud returned, so a later edit can't blank them.
+    expect(store.linkedMission?.description).toBe(cloudMission.description)
+    expect(store.linkedMission?.start_latitude).toBe(cloudMission.start_latitude)
+  })
+
+  it('keeps showing the edit after it syncs on a start with no list fetched', async () => {
+    const store = useBlueOsCloudStore()
+    store.missions = [cloudMission]
+    store.linkExistingMission(cloudMission.id, 1)
+    await nextTick()
+    store.updateLinkedMission({ name: 'Reef survey, south wall' })
+    await nextTick()
+
+    const editedMission = { ...cloudMission, title: 'Reef survey, south wall' }
+    vi.mocked(updateMission).mockResolvedValue(editedMission)
+
+    const reloaded = reloadStore()
+    signIn(reloaded)
+    await reloaded.flushMissionSyncQueue()
+
+    expect(reloaded.linkedMission).toEqual(editedMission)
+  })
+
+  it('reports a mission created offline as not yet synced', () => {
+    const store = useBlueOsCloudStore()
+    const clientId = store.startCloudMission({ name: 'Hull inspection' }, 1)
+
+    expect(store.linkedMission?.title).toBe('Hull inspection')
+    expect(store.isLinkedMissionSynced).toBe(false)
+    expect(clientId).not.toBe('')
+  })
+
+  it('uploads a mission created offline with the time it started, not the time it reached the cloud', async () => {
+    const startedAt = new Date('2026-08-19T09:00:00.000Z').getTime()
+    const store = useBlueOsCloudStore()
+    store.startCloudMission({ name: 'Hull inspection' }, startedAt)
+    await nextTick()
+    vi.mocked(createMission).mockResolvedValue({ ...cloudMission, title: 'Hull inspection' })
+
+    const reloaded = reloadStore()
+    signIn(reloaded)
+    await reloaded.flushMissionSyncQueue()
+
+    expect(createMission).toHaveBeenCalledWith(expect.objectContaining({ startTime: startedAt }), 'token')
+  })
+
+  it('keeps the mission linked when the cloud gives up on an edit, since the mission itself is fine', async () => {
+    const store = useBlueOsCloudStore()
+    store.missions = [cloudMission]
+    store.linkExistingMission(cloudMission.id, 1)
+    store.updateLinkedMission({ name: 'Reef survey, south wall' })
+    await nextTick()
+
+    vi.mocked(updateMission).mockRejectedValue(new BlueOsCloudApiError('bad request', 400))
+    const reloaded = reloadStore()
+    signIn(reloaded)
+    // One flush per attempt, since the queue backs off to its retry timer after each refusal.
+    for (let attempt = 0; attempt < 5; attempt++) await reloaded.flushMissionSyncQueue()
+
+    // The edit was given up on, but the mission it targeted is on the cloud and stays linked.
+    expect(reloaded.isLinkedMissionSynced).toBe(true)
+    expect(reloaded.linkedMissionId).toBe(cloudMission.id)
+  })
+})


### PR DESCRIPTION
## What's new

BlueOS Cloud missions, managed from the Mission Identifier dialog when you're in pirate mode and signed in.

You can:
- **Create** a mission (name, optional description, optional start location on a map)
- **Select** an existing cloud mission to keep logging into
- **Edit** the linked mission's name, description, and location
- **Reset** to unlink the cloud mission and start a fresh local mission cycle

Creates and edits work offline: they're queued locally and pushed to BlueOS Cloud when the connection is back. If a linked cloud mission was deleted remotely, the next sync recreates it instead of getting stuck on 404s.

On Cockpit startup (pirate + signed in), a dialog asks how you want to work with cloud missions for this session: continue the previous mission, select an existing one, create a new one, or continue without a mission. It's skipped entirely when a mission is already linked to the current cycle, so reloading mid-mission just resumes.

## What changed (local mission dialog)

When BlueOS Cloud missions aren't active, the dialog stays local-only but a few UX bits moved:
- The old restore-last-name control is gone; there's a **Reset current mission** action instead (new automatic name + new mission cycle)
- Top-right close control on the dialog
- Mission Identifier widget: edit icon only on hover, no background hover tint

## Mission flows

### Not in pirate mode
Same local mission name flow as before (with the reset/hover tweaks above). No BlueOS Cloud mission UI — cloud missions stay behind pirate mode like the Cloud settings menu.

### Pirate mode, not signed into BlueOS Cloud
Still the local name flow (edit name, generate name, reset, save). A short note points you to Cloud settings to log in if you want cloud missions.

### Pirate mode, signed into BlueOS Cloud
Cloud missions take over the dialog:

1. **No mission linked this cycle** — choose **Continue previous mission**, **Select existing mission** or **Create a new mission**. Close dismisses the dialog.
2. **Mission linked this cycle** — read-only name / description / location / sync status (with a link to open it on BlueOS Cloud when synced). Actions: **Edit mission**, **Reset mission**, or Close.

Linking is tied to the current mission cycle (the same ~6h idle / new-day cycle as the automatic mission name). When the cycle renews, the cloud association clears and you're back to select/create.

The startup dialog and the mission configuration dialog share the same cycle state and linking actions through a single composable, so both entry points behave identically.

Closes #2711.
