### PR TITLE
Widgets: Fix north indicator staying visible over hidden map toolset

### DIFF
--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -62,7 +62,7 @@
         :activator-style="{ bottom: bottomButtonsDisplacement }"
         @center-on-mission="centerOnMission"
       />
-      <MapNorthIndicator class="north-indicator" />
+      <MapNorthIndicator v-if="showButtons" class="north-indicator" />
       <PoiMapArrows
         :map-ready="mapReady"
         :show-poi-arrows="widget.options.showPoiArrows"


### PR DESCRIPTION
**Problem:**

- On a map widget that isn't in fullscreen, the north indicator stayed on screen after the pointer left, floating alone over the map while the zoom, layer selector, scale, center-on, edit mission and tile download controls all hid themselves.

**Fix:**

- The north indicator now appears and disappears on hover together with the rest of the map widget toolset, and stays permanently visible in fullscreen like the other controls.

Closes #2879