### PR TITLE
Alerts: Fix silent voice alerts on Linux and add OS independent voices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,10 +195,22 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "COCKPIT_VERSION=$VERSION" >> $GITHUB_ENV
 
+      - name: Cache the Piper runtime (macOS arm64)
+        if: matrix.os == 'macos-15'
+        uses: actions/cache@v4
+        with:
+          path: binaries/piper
+          key: piper-macos-arm64-${{ hashFiles('scripts/build-piper-macos-arm64.js', 'scripts/download-piper.js') }}
+
       - name: Install and build
         run: |
           yarn install --frozen-lockfile --network-timeout 600000
           yarn build
+
+      # Apple Silicon has no usable prebuilt Piper binary, so it compiles one.
+      - name: Build the Piper runtime (macOS arm64)
+        if: matrix.os == 'macos-15'
+        run: yarn build:piper
 
       - name: Import Apple Certificate and Setup Keychain
         if: (matrix.os == 'macos-15-intel' || matrix.os == 'macos-15') && github.event_name != 'pull_request'

--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ We welcome contributions! We don't have a contribution guide yet, but you can he
 ### Prerequisites
 - **Node.js** 18+ and **yarn** package manager
 - **Git** with submodule support
+- **On ARM-based macOS (Apple Silicon) only**: **CMake**, plus `yarn build:piper` after installing, to compile the offline alert voice from source. There is no prebuilt release for this platform, so without it voice alerts fall back to the system voices.
 
 ### Development Workflow
 1. Fork the repository

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Below is a table summarizing the current status, but in general, you can expect 
 | **Updates** | Manual updates required | ✅ Auto-updates / update notifications |
 | **System Monitoring** | Memory usage only | ✅ CPU and Memory tracking |
 | **Workspace Capture** | ❌ Not available | ✅ Full interface screenshots |
+| **Voice Alerts** | Uses the browser/OS speech voices, which vary per system | ✅ Built-in offline voice on every platform (no setup), so alerts sound the same everywhere |
 | **Performance** | Standard | ✅ Optimized build for each system |
 | **Installation** | ✅ No install needed | Requires download |
 | **Multi-platform** | ✅ Any device | Windows, macOS, Linux |

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "description": "An intuitive and customizable cross-platform ground control station for remote vehicles of all types.",
   "scripts": {
     "build": "vite build",
+    "build:piper": "node scripts/build-piper-macos-arm64.js",
     "build:serve": "vite build && vite preview",
     "coverage": "vitest --coverage",
     "deploy:electron:dir": "ELECTRON=true electron-builder --dir",
@@ -21,7 +22,7 @@
     "dev:electron": "cross-env ELECTRON=true vite --host",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --ignore-path .gitignore --max-warnings=0",
     "lint:fix": "eslint --fix . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --ignore-path .gitignore --max-warnings=0",
-    "postinstall": "node scripts/download-ffmpeg.js && node scripts/download-go2rtc.js && node scripts/verify-sdl.js",
+    "postinstall": "node scripts/download-ffmpeg.js && node scripts/download-go2rtc.js && node scripts/download-piper.js && node scripts/verify-sdl.js",
     "preview": "vite preview --port 5050",
     "serve": "vite preview",
     "test:ci": "vitest --coverage --run",
@@ -169,6 +170,13 @@
       {
         "from": "binaries/go2rtc/",
         "to": "go2rtc/",
+        "filter": [
+          "**/*"
+        ]
+      },
+      {
+        "from": "binaries/piper/",
+        "to": "piper/",
         "filter": [
           "**/*"
         ]

--- a/scripts/build-piper-macos-arm64.js
+++ b/scripts/build-piper-macos-arm64.js
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+/* eslint-disable no-undef */
+
+const fs = require('fs')
+const path = require('path')
+const os = require('os')
+const { execSync } = require('child_process')
+const { addMacRpath, hasRuntime } = require('./download-piper')
+
+/**
+ * Build the Piper runtime for Apple Silicon from source.
+ *
+ * Every other platform gets a prebuilt binary from the archived rhasspy/piper
+ * release, but its `aarch64` macOS asset is really an x86_64 build, so it runs
+ * under Rosetta 2 and aborts inside the signed app. The maintained piper1-gpl
+ * repository has no downloadable binaries at all, only CI artifacts, so the one
+ * way to get a native arm64 synthesizer is to compile its CLI ourselves. That
+ * CLI takes the same arguments as the rhasspy one, so the app cannot tell the
+ * two apart.
+ */
+
+const PIPER_SOURCE_TAG = 'v1.6.0'
+const PIPER_SOURCE_REPO = 'https://github.com/OHF-Voice/piper1-gpl.git'
+
+// Electron itself supports macOS 11 and later, and so must the binary we spawn.
+const MACOS_DEPLOYMENT_TARGET = '11.0'
+
+// espeak-ng composes every phoneme source path into a 180-byte buffer, appending
+// up to 36 bytes ("/../phsource/" plus its longest name) to its data directory.
+// Past that it truncates each of them and fails with hundreds of "Bad vowel
+// file" errors that never mention the length, so keep the build tree shallow.
+const MAX_ESPEAK_DATA_PATH = 179 - 36
+
+const run = (command, cwd) => execSync(command, { cwd, stdio: 'inherit' })
+
+/**
+ * Lay the CMake install tree out the way the app expects: the binary named
+ * `piper`, its libraries beside it and the phoneme data in `espeak-ng-data`.
+ * @param {string} installDir
+ * @param {string} targetDir
+ */
+function collectRuntime(installDir, targetDir) {
+  // `cp -R` keeps the onnxruntime version symlink a symlink, which `fs.cpSync`
+  // would otherwise turn into an absolute path into this build dir. The rest of
+  // `lib` is CMake and pkg-config metadata that the app has no use for.
+  run(`cp -R "${installDir}"/libpiper.dylib "${installDir}"/lib/*.dylib "${targetDir}"`)
+  run(`cp -R "${path.join(installDir, 'espeak-ng-data')}" "${targetDir}"`)
+
+  // The library resolves onnxruntime through `@rpath` as well, and it is loaded
+  // by the app when Piper runs as a child of it, not only by the CLI.
+  addMacRpath(path.join(targetDir, 'libpiper.dylib'), '@loader_path')
+
+  // The binary is staged under a `.part` name and only takes its final one once
+  // it is patched and signed, so an interrupted build never leaves a tree that
+  // `hasRuntime` reads as a finished runtime.
+  const stagedBinary = path.join(targetDir, 'piper.part')
+  fs.copyFileSync(path.join(installDir, 'bin', 'piper_exe'), stagedBinary)
+  fs.chmodSync(stagedBinary, '755')
+  addMacRpath(stagedBinary)
+  fs.renameSync(stagedBinary, path.join(targetDir, 'piper'))
+}
+
+/**
+ * Compile Piper and install it into `binaries/piper`.
+ */
+function buildPiper() {
+  if (os.platform() !== 'darwin' || os.arch() !== 'arm64') {
+    throw new Error(`This build is only for macOS on Apple Silicon, not ${os.platform()}-${os.arch()}.`)
+  }
+
+  const targetDir = path.join(__dirname, '..', 'binaries', 'piper')
+  if (hasRuntime(targetDir, os.platform())) {
+    console.log('Piper runtime already built. Skipping.')
+    return
+  }
+  fs.mkdirSync(targetDir, { recursive: true })
+
+  // Not `os.tmpdir()`: on macOS that is a ~50 character path under /var/folders,
+  // which on its own is deep enough to break the espeak-ng build below.
+  const workDir = fs.mkdtempSync(path.join(fs.realpathSync('/tmp'), 'cockpit-piper-'))
+  try {
+    const sourceDir = path.join(workDir, 'piper1-gpl', 'libpiper')
+    const installDir = path.join(workDir, 'install')
+    const espeakDataDir = path.join(sourceDir, 'build/espeak_ng/src/espeak_ng_external-build/espeak-ng-data')
+    if (espeakDataDir.length > MAX_ESPEAK_DATA_PATH) {
+      throw new Error(`The build path "${espeakDataDir}" is too long for espeak-ng to compile its phoneme data.`)
+    }
+
+    console.log(`Building Piper ${PIPER_SOURCE_TAG} for macOS arm64...`)
+    run(`git clone --depth 1 --branch ${PIPER_SOURCE_TAG} ${PIPER_SOURCE_REPO} "${workDir}/piper1-gpl"`)
+
+    const cmakeFlags = [
+      '-DCMAKE_BUILD_TYPE=Release',
+      `-DCMAKE_INSTALL_PREFIX="${installDir}"`,
+      `-DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOS_DEPLOYMENT_TARGET}`,
+      '-DCMAKE_OSX_ARCHITECTURES=arm64',
+    ].join(' ')
+
+    run(`cmake -B build ${cmakeFlags}`, sourceDir)
+    run('cmake --build build --config Release --parallel', sourceDir)
+    run('cmake --install build --config Release', sourceDir)
+
+    collectRuntime(installDir, targetDir)
+    console.log('✅ Piper runtime built successfully!')
+  } finally {
+    fs.rmSync(workDir, { recursive: true, force: true })
+  }
+}
+
+if (require.main === module) {
+  try {
+    buildPiper()
+  } catch (error) {
+    console.error('❌ Could not build the Piper runtime:', error.message)
+    process.exit(1)
+  }
+}
+
+module.exports = { buildPiper }

--- a/scripts/download-piper.js
+++ b/scripts/download-piper.js
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+/* eslint-disable no-undef */
+
+const fs = require('fs')
+const path = require('path')
+const os = require('os')
+const { execSync } = require('child_process')
+
+const { downloadFile } = require('./lib/download')
+
+/**
+ * Download the Piper neural TTS runtime and one bundled voice, so every
+ * Standalone build speaks alerts with the same voice out of the box, instead of
+ * whatever the host exposes through the Web Speech API.
+ */
+
+const PIPER_VERSION = '2023.11.14-2'
+
+// The macOS `aarch64` asset of this release is really an x86_64 build, so Apple
+// Silicon has no usable prebuilt runtime and compiles its own instead, through
+// `build-piper-macos-arm64.js`.
+const RUNTIME_ARCHIVES = {
+  linux: { x64: 'piper_linux_x86_64.tar.gz', arm64: 'piper_linux_aarch64.tar.gz' },
+  darwin: { x64: 'piper_macos_x64.tar.gz' },
+  win32: { x64: 'piper_windows_amd64.zip' },
+}
+
+const piperBinaryName = (platform) => (platform === 'win32' ? 'piper.exe' : 'piper')
+
+/**
+ * Whether a complete runtime sits in the target dir. The binary alone is not
+ * enough: the app refuses to speak without the phoneme data beside it, so an
+ * interrupted install that left only the binary must not pass for installed.
+ * @param {string} targetDir
+ * @param {string} platform
+ * @returns {boolean}
+ */
+function hasRuntime(targetDir, platform) {
+  return (
+    fs.existsSync(path.join(targetDir, piperBinaryName(platform))) &&
+    fs.existsSync(path.join(targetDir, 'espeak-ng-data'))
+  )
+}
+
+// Bundled voice. Only the low-quality Amy model ships in the build to keep the
+// installer smaller; the app downloads the higher-quality voices on demand. All
+// en_US Piper models are ~63 MB regardless of tier, so "low" here is about
+// output quality (16 kHz), not size.
+const VOICE = {
+  name: 'en_US-amy-low',
+  onnxUrl: 'https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/amy/low/en_US-amy-low.onnx?download=true',
+  jsonUrl:
+    'https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/amy/low/en_US-amy-low.onnx.json?download=true',
+}
+
+/**
+ * The macOS build links its dylibs through `@rpath` but ships no rpath entry of
+ * its own, so dyld cannot find them. Point the rpath at the binary's directory,
+ * where the dylibs sit. `DYLD_LIBRARY_PATH` is not an option, since the signed
+ * app runs under the hardened runtime, which strips `DYLD_*` from the child.
+ * @param {string} binaryPath
+ * @param {string} rpath
+ */
+function addMacRpath(binaryPath, rpath = '@executable_path') {
+  try {
+    execSync(`install_name_tool -add_rpath ${rpath} "${binaryPath}"`, { stdio: 'pipe' })
+    // Rewriting the load commands invalidates the signature, and macOS kills a
+    // binary whose signature no longer matches, so sign it again ad-hoc.
+    execSync(`codesign --force --sign - "${binaryPath}"`, { stdio: 'pipe' })
+  } catch (error) {
+    throw new Error(`Could not add the ${rpath} rpath to "${binaryPath}": ${error.message}`)
+  }
+}
+
+/**
+ * Extract the Piper runtime archive straight into the target dir. The archive
+ * expands into a top-level `piper/` folder holding the binary, shared libraries
+ * (with relative symlinks between them) and the espeak-ng phoneme data;
+ * `--strip-components=1` drops that folder while keeping the symlinks intact.
+ * @param {string} archivePath
+ * @param {string} targetDir
+ * @param {string} platform
+ */
+function extractRuntime(archivePath, targetDir, platform) {
+  try {
+    console.log('Extracting Piper runtime...')
+    try {
+      // Windows ships a zip, which its bundled tar (bsdtar) reads just as well.
+      execSync(`tar ${platform === 'win32' ? '-xf' : '-xzf'} "${archivePath}" -C "${targetDir}" --strip-components=1`)
+    } catch (error) {
+      throw new Error('tar command not available. Please install tar.')
+    }
+
+    const binaryPath = path.join(targetDir, piperBinaryName(platform))
+    if (!fs.existsSync(binaryPath)) {
+      throw new Error(`Piper binary not found after extraction at: ${binaryPath}`)
+    }
+    if (platform !== 'win32') {
+      fs.chmodSync(binaryPath, '755')
+    }
+    if (platform === 'darwin') {
+      addMacRpath(binaryPath)
+    }
+
+    fs.unlinkSync(archivePath)
+
+    console.log('✅ Piper runtime installed successfully!')
+  } catch (error) {
+    try {
+      fs.unlinkSync(archivePath)
+    } catch (cleanupError) {
+      // Ignore cleanup errors
+    }
+    throw error
+  }
+}
+
+/**
+ * Download and install the Piper runtime and bundled voice for the current platform.
+ */
+async function installPiper() {
+  const platform = os.platform()
+  const arch = os.arch()
+
+  // Always create the target dir so `extraResources` has a source on every build
+  // platform, even where the bundle is skipped and it stays empty.
+  const targetDir = path.join(__dirname, '..', 'binaries', 'piper')
+  fs.mkdirSync(targetDir, { recursive: true })
+
+  const runtimeArchive = RUNTIME_ARCHIVES[platform]?.[arch]
+  const buildsFromSource = platform === 'darwin' && arch === 'arm64'
+  if (!runtimeArchive && !buildsFromSource) {
+    console.log(`Skipping Piper download: no bundled runtime for ${platform}-${arch}.`)
+    return
+  }
+
+  console.log(`Installing the Piper runtime and voice for ${platform}-${arch}...`)
+
+  const voicesDir = path.join(targetDir, 'voices')
+  fs.mkdirSync(voicesDir, { recursive: true })
+
+  const onnxPath = path.join(voicesDir, `${VOICE.name}.onnx`)
+  const jsonPath = path.join(voicesDir, `${VOICE.name}.onnx.json`)
+
+  if (hasRuntime(targetDir, platform) && fs.existsSync(onnxPath) && fs.existsSync(jsonPath)) {
+    console.log('Piper runtime and voice already exist. Skipping download.')
+    return
+  }
+
+  try {
+    if (!hasRuntime(targetDir, platform)) {
+      if (runtimeArchive) {
+        const archiveFile = path.join(targetDir, `piper-${platform}-${arch}.${platform === 'win32' ? 'zip' : 'tar.gz'}`)
+        await downloadFile(
+          `https://github.com/rhasspy/piper/releases/download/${PIPER_VERSION}/${runtimeArchive}`,
+          archiveFile
+        )
+        extractRuntime(archiveFile, targetDir, platform)
+      } else {
+        console.log('No prebuilt Piper runtime for this platform. Build one with `yarn build:piper`.')
+      }
+    }
+
+    if (!fs.existsSync(onnxPath)) {
+      await downloadFile(VOICE.onnxUrl, onnxPath)
+    }
+    if (!fs.existsSync(jsonPath)) {
+      await downloadFile(VOICE.jsonUrl, jsonPath)
+    }
+
+    console.log(`✅ Piper voice "${VOICE.name}" installed successfully!`)
+  } catch (error) {
+    console.error('❌ Failed to install Piper:', error.message)
+    process.exit(1)
+  }
+}
+
+if (require.main === module) {
+  installPiper().catch((error) => {
+    console.error('❌ Installation failed:', error.message)
+    process.exit(1)
+  })
+}
+
+module.exports = { addMacRpath, hasRuntime, installPiper }

--- a/scripts/lib/download.js
+++ b/scripts/lib/download.js
@@ -1,0 +1,76 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+/* eslint-disable no-undef */
+
+const https = require('https')
+const fs = require('fs')
+
+/**
+ * Download a file from a URL, following redirects. The bytes land in a `.part`
+ * file that is only renamed once the whole body arrived, so a failed download
+ * never leaves behind a file that the next run mistakes for a finished one and
+ * skips.
+ * @param {string} url
+ * @param {string} outputPath
+ */
+function downloadFile(url, outputPath) {
+  const partPath = `${outputPath}.part`
+
+  return new Promise((resolve, reject) => {
+    console.log(`Downloading from: ${url}`)
+
+    const file = fs.createWriteStream(partPath)
+    const fail = (error) => file.close(() => fs.unlink(partPath, () => reject(error)))
+
+    https
+      .get(url, (response) => {
+        if ([301, 302, 303, 307, 308].includes(response.statusCode) && response.headers.location) {
+          const nextUrl = new URL(response.headers.location, url).toString()
+          response.resume()
+          file.close(() => fs.unlink(partPath, () => downloadFile(nextUrl, outputPath).then(resolve).catch(reject)))
+          return
+        }
+
+        if (response.statusCode !== 200) {
+          response.resume()
+          fail(new Error(`Failed to download: ${response.statusCode}`))
+          return
+        }
+
+        const totalSize = parseInt(response.headers['content-length'] || '0', 10)
+        let downloadedSize = 0
+
+        response.on('data', (chunk) => {
+          downloadedSize += chunk.length
+          if (totalSize > 0) {
+            const percent = ((downloadedSize / totalSize) * 100).toFixed(1)
+            process.stdout.write(`\rDownloading... ${percent}%`)
+          }
+        })
+        response.on('error', fail)
+
+        response.pipe(file)
+
+        file.on('finish', () => {
+          file.close(() => {
+            if (totalSize > 0 && downloadedSize !== totalSize) {
+              fs.unlink(partPath, () =>
+                reject(new Error(`Truncated download: got ${downloadedSize} of ${totalSize} bytes`))
+              )
+              return
+            }
+            fs.rename(partPath, outputPath, (error) => {
+              if (error) {
+                reject(error)
+                return
+              }
+              console.log('\nDownload completed!')
+              resolve()
+            })
+          })
+        })
+      })
+      .on('error', fail)
+  })
+}
+
+module.exports = { downloadFile }

--- a/src/composables/useTextToSpeech.ts
+++ b/src/composables/useTextToSpeech.ts
@@ -1,0 +1,342 @@
+import { computed, ref, shallowRef, watch } from 'vue'
+
+import { NativePiperEngine } from '@/libs/tts/nativePiperEngine'
+import { type TtsEngine, type TtsVoice, clampVolume } from '@/libs/tts/types'
+import { WebSpeechEngine } from '@/libs/tts/webSpeechEngine'
+import { isElectron } from '@/libs/utils'
+import {
+  type PiperVoiceStatus,
+  type TtsDownloadProgress,
+  type TtsDownloadResult,
+  defaultPiperVoiceKey,
+  parsePiperVoiceKey,
+  piperVoiceOptionValue,
+  piperVoices,
+} from '@/types/tts'
+
+import { useBlueOsStorage } from './settingsSyncer'
+import { openSnackbar } from './snackbar'
+
+const webSpeechEngine = new WebSpeechEngine()
+const nativePiperEngine = new NativePiperEngine()
+
+// Module-level state so the store and the settings view share one selection and one voice list.
+// The key is vehicle-synced, so it can name a voice another topside machine has and this one does not.
+const storedVoiceId = useBlueOsStorage<string | null>('cockpit-selected-alert-speech-voice', null)
+const showOsVoices = useBlueOsStorage('cockpit-show-os-alert-voices', false)
+const voices = shallowRef<TtsVoice[]>([])
+const hostVoices = shallowRef<TtsVoice[]>([])
+const piperAvailable = ref(false)
+const piperVoiceStatuses = shallowRef<PiperVoiceStatus[]>([])
+const downloadingHdVoices = ref(false)
+const hdDownloadProgress = ref<TtsDownloadProgress>({ completed: 0, total: 0, voiceProgress: 0 })
+
+// Serializes playback so alerts never overlap, whichever engine speaks them.
+let speakQueue: Promise<void> = Promise.resolve()
+
+// Resolves once the offered voices are known. The availability probe synthesizes a word to prove Piper
+// works, so an alert raised in the first second would otherwise be handed to the host default: the wrong
+// voice on Windows and macOS, and nothing at all on a Linux desktop with no speech backend.
+let voicesReady: Promise<void> = Promise.resolve()
+
+// Bound on that wait, so a probe that never answers delays the first alert rather than muting every one.
+const voicesReadyTimeoutMs = 25000
+
+// Chromium reports an empty voice list until `voiceschanged` fires, and a machine with no bundled runtime
+// answers the probe in milliseconds with nothing known yet, so the wait ends on the first listing that
+// actually found a voice rather than on the first listing at all.
+let announceVoicesFound: (() => void) | undefined
+const firstVoicesFound = new Promise<void>((resolve) => {
+  announceVoicesFound = resolve
+})
+
+// The bundled voices are only known once the availability probe answers, and the host list is an
+// in-process enumeration that routinely beats it, so a list published before then is provisional: acting
+// on it would hand the first alerts to the host default on a machine that ships a bundled voice.
+const voiceListSettled = ref(false)
+
+// Long enough for any alert sentence. Past it the utterance is treated as lost,
+// since a stuck one would otherwise hold the queue for the rest of the session.
+const speechTimeoutMs = 30000
+
+// Rough pace of synthesized speech, used to make a muted alert take about as
+// long as a spoken one: the Alerter widget advances its display when the
+// previous alert finishes speaking.
+// ponytail: a flat per-character guess. Measuring the real rate would mean
+// synthesizing the audio we are trying not to synthesize.
+const mutedSpeechPacePerCharMs = 70
+const maxMutedSpeechMs = 10000
+
+const engineForVoice = (voiceId: string | undefined): TtsEngine =>
+  parsePiperVoiceKey(voiceId) ? nativePiperEngine : webSpeechEngine
+
+// The voice this machine actually speaks with: the stored choice while it is offered here, then the
+// bundled voice, then the host default. Resolving instead of rewriting keeps the stored choice intact
+// for the machines that can play it, and makes the bundled voice win wherever it exists.
+const selectedVoiceId = computed<string | undefined>({
+  get: () => {
+    const ids = voices.value.map((voice) => voice.id)
+    const preferences = [
+      storedVoiceId.value,
+      piperVoiceOptionValue(defaultPiperVoiceKey),
+      webSpeechEngine.defaultVoiceId(),
+    ]
+    return preferences.find((id) => id != null && ids.includes(id)) ?? ids[0]
+  },
+  set: (value) => {
+    storedVoiceId.value = value ?? null
+  },
+})
+
+// Only the control that can actually produce the missing voice is worth naming: the checkbox lists this
+// computer's own voices, which will never bring back a curated one that was never downloaded here.
+const wayBackTo = (stored: string): string => {
+  if (parsePiperVoiceKey(stored)) {
+    return piperAvailable.value ? ' The Alerts settings can download the higher-quality voices.' : ''
+  }
+  const canListHostVoices = piperAvailable.value && hostVoices.value.length > 0 && !showOsVoices.value
+  return canListHostVoices ? " The Alerts settings can list this computer's own voices again." : ''
+}
+
+// The stored choice survives untouched when this machine cannot offer it, so an operator who had picked a
+// voice hears a different one with nothing to explain it. Said once, naming both voices and the way back.
+let reportedVoiceOverride = false
+const reportVoiceOverride = (): void => {
+  const stored = storedVoiceId.value
+  if (reportedVoiceOverride || stored === null || voices.value.length === 0) return
+  if (voices.value.some((voice) => voice.id === stored)) return
+  reportedVoiceOverride = true
+  const speaking = voices.value.find((voice) => voice.id === selectedVoiceId.value)?.label
+  const chosen = piperVoices.find((voice) => piperVoiceOptionValue(voice.key) === stored)?.label ?? stored
+  const wayBack = wayBackTo(stored)
+  openSnackbar({
+    message: `Alerts are now read by ${speaking}, because ${chosen} is not offered on this computer.${wayBack}`,
+    variant: 'info',
+    duration: 8000,
+  })
+}
+
+// A refresh awaits the main process midway, so a later one can finish first and
+// leave the stale list behind. Only the newest is allowed to publish.
+let refreshGeneration = 0
+
+/**
+ * Rebuild the offered voice list. The host voices are hidden by default whenever
+ * the bundled ones are usable, since they vary per machine, are unpredictable in
+ * language and quality, and bury the curated voices in a list of dozens.
+ * @returns {Promise<void>} Resolves once the offered voices are refreshed.
+ */
+const refreshVoices = async (): Promise<void> => {
+  const generation = ++refreshGeneration
+  const statuses = piperAvailable.value ? await nativePiperEngine.voiceStatuses() : []
+  if (generation !== refreshGeneration) return
+
+  piperVoiceStatuses.value = statuses
+  const bundled = nativePiperEngine.voicesFromStatuses(statuses)
+  hostVoices.value = webSpeechEngine.listVoices()
+  const hideHostVoices = bundled.length > 0 && !showOsVoices.value
+  voices.value = hideHostVoices ? bundled : [...bundled, ...hostVoices.value]
+  if (!voiceListSettled.value) return
+  if (voices.value.length > 0) {
+    announceVoicesFound?.()
+    announceVoicesFound = undefined
+  }
+  reportVoiceOverride()
+}
+
+let initialized = false
+const init = (): void => {
+  if (initialized) return
+  initialized = true
+
+  webSpeechEngine.onVoicesChanged(() => void refreshVoices())
+  watch(showOsVoices, () => void refreshVoices())
+
+  if (isElectron()) {
+    void nativePiperEngine
+      .isAvailable()
+      .then((available) => {
+        piperAvailable.value = available
+      })
+      .catch((error) => console.error(`Could not check bundled voice availability: ${error}`))
+      .then(() => {
+        voiceListSettled.value = true
+        return refreshVoices()
+      })
+      .catch((error) => console.error(`Could not list the alert voices: ${error}`))
+    window.electronAPI?.onTtsDownloadProgress?.((info) => {
+      hdDownloadProgress.value = info
+    })
+  } else {
+    voiceListSettled.value = true
+    void refreshVoices()
+  }
+
+  const cap = new Promise<void>((resolve) => setTimeout(resolve, voicesReadyTimeoutMs))
+  voicesReady = Promise.race([firstVoicesFound, cap])
+}
+
+// A broken speech stack fails on every single alert, so it is reported once.
+let reportedSpeechFailure = false
+const reportSpeechFailure = (error: unknown): void => {
+  if (reportedSpeechFailure) return
+  reportedSpeechFailure = true
+  console.error(`Text-to-speech failed: ${error}`)
+  openSnackbar({
+    message: 'Voice system not working. Check the alert voice in the Alerts settings.',
+    variant: 'error',
+    duration: 6000,
+  })
+}
+
+/**
+ * Wait about as long as speaking the text would have taken, without synthesizing
+ * anything.
+ * @param {string} text - The text that is not being spoken.
+ * @returns {Promise<void>} Resolves once the estimated duration elapsed.
+ */
+const waitAsIfSpoken = (text: string): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, Math.min(text.length * mutedSpeechPacePerCharMs, maxMutedSpeechMs)))
+
+/**
+ * Give up on speech that never finishes. A Piper child that never exits, a
+ * stalled audio element or a Web Speech utterance whose `onend` never fires
+ * would otherwise block every later alert.
+ * @param {Promise<void>} speech - The in-flight utterance.
+ * @returns {Promise<void>} The utterance, rejected once it overruns.
+ */
+const withSpeechTimeout = (speech: Promise<void>): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const overrun = new Error(`Speech did not finish within ${speechTimeoutMs} ms`)
+    const timeout = setTimeout(() => reject(overrun), speechTimeoutMs)
+    speech.then(resolve, reject).finally(() => clearTimeout(timeout))
+  })
+
+/**
+ * Speak text once the voice list is known, so the voice is resolved against the real list rather than
+ * against the empty one the first alert of a session would otherwise see.
+ * @param {string} text - The text to speak.
+ * @param {number} volume - Playback volume in (0, 1].
+ * @returns {Promise<void>} Resolves when the utterance finishes playing.
+ */
+const speakWithSelectedVoice = async (text: string, volume: number): Promise<void> => {
+  await voicesReady
+  const voiceId = selectedVoiceId.value
+  await withSpeechTimeout(engineForVoice(voiceId).speak(voiceId ?? '', text, { volume }))
+}
+
+/**
+ * Speak text with the currently selected voice, serialized behind any speech
+ * already in flight.
+ * @param {string} text - The text to speak.
+ * @param {number} volume - Playback volume in [0, 1]; 0 skips synthesis but keeps the alert's timing.
+ * @returns {Promise<void>} Resolves when this utterance finishes playing.
+ */
+const speak = (text: string, volume: number): Promise<void> => {
+  const clampedVolume = clampVolume(volume)
+  speakQueue = speakQueue.then(() =>
+    clampedVolume === 0 ? waitAsIfSpoken(text) : speakWithSelectedVoice(text, clampedVolume).catch(reportSpeechFailure)
+  )
+  return speakQueue
+}
+
+/**
+ * Download the higher-quality model for every curated Piper voice.
+ * @returns {Promise<TtsDownloadResult | undefined>} How the download ended, or undefined when it never started.
+ */
+const downloadHdVoices = async (): Promise<TtsDownloadResult | undefined> => {
+  if (!piperAvailable.value || downloadingHdVoices.value) return undefined
+  downloadingHdVoices.value = true
+  // The counts come from the main process as it works, so they are not guessed here too.
+  hdDownloadProgress.value = { completed: 0, total: 0, voiceProgress: 0 }
+  try {
+    const result = await nativePiperEngine.downloadHdVoices()
+    await refreshVoices()
+    return result
+  } finally {
+    downloadingHdVoices.value = false
+  }
+}
+
+/** Abort the higher-quality download in progress, keeping the voices already fetched. */
+const cancelHdVoicesDownload = (): void => {
+  nativePiperEngine.cancelHdVoicesDownload()
+}
+
+/**
+ * Delete every downloaded higher-quality Piper model.
+ * @returns {Promise<boolean>} True when the downloaded voices were removed.
+ */
+const deleteHdVoices = async (): Promise<boolean> => {
+  if (!piperAvailable.value) return false
+  const ok = await nativePiperEngine.deleteHdVoices()
+  // The stored choice is vehicle-synced, so it must not move for a local cleanup. Suppressing the notice
+  // is enough: the operator asked for this voice to be gone, so it needs no explaining to them.
+  reportedVoiceOverride = true
+  await refreshVoices()
+  return ok
+}
+
+const voiceOptions = computed(() => voices.value.map((voice) => ({ value: voice.id, name: voice.label })))
+const hasOsVoices = computed(() => hostVoices.value.length > 0)
+const allHdVoicesDownloaded = computed(
+  () => piperVoiceStatuses.value.length > 0 && piperVoiceStatuses.value.every((voice) => voice.hd)
+)
+const hasDownloadedHdVoices = computed(() => piperVoiceStatuses.value.some((voice) => voice.hd))
+
+/** Reactive voice state and actions shared by the alert store and the settings view. */
+export interface TextToSpeechApi {
+  /** Dropdown options: `{ value, name }` for every offered voice. */
+  voiceOptions: typeof voiceOptions
+  /** Id of the voice in use here; writing to it persists a new choice. */
+  selectedVoiceId: typeof selectedVoiceId
+  /** Whether the bundled Piper synthesizer is usable. */
+  piperAvailable: typeof piperAvailable
+  /** Whether the offered voice list is final, i.e. the availability check has answered. */
+  voiceListSettled: typeof voiceListSettled
+  /** Whether the host's own voices are listed alongside the bundled ones. */
+  showOsVoices: typeof showOsVoices
+  /** Whether the host exposes any voice of its own to list. */
+  hasOsVoices: typeof hasOsVoices
+  /** Whether every curated voice already has its higher-quality model. */
+  allHdVoicesDownloaded: typeof allHdVoicesDownloaded
+  /** Whether at least one higher-quality model has been downloaded. */
+  hasDownloadedHdVoices: typeof hasDownloadedHdVoices
+  /** Whether a higher-quality download is in progress. */
+  downloadingHdVoices: typeof downloadingHdVoices
+  /** Progress of the current higher-quality download. */
+  hdDownloadProgress: typeof hdDownloadProgress
+  /** Speak text with the selected voice. */
+  speak: typeof speak
+  /** Download every higher-quality Piper model. */
+  downloadHdVoices: typeof downloadHdVoices
+  /** Abort the higher-quality download in progress. */
+  cancelHdVoicesDownload: typeof cancelHdVoicesDownload
+  /** Delete every downloaded higher-quality Piper model. */
+  deleteHdVoices: typeof deleteHdVoices
+}
+
+/**
+ * Shared text-to-speech orchestration for alert voices, backed by a pluggable
+ * set of engines (Web Speech everywhere, bundled Piper on the desktop build).
+ * @returns {TextToSpeechApi} The reactive voice state and actions consumed by the store and the settings view.
+ */
+export const useTextToSpeech = (): TextToSpeechApi => {
+  init()
+  return {
+    voiceOptions,
+    selectedVoiceId,
+    piperAvailable,
+    voiceListSettled,
+    showOsVoices,
+    hasOsVoices,
+    allHdVoicesDownloaded,
+    hasDownloadedHdVoices,
+    downloadingHdVoices,
+    hdDownloadProgress,
+    speak,
+    downloadHdVoices,
+    cancelHdVoicesDownload,
+    deleteHdVoices,
+  }
+}

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -13,6 +13,7 @@ import { setupOsmRefererService } from './services/osm-referer'
 import { setupResourceMonitoringService } from './services/resource-monitoring'
 import { setupFilesystemStorage } from './services/storage'
 import { setupSystemInfoService } from './services/system-info'
+import { setupTTSService } from './services/tts'
 import { setupUserAgentService } from './services/user-agent'
 import { setupVideoRecordingService } from './services/video-recording'
 import { setupWorkspaceService } from './services/workspace'
@@ -135,6 +136,7 @@ setupWorkspaceService()
 setupJoystickMonitoring()
 setupVideoRecordingService()
 setupGo2RTCService()
+setupTTSService()
 
 app.whenReady().then(async () => {
   console.log('Electron app is ready.')

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -20,6 +20,13 @@ import { setupWorkspaceService } from './services/workspace'
 // Setup the logger service as soon as possible to avoid different behaviors across runtime
 setupElectronLogService()
 
+// On Linux, Chromium gates its Web Speech API backend (used by the voice-alerts feature) behind
+// the `--enable-speech-dispatcher` switch, and it must be set before `app.whenReady()` to take effect.
+// Harmless when speech-dispatcher / libspeechd is not available on the host.
+if (process.platform === 'linux') {
+  app.commandLine.appendSwitch('enable-speech-dispatcher')
+}
+
 export const ROOT_PATH = {
   dist: join(__dirname, '..'),
 }

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -2,6 +2,7 @@ import { contextBridge, ipcRenderer } from 'electron'
 
 import type { ElectronSDLJoystickControllerStateEventData } from '@/types/joystick'
 import type { FileDialogOptions, FileStats } from '@/types/storage'
+import type { TtsDownloadProgress } from '@/types/tts'
 
 contextBridge.exposeInMainWorld('electronAPI', {
   getInfoOnSubnets: () => ipcRenderer.invoke('get-info-on-subnets'),
@@ -101,4 +102,15 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getCurrentUserAgent: () => ipcRenderer.invoke('get-current-user-agent'),
   getSystemInfo: () => ipcRenderer.invoke('get-system-info'),
   getHardwareTelemetryInfo: () => ipcRenderer.invoke('get-hardware-telemetry-info'),
+  ttsAvailable: () => ipcRenderer.invoke('tts-available'),
+  ttsListVoices: () => ipcRenderer.invoke('tts-list-voices'),
+  ttsSynthesize: async (text: string, voiceKey: string) => {
+    const audio: Uint8Array | null = await ipcRenderer.invoke('tts-synthesize', text, voiceKey)
+    return audio ? audio.buffer.slice(audio.byteOffset, audio.byteOffset + audio.byteLength) : null
+  },
+  ttsDownloadVoices: () => ipcRenderer.invoke('tts-download-voices'),
+  ttsCancelDownload: () => ipcRenderer.invoke('tts-cancel-download'),
+  ttsDeleteVoices: () => ipcRenderer.invoke('tts-delete-voices'),
+  onTtsDownloadProgress: (callback: (info: TtsDownloadProgress) => void) =>
+    ipcRenderer.on('tts-download-progress', (_event, info) => callback(info)),
 })

--- a/src/electron/services/piper-tts-path.ts
+++ b/src/electron/services/piper-tts-path.ts
@@ -1,0 +1,95 @@
+import { app } from 'electron'
+import fs from 'fs'
+import path from 'path'
+
+import { piperVoices } from '../../types/tts'
+import { getCockpitFolderPath } from './storage'
+
+/**
+ * Filesystem paths to the bundled Piper runtime.
+ */
+export interface PiperRuntime {
+  /** Piper executable. */
+  binary: string
+  /** espeak-ng phoneme data directory Piper needs for text processing. */
+  espeakData: string
+  /** Directory holding the binary and its shared libraries. */
+  baseDir: string
+}
+
+/**
+ * Resolved `.onnx` model and its `.onnx.json` config for a voice.
+ */
+export interface VoiceModel {
+  /** Voice model (`.onnx`) file. */
+  model: string
+  /** Voice config (`.onnx.json`) file. */
+  config: string
+}
+
+let cachedRuntime: PiperRuntime | null | undefined = undefined
+
+const bundledBaseDir = (): string =>
+  app.isPackaged ? path.join(process.resourcesPath, 'piper') : path.join(process.cwd(), 'binaries', 'piper')
+
+/**
+ * Writable directory where the higher-quality voices are downloaded at runtime,
+ * kept next to the videos and snapshots under the Cockpit folder.
+ * @returns {string} The absolute path to the downloaded-voices directory.
+ */
+export const downloadedVoicesDir = (): string => path.join(getCockpitFolderPath(), 'voices')
+
+/**
+ * Resolve the bundled Piper runtime for the current install, or null when it is
+ * not present (a build without the bundle, or an unsupported architecture).
+ * @returns {PiperRuntime | null} The resolved runtime, or null when unavailable.
+ */
+export const getPiperRuntime = (): PiperRuntime | null => {
+  if (cachedRuntime !== undefined) {
+    return cachedRuntime
+  }
+
+  const baseDir = bundledBaseDir()
+  const runtime: PiperRuntime = {
+    binary: path.join(baseDir, process.platform === 'win32' ? 'piper.exe' : 'piper'),
+    espeakData: path.join(baseDir, 'espeak-ng-data'),
+    baseDir,
+  }
+
+  if (!fs.existsSync(runtime.binary) || !fs.existsSync(runtime.espeakData)) {
+    cachedRuntime = null
+    return null
+  }
+
+  // The binary ships executable, but make it best-effort so a stripped
+  // permission bit does not disable voice alerts.
+  try {
+    fs.chmodSync(runtime.binary, '755')
+  } catch (error) {
+    console.warn(`Could not set executable permission on Piper binary: ${error}`)
+  }
+
+  cachedRuntime = runtime
+  return runtime
+}
+
+/**
+ * Resolve a usable model for a curated voice, preferring the downloaded
+ * higher-quality model over the bundled low-quality one.
+ * @param {string} voiceKey - The Piper speaker key (e.g. `amy`).
+ * @returns {VoiceModel | null} The model paths, or null when the voice has no model on disk.
+ */
+export const resolveVoiceModel = (voiceKey: string): VoiceModel | null => {
+  const voice = piperVoices.find((v) => v.key === voiceKey)
+  if (!voice) return null
+
+  const bases = [path.join(downloadedVoicesDir(), voice.hdModel)]
+  if (voice.bundledModel) bases.push(path.join(bundledBaseDir(), 'voices', voice.bundledModel))
+
+  for (const base of bases) {
+    const model = `${base}.onnx`
+    const config = `${base}.onnx.json`
+    if (fs.existsSync(model) && fs.existsSync(config)) return { model, config }
+  }
+  return null
+}

--- a/src/electron/services/tts.ts
+++ b/src/electron/services/tts.ts
@@ -1,0 +1,323 @@
+import { type ChildProcess, spawn } from 'child_process'
+import { type IpcMainInvokeEvent, app, ipcMain } from 'electron'
+import { promises as fs } from 'fs'
+import { type FileHandle } from 'fs/promises'
+import { randomUUID } from 'node:crypto'
+import path from 'path'
+
+import { type PiperVoiceStatus, type TtsDownloadResult, defaultPiperVoiceKey, piperVoices } from '../../types/tts'
+import { type VoiceModel, downloadedVoicesDir, getPiperRuntime, resolveVoiceModel } from './piper-tts-path'
+
+const runningProcesses = new Set<ChildProcess>()
+
+// A crashed or wedged Piper would otherwise never answer, and the renderer
+// serializes alerts behind each other, so an unanswered request would silence
+// every later alert.
+const synthesisTimeoutMs = 20000
+
+const huggingFaceBase = 'https://huggingface.co/rhasspy/piper-voices/resolve/main'
+
+/**
+ * Build the HuggingFace download URL for a Piper model file. The basename encodes
+ * the location, e.g. `en_US-amy-medium` lives under `en/en_US/amy/medium/`.
+ * @param {string} basename - Model basename without extension.
+ * @param {string} extension - File extension, `.onnx` or `.onnx.json`.
+ * @returns {string} The absolute download URL.
+ */
+const modelUrl = (basename: string, extension: string): string => {
+  const [region, speaker, quality] = basename.split('-')
+  const lang = region.split('_')[0]
+  return `${huggingFaceBase}/${lang}/${region}/${speaker}/${quality}/${basename}${extension}?download=true`
+}
+
+const fileExists = (filePath: string): Promise<boolean> =>
+  fs.access(filePath).then(
+    () => true,
+    () => false
+  )
+
+/**
+ * Download a URL to a destination via a `.part` file that is renamed on success,
+ * so an interrupted download never looks complete. `fetch` follows redirects.
+ * @param {string} url - Source URL.
+ * @param {string} dest - Destination path.
+ * @param {(ratio: number) => void} onProgress - Called with the fraction received so far.
+ * @param {AbortSignal} signal - Aborts the transfer when the user cancels.
+ * @returns {Promise<void>} Resolves once the file is fully written.
+ */
+const downloadTo = async (
+  url: string,
+  dest: string,
+  onProgress: (ratio: number) => void,
+  signal: AbortSignal
+): Promise<void> => {
+  const partPath = `${dest}.part`
+  let file: FileHandle | undefined
+  try {
+    const response = await fetch(url, { signal })
+    if (!response.ok || !response.body) throw new Error(`HTTP ${response.status} for ${url}`)
+
+    const total = Number(response.headers.get('content-length') ?? 0)
+    let received = 0
+    let reported = 0
+    file = await fs.open(partPath, 'w')
+
+    const reader = response.body.getReader()
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      await file.write(value)
+      received += value.length
+      // A model arrives in thousands of chunks, so the renderer only hears about
+      // the ones that move a progress bar.
+      const ratio = total > 0 ? received / total : 0
+      if (ratio - reported >= 0.01) {
+        reported = ratio
+        onProgress(ratio)
+      }
+    }
+
+    await file.close()
+    file = undefined
+    if (total > 0 && received !== total) throw new Error(`Truncated download: got ${received} of ${total} bytes`)
+    await fs.rename(partPath, dest)
+  } catch (error) {
+    await file?.close().catch(() => undefined)
+    await fs.unlink(partPath).catch(() => undefined)
+    throw error
+  }
+}
+
+/**
+ * Synthesize speech for the given text with a curated Piper voice.
+ * @param {string} text - Text to speak.
+ * @param {string} voiceKey - The Piper speaker key to synthesize with.
+ * @returns {Promise<Buffer | null>} WAV audio bytes, or null when the runtime/voice is unavailable or synthesis fails.
+ */
+const synthesize = async (text: string, voiceKey: string): Promise<Buffer | null> => {
+  const runtime = getPiperRuntime()
+  if (!runtime) return null
+
+  const voice: VoiceModel | null = resolveVoiceModel(voiceKey)
+  if (!voice) return null
+
+  const spoken = text.replace(/\s+/g, ' ').trim()
+  if (!spoken) return null
+
+  const outputFile = path.join(app.getPath('temp'), `cockpit-tts-${randomUUID()}.wav`)
+
+  return new Promise<Buffer | null>((resolve) => {
+    const child = spawn(
+      runtime.binary,
+      [
+        '--model',
+        voice.model,
+        '--config',
+        voice.config,
+        '--espeak_data',
+        runtime.espeakData,
+        '--output_file',
+        outputFile,
+      ],
+      { cwd: runtime.baseDir, env: { ...process.env, LD_LIBRARY_PATH: runtime.baseDir } }
+    )
+    runningProcesses.add(child)
+
+    const timeout = setTimeout(() => {
+      console.error(`[tts] Piper took longer than ${synthesisTimeoutMs} ms to speak. Killing it.`)
+      child.kill('SIGKILL')
+    }, synthesisTimeoutMs)
+
+    /**
+     * Remove a temp WAV, ignoring the error when it was never created.
+     * @returns {Promise<void>} Resolves once cleanup is attempted.
+     */
+    const cleanup = (): Promise<void> => fs.unlink(outputFile).catch(() => undefined)
+
+    child.on('error', async (error) => {
+      clearTimeout(timeout)
+      runningProcesses.delete(child)
+      console.error(`[tts] Failed to run Piper: ${error.message}`)
+      await cleanup()
+      resolve(null)
+    })
+
+    child.on('close', async (code, signal) => {
+      clearTimeout(timeout)
+      runningProcesses.delete(child)
+      if (code !== 0) {
+        console.error(`[tts] Piper exited with code ${code}${signal ? ` (signal ${signal})` : ''}`)
+        await cleanup()
+        resolve(null)
+        return
+      }
+      try {
+        const audio = await fs.readFile(outputFile)
+        resolve(audio)
+      } catch (error) {
+        console.error(`[tts] Could not read synthesized audio: ${error}`)
+        resolve(null)
+      } finally {
+        await cleanup()
+      }
+    })
+
+    child.stdin.on('error', () => undefined)
+    child.stdin.end(spoken)
+  })
+}
+
+let synthesisProbe: Promise<boolean> | undefined
+
+/**
+ * Whether the bundled runtime can actually speak, probed once with a real
+ * synthesis. Having the files on disk is not enough: the binary can still fail
+ * to launch (missing system libraries, macOS refusing an unsigned dylib), and a
+ * runtime that cannot speak must fall back to the host voices instead of
+ * leaving the user with a silent picker.
+ * @returns {Promise<boolean>} True when a test synthesis produced audio.
+ */
+const canSynthesize = (): Promise<boolean> => {
+  synthesisProbe ??= synthesize('Cockpit', defaultPiperVoiceKey).then(
+    (audio) => audio !== null,
+    () => false
+  )
+  return synthesisProbe
+}
+
+/**
+ * Availability of each curated voice on disk (bundled or downloaded).
+ * @returns {Promise<PiperVoiceStatus[]>} One status entry per curated voice.
+ */
+const listVoices = async (): Promise<PiperVoiceStatus[]> => {
+  const dir = downloadedVoicesDir()
+  return Promise.all(
+    piperVoices.map(async (voice) => ({
+      key: voice.key,
+      label: voice.label,
+      available: resolveVoiceModel(voice.key) !== null,
+      hd:
+        (await fileExists(path.join(dir, `${voice.hdModel}.onnx`))) &&
+        (await fileExists(path.join(dir, `${voice.hdModel}.onnx.json`))),
+    }))
+  )
+}
+
+let runningDownload: AbortController | undefined
+
+/**
+ * Download the higher-quality model for every curated voice, reporting progress.
+ * Each model is ~63 MB, so progress is reported as bytes arrive rather than once
+ * per finished voice. Voices already on disk are kept, making a retry resume.
+ * @param {IpcMainInvokeEvent} event - Invoke event used to push progress to the renderer.
+ * @returns {Promise<TtsDownloadResult>} How the download ended.
+ */
+const downloadHdVoices = async (event: IpcMainInvokeEvent): Promise<TtsDownloadResult> => {
+  if (!getPiperRuntime()) return 'failed'
+  // Single-flight here rather than in the renderer, whose state a window reload resets while this loop
+  // keeps running: two loops would write the same `.part` file and rename interleaved bytes over a model.
+  if (runningDownload) return 'busy'
+
+  const dir = downloadedVoicesDir()
+  await fs.mkdir(dir, { recursive: true })
+
+  runningDownload = new AbortController()
+  const { signal } = runningDownload
+
+  const total = piperVoices.length
+  let completed = 0
+  const report = (voiceProgress: number): void => {
+    event.sender.send('tts-download-progress', { completed, total, voiceProgress })
+  }
+  report(0)
+
+  try {
+    for (const voice of piperVoices) {
+      const onnx = path.join(dir, `${voice.hdModel}.onnx`)
+      const config = path.join(dir, `${voice.hdModel}.onnx.json`)
+      if (!(await fileExists(onnx))) await downloadTo(modelUrl(voice.hdModel, '.onnx'), onnx, report, signal)
+      // The config is a few kilobytes next to a ~63 MB model, so it does not move the bar.
+      if (!(await fileExists(config))) {
+        await downloadTo(modelUrl(voice.hdModel, '.onnx.json'), config, () => undefined, signal)
+      }
+      completed += 1
+      report(0)
+    }
+    return 'ok'
+  } catch (error) {
+    if (signal.aborted) return 'cancelled'
+    console.error(`[tts] Failed to download the higher-quality voices: ${error}`)
+    return 'failed'
+  } finally {
+    runningDownload = undefined
+  }
+}
+
+/**
+ * Delete every downloaded higher-quality voice, reverting to the bundled model.
+ * @returns {Promise<boolean>} True when the downloaded models were removed.
+ */
+const deleteHdVoices = async (): Promise<boolean> => {
+  const dir = downloadedVoicesDir()
+  try {
+    await Promise.all(
+      piperVoices.flatMap((voice) => [
+        fs.rm(path.join(dir, `${voice.hdModel}.onnx`), { force: true }),
+        fs.rm(path.join(dir, `${voice.hdModel}.onnx.json`), { force: true }),
+      ])
+    )
+    // Remove the folder too when nothing else lives in it, best-effort.
+    await fs.rmdir(dir).catch(() => undefined)
+    return true
+  } catch (error) {
+    console.error(`[tts] Failed to delete downloaded voices: ${error}`)
+    return false
+  }
+}
+
+/**
+ * Register the bundled-TTS IPC handlers and ensure Piper processes are stopped on exit.
+ */
+export const setupTTSService = (): void => {
+  ipcMain.handle('tts-available', async () => {
+    if (!getPiperRuntime() || !resolveVoiceModel(defaultPiperVoiceKey)) return false
+    return canSynthesize()
+  })
+
+  ipcMain.handle('tts-list-voices', async () => {
+    try {
+      return await listVoices()
+    } catch (error) {
+      console.error('[tts] Error listing voices:', error)
+      return []
+    }
+  })
+
+  ipcMain.handle('tts-synthesize', async (_event, text: string, voiceKey: string) => {
+    try {
+      return await synthesize(text, voiceKey)
+    } catch (error) {
+      console.error('[tts] Error synthesizing speech:', error)
+      return null
+    }
+  })
+
+  ipcMain.handle('tts-download-voices', async (event) => {
+    try {
+      return await downloadHdVoices(event)
+    } catch (error) {
+      console.error('[tts] Error downloading voices:', error)
+      return 'failed'
+    }
+  })
+
+  ipcMain.handle('tts-cancel-download', () => runningDownload?.abort())
+
+  ipcMain.handle('tts-delete-voices', () => deleteHdVoices())
+
+  process.on('exit', () => {
+    runningDownload?.abort()
+    runningProcesses.forEach((child) => child.kill())
+    runningProcesses.clear()
+  })
+}

--- a/src/libs/cosmos.ts
+++ b/src/libs/cosmos.ts
@@ -8,6 +8,7 @@ import type { TelemetrySystemHardwareInfo } from '@/types/platform'
 import { SDLStatus } from '@/types/sdl'
 import type { SerialData, SerialPortInfo } from '@/types/serial'
 import type { FileDialogOptions, FileStats } from '@/types/storage'
+import type { PiperVoiceStatus, TtsDownloadProgress, TtsDownloadResult } from '@/types/tts'
 import type { Go2RTCStreamInfo } from '@/types/video'
 
 import {
@@ -481,6 +482,44 @@ declare global {
        * @returns {Promise<TelemetrySystemHardwareInfo>} Serializable hardware fields
        */
       getHardwareTelemetryInfo: () => Promise<TelemetrySystemHardwareInfo>
+      /**
+       * Whether the bundled Piper synthesizer is available for offline alert speech
+       * @returns {Promise<boolean>} True when the runtime and the default voice are present
+       */
+      ttsAvailable: () => Promise<boolean>
+      /**
+       * Availability of each curated Piper voice on disk (bundled or downloaded)
+       * @returns {Promise<PiperVoiceStatus[]>} One status entry per curated voice
+       */
+      ttsListVoices: () => Promise<PiperVoiceStatus[]>
+      /**
+       * Synthesize speech for a text using a curated Piper voice
+       * @param {string} text - Text to speak
+       * @param {string} voiceKey - The Piper speaker key to synthesize with
+       * @returns {Promise<ArrayBuffer | null>} WAV audio bytes, or null when unavailable or synthesis failed
+       */
+      ttsSynthesize: (text: string, voiceKey: string) => Promise<ArrayBuffer | null>
+      /**
+       * Download the higher-quality model for every curated Piper voice
+       * @returns {Promise<TtsDownloadResult>} How the download ended
+       */
+      ttsDownloadVoices: () => Promise<TtsDownloadResult>
+      /**
+       * Abort the higher-quality voice download currently in progress, if any
+       * @returns {Promise<void>} Resolves once the abort was requested
+       */
+      ttsCancelDownload: () => Promise<void>
+      /**
+       * Delete every downloaded higher-quality Piper voice, reverting to the bundled model
+       * @returns {Promise<boolean>} True when the downloaded voices were removed
+       */
+      ttsDeleteVoices: () => Promise<boolean>
+      /**
+       * Subscribe to progress updates while the higher-quality voices download
+       * @param {(info: TtsDownloadProgress) => void} callback - Receives the voice counts and the current voice's progress
+       * @returns {void}
+       */
+      onTtsDownloadProgress: (callback: (info: TtsDownloadProgress) => void) => void
       /**
        * Start live video streaming process with FFmpeg
        * @param firstChunk - The first video chunk blob

--- a/src/libs/tts/audio.ts
+++ b/src/libs/tts/audio.ts
@@ -1,0 +1,20 @@
+/**
+ * Play WAV audio bytes and resolve once playback finishes.
+ * @param {ArrayBuffer} buffer - WAV audio bytes.
+ * @param {number} volume - Playback volume in the [0, 1] range.
+ * @returns {Promise<void>} Resolves when playback ends, rejects when it fails.
+ */
+export const playWavBuffer = (buffer: ArrayBuffer, volume: number): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(new Blob([buffer], { type: 'audio/wav' }))
+    const audio = new Audio(url)
+    audio.volume = volume
+    const settle = (error?: unknown): void => {
+      URL.revokeObjectURL(url)
+      if (error === undefined) resolve()
+      else reject(error)
+    }
+    audio.onended = () => settle()
+    audio.onerror = () => settle(new Error('Could not play the synthesized audio'))
+    audio.play().catch(settle)
+  })

--- a/src/libs/tts/nativePiperEngine.ts
+++ b/src/libs/tts/nativePiperEngine.ts
@@ -1,0 +1,56 @@
+import { type PiperVoiceStatus, type TtsDownloadResult, parsePiperVoiceKey, piperVoiceOptionValue } from '@/types/tts'
+
+import { playWavBuffer } from './audio'
+import { type SpeakOptions, type TtsEngine, type TtsVoice } from './types'
+
+/**
+ * Speech engine backed by the Piper synthesizer bundled with the desktop build.
+ * All platform work (running the binary, managing models) happens in the
+ * Electron main process; this engine only talks to it over the preload bridge.
+ */
+export class NativePiperEngine implements TtsEngine {
+  /** @returns {Promise<boolean>} True when the bundled synthesizer can speak. */
+  isAvailable(): Promise<boolean> {
+    return window.electronAPI?.ttsAvailable?.() ?? Promise.resolve(false)
+  }
+
+  /** @returns {Promise<PiperVoiceStatus[]>} Per-voice availability and download state. */
+  voiceStatuses(): Promise<PiperVoiceStatus[]> {
+    return window.electronAPI?.ttsListVoices?.() ?? Promise.resolve([])
+  }
+
+  /**
+   * Map already-fetched voice statuses to the selectable voices with a usable model.
+   * @param {PiperVoiceStatus[]} statuses - Per-voice availability and download state.
+   * @returns {TtsVoice[]} The curated voices that currently have a usable model.
+   */
+  voicesFromStatuses(statuses: PiperVoiceStatus[]): TtsVoice[] {
+    return statuses
+      .filter((status) => status.available)
+      .map((status) => ({ id: piperVoiceOptionValue(status.key), label: status.label }))
+  }
+
+  /** @inheritdoc */
+  async speak(voiceId: string, text: string, { volume }: SpeakOptions): Promise<void> {
+    const key = parsePiperVoiceKey(voiceId)
+    if (!key || !window.electronAPI?.ttsSynthesize) return
+    const audio = await window.electronAPI.ttsSynthesize(text, key)
+    if (!audio) throw new Error('The bundled synthesizer produced no audio')
+    await playWavBuffer(audio, volume)
+  }
+
+  /** @returns {Promise<TtsDownloadResult>} How the higher-quality download ended. */
+  downloadHdVoices(): Promise<TtsDownloadResult> {
+    return window.electronAPI?.ttsDownloadVoices?.() ?? Promise.resolve('failed')
+  }
+
+  /** Abort the higher-quality download currently in progress, if any. */
+  cancelHdVoicesDownload(): void {
+    void window.electronAPI?.ttsCancelDownload?.()
+  }
+
+  /** @returns {Promise<boolean>} True when the downloaded models were removed. */
+  deleteHdVoices(): Promise<boolean> {
+    return window.electronAPI?.ttsDeleteVoices?.() ?? Promise.resolve(false)
+  }
+}

--- a/src/libs/tts/types.ts
+++ b/src/libs/tts/types.ts
@@ -1,0 +1,42 @@
+/**
+ * A voice offered to the user, normalized across every engine so the UI and the
+ * selection state never need to know which engine produced it.
+ */
+export interface TtsVoice {
+  /**
+   * Stable value persisted as the selected voice and used to route speech.
+   * Web Speech voices use the raw voice name; Piper voices use the `piper:` prefixed key.
+   */
+  id: string
+  /** Human-readable label for the dropdown. */
+  label: string
+}
+
+/** Options for a single speak request. */
+export interface SpeakOptions {
+  /** Playback volume in the [0, 1] range. 0 keeps timing but stays silent. */
+  volume: number
+}
+
+/**
+ * A speech engine: the ability to speak with one of its voices. Implementations
+ * keep their platform specifics (Web Speech API, Electron IPC) internal so the
+ * manager stays runtime-agnostic.
+ */
+export interface TtsEngine {
+  /**
+   * Speak text with one of the engine's voices, resolving when playback ends.
+   * @param {string} voiceId - The {@link TtsVoice.id} to speak with.
+   * @param {string} text - The text to speak.
+   * @param {SpeakOptions} options - Playback options.
+   * @returns {Promise<void>} Resolves when playback finishes or cannot start.
+   */
+  speak(voiceId: string, text: string, options: SpeakOptions): Promise<void>
+}
+
+/**
+ * Clamp a volume into the [0, 1] range accepted by the audio backends.
+ * @param {number} volume - Requested volume.
+ * @returns {number} The volume clamped to [0, 1].
+ */
+export const clampVolume = (volume: number): number => Math.min(Math.max(volume, 0), 1)

--- a/src/libs/tts/webSpeechEngine.ts
+++ b/src/libs/tts/webSpeechEngine.ts
@@ -1,0 +1,72 @@
+import { type SpeakOptions, type TtsEngine, type TtsVoice } from './types'
+
+/**
+ * Speech engine backed by the browser's Web Speech API. Available on every
+ * platform, using whatever voices the host OS/browser exposes.
+ */
+export class WebSpeechEngine implements TtsEngine {
+  private readonly synth = typeof window !== 'undefined' ? window.speechSynthesis : undefined
+  // Utterances are cached until they finish so the browser does not garbage-collect them mid-speech.
+  private readonly pending = new Set<SpeechSynthesisUtterance>()
+
+  /** @returns {SpeechSynthesisVoice[]} The raw host voices, or an empty list. */
+  private rawVoices(): SpeechSynthesisVoice[] {
+    return this.synth?.getVoices() ?? []
+  }
+
+  /** @returns {TtsVoice[]} The host voices normalized for the shared picker. */
+  listVoices(): TtsVoice[] {
+    return this.rawVoices().map((voice) => ({ id: voice.name, label: `${voice.name} (${voice.lang})` }))
+  }
+
+  /**
+   * Register a callback for when the host voice list becomes available or changes.
+   * @param {() => void} callback - Invoked on every `voiceschanged` event.
+   */
+  onVoicesChanged(callback: () => void): void {
+    if (this.synth) this.synth.onvoiceschanged = callback
+  }
+
+  /**
+   * Pick a sensible default host voice: the one the platform itself marks as
+   * default, then any voice matching the interface language.
+   * @returns {string | undefined} The chosen voice id, or undefined when none exist.
+   */
+  defaultVoiceId(): string | undefined {
+    const voices = this.rawVoices()
+    const preferred = voices.find((voice) => voice.default) ?? voices.find((voice) => voice.lang === navigator.language)
+    return (preferred ?? voices[0])?.name
+  }
+
+  /** @inheritdoc */
+  speak(voiceId: string, text: string, { volume }: SpeakOptions): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (!this.synth) {
+        reject(new Error('This system has no speech synthesis support'))
+        return
+      }
+      const utterance = new SpeechSynthesisUtterance(text)
+      utterance.volume = volume
+      const voice = this.rawVoices().find((candidate) => candidate.name === voiceId)
+      if (voice) {
+        utterance.voice = voice
+        utterance.lang = voice.lang
+      }
+      this.pending.add(utterance)
+      const finish = (): void => {
+        this.pending.delete(utterance)
+      }
+      utterance.onend = (): void => {
+        finish()
+        resolve()
+      }
+      utterance.onerror = (event): void => {
+        finish()
+        // Interruptions are a normal outcome, not a failing speech stack.
+        if (event.error === 'canceled' || event.error === 'interrupted') resolve()
+        else reject(new Error(`Speech synthesis failed: ${event.error}`))
+      }
+      this.synth.speak(utterance)
+    })
+  }
+}

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -193,6 +193,18 @@ export const isElectron = (): boolean => {
 }
 
 /**
+ * Detects the host operating system, named as users know it
+ * @returns {'Linux' | 'Windows' | 'macOS' | undefined} The host OS name, or undefined when it cannot be told
+ */
+export const hostOsName = (): 'Linux' | 'Windows' | 'macOS' | undefined => {
+  const platform = (navigator.userAgentData?.platform ?? navigator.platform ?? navigator.userAgent).toLowerCase()
+  if (platform.includes('linux')) return 'Linux'
+  if (platform.includes('win')) return 'Windows'
+  if (platform.includes('mac')) return 'macOS'
+  return undefined
+}
+
+/**
  * Copy text to clipboard
  * @param {string} text The text to copy
  * @returns {Promise<void>} A promise that resolves when the text is copied

--- a/src/stores/alert.ts
+++ b/src/stores/alert.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { computed, reactive, ref, watch } from 'vue'
 
 import { useBlueOsStorage } from '@/composables/settingsSyncer'
+import { useTextToSpeech } from '@/composables/useTextToSpeech'
 
 import { Alert, AlertLevel } from '../types/alert'
 
@@ -10,12 +11,7 @@ export const useAlertStore = defineStore('alert', () => {
   const enableVoiceAlerts = useBlueOsStorage('cockpit-enable-voice-alerts', true)
   const neverShowArmedMenuWarning = useBlueOsStorage('cockpit-never-show-armed-menu-warning', false)
   const skipArmedMenuWarningThisSession = ref(false)
-  // eslint-disable-next-line jsdoc/require-jsdoc
-  const availableAlertSpeechVoices = reactive<SpeechSynthesisVoice[]>([])
-  const selectedAlertSpeechVoiceName = useBlueOsStorage<string | undefined>(
-    'cockpit-selected-alert-speech-voice',
-    undefined
-  )
+  const { speak } = useTextToSpeech()
   const enabledAlertLevels = useBlueOsStorage('cockpit-enabled-alert-levels', [
     { level: AlertLevel.Info, enabled: false },
     { level: AlertLevel.Success, enabled: true },
@@ -71,81 +67,8 @@ export const useAlertStore = defineStore('alert', () => {
     pushAlert(new Alert(AlertLevel.Critical, message, time_created))
   }
 
-  // Alert speech syntesis routine
-  const synth = window.speechSynthesis
-
-  // We need to cache these otherwise they get garbage collected...
-  const utterance_cache: SpeechSynthesisUtterance[] = []
-
-  // By default we use the platform language over the default speech text,
-  // it appears that browsers like chrome fail to have it correctly based on the system.
-  // The default speech langauge _should_ be the same as platform language.
-  if (synth) {
-    synth.onvoiceschanged = () => {
-      let default_speech: undefined | string = undefined
-      let default_speech_by_language: undefined | string = undefined
-      synth.getVoices().forEach((voice) => {
-        availableAlertSpeechVoices.push(voice)
-
-        if (voice.default) {
-          default_speech = voice.name
-        }
-
-        if (voice.lang === navigator.language) {
-          default_speech_by_language = voice.name
-        }
-      })
-
-      if (selectedAlertSpeechVoiceName.value === undefined) {
-        if (default_speech_by_language !== undefined) {
-          selectedAlertSpeechVoiceName.value = default_speech_by_language
-          return
-        }
-
-        if (default_speech) {
-          selectedAlertSpeechVoiceName.value = default_speech
-        }
-      }
-    }
-  }
-
-  const availableAlertSpeechVoiceNames = computed(() =>
-    availableAlertSpeechVoices.map((v) => ({ value: v.name, name: `${v.name} (${v.lang})` }))
-  )
-
-  // Track the index of the last alert that finished being spoken
+  // Track the index of the last alert that finished being spoken.
   const lastSpokenAlertIndex = ref(0)
-
-  /**
-   * Speaks a text out loud using the browsers TTS engine
-   * @param {string} text - The text to speak
-   * @param {number} alertIndex - The index of the alert being spoken
-   * @param {boolean} muted - If true, speech will be silent (volume 0) but still run for timing purposes
-   */
-  function speak(text: string, alertIndex: number, muted = false): void {
-    if (!synth) {
-      console.warn('No speechSynthesis available')
-      lastSpokenAlertIndex.value = alertIndex
-      return
-    }
-    const utterance = new SpeechSynthesisUtterance(text)
-    utterance.volume = muted ? 0 : Math.min(Math.max(alertVolume.value, 0), 1)
-    const voice = availableAlertSpeechVoices.find((v) => v.name === selectedAlertSpeechVoiceName.value)
-    if (voice) {
-      utterance.voice = voice
-      utterance.lang = voice.lang
-    }
-    utterance_cache.push(utterance)
-    utterance.onend = function () {
-      delete utterance_cache[utterance_cache.indexOf(utterance)]
-      lastSpokenAlertIndex.value = alertIndex
-    }
-    utterance.onerror = function (event) {
-      console.error(`SpeechSynthesisUtterance error: ${event.error}`)
-      lastSpokenAlertIndex.value = alertIndex
-    }
-    synth.speak(utterance)
-  }
 
   watch(alerts, () => {
     const lastAlertIndex = alerts.length - 1
@@ -154,15 +77,16 @@ export const useAlertStore = defineStore('alert', () => {
     const shouldMute =
       !enableVoiceAlerts.value ||
       ((alertLevelEnabled === undefined || !alertLevelEnabled.enabled) && !lastAlert.message.startsWith('#'))
-    speak(lastAlert.message, lastAlertIndex, shouldMute)
+    const volume = shouldMute ? 0 : alertVolume.value
+    speak(lastAlert.message, volume).finally(() => {
+      lastSpokenAlertIndex.value = lastAlertIndex
+    })
   })
 
   return {
     alerts,
     enableVoiceAlerts,
     enabledAlertLevels,
-    selectedAlertSpeechVoiceName,
-    availableAlertSpeechVoiceNames,
     sortedAlerts,
     pushAlert,
     pushSuccessAlert,

--- a/src/types/tts.ts
+++ b/src/types/tts.ts
@@ -1,0 +1,83 @@
+/**
+ * A curated Piper voice offered for alert speech on the Standalone build.
+ */
+export interface PiperVoice {
+  /** Stable speaker key used in dropdown option values and IPC (e.g. `amy`). */
+  key: string
+  /** Label shown in the alert-voice dropdown. */
+  label: string
+  /**
+   * Model basename shipped inside the build (without extension), or undefined
+   * when the voice is only available after the higher-quality download.
+   */
+  bundledModel?: string
+  /** Higher-quality model basename fetched by the in-app download. */
+  hdModel: string
+}
+
+/**
+ * Curated voices for the bundled synthesizer. Only Amy ships in the build (at
+ * low quality); the higher-quality Amy model and the other three voices are
+ * fetched on demand by the in-app download. Every `en_US` Piper model is ~63 MB
+ * regardless of quality tier, so the whole set is ~250 MB.
+ */
+export const piperVoices: PiperVoice[] = [
+  {
+    key: 'amy',
+    label: 'Amy (US English, female)',
+    bundledModel: 'en_US-amy-low',
+    hdModel: 'en_US-amy-medium',
+  },
+  { key: 'lessac', label: 'Lessac (US English, female)', hdModel: 'en_US-lessac-medium' },
+  { key: 'ryan', label: 'Ryan (US English, male)', hdModel: 'en_US-ryan-medium' },
+  { key: 'joe', label: 'Joe (US English, male)', hdModel: 'en_US-joe-medium' },
+]
+
+/** Voice selected by default whenever the bundled synthesizer is available. */
+export const defaultPiperVoiceKey = 'amy'
+
+const piperOptionPrefix = 'piper:'
+
+/**
+ * Build the dropdown value that routes speech through the bundled Piper voice.
+ * @param {string} key - The Piper speaker key.
+ * @returns {string} The prefixed option value stored as the selected voice.
+ */
+export const piperVoiceOptionValue = (key: string): string => `${piperOptionPrefix}${key}`
+
+/**
+ * Extract the Piper speaker key from a selected-voice value, when it is one.
+ * @param {string | undefined} value - The persisted selected-voice value.
+ * @returns {string | undefined} The speaker key, or undefined for host voices.
+ */
+export const parsePiperVoiceKey = (value: string | undefined): string | undefined =>
+  value?.startsWith(piperOptionPrefix) ? value.slice(piperOptionPrefix.length) : undefined
+
+/**
+ * Progress of the in-app higher-quality voice download.
+ */
+export interface TtsDownloadProgress {
+  /** Number of curated voices finished downloading. */
+  completed: number
+  /** Total number of curated voices to download. */
+  total: number
+  /** Fraction in [0, 1] of the voice currently downloading. */
+  voiceProgress: number
+}
+
+/** Outcome of an in-app higher-quality voice download. */
+export type TtsDownloadResult = 'ok' | 'failed' | 'cancelled' | 'busy'
+
+/**
+ * Availability of a curated Piper voice on the current install.
+ */
+export interface PiperVoiceStatus {
+  /** Stable speaker key. */
+  key: string
+  /** Label shown in the alert-voice dropdown. */
+  label: string
+  /** A model (bundled or downloaded) is present to synthesize this voice. */
+  available: boolean
+  /** The higher-quality model has been downloaded. */
+  hd: boolean
+}

--- a/src/views/ConfigurationAlertsView.vue
+++ b/src/views/ConfigurationAlertsView.vue
@@ -50,13 +50,72 @@
               </div>
             </div>
             <span class="text-sm font-medium mt-4">Alert voice:</span>
-            <Dropdown
-              :model-value="alertStore.selectedAlertSpeechVoiceName"
-              :options="alertStore.availableAlertSpeechVoiceNames"
-              name-key="name"
-              value-key="value"
-              class="max-w-[350px] mt-2 mb-4 ml-2"
-              @update:model-value="setAlertVoice"
+            <div class="flex items-center gap-x-3 mt-2 mb-2 ml-2 max-w-[620px]">
+              <v-select
+                v-if="voiceOptions.length > 0"
+                :model-value="selectedVoiceId"
+                :items="voiceOptions"
+                item-title="name"
+                item-value="value"
+                aria-label="Alert voice"
+                theme="dark"
+                density="compact"
+                variant="outlined"
+                hide-details
+                class="flex-1 min-w-0 max-w-[350px] text-sm"
+                @update:model-value="setAlertVoice"
+              />
+              <p v-else-if="voiceListSettled" class="text-sm text-yellow-300 max-w-[350px]">
+                Voice system not working: no speech voice found.
+                <template v-if="hostOs === 'Linux'">
+                  Install <span class="font-mono">speech-dispatcher</span> and <span class="font-mono">espeak-ng</span>.
+                </template>
+              </p>
+              <template v-if="piperAvailable && !allHdVoicesDownloaded">
+                <v-btn
+                  v-if="!downloadingHdVoices"
+                  variant="flat"
+                  size="x-small"
+                  class="text-none bg-[#FFFFFF22] text-white shrink-0"
+                  @click="promptDownloadHdVoices"
+                >
+                  Download higher-quality voices
+                </v-btn>
+                <div v-else class="flex items-center gap-x-2 shrink-0">
+                  <div class="w-[220px]">
+                    <v-progress-linear :model-value="hdDownloadPercent" height="4" color="white" rounded />
+                    <p class="text-xs opacity-70 mt-1 text-center leading-none">
+                      {{ hdDownloadProgress.completed }} of {{ hdDownloadProgress.total }} voices
+                    </p>
+                  </div>
+                  <v-btn
+                    variant="flat"
+                    size="x-small"
+                    class="text-none bg-[#FFFFFF22] text-white"
+                    @click="cancelHdVoiceDownload"
+                  >
+                    Cancel
+                  </v-btn>
+                </div>
+              </template>
+              <v-btn
+                v-if="piperAvailable && hasDownloadedHdVoices && !downloadingHdVoices"
+                variant="flat"
+                size="x-small"
+                class="text-none bg-[#FFFFFF22] text-white shrink-0 ml-auto"
+                @click="promptDeleteHdVoices"
+              >
+                Remove higher-quality voices
+              </v-btn>
+            </div>
+            <v-checkbox
+              v-if="piperAvailable && hasOsVoices"
+              :model-value="showOsVoices"
+              :label="osVoicesLabel"
+              hide-details
+              color="white"
+              class="ml-2"
+              @update:model-value="setShowOsVoices"
             />
           </template>
         </ExpansiblePanel>
@@ -75,10 +134,13 @@
 </template>
 
 <script setup lang="ts">
-import { capitalize } from 'vue'
+import { capitalize, computed } from 'vue'
 
-import Dropdown from '@/components/Dropdown.vue'
 import ExpansiblePanel from '@/components/ExpansiblePanel.vue'
+import { useInteractionDialog } from '@/composables/interactionDialog'
+import { openSnackbar } from '@/composables/snackbar'
+import { useTextToSpeech } from '@/composables/useTextToSpeech'
+import { hostOsName } from '@/libs/utils'
 import { useAlertStore } from '@/stores/alert'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 
@@ -86,6 +148,31 @@ import BaseConfigurationView from './BaseConfigurationView.vue'
 
 const interfaceStore = useAppInterfaceStore()
 const alertStore = useAlertStore()
+const { showDialog, closeDialog } = useInteractionDialog()
+const {
+  voiceOptions,
+  selectedVoiceId,
+  piperAvailable,
+  voiceListSettled,
+  showOsVoices,
+  hasOsVoices,
+  allHdVoicesDownloaded,
+  hasDownloadedHdVoices,
+  downloadingHdVoices,
+  hdDownloadProgress,
+  speak,
+  downloadHdVoices,
+  cancelHdVoicesDownload,
+  deleteHdVoices,
+} = useTextToSpeech()
+
+const hostOs = hostOsName()
+const osVoicesLabel = `Also list ${hostOs ?? "this computer's"} default speech voices`
+
+const hdDownloadPercent = computed(() => {
+  const { completed, total, voiceProgress } = hdDownloadProgress.value
+  return total > 0 ? ((completed + voiceProgress) / total) * 100 : 0
+})
 
 const setVoiceAlertsEnabled = (value: boolean | null): void => {
   const enabled = value ?? false
@@ -103,12 +190,113 @@ const setAlertLevelEnabled = (level: string, value: boolean | null): void => {
 
 const setAlertVoice = (value: unknown): void => {
   logUserAction(`Set alert voice to '${value}'`)
-  alertStore.selectedAlertSpeechVoiceName = value as string
+  selectedVoiceId.value = value as string
+  if (alertStore.alertVolume === 0) {
+    openSnackbar({ message: 'Voice set. Raise the alerts volume to hear it.', variant: 'info', duration: 5000 })
+    return
+  }
+  void speak('Voice alerts will sound like this.', alertStore.alertVolume)
+}
+
+const setShowOsVoices = (value: boolean | null): void => {
+  const show = value ?? false
+  logUserAction(`${show ? 'Showed' : 'Hid'} the ${hostOs ?? 'host'} default TTS voices`)
+  showOsVoices.value = show
 }
 
 const setShowArmedMenuWarning = (value: boolean | null): void => {
   const show = value ?? false
   logUserAction(`${show ? 'Enabled' : 'Disabled'} armed-vehicle menu warning`)
   alertStore.neverShowArmedMenuWarning = !show
+}
+
+const downloadOutcomes = {
+  ok: { message: 'Higher-quality voices downloaded.', variant: 'success' },
+  cancelled: { message: 'Higher-quality voices download cancelled.', variant: 'info' },
+  failed: { message: 'Could not download all voices. Check your internet connection and try again.', variant: 'error' },
+  busy: { message: 'A voice download is already running.', variant: 'info' },
+} as const
+
+const startHdVoiceDownload = async (): Promise<void> => {
+  const result = await downloadHdVoices()
+  // Undefined means a second press never started a download, which is not a failure to report.
+  if (result === undefined) return
+  openSnackbar({ ...downloadOutcomes[result], duration: 5000 })
+}
+
+const cancelHdVoiceDownload = (): void => {
+  logUserAction('Cancelled the higher-quality voices download in progress')
+  cancelHdVoicesDownload()
+}
+
+const promptDownloadHdVoices = (): void => {
+  logUserAction('Opened the higher-quality voices download dialog')
+  showDialog({
+    title: 'Download higher-quality voices',
+    variant: 'info',
+    maxWidth: 520,
+    message: [
+      'Downloads four higher-quality neural voices: Amy and Lessac (female), Ryan and Joe (male).',
+      'This transfers about 250 MB and uses roughly the same amount of disk space. The voices then work offline.',
+    ],
+    actions: [
+      {
+        text: 'Cancel',
+        action: () => {
+          logUserAction('Cancelled the higher-quality voices download')
+          closeDialog()
+        },
+      },
+      {
+        text: 'Download',
+        class: 'bg-[#FFFFFF33] text-white',
+        action: () => {
+          logUserAction('Confirmed the higher-quality voices download')
+          closeDialog()
+          void startHdVoiceDownload()
+        },
+      },
+    ],
+  })
+}
+
+const removeHdVoices = async (): Promise<void> => {
+  const success = await deleteHdVoices()
+  openSnackbar({
+    message: success ? 'Higher-quality voices removed.' : 'Could not remove the downloaded voices.',
+    variant: success ? 'success' : 'error',
+    duration: 5000,
+  })
+}
+
+const promptDeleteHdVoices = (): void => {
+  logUserAction('Opened the remove higher-quality voices dialog')
+  showDialog({
+    title: 'Remove higher-quality voices',
+    variant: 'warning',
+    maxWidth: 520,
+    message: [
+      'Delete the downloaded higher-quality voices and free up their disk space?',
+      'Amy reverts to the built-in voice, and the others are removed until downloaded again.',
+    ],
+    actions: [
+      {
+        text: 'Cancel',
+        action: () => {
+          logUserAction('Cancelled removing the higher-quality voices')
+          closeDialog()
+        },
+      },
+      {
+        text: 'Remove',
+        class: 'bg-[#FFFFFF33] text-white',
+        action: () => {
+          logUserAction('Confirmed removing the higher-quality voices')
+          closeDialog()
+          void removeHdVoices()
+        },
+      },
+    ],
+  })
 }
 </script>


### PR DESCRIPTION
- Alert voices used to rely on whatever the OS/browser exposed, which was inconsistent across systems and sometimes read English alerts in the user's local language (e.g. Portuguese or Turkish), producing a potential odd-sounding speech lottery the user never selected.
- Voice alerts now work on all Standalone builds.
- A neural voice (Piper) ships built into the standalone app, so alerts speak out of the box with no system speech setup.
- The picker lists only the built-in voices by default, since the OS ones vary per machine and bury them in a list of dozens; a checkbox named after the detected system ("Also list Windows default TTS voices") brings the computer's own voices back into the list for anyone who wants them, and only appears on machines that actually expose some.
- The bundled voice is a low-quality (16 kHz) neural Amy, and a "download higher-quality voices" button fetches four natural voices (Amy and Lessac female, Ryan and Joe male), a one-time ~250 MB download that then works offline, behind a confirmation dialog with a cancellable progress bar. Files go to the "voices" folder inside the Cockpit folder (`~/Cockpit/voices` by default).
- A remove button deletes the downloaded higher-quality voices and frees the disk space, reverting to the built-in voice.
- When no speech voice is available, the settings page says so, and on Linux points at the speech stack to install, instead of failing silently.
- On Cockpit Lite, alerts keep using the browser's speech voices, since the bundled offline voice and the higher-quality download are Standalone-only; the picker there lists the available OS voices with the same improved selection handling, and the download/remove controls are hidden.

Closes #1834
