### PR TITLE
Mission Planning: Fix edge points of interest covering the main menu

### DIFF
--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -614,18 +614,20 @@
   </SideConfigPanel>
   <HomePositionSettingHelp v-model="showHomePositionNotSetDialog" />
   <PoiManager ref="poiManagerRef" />
-  <PoiMapArrows
-    :map-ready="mapReady"
-    :force-full-screen="true"
-    :show-poi-arrows="true"
-    :show-home-arrow="true"
-    :show-vehicle-arrow="true"
-    :vehicle-position="vehiclePosition"
-    :home="home"
-    :map-center="mapCenter"
-    :zoom="zoom"
-    :target-follower="targetFollower"
-  />
+  <Teleport to="#planningMap">
+    <PoiMapArrows
+      :map-ready="mapReady"
+      :force-full-screen="true"
+      :show-poi-arrows="true"
+      :show-home-arrow="true"
+      :show-vehicle-arrow="true"
+      :vehicle-position="vehiclePosition"
+      :home="home"
+      :map-center="mapCenter"
+      :zoom="zoom"
+      :target-follower="targetFollower"
+    />
+  </Teleport>
 
   <v-progress-linear
     v-if="fetchingMission"


### PR DESCRIPTION
**Problem:**

- On the mission planning page, the edge indicators for off-screen points of interest (and the vehicle and home arrows) could render on top of the main menu and intercept its clicks, so menu buttons sitting under a pin stopped responding.

**Fix:**

- The edge indicators are now kept inside the map area, so they stay behind the main menu and no longer block its buttons, while still appearing in the same place along the map edges.

https://github.com/user-attachments/assets/eb326745-602f-472f-8f86-a285c3d615bb

Closes #2868