### PR TITLE
fix: reference vehicle history persistence through the mission store

### DIFF
--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -656,7 +656,7 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
       isArmed.value = armed
 
       // Clear vehicle history on disarm/arm transition only when not persistent (persistent history is cleared only via map context menu)
-      if (wasArmed !== undefined && wasArmed !== armed && !isVehiclePositionHistoryPersistent.value) {
+      if (wasArmed !== undefined && wasArmed !== armed && !missionStore.isVehiclePositionHistoryPersistent) {
         missionStore.clearVehicleHistory()
       }
 


### PR DESCRIPTION
## Summary

The `onArm` handler in `mainVehicle.ts` read a bare `isVehiclePositionHistoryPersistent`, which is not defined or imported in that module — the value lives on the mission store (the very next line already uses `missionStore.clearVehicleHistory()`).

As a result, **every arm/disarm transition threw a `ReferenceError: isVehiclePositionHistoryPersistent is not defined`** inside the websocket message reader (the handler runs while processing incoming MAVLink). In users' logs this surfaces as repeated:

```
[WebSocketConnection] Error reading websocket message: isVehiclePositionHistoryPersistent is not defined
```

and the intended clear-history-on-disarm never runs.

Fix: read it through the store as `missionStore.isVehiclePositionHistoryPersistent` (Pinia unwraps the ref, matching how `ConfigurationMissionView.vue` accesses it).

Introduced in #2469.

Spotted while investigating https://discuss.bluerobotics.com/t/mygcs-heartbeat-lost-fiber-optic-cable/23376 (the error is visible in the user's Cockpit syslog).

## Test plan

- [ ] Arm and disarm the vehicle repeatedly; confirm no `Error reading websocket message: isVehiclePositionHistoryPersistent is not defined` appears in the logs.
- [ ] With path history persistence **off**, confirm the vehicle path history clears on arm/disarm transition.
- [ ] With persistence **on**, confirm the history is retained across arm/disarm and only cleared via the map context menu.