### PR TITLE
fix: stop the map widget from setting the home position by itself

### DIFF
--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -1718,8 +1718,9 @@ const drawMission = (missionItems: Waypoint[]): void => {
   const drawn: Waypoint[] = []
   missionItems.forEach((wp, idx) => {
     if (idx === 0) {
+      // Only moves the marker. Echoing this back as a set-home command would overwrite the vehicle's home with a
+      // possibly stale one, as missions are restored from persistent storage on startup.
       home.value = wp.coordinates
-      setHomePosition(wp.coordinates)
     } else {
       drawn.push(wp)
     }

--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -1252,6 +1252,11 @@ watch([vehiclePosition, vehicleHeading, timeAgoSeenText, () => vehicleStore.isAr
   }
 })
 
+const homeWasCommandedByUser = computed(() => {
+  const commanded = missionStore.userCommandedHomePosition
+  return commanded !== undefined && home.value?.[0] === commanded[0] && home.value?.[1] === commanded[1]
+})
+
 // Create marker for the home position
 const homeMarker = shallowRef<L.Marker>()
 watch(home, () => {
@@ -1275,6 +1280,17 @@ watch(home, () => {
     homeMarker.value.bindTooltip(homeMarkerTooltip)
     homeMarker.value.on('dragend', (e: L.DragEndEvent) => {
       const marker = e.target as L.Marker
+      // A home drawn from a mission is just a rendering of that mission, so dragging it must not command the vehicle.
+      // Snapping back keeps the marker honest, as nothing anywhere would hold the dragged-to position.
+      if (!homeWasCommandedByUser.value) {
+        if (home.value) marker.setLatLng(home.value as LatLngTuple)
+        openSnackbar({
+          message: 'This home point comes from the mission. Use "Set home waypoint" on the map menu to move it.',
+          variant: 'info',
+          duration: 5000,
+        })
+        return
+      }
       const latlng = marker.getLatLng()
       setHomePosition([latlng.lat, latlng.lng])
     })
@@ -1774,8 +1790,10 @@ const downloadMissionFromVehicle = async (): Promise<void> => {
 }
 
 const setHomePosition = async (homePosition: [number, number]): Promise<void> => {
+  logUserAction('Set the home position from the map')
   const newHome: [number, number] = [homePosition[0], homePosition[1]]
   home.value = newHome
+  missionStore.userCommandedHomePosition = newHome
 
   await vehicleStore.setHomeWaypoint(newHome, 0)
   if (contextMenuVisible.value) {

--- a/src/stores/mission.ts
+++ b/src/stores/mission.ts
@@ -103,6 +103,9 @@ export const useMissionStore = defineStore('mission', () => {
   const mapClearRequestRevision = ref(0)
   const mapDownloadRequestRevision = ref(0)
   const homeMarkerPosition = ref<WaypointCoordinates | undefined>(undefined)
+  // Home position the user last commanded. Compared against homeMarkerPosition to tell a home the user placed apart
+  // from one that merely came from a mission, so any other writer invalidates it without having to know about this.
+  const userCommandedHomePosition = ref<WaypointCoordinates | undefined>(undefined)
   // Request for any active map to center on given coordinates. Replaced (new object) on each request.
   const mapCenterOnRequest = ref<{
     /** Coordinates the map should center on */
@@ -885,6 +888,7 @@ export const useMissionStore = defineStore('mission', () => {
     canRedo,
     clearUndoStack,
     homeMarkerPosition,
+    userCommandedHomePosition,
     plannedVehicleType,
     effectiveVehicleType,
     savedMissions,


### PR DESCRIPTION
## Summary

The flight-view map widget wrote the home position to the vehicle without anyone asking it to. Two separate paths did it, so there are two commits.

### Drawing a mission no longer commands the vehicle

`drawMission` treats mission item 0 as home and echoed it straight back as a `MAV_CMD_DO_SET_HOME`. None of the paths reaching it are a user setting a home point:

- `onMounted`, when the vehicle is offline and a stored mission exists.
- `refreshMission()`, which runs on mount, when the vehicle comes back online, and on every `vehicleMissionRevision` bump — so after every mission upload from the planning view.
- `checkIfMissionChanged()`, whenever the vehicle's mission differs from the stored one.
- `downloadMissionFromVehicle()`, itself triggered automatically by `refreshMission` and by the `mapDownloadRequestRevision` watcher.

The download paths echo back coordinates that came from the vehicle, so they were mostly a redundant write. The dangerous one is the stored-mission path: `cockpit-vehicle-mission` is persisted through `useBlueOsStorage`, so opening Cockpit with a mission left over from a previous session — potentially at a completely different site — silently overwrote the vehicle's home position.

Dropping the call is enough. `home.value` already moves the marker and updates `missionStore.homeMarkerPosition`, so the map draws exactly what it drew before.

### Dragging only commands the vehicle for a home the user placed

Dragging the home marker always sent a command, including when the marker was only a rendering of a mission's first item. Home positions now carry provenance: the map records the position the user commanded in `missionStore.userCommandedHomePosition`, and a drag only sends while the marker still sits on it.

The provenance is a stored position rather than a boolean so that every other writer of `homeMarkerPosition` — the mission-planning pipeline, a home fetched from the vehicle, a freshly drawn mission — invalidates it without having to know this mechanism exists. That also keeps this PR from touching `MissionPlanningView.vue`, so it stays independent of #2873.

Two judgement calls worth a look:

- Dragging a mission-drawn home **snaps the marker back** and shows a snackbar pointing at the "Set home waypoint" menu action. Letting it move would leave `homeMarkerPosition` — which also feeds the compass HUD home arrow and the mission distance estimates — pointing at a place that is home neither on the vehicle nor in the mission. Say the word if you would rather it move freely and just stay silent.
- `setHomePosition` had no `logUserAction`, unlike the neighbouring context-menu actions, so I added one at that funnel since both explicit paths pass through it. Easy to drop if you consider it out of scope here.

## Test plan

- [ ] Upload a mission, reload Cockpit with the vehicle offline, then bring it online → the home marker is drawn and no `DO_SET_HOME` reaches the vehicle.
- [ ] Set a distinct home on the vehicle, then open Cockpit with a stored mission from another site → the vehicle's home is unchanged.
- [ ] Download a mission from the vehicle → marker drawn, no home command sent.
- [ ] Change the mission on the vehicle so `checkIfMissionChanged` trips → mission redrawn, no home command sent.
- [ ] Set home from the map context menu → command still sent.
- [ ] Immediately drag that marker → command sent, since the user placed it.
- [ ] Load or download a mission, then drag its home marker → no command, marker snaps back, snackbar shown.
- [ ] Set home from the map, then set a different home in mission planning, return to the map and drag → no command, since the planning write invalidated the provenance.
- [ ] With home fetched from the vehicle and no mission loaded, drag the marker → no command.

Fixes #2869.