### PR TITLE
refactor: send the set-home command as COMMAND_INT

### DIFF
--- a/src/libs/vehicle/mavlink/vehicle.ts
+++ b/src/libs/vehicle/mavlink/vehicle.ts
@@ -244,6 +244,7 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
    * @param {number} x (latitude)
    * @param {number} y (longitude)
    * @param {number} z (altitude)
+   * @param {MavFrame} frame Reference frame the altitude is expressed in
    * @returns {Promise<void>} A promise that resolves when the command is acknowledged.
    */
   async sendCommandInt(
@@ -254,7 +255,8 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
     param4 = 0,
     x = 0,
     y = 0,
-    z = 0
+    z = 0,
+    frame: MavFrame = MavFrame.MAV_FRAME_GLOBAL
   ): Promise<void> {
     const commandMessage: Message.CommandInt = {
       type: MAVLinkType.COMMAND_INT,
@@ -270,7 +272,7 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
       },
       target_system: this.currentSystemId,
       target_component: 1,
-      frame: { type: MavFrame.MAV_FRAME_GLOBAL },
+      frame: { type: frame },
       current: 0,
       autocontinue: 0,
     }
@@ -1198,9 +1200,14 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
    * Set home waypoint on the vehicle
    * @param { [number, number] } coordinates Coordinates of the home waypoint
    * @param { number } altitude Altitude of the home waypoint
+   * @param { MavFrame } frame Reference frame the altitude is expressed in
    */
-  async setHomeWaypoint(coordinates: [number, number], altitude: number): Promise<void> {
-    await this.sendCommandLong(MavCmd.MAV_CMD_DO_SET_HOME, 0, 0, 0, 0, coordinates[0], coordinates[1], altitude)
+  async setHomeWaypoint(
+    coordinates: [number, number],
+    altitude: number,
+    frame: MavFrame = MavFrame.MAV_FRAME_GLOBAL
+  ): Promise<void> {
+    await this.sendCommandInt(MavCmd.MAV_CMD_DO_SET_HOME, 0, 0, 0, 0, coordinates[0], coordinates[1], altitude, frame)
   }
 
   /**

--- a/src/libs/vehicle/mavlink/vehicle.ts
+++ b/src/libs/vehicle/mavlink/vehicle.ts
@@ -1200,12 +1200,13 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
    * Set home waypoint on the vehicle
    * @param { [number, number] } coordinates Coordinates of the home waypoint
    * @param { number } altitude Altitude of the home waypoint
-   * @param { MavFrame } frame Reference frame the altitude is expressed in
+   * @param { MavFrame } frame Reference frame the altitude is expressed in. Defaults to home-relative, where an
+   * altitude of zero moves home horizontally and leaves its altitude untouched.
    */
   async setHomeWaypoint(
     coordinates: [number, number],
     altitude: number,
-    frame: MavFrame = MavFrame.MAV_FRAME_GLOBAL
+    frame: MavFrame = MavFrame.MAV_FRAME_GLOBAL_RELATIVE_ALT
   ): Promise<void> {
     await this.sendCommandInt(MavCmd.MAV_CMD_DO_SET_HOME, 0, 0, 0, 0, coordinates[0], coordinates[1], altitude, frame)
   }

--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -527,13 +527,14 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
    * Set home waypoint on vehicle
    * @param { [ number, number ] } coordinate Coordinate of the home waypoint
    * @param { number } height Height of the home waypoint
-   * @param { MavFrame } frame Reference frame the height is expressed in
+   * @param { MavFrame } frame Reference frame the height is expressed in. Defaults to home-relative, where a height
+   * of zero moves home horizontally and leaves its altitude untouched.
    * @returns { Promise<void> }
    */
   async function setHomeWaypoint(
     coordinate: [number, number],
     height: number,
-    frame: MavFrame = MavFrame.MAV_FRAME_GLOBAL
+    frame: MavFrame = MavFrame.MAV_FRAME_GLOBAL_RELATIVE_ALT
   ): Promise<void> {
     if (!mainVehicle.value) {
       throw new Error('No vehicle available to set home waypoint.')

--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -22,7 +22,7 @@ import {
 import * as Connection from '@/libs/connection/connection'
 import { ConnectionManager } from '@/libs/connection/connection-manager'
 import type { Package } from '@/libs/connection/m2r/messages/mavlink2rest'
-import { MavAutopilot, MAVLinkType, MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
+import { MavAutopilot, MavFrame, MAVLinkType, MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import type { Message } from '@/libs/connection/m2r/messages/mavlink2rest-message'
 import eventTracker from '@/libs/external-telemetry/event-tracking'
 import { availableCockpitActions, registerActionCallback } from '@/libs/joystick/protocols/cockpit-actions'
@@ -525,15 +525,20 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
 
   /**
    * Set home waypoint on vehicle
-   * @param { [ number, number ] } coordinate of the home waypoint
-   * @param { number } height of the home waypoint
+   * @param { [ number, number ] } coordinate Coordinate of the home waypoint
+   * @param { number } height Height of the home waypoint
+   * @param { MavFrame } frame Reference frame the height is expressed in
    * @returns { Promise<void> }
    */
-  async function setHomeWaypoint(coordinate: [number, number], height: number): Promise<void> {
+  async function setHomeWaypoint(
+    coordinate: [number, number],
+    height: number,
+    frame: MavFrame = MavFrame.MAV_FRAME_GLOBAL
+  ): Promise<void> {
     if (!mainVehicle.value) {
       throw new Error('No vehicle available to set home waypoint.')
     }
-    await mainVehicle.value.setHomeWaypoint(coordinate, height)
+    await mainVehicle.value.setHomeWaypoint(coordinate, height, frame)
     missionStore.homeMarkerPosition = coordinate
   }
 


### PR DESCRIPTION
## Summary

`DO_SET_HOME` went out as a `COMMAND_LONG`, which carries latitude and longitude as floats and has no frame field, leaving the altitude reference implicit. `COMMAND_INT` carries the position as scaled integers and states the frame explicitly, which is what lets the user pick an altitude reference when setting a home point.

Two commits:

**Send the command as `COMMAND_INT`.** `setHomeWaypoint` now goes through `sendCommandInt`. The parameter slots line up with the previous `sendCommandLong` call, so `param1` stays 0 (use the coordinates carried by the command rather than the vehicle's current position) and lat/lon/alt keep their positions. `sendCommandInt` hardcoded `MAV_FRAME_GLOBAL`, so it now takes a frame, still defaulting to `MAV_FRAME_GLOBAL` so the existing `goTo` caller is untouched.

**Default the set-home altitude to home-relative.** Both call sites pass an altitude of `0`. Under `MAV_FRAME_GLOBAL` that means 0 m AMSL, so setting a home point was putting home's altitude at sea level — wrong for any vehicle operating at elevation, and it skews return-to-launch altitudes. `setHomeWaypoint` now defaults to `MAV_FRAME_GLOBAL_RELATIVE_ALT`, where zero resolves against the current home: home moves horizontally and its altitude is left alone.

This is also groundwork for the dialog that will let the user choose the frame and altitude explicitly, which is where a non-default frame will first get passed in.

## Test plan

- [ ] Set home from the map context menu → vehicle accepts the command and home moves to the clicked point.
- [ ] Confirm on the wire (mavlink2rest / autopilot logs) that a `COMMAND_INT` is sent with `MAV_FRAME_GLOBAL_RELATIVE_ALT` and lat/lon arrive scaled by 1e7, not zeroed.
- [ ] With the vehicle at meaningful elevation, set home and confirm its altitude is preserved rather than dropped to sea level, and that RTL altitude behaves accordingly.
- [ ] Verify the target firmware actually honours a home-relative frame for `DO_SET_HOME` (ArduPilot's handling has varied by version and vehicle) — if it rejects the command, the default should move to `MAV_FRAME_GLOBAL` with a real altitude rather than zero.
- [ ] Drag the home marker → same result.
- [ ] Use "go to" on the map → `DO_REPOSITION` still behaves as before, confirming the `sendCommandInt` frame default did not regress that caller.

Fixes #2871.