### PR TITLE
Mission Planning: Fix failed upload deleting the planned mission

### DIFF
--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -254,7 +254,7 @@ import {
   WhoToFollow,
 } from '@/libs/map/utils-map'
 import { datalogger, DatalogVariable } from '@/libs/sensors-logging'
-import { copyToClipboard, degrees } from '@/libs/utils'
+import { copyToClipboard, degrees, messageFromError } from '@/libs/utils'
 import type { MAVLinkVehicle } from '@/libs/vehicle/mavlink/vehicle'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
@@ -1766,7 +1766,7 @@ const downloadMissionFromVehicle = async (): Promise<void> => {
 
     openSnackbar({ variant: 'success', message: 'Mission download succeeded!', duration: 3000 })
   } catch (error) {
-    showDialog({ variant: 'error', title: 'Mission download failed', message: error as string, timer: 5000 })
+    showDialog({ variant: 'error', title: 'Mission download failed', message: messageFromError(error), timer: 5000 })
   } finally {
     fetchingMission.value = false
   }

--- a/src/composables/interactionDialog.ts
+++ b/src/composables/interactionDialog.ts
@@ -61,6 +61,16 @@ export interface DialogResult {
 }
 
 /**
+ * Reactive state backing the mounted dialog component.
+ */
+type DialogState = DialogOptions & {
+  /**
+   * Indicates whether the dialog should be shown.
+   */
+  showDialog: boolean
+}
+
+/**
  * Provides methods to control the interaction dialog.
  * @returns {object} - An object containing the showDialog and closeDialog methods.
  */
@@ -77,15 +87,7 @@ export function useInteractionDialog(): {
    */
   closeDialog: () => void
 } {
-  const dialogProps = reactive<
-    DialogOptions & {
-      /**
-       * Indicates whether the dialog should be shown.
-       * @type {boolean}
-       */
-      showDialog: boolean
-    }
-  >({
+  const defaultDialogState = (): DialogState => ({
     message: '',
     variant: '',
     title: '',
@@ -95,6 +97,8 @@ export function useInteractionDialog(): {
     persistent: true,
     timer: 0,
   })
+
+  const dialogProps = reactive<DialogState>(defaultDialogState())
 
   let dialogApp: App<Element> | null = null
   let mountPoint: HTMLElement | null = null
@@ -137,7 +141,9 @@ export function useInteractionDialog(): {
     // forever. Resolve (rather than reject) to avoid unhandled rejections for the many callers that don't await.
     resolveFn?.({ isConfirmed: false })
     return new Promise((resolve, reject) => {
-      Object.assign(dialogProps, options, { showDialog: true })
+      // Merge over a fresh set of defaults so options the caller omits (notably `actions`) never leak from the
+      // previous dialog, which would otherwise leave a stale destructive button on an unrelated dialog.
+      Object.assign(dialogProps, defaultDialogState(), options, { showDialog: true })
       resolveFn = resolve
       rejectFn = reject
       mountDialog()

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -401,3 +401,12 @@ export const tryACoupleOfTimes = async <T>(
   // If we have reached the limit of tries, throw an error
   throw new Error(`Failed to execute function '${fn.name || 'function'}' after ${times} tries. Will stop trying.`)
 }
+
+/**
+ * Extract a displayable message from a caught value.
+ * @param {unknown} error The value caught in a try/catch block.
+ * @returns {string} The error message, or the value's string representation when it is not an Error.
+ */
+export const messageFromError = (error: unknown): string => {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -730,7 +730,7 @@ import {
   polygonAreaSquareMeters,
 } from '@/libs/mission/general-estimates'
 import { PLANNABLE_VEHICLE_TYPES, vehicleTypeLabel } from '@/libs/mission/library'
-import { degrees } from '@/libs/utils'
+import { degrees, messageFromError } from '@/libs/utils'
 import router from '@/router'
 import { SubMenuComponentName, SubMenuName, useAppInterfaceStore } from '@/stores/appInterface'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
@@ -904,7 +904,7 @@ const uploadMissionToVehicle = async (): Promise<void> => {
     showDialog({
       variant: 'error',
       title: 'Mission upload failed',
-      message: error as string,
+      message: messageFromError(error),
       timer: 3000,
       persistent: false,
     })
@@ -942,7 +942,7 @@ const downloadMissionFromVehicle = async (): Promise<void> => {
 
     openSnackbar({ variant: 'success', message: 'Mission download succeeded!', duration: 3000 })
   } catch (error) {
-    showDialog({ variant: 'error', title: 'Mission download failed', message: error as string, timer: 5000 })
+    showDialog({ variant: 'error', title: 'Mission download failed', message: messageFromError(error), timer: 5000 })
   } finally {
     loading.value = false
     fetchingMission.value = false


### PR DESCRIPTION
**Problem:**

- After opening the clear mission dialog independent of the action taken, the upcoming "Mission upload failed" dialog carried the "Clear" button from the earlier clear-mission confirmation, so dismissing the error deleted the mission that had just been planned (video attached).
- Any dialog opened without its own buttons inherited the previous dialog's ones, so the same could happen from a failed mission download.
- Both failure dialogs showed a blank message instead of the reason for the failure.

https://github.com/user-attachments/assets/cb0415d6-b9d5-458c-8776-6bf95f4d8fad

**Fix:**

- Dialogs now start from a clean slate and show only the buttons, title, and message their caller asked for, so an error dialog gets its usual "Close" button back.
- Mission upload and download failures now show the actual error text.

There was no actual relation with #2838 

Closes #2867