### PR TITLE
Mission Runtime: Fix cruise speed lost after a mode change

### DIFF
--- a/src/components/mini-widgets/MiniMissionControlPanel.vue
+++ b/src/components/mini-widgets/MiniMissionControlPanel.vue
@@ -50,7 +50,7 @@
           />
         </template>
       </v-tooltip>
-      <CruiseSpeedControl icon-class="text-[16px]" />
+      <CruiseSpeedControl icon-class="text-[16px]" :show-speed-value="false" />
       <v-tooltip location="top" open-delay="800" text="Return to home">
         <template #activator="{ props: homeProps }">
           <v-btn

--- a/src/components/mini-widgets/MiniMissionControlPanel.vue
+++ b/src/components/mini-widgets/MiniMissionControlPanel.vue
@@ -50,38 +50,7 @@
           />
         </template>
       </v-tooltip>
-      <v-menu :close-on-content-click="false" location="top" offset="8">
-        <template #activator="{ props: speedProps }">
-          <v-tooltip location="top" open-delay="800" text="Cruise speed">
-            <template #activator="{ props: speedTooltipProps }">
-              <v-btn
-                v-bind="{ ...speedProps, ...speedTooltipProps }"
-                size="x-small"
-                icon="mdi-speedometer"
-                variant="text"
-                class="text-[16px]"
-                :disabled="!vehicleStore.isVehicleOnline"
-              />
-            </template>
-          </v-tooltip>
-        </template>
-        <div class="flex flex-col p-3 rounded-lg w-[210px] text-white" :style="interfaceStore.globalGlassMenuStyles">
-          <div class="flex justify-between items-center mb-1 text-xs">
-            <span>Cruise speed</span>
-            <span class="font-bold">{{ liveCruiseSpeed.toFixed(1) }} m/s</span>
-          </div>
-          <v-slider
-            v-model="liveCruiseSpeed"
-            :min="0.1"
-            :max="5"
-            :step="0.1"
-            color="white"
-            density="compact"
-            hide-details
-            @update:model-value="handleCruiseSpeedInput"
-          />
-        </div>
-      </v-menu>
+      <CruiseSpeedControl icon-class="text-[16px]" />
       <v-tooltip location="top" open-delay="800" text="Return to home">
         <template #activator="{ props: homeProps }">
           <v-btn
@@ -105,16 +74,15 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed } from 'vue'
 
+import CruiseSpeedControl from '@/components/mission-planning/CruiseSpeedControl.vue'
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { openSnackbar } from '@/composables/snackbar'
-import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useMissionStore } from '@/stores/mission'
 
 const { showDialog, closeDialog } = useInteractionDialog()
-const interfaceStore = useAppInterfaceStore()
 const missionStore = useMissionStore()
 const vehicleStore = useMainVehicleStore()
 
@@ -122,23 +90,6 @@ const currentWaypointOnMission = computed<string>((): string => {
   const wpIndex = missionStore.currentWaypointOnMission
   return wpIndex > 0 ? wpIndex.toString() : '--'
 })
-
-const liveCruiseSpeed = ref<number>(Number(missionStore.cruiseSpeed))
-watch(
-  () => missionStore.cruiseSpeed,
-  (newSpeed) => (liveCruiseSpeed.value = Number(newSpeed))
-)
-
-// Debounce live speed commands so dragging the slider doesn't flood the vehicle with DO_CHANGE_SPEED.
-let cruiseSpeedDebounce: ReturnType<typeof setTimeout> | undefined
-const handleCruiseSpeedInput = (value: number): void => {
-  if (cruiseSpeedDebounce) clearTimeout(cruiseSpeedDebounce)
-  cruiseSpeedDebounce = setTimeout(() => {
-    missionStore.applyCruiseSpeed(value).catch((err) => {
-      openSnackbar({ message: `Failed to set cruise speed: ${(err as Error).message}`, variant: 'error' })
-    })
-  }, 300)
-}
 
 const skipToPreviousWaypoint = (): void => {
   logUserAction('Skipped to previous mission waypoint')

--- a/src/components/mission-planning/CruiseSpeedControl.vue
+++ b/src/components/mission-planning/CruiseSpeedControl.vue
@@ -2,7 +2,7 @@
   <div class="relative flex items-center -mt-[2px]">
     <v-menu :close-on-content-click="false" location="top" offset="8">
       <template #activator="{ props: speedProps }">
-        <v-tooltip location="top" open-delay="800" text="Cruise speed">
+        <v-tooltip location="top" open-delay="800" :text="`Cruise speed (${liveCruiseSpeed.toFixed(1)} m/s)`">
           <template #activator="{ props: speedTooltipProps }">
             <v-btn
               v-bind="{ ...speedProps, ...speedTooltipProps }"
@@ -32,6 +32,13 @@
         />
       </div>
     </v-menu>
+    <span
+      v-if="showSpeedValue"
+      class="absolute left-1/2 top-full -translate-x-1/2 mt-[-5px] px-[3px] rounded-[2px] bg-white text-[#333333] text-[8px] font-bold leading-[11px] select-none pointer-events-none"
+      aria-hidden="true"
+    >
+      {{ liveCruiseSpeed.toFixed(1) }}
+    </span>
   </div>
 </template>
 
@@ -49,8 +56,12 @@ withDefaults(
      * Classes applied to the speedometer icon button
      */
     iconClass?: string
+    /**
+     * Whether the commanded speed is shown as a tag under the button
+     */
+    showSpeedValue?: boolean
   }>(),
-  { iconClass: 'text-[18px]' }
+  { iconClass: 'text-[18px]', showSpeedValue: true }
 )
 
 const interfaceStore = useAppInterfaceStore()

--- a/src/components/mission-planning/CruiseSpeedControl.vue
+++ b/src/components/mission-planning/CruiseSpeedControl.vue
@@ -1,0 +1,79 @@
+<template>
+  <div class="relative flex items-center -mt-[2px]">
+    <v-menu :close-on-content-click="false" location="top" offset="8">
+      <template #activator="{ props: speedProps }">
+        <v-tooltip location="top" open-delay="800" text="Cruise speed">
+          <template #activator="{ props: speedTooltipProps }">
+            <v-btn
+              v-bind="{ ...speedProps, ...speedTooltipProps }"
+              size="x-small"
+              icon="mdi-speedometer"
+              variant="text"
+              :class="iconClass"
+              :disabled="!vehicleStore.isVehicleOnline"
+            />
+          </template>
+        </v-tooltip>
+      </template>
+      <div class="flex flex-col p-3 rounded-lg w-[210px] text-white" :style="interfaceStore.globalGlassMenuStyles">
+        <div class="flex justify-between items-center mb-1 text-xs">
+          <span>Cruise speed</span>
+          <span class="font-bold">{{ liveCruiseSpeed.toFixed(1) }} m/s</span>
+        </div>
+        <v-slider
+          v-model="liveCruiseSpeed"
+          :min="0.1"
+          :max="5"
+          :step="0.1"
+          color="white"
+          density="compact"
+          hide-details
+          @update:model-value="handleCruiseSpeedInput"
+        />
+      </div>
+    </v-menu>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, ref, watch } from 'vue'
+
+import { openSnackbar } from '@/composables/snackbar'
+import { useAppInterfaceStore } from '@/stores/appInterface'
+import { useMainVehicleStore } from '@/stores/mainVehicle'
+import { useMissionStore } from '@/stores/mission'
+
+withDefaults(
+  defineProps<{
+    /**
+     * Classes applied to the speedometer icon button
+     */
+    iconClass?: string
+  }>(),
+  { iconClass: 'text-[18px]' }
+)
+
+const interfaceStore = useAppInterfaceStore()
+const missionStore = useMissionStore()
+const vehicleStore = useMainVehicleStore()
+
+const liveCruiseSpeed = ref<number>(Number(missionStore.cruiseSpeed))
+watch(
+  () => missionStore.cruiseSpeed,
+  (newSpeed) => (liveCruiseSpeed.value = Number(newSpeed))
+)
+
+// Debounce live speed commands so dragging the slider doesn't flood the vehicle with DO_CHANGE_SPEED.
+let cruiseSpeedDebounce: ReturnType<typeof setTimeout> | undefined
+const handleCruiseSpeedInput = (value: number): void => {
+  if (cruiseSpeedDebounce) clearTimeout(cruiseSpeedDebounce)
+  cruiseSpeedDebounce = setTimeout(() => {
+    logUserAction(`Set the cruise speed to ${value.toFixed(1)} m/s`)
+    missionStore.applyCruiseSpeed(value).catch((err) => {
+      openSnackbar({ message: `Failed to set cruise speed: ${(err as Error).message}`, variant: 'error' })
+    })
+  }, 300)
+}
+
+onBeforeUnmount(() => clearTimeout(cruiseSpeedDebounce))
+</script>

--- a/src/components/widgets/MissionControlPanel.vue
+++ b/src/components/widgets/MissionControlPanel.vue
@@ -71,41 +71,7 @@
                 </template>
               </v-tooltip>
               <v-divider vertical class="h-[25px] mt-[3px] mx-1 opacity-10" />
-              <v-menu :close-on-content-click="false" location="top" offset="8">
-                <template #activator="{ props: speedProps }">
-                  <v-tooltip location="top" open-delay="800" text="Cruise speed">
-                    <template #activator="{ props: speedTooltipProps }">
-                      <v-btn
-                        v-bind="{ ...speedProps, ...speedTooltipProps }"
-                        size="x-small"
-                        icon="mdi-speedometer"
-                        variant="text"
-                        class="text-[18px]"
-                        :disabled="!vehicleStore.isVehicleOnline"
-                      />
-                    </template>
-                  </v-tooltip>
-                </template>
-                <div
-                  class="flex flex-col p-3 rounded-lg w-[210px] text-white"
-                  :style="interfaceStore.globalGlassMenuStyles"
-                >
-                  <div class="flex justify-between items-center mb-1 text-xs">
-                    <span>Cruise speed</span>
-                    <span class="font-bold">{{ liveCruiseSpeed.toFixed(1) }} m/s</span>
-                  </div>
-                  <v-slider
-                    v-model="liveCruiseSpeed"
-                    :min="0.1"
-                    :max="5"
-                    :step="0.1"
-                    color="white"
-                    density="compact"
-                    hide-details
-                    @update:model-value="handleCruiseSpeedInput"
-                  />
-                </div>
-              </v-menu>
+              <CruiseSpeedControl />
               <v-tooltip location="top" open-delay="800" text="Return to home">
                 <template #activator="{ props: homeProps }">
                   <v-btn
@@ -161,8 +127,9 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeMount, ref, toRefs, watch } from 'vue'
+import { computed, onBeforeMount, ref, toRefs } from 'vue'
 
+import CruiseSpeedControl from '@/components/mission-planning/CruiseSpeedControl.vue'
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { openSnackbar } from '@/composables/snackbar'
 import { useAppInterfaceStore } from '@/stores/appInterface'
@@ -191,23 +158,6 @@ const currentWaypointOnMission = computed<string>((): string => {
   const wpIndex = missionStore.currentWaypointOnMission
   return wpIndex > 0 ? wpIndex.toString() : '--'
 })
-
-const liveCruiseSpeed = ref<number>(Number(missionStore.cruiseSpeed))
-watch(
-  () => missionStore.cruiseSpeed,
-  (newSpeed) => (liveCruiseSpeed.value = Number(newSpeed))
-)
-
-// Debounce live speed commands so dragging the slider doesn't flood the vehicle with DO_CHANGE_SPEED.
-let cruiseSpeedDebounce: ReturnType<typeof setTimeout> | undefined
-const handleCruiseSpeedInput = (value: number): void => {
-  if (cruiseSpeedDebounce) clearTimeout(cruiseSpeedDebounce)
-  cruiseSpeedDebounce = setTimeout(() => {
-    missionStore.applyCruiseSpeed(value).catch((err) => {
-      openSnackbar({ message: `Failed to set cruise speed: ${(err as Error).message}`, variant: 'error' })
-    })
-  }, 300)
-}
 
 const toggleWrapContainer = (): void => {
   isWrapped.value = !isWrapped.value

--- a/src/stores/mission.ts
+++ b/src/stores/mission.ts
@@ -595,6 +595,10 @@ export const useMissionStore = defineStore('mission', () => {
 
   let didAutoEndCurrentRun = false
 
+  // Distinguishes a cruise speed the user actually asked for from the untouched default, so a vehicle running a
+  // mission that was never planned here keeps the speed its own parameters define.
+  let cruiseSpeedWasCommanded = false
+
   /**
    * Applies the active cruise speed to the vehicle as a live command.
    * @param {number} [speedMps] - Speed to apply; defaults to the current active cruise speed
@@ -604,9 +608,21 @@ export const useMissionStore = defineStore('mission', () => {
     const speed = Number(speedMps)
     if (!Number.isFinite(speed) || speed <= 0) return
     cruiseSpeed.value = speed
+    cruiseSpeedWasCommanded = true
     if (!mainVehicleStore.isVehicleOnline) return
     await mainVehicleStore.setCruiseSpeed(speed)
   }
+
+  // Entering a mode resets the autopilot's desired speed to its cruise-speed parameter, and a mission resumed mid-way
+  // never replays the DO_CHANGE_SPEED uploaded with the first waypoint. Only AUTO is re-commanded, so a deliberately
+  // slower Guided leg keeps the speed the pilot chose there.
+  watch(
+    () => mainVehicleStore.mode,
+    (newMode) => {
+      if (newMode !== 'AUTO' || !cruiseSpeedWasCommanded) return
+      applyCruiseSpeed().catch((err) => console.error('Failed to re-apply cruise speed on AUTO mode:', err))
+    }
+  )
 
   // Allow executing missions
   const executeMissionOnVehicle = async (): Promise<boolean> => {


### PR DESCRIPTION
**Problem:**

- After switching to Guided and back to Auto mid-mission, the vehicle ignored the speed set for the mission and ran the rest of the survey at the autopilot's own cruise-speed parameter.
- Cockpit only re-sent the mission speed when the mission was started or resumed from its own play button, so a mode change made anywhere else (mode selector, joystick, transmitter) silently lost it.
- The commanded speed was only readable after opening the speedometer menu, so a mission running slower than planned could go unnoticed for a long time.

**Fix:**

- The mission speed is re-commanded whenever the vehicle returns to Auto, whatever caused the mode change, so a detour through Guided no longer slows the rest of the mission down.
- Other modes are left alone, so a deliberately slower Guided leg keeps the speed the pilot chose there.
- A vehicle running a mission that was not planned in Cockpit keeps its own speed parameters, since the speed is only re-commanded once one has been set here in the running session.
- The speedometer icon on the mission control panel now carries a tag with the speed currently commanded, and its tooltip shows the value with the unit; the compact mini-widget bar keeps just the icon.
- Every cruise-speed change made from the panel is now recorded in the system log.
- The speedometer control became a single shared piece used by both the mission control widget and its mini-widget, instead of two copies.

Image 1 - The speedometer icon on the mission control panel now shows the commanded cruise speed (1), here 2.5 m/s, without having to open the speed menu.
![Cruise speed tag on the mission control panel](https://raw.githubusercontent.com/ArturoManzoli/cockpit/pr-assets/cruise-speed-tag.png)

Closes #2864