### PR TITLE
Stop unrelated comments cancelling an in-flight re-review

### DIFF
--- a/.github/workflows/claude-pr-review-continue.yml
+++ b/.github/workflows/claude-pr-review-continue.yml
@@ -5,7 +5,10 @@ on:
     types: [created]
 
 concurrency:
-  group: claude-pr-rereview-${{ github.event.issue.number }}
+  # Keyed on the command as well as the PR: concurrency is evaluated before the job's `if:`, so the
+  # run for an ordinary comment still joins the group and, with cancel-in-progress, cancels a
+  # re-review already running.
+  group: claude-pr-rereview-${{ github.event.issue.number }}-${{ startsWith(github.event.comment.body, '/review') }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Fixes #2889.

A `/review` re-review is cancelled by any comment posted while it runs, silently — no review appears, and the only trace is a cancelled workflow run.

GitHub evaluates `concurrency` at the workflow-run level, **before** any job's `if:` condition. The group was keyed on the PR number alone, and `issue_comment` fires for every comment on the PR, so each comment created a run that joined the group even when its job was then skipped. With `cancel-in-progress: true`, such a run cancelled whatever re-review was in flight.

The fix keys the group on the command as well, so only a newer `/review` supersedes an older one:

```yaml
group: claude-pr-rereview-${{ github.event.issue.number }}-${{ startsWith(github.event.comment.body, '/review') }}
```

Ordinary comments then share a single `...-false` group, where cancelling one another is harmless because those runs are skipped immediately.

## Modified Features

- Automated PR review
  - A comment posted while a `/review` is running no longer cancels it. Two `/review` commands in quick succession still collapse to the latest, which was the point of `cancel-in-progress`.

## Tests Required to Merge (by dev and/or testers)

CI-only change; no Cockpit runtime code is touched, so the vehicle-usage and widget checklists do not apply.

- [ ] Comment `/review` on a PR, then post an ordinary comment a few seconds later, and confirm the re-review still completes and posts
- [ ] Comment `/review` twice in quick succession and confirm the older run is superseded

Both checks can only be run **after** this merges: `issue_comment` workflows always execute from the default branch, so the current grouping stays in effect until then.

## Notes

Observed on #2885, which introduces a second `issue_comment` workflow with the same pattern and fixes it there. The `/demo` case is worse, since a recording takes minutes and any comment posted during it would kill the run. This PR covers only the pre-existing `/review` workflow.
