### PR TITLE
Let users configure Chromium initialization switches, with a startup failsafe

### DIFF
--- a/src/components/AdvancedInitializationOptionsDialog.vue
+++ b/src/components/AdvancedInitializationOptionsDialog.vue
@@ -1,0 +1,247 @@
+<template>
+  <teleport to="body">
+    <InteractionDialog v-model:show-dialog="internalShowDialog" max-width="680" variant="text-only" persistent>
+      <template #title>
+        <div class="relative flex items-center w-full justify-center">
+          <span>Advanced initialization options</span>
+        </div>
+      </template>
+      <template #content>
+        <div class="flex flex-col w-full -mt-6 gap-4 mb-2 max-h-[60vh] overflow-y-auto pr-1">
+          <p class="text-sm text-white/85">
+            These options change how Cockpit itself starts up, and are meant for working around graphics and video
+            problems on specific computers. They only take effect after a restart. If Cockpit fails to start with an
+            option enabled, it is turned off automatically on the next launch.
+          </p>
+
+          <div
+            v-if="disabledAfterFailedStartup.length > 0"
+            class="rounded-md bg-[#FFCC0022] border border-[#FFCC0055] px-3 py-3"
+          >
+            <div class="flex items-center gap-2">
+              <v-icon size="18" color="#FFCC00">mdi-alert-outline</v-icon>
+              <span class="text-[14px] font-semibold text-white">Options turned off after a failed startup</span>
+            </div>
+            <p class="text-[12px] text-white/70 leading-snug mt-1">
+              Cockpit could not finish starting with {{ disabledAfterFailedStartup.map(withDashes).join(', ') }}, so it
+              started without them.
+            </p>
+          </div>
+
+          <div
+            v-for="option in availableOptions"
+            :key="option.entry"
+            role="switch"
+            tabindex="0"
+            :aria-checked="isEnabled(option.entry)"
+            class="rounded-md bg-white/[0.04] border border-white/10 px-3 py-3 cursor-pointer hover:bg-white/[0.06] transition-colors duration-150"
+            @click="setOptionEnabled(option, !isEnabled(option.entry))"
+            @keydown.enter.prevent="setOptionEnabled(option, !isEnabled(option.entry))"
+            @keydown.space.prevent="setOptionEnabled(option, !isEnabled(option.entry))"
+          >
+            <div class="flex items-center gap-3">
+              <span class="text-[14px] font-semibold text-white">{{ option.title }}</span>
+              <v-switch
+                :model-value="isEnabled(option.entry)"
+                hide-details
+                density="compact"
+                color="#4fa483"
+                class="ml-auto -my-1 scale-75"
+                inset
+                :aria-label="option.title"
+                @click.stop
+                @update:model-value="setOptionEnabled(option, Boolean($event))"
+              />
+            </div>
+            <code class="text-[11px] text-[#8ecfae] font-mono">{{ withDashes(option.entry) }}</code>
+            <p class="text-[12px] text-white/70 leading-snug mt-1">{{ option.description }}</p>
+          </div>
+
+          <div class="rounded-md bg-white/[0.04] border border-white/10 px-3 py-3">
+            <span class="text-[14px] font-semibold text-white">Custom options</span>
+            <p class="text-[12px] text-white/70 leading-snug mt-1 mb-2">
+              Add a switch only if you were asked to. Unknown switches are ignored by Cockpit, but a valid one can still
+              stop it from rendering.
+            </p>
+            <div class="flex items-start gap-2">
+              <v-text-field
+                v-model="customEntry"
+                density="compact"
+                variant="outlined"
+                hide-details="auto"
+                placeholder="disable-gpu-compositing"
+                aria-label="Custom initialization switch"
+                :error-messages="customEntryError ? [customEntryError] : []"
+                class="flex-1"
+                @keydown.enter.prevent="addCustomEntry"
+              />
+              <v-btn
+                variant="flat"
+                size="small"
+                class="bg-[#FFFFFF33] text-white mt-1"
+                :disabled="!canAddCustomEntry"
+                @click="addCustomEntry"
+              >
+                Add
+              </v-btn>
+            </div>
+            <div v-if="customEntries.length > 0" class="flex flex-wrap gap-2 mt-3">
+              <v-chip
+                v-for="entry in customEntries"
+                :key="entry"
+                size="small"
+                closable
+                variant="outlined"
+                @click:close="removeCustomEntry(entry)"
+              >
+                {{ withDashes(entry) }}
+              </v-chip>
+            </div>
+          </div>
+        </div>
+      </template>
+      <template #actions>
+        <div class="flex w-full justify-end items-center gap-2 px-1">
+          <v-btn variant="text" size="small" @click="cancel">Cancel</v-btn>
+          <v-btn
+            variant="flat"
+            size="small"
+            class="bg-[#FFFFFF33] text-white"
+            :disabled="!hasChanges"
+            @click="saveAndRestart"
+          >
+            Save and restart
+          </v-btn>
+        </div>
+      </template>
+    </InteractionDialog>
+  </teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+
+import InteractionDialog from '@/components/InteractionDialog.vue'
+import { useSnackbar } from '@/composables/snackbar'
+import {
+  type PredefinedChromiumSwitch,
+  predefinedChromiumSwitches,
+  validateChromiumSwitchEntry,
+} from '@/libs/chromium-switches'
+import { Platform } from '@/types/platform'
+
+const props = defineProps<{
+  /**
+   * Whether the dialog should be shown.
+   */
+  showDialog: boolean
+}>()
+
+const emit = defineEmits<{
+  /**
+   * Fired when the dialog opens or closes.
+   */
+  (event: 'update:showDialog', value: boolean): void
+}>()
+
+const { openSnackbar } = useSnackbar()
+
+const internalShowDialog = computed({
+  get: () => props.showDialog,
+  set: (value: boolean) => emit('update:showDialog', value),
+})
+
+const entries = ref<string[]>([])
+const savedEntries = ref<string[]>([])
+const disabledAfterFailedStartup = ref<string[]>([])
+const platform = ref<string>('')
+const customEntry = ref('')
+
+const normalize = (entry: string): string => entry.trim().replace(/^-+/, '')
+const withDashes = (entry: string): string => `--${entry}`
+
+// Falling back to every option keeps the list usable if the platform cannot be read.
+const availableOptions = computed(() => {
+  const current = platform.value as Platform
+  if (!Object.values(Platform).includes(current)) return predefinedChromiumSwitches
+  return predefinedChromiumSwitches.filter(({ platforms }) => platforms.includes(current))
+})
+
+// Options saved on another platform have no card here, so they are listed as custom rather than left invisible.
+const customEntries = computed(() =>
+  entries.value.filter((entry) => !availableOptions.value.some((option) => option.entry === entry))
+)
+
+const customEntryError = computed(() => {
+  if (customEntry.value.trim() === '') return undefined
+  const normalized = normalize(customEntry.value)
+  if (entries.value.includes(normalized)) return 'This switch was already added.'
+  return validateChromiumSwitchEntry(customEntry.value)
+})
+
+const canAddCustomEntry = computed(() => customEntry.value.trim() !== '' && customEntryError.value === undefined)
+
+const hasChanges = computed(() => {
+  const current = [...entries.value].sort()
+  const saved = [...savedEntries.value].sort()
+  return current.length !== saved.length || current.some((entry, index) => entry !== saved[index])
+})
+
+const isEnabled = (entry: string): boolean => entries.value.includes(entry)
+
+const load = async (): Promise<void> => {
+  const state = await window.electronAPI?.getChromiumSwitches()
+  entries.value = (state?.entries ?? []).map(normalize)
+  savedEntries.value = [...entries.value]
+  disabledAfterFailedStartup.value = (state?.disabledAfterFailedStartup ?? []).map(normalize)
+  platform.value = (await window.electronAPI?.getSystemInfo())?.platform ?? ''
+  customEntry.value = ''
+}
+
+watch(
+  () => props.showDialog,
+  (isOpen) => {
+    if (isOpen) load()
+  },
+  { immediate: true }
+)
+
+const setOptionEnabled = (option: PredefinedChromiumSwitch, enabled: boolean): void => {
+  logUserAction(`${enabled ? 'Enabled' : 'Disabled'} the "${option.title}" initialization option`)
+  entries.value = enabled
+    ? [...new Set([...entries.value, option.entry])]
+    : entries.value.filter((entry) => entry !== option.entry)
+}
+
+const addCustomEntry = (): void => {
+  if (!canAddCustomEntry.value) return
+  const normalized = normalize(customEntry.value)
+  logUserAction(`Added the custom initialization switch "${withDashes(normalized)}"`)
+  entries.value = [...entries.value, normalized]
+  customEntry.value = ''
+}
+
+const removeCustomEntry = (entry: string): void => {
+  logUserAction(`Removed the custom initialization switch "${withDashes(entry)}"`)
+  entries.value = entries.value.filter((current) => current !== entry)
+}
+
+const cancel = (): void => {
+  logUserAction('Cancelled the advanced initialization options changes')
+  entries.value = [...savedEntries.value]
+  customEntry.value = ''
+  internalShowDialog.value = false
+}
+
+const saveAndRestart = async (): Promise<void> => {
+  const requested = entries.value.map(withDashes).join(' ') || '(none)'
+  logUserAction(`Saved the advanced initialization options and restarted Cockpit: ${requested}`)
+  try {
+    await window.electronAPI?.setChromiumSwitches(entries.value)
+  } catch (error) {
+    openSnackbar({ message: `Could not save the initialization options. ${error}`, variant: 'error' })
+    return
+  }
+  await window.electronAPI?.relaunchApp()
+}
+</script>

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -5,7 +5,7 @@ import { setupAutoUpdater } from './services/auto-update'
 import store from './services/config-store'
 import { setupElectronLogService } from './services/electron-log'
 import { setupGo2RTCService } from './services/go2rtc'
-import { applyChromiumSwitches, logGpuStatus, markStartupAsHealthy } from './services/gpu'
+import { applyChromiumSwitches, logGpuStatus, markStartupAsHealthy, setupGpuService } from './services/gpu'
 import { setupHardwareTelemetryService } from './services/hardware-telemetry'
 import { setupJoystickMonitoring } from './services/joystick'
 import { linkService } from './services/link'
@@ -133,6 +133,7 @@ setupWorkspaceService()
 setupJoystickMonitoring()
 setupVideoRecordingService()
 setupGo2RTCService()
+setupGpuService()
 
 app.whenReady().then(async () => {
   console.log('Electron app is ready.')

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -5,6 +5,7 @@ import { setupAutoUpdater } from './services/auto-update'
 import store from './services/config-store'
 import { setupElectronLogService } from './services/electron-log'
 import { setupGo2RTCService } from './services/go2rtc'
+import { applyChromiumSwitches } from './services/gpu'
 import { setupHardwareTelemetryService } from './services/hardware-telemetry'
 import { setupJoystickMonitoring } from './services/joystick'
 import { linkService } from './services/link'
@@ -19,6 +20,9 @@ import { setupWorkspaceService } from './services/workspace'
 
 // Setup the logger service as soon as possible to avoid different behaviors across runtime
 setupElectronLogService()
+
+// Chromium only reads its command line when the GPU process starts, so this has to happen before the app is ready
+applyChromiumSwitches()
 
 export const ROOT_PATH = {
   dist: join(__dirname, '..'),

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -5,7 +5,7 @@ import { setupAutoUpdater } from './services/auto-update'
 import store from './services/config-store'
 import { setupElectronLogService } from './services/electron-log'
 import { setupGo2RTCService } from './services/go2rtc'
-import { applyChromiumSwitches } from './services/gpu'
+import { applyChromiumSwitches, logGpuStatus } from './services/gpu'
 import { setupHardwareTelemetryService } from './services/hardware-telemetry'
 import { setupJoystickMonitoring } from './services/joystick'
 import { linkService } from './services/link'
@@ -136,6 +136,8 @@ setupGo2RTCService()
 app.whenReady().then(async () => {
   console.log('Electron app is ready.')
   console.log(`Cockpit version: ${app.getVersion()}`)
+
+  await logGpuStatus()
 
   // Inject a Referer header for OSM tile requests before the first tile is fetched, so the
   // standalone build (loaded from file://) complies with the OSM tile usage policy.

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -5,7 +5,7 @@ import { setupAutoUpdater } from './services/auto-update'
 import store from './services/config-store'
 import { setupElectronLogService } from './services/electron-log'
 import { setupGo2RTCService } from './services/go2rtc'
-import { applyChromiumSwitches, logGpuStatus } from './services/gpu'
+import { applyChromiumSwitches, logGpuStatus, markStartupAsHealthy } from './services/gpu'
 import { setupHardwareTelemetryService } from './services/hardware-telemetry'
 import { setupJoystickMonitoring } from './services/joystick'
 import { linkService } from './services/link'
@@ -89,6 +89,7 @@ function createWindow(): void {
 
   mainWindow.webContents.on('did-finish-load', () => {
     mainWindow?.setTitle(`Cockpit (${app.getVersion()})`)
+    markStartupAsHealthy()
   })
 
   if (process.env.VITE_DEV_SERVER_URL) {

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -1,5 +1,6 @@
 import { contextBridge, ipcRenderer } from 'electron'
 
+import type { ChromiumSwitchesState } from '@/types/chromium-switches'
 import type { ElectronSDLJoystickControllerStateEventData } from '@/types/joystick'
 import type { FileDialogOptions, FileStats } from '@/types/storage'
 
@@ -101,4 +102,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getCurrentUserAgent: () => ipcRenderer.invoke('get-current-user-agent'),
   getSystemInfo: () => ipcRenderer.invoke('get-system-info'),
   getHardwareTelemetryInfo: () => ipcRenderer.invoke('get-hardware-telemetry-info'),
+  getChromiumSwitches: (): Promise<ChromiumSwitchesState> => ipcRenderer.invoke('get-chromium-switches'),
+  setChromiumSwitches: (entries: string[]): Promise<void> => ipcRenderer.invoke('set-chromium-switches', entries),
+  relaunchApp: (): Promise<void> => ipcRenderer.invoke('relaunch-app'),
 })

--- a/src/electron/services/config-store.ts
+++ b/src/electron/services/config-store.ts
@@ -7,6 +7,15 @@ const electronStoreSchema = {
       type: 'string',
     },
   },
+  chromiumSwitchesBootPending: {
+    type: 'boolean',
+  },
+  chromiumSwitchesDisabled: {
+    type: 'array',
+    items: {
+      type: 'string',
+    },
+  },
   cockpitFolderPath: {
     type: 'string',
   },
@@ -38,6 +47,14 @@ export interface ElectronStoreSchema {
    * Extra Chromium command-line switches applied at launch, as a workaround for GPU and video driver bugs
    */
   chromiumSwitches: string[] | undefined
+  /**
+   * Whether a launch with custom Chromium switches is still waiting to be confirmed as successful
+   */
+  chromiumSwitchesBootPending: boolean | undefined
+  /**
+   * Switches that were set aside because Cockpit failed to start with them
+   */
+  chromiumSwitchesDisabled: string[] | undefined
   /**
    * Custom Cockpit folder path, overriding the default ~/Cockpit
    */

--- a/src/electron/services/config-store.ts
+++ b/src/electron/services/config-store.ts
@@ -1,6 +1,12 @@
 import Store from 'electron-store'
 
 const electronStoreSchema = {
+  chromiumSwitches: {
+    type: 'array',
+    items: {
+      type: 'string',
+    },
+  },
   cockpitFolderPath: {
     type: 'string',
   },
@@ -28,6 +34,10 @@ const electronStoreSchema = {
  * Stores configuration data
  */
 export interface ElectronStoreSchema {
+  /**
+   * Extra Chromium command-line switches applied at launch, as a workaround for GPU and video driver bugs
+   */
+  chromiumSwitches: string[] | undefined
   /**
    * Custom Cockpit folder path, overriding the default ~/Cockpit
    */

--- a/src/electron/services/gpu.ts
+++ b/src/electron/services/gpu.ts
@@ -1,6 +1,7 @@
-import { app } from 'electron'
+import { app, ipcMain } from 'electron'
 
-import { parseChromiumSwitches } from '@/libs/chromium-switches'
+import { parseChromiumSwitches, validateChromiumSwitchEntry } from '@/libs/chromium-switches'
+import type { ChromiumSwitchesState } from '@/types/chromium-switches'
 
 import store from './config-store'
 
@@ -64,4 +65,36 @@ export const logGpuStatus = async (): Promise<void> => {
   } catch (error) {
     console.error('Failed to read the GPU status.', error)
   }
+}
+
+/**
+ * Registers IPC for reading and writing the Chromium switches, and for restarting the app so they take effect.
+ */
+export const setupGpuService = (): void => {
+  ipcMain.handle('get-chromium-switches', (): ChromiumSwitchesState => {
+    return {
+      entries: store.get('chromiumSwitches') ?? [],
+      disabledAfterFailedStartup: store.get('chromiumSwitchesDisabled') ?? [],
+    }
+  })
+
+  ipcMain.handle('set-chromium-switches', (_event, entries: string[]): void => {
+    // The renderer already validates, but this is the boundary that decides what gets on the command line.
+    entries.forEach((entry) => {
+      const problem = validateChromiumSwitchEntry(entry)
+      if (problem !== undefined) {
+        throw new Error(`Refused to save the Chromium switch "${entry}": ${problem}`)
+      }
+    })
+
+    store.set('chromiumSwitches', entries)
+    store.set('chromiumSwitchesDisabled', [])
+    console.log(`Saved custom Chromium switches: ${entries.join(' ') || '(none)'}`)
+  })
+
+  ipcMain.handle('relaunch-app', (): void => {
+    console.log('Relaunching the application.')
+    app.relaunch()
+    app.quit()
+  })
 }

--- a/src/electron/services/gpu.ts
+++ b/src/electron/services/gpu.ts
@@ -26,3 +26,17 @@ export const applyChromiumSwitches = (): void => {
     console.log(`Applied custom Chromium switch: --${name}${value === undefined ? '' : `=${value}`}`)
   })
 }
+
+/**
+ * Log the GPU feature status and driver identification, so video problems can be told apart from rendering ones
+ * without asking the user to reproduce anything. Only meaningful after the app is ready.
+ */
+export const logGpuStatus = async (): Promise<void> => {
+  try {
+    console.log(`GPU feature status: ${JSON.stringify(app.getGPUFeatureStatus())}`)
+    const gpuInfo = await app.getGPUInfo('basic')
+    console.log(`GPU info: ${JSON.stringify(gpuInfo)}`)
+  } catch (error) {
+    console.error('Failed to read the GPU status.', error)
+  }
+}

--- a/src/electron/services/gpu.ts
+++ b/src/electron/services/gpu.ts
@@ -1,0 +1,28 @@
+import { app } from 'electron'
+
+import { parseChromiumSwitches } from '@/libs/chromium-switches'
+
+import store from './config-store'
+
+/**
+ * Apply extra Chromium switches from the config store and the COCKPIT_CHROMIUM_SWITCHES environment variable.
+ *
+ * These exist as an escape hatch for GPU and video driver bugs that only reproduce on specific hardware, where the
+ * workaround is a Chromium switch (e.g. "disable-zero-copy-dxgi-video" for stalling video on some Windows/AMD
+ * combinations). Must run before the app is ready, as the GPU process reads the command line on startup.
+ */
+export const applyChromiumSwitches = (): void => {
+  const switches = [
+    ...parseChromiumSwitches(store.get('chromiumSwitches')),
+    ...parseChromiumSwitches(process.env.COCKPIT_CHROMIUM_SWITCHES),
+  ]
+
+  switches.forEach(({ name, value }) => {
+    if (value === undefined) {
+      app.commandLine.appendSwitch(name)
+    } else {
+      app.commandLine.appendSwitch(name, value)
+    }
+    console.log(`Applied custom Chromium switch: --${name}${value === undefined ? '' : `=${value}`}`)
+  })
+}

--- a/src/electron/services/gpu.ts
+++ b/src/electron/services/gpu.ts
@@ -10,12 +10,28 @@ import store from './config-store'
  * These exist as an escape hatch for GPU and video driver bugs that only reproduce on specific hardware, where the
  * workaround is a Chromium switch (e.g. "disable-zero-copy-dxgi-video" for stalling video on some Windows/AMD
  * combinations). Must run before the app is ready, as the GPU process reads the command line on startup.
+ *
+ * A switch can always turn out to break rendering on a given machine, so the persisted ones are guarded: a flag is
+ * raised before they are applied and only lowered once a window finishes loading. Finding it still raised on the next
+ * launch means the previous attempt never got that far, so the switches are set aside instead of applied again.
  */
 export const applyChromiumSwitches = (): void => {
-  const switches = [
-    ...parseChromiumSwitches(store.get('chromiumSwitches')),
-    ...parseChromiumSwitches(process.env.COCKPIT_CHROMIUM_SWITCHES),
-  ]
+  const persisted = store.get('chromiumSwitches') ?? []
+
+  if (store.get('chromiumSwitchesBootPending') && persisted.length > 0) {
+    store.set('chromiumSwitchesDisabled', persisted)
+    store.set('chromiumSwitches', [])
+    store.set('chromiumSwitchesBootPending', false)
+    console.warn(`Cockpit failed to start with these Chromium switches, so they were disabled: ${persisted.join(' ')}`)
+  }
+
+  const entries = store.get('chromiumSwitches') ?? []
+  if (entries.length > 0) {
+    store.set('chromiumSwitchesBootPending', true)
+  }
+
+  // Switches from the environment are a support and development override, so they stay outside of the failsafe.
+  const switches = [...parseChromiumSwitches(entries), ...parseChromiumSwitches(process.env.COCKPIT_CHROMIUM_SWITCHES)]
 
   switches.forEach(({ name, value }) => {
     if (value === undefined) {
@@ -25,6 +41,15 @@ export const applyChromiumSwitches = (): void => {
     }
     console.log(`Applied custom Chromium switch: --${name}${value === undefined ? '' : `=${value}`}`)
   })
+}
+
+/**
+ * Clear the pending-boot flag, marking the applied switches as safe. Called once a window has finished loading.
+ */
+export const markStartupAsHealthy = (): void => {
+  if (store.get('chromiumSwitchesBootPending')) {
+    store.set('chromiumSwitchesBootPending', false)
+  }
 }
 
 /**

--- a/src/libs/chromium-switches.ts
+++ b/src/libs/chromium-switches.ts
@@ -1,3 +1,14 @@
+import { Platform } from '@/types/platform'
+
+/**
+ * Chromium command-line switches that Cockpit Standalone can apply at launch, used to work around GPU and video
+ * driver bugs that only show up on specific hardware.
+ *
+ * Whether a switch actually exists is deliberately not checked: Chromium ignores switches it does not recognize, so a
+ * typo is harmless, while a perfectly valid switch can still break rendering. Startup is protected by the boot
+ * failsafe in the GPU service rather than by validation here.
+ */
+
 /** A Chromium command-line switch, stripped of its leading dashes. */
 export interface ChromiumSwitch {
   /**
@@ -9,6 +20,113 @@ export interface ChromiumSwitch {
    */
   value?: string
 }
+
+/** A curated switch offered in the advanced initialization options. */
+export interface PredefinedChromiumSwitch {
+  /**
+   * The switch exactly as it is applied, e.g. "enable-features=D3D11VideoDecoderAlwaysCopy"
+   */
+  entry: string
+  /**
+   * Short label shown to the user
+   */
+  title: string
+  /**
+   * What the switch does and which problem it usually helps with
+   */
+  description: string
+  /**
+   * Platforms where the switch has any effect
+   */
+  platforms: Platform[]
+}
+
+const allPlatforms = [Platform.WINDOWS, Platform.MACOS, Platform.LINUX]
+
+/**
+ * Switches that would weaken Cockpit's security or reliably destabilize it, so they cannot be added by hand.
+ */
+export const blockedChromiumSwitchNames = [
+  'allow-running-insecure-content',
+  'disable-web-security',
+  'in-process-gpu',
+  'inspect',
+  'js-flags',
+  'no-sandbox',
+  'remote-debugging-pipe',
+  'remote-debugging-port',
+  'single-process',
+  'user-data-dir',
+]
+
+export const predefinedChromiumSwitches: PredefinedChromiumSwitch[] = [
+  {
+    entry: 'disable-zero-copy-dxgi-video',
+    title: 'Copy video frames instead of sharing them',
+    description:
+      'Stops the video decoder from writing straight into shared graphics memory. This is the first thing to try ' +
+      'when video freezes or drops to zero frames per second on Windows, and it keeps hardware decoding enabled.',
+    platforms: [Platform.WINDOWS],
+  },
+  {
+    entry: 'enable-features=D3D11VideoDecoderAlwaysCopy',
+    title: 'Force the video decoder to copy every frame',
+    description:
+      'Applies the same fix as the option above, from the decoder side instead of the graphics side. Worth trying ' +
+      'when video still stalls with multiple streams open.',
+    platforms: [Platform.WINDOWS],
+  },
+  {
+    entry: 'disable-direct-composition-video-overlays',
+    title: 'Disable Windows video overlays',
+    description:
+      'Draws video through the normal rendering path instead of a hardware overlay. Helps with black, torn or ' +
+      'flickering video areas on some graphics drivers.',
+    platforms: [Platform.WINDOWS],
+  },
+  {
+    entry: 'use-angle=gl',
+    title: 'Render through OpenGL instead of Direct3D',
+    description:
+      'Replaces the Direct3D renderer with OpenGL, which can recover video that no other option fixes. Chromium ' +
+      'does not officially support this on Windows, so instruments and the map may show visual glitches. Last resort.',
+    platforms: [Platform.WINDOWS],
+  },
+  {
+    entry: 'enable-features=VaapiVideoDecodeLinuxGL',
+    title: 'Enable hardware video decoding on Linux',
+    description:
+      'Turns on GPU video decoding, which Chromium leaves off by default on Linux. Reduces processor load when ' +
+      'several streams are open, as long as the system has working VA-API drivers.',
+    platforms: [Platform.LINUX],
+  },
+  {
+    entry: 'disable-accelerated-video-decode',
+    title: 'Decode video on the processor',
+    description:
+      'Bypasses the graphics card for video decoding entirely. Reliable when the graphics driver is at fault, but it ' +
+      'uses noticeably more processor time and battery.',
+    platforms: allPlatforms,
+  },
+  {
+    entry: 'ignore-gpu-blocklist',
+    title: 'Use the graphics card even if it is blocked',
+    description:
+      'Forces graphics acceleration on when Chromium has disabled it for your driver. Can restore smooth video and ' +
+      'instruments on older hardware, at the risk of instability.',
+    platforms: allPlatforms,
+  },
+  {
+    entry: 'disable-gpu',
+    title: 'Disable graphics acceleration',
+    description:
+      'Renders everything on the processor. Use only when Cockpit shows a blank or corrupted window on startup, as ' +
+      'video and instruments will run slowly.',
+    platforms: allPlatforms,
+  },
+]
+
+const switchNamePattern = /^[a-z0-9]+(-[a-z0-9]+)*$/
 
 /**
  * Parse Chromium command-line switches from a persisted list or a whitespace-separated string.
@@ -26,4 +144,23 @@ export const parseChromiumSwitches = (input: string | string[] | undefined): Chr
       return { name: normalized.slice(0, separatorIndex), value: normalized.slice(separatorIndex + 1) }
     })
     .filter(({ name }) => name !== '')
+}
+
+/**
+ * Check a switch typed by the user, rejecting entries that are malformed or unsafe to apply.
+ * @param {string} entry Switch as typed, with or without leading dashes
+ * @returns {string | undefined} Reason the entry cannot be used, or undefined when it is acceptable
+ */
+export const validateChromiumSwitchEntry = (entry: string): string | undefined => {
+  const trimmed = entry.trim()
+  if (/\s/.test(trimmed)) return 'Add one switch at a time, without spaces.'
+
+  const [parsed] = parseChromiumSwitches([trimmed])
+  if (parsed === undefined) return 'Type the name of a switch, such as disable-gpu.'
+  if (!switchNamePattern.test(parsed.name)) return 'Switch names only use lowercase letters, numbers and dashes.'
+  if (blockedChromiumSwitchNames.includes(parsed.name)) {
+    return `"${parsed.name}" is not allowed, as it would weaken Cockpit's security or stability.`
+  }
+
+  return undefined
 }

--- a/src/libs/chromium-switches.ts
+++ b/src/libs/chromium-switches.ts
@@ -1,0 +1,29 @@
+/** A Chromium command-line switch, stripped of its leading dashes. */
+export interface ChromiumSwitch {
+  /**
+   * Switch name, e.g. "disable-zero-copy-dxgi-video"
+   */
+  name: string
+  /**
+   * Value for switches that take one, e.g. "gl" for "use-angle=gl"
+   */
+  value?: string
+}
+
+/**
+ * Parse Chromium command-line switches from a persisted list or a whitespace-separated string.
+ * Entries are separated by whitespace only, as values like "enable-features=A,B" are comma-separated themselves.
+ * @param {string | string[] | undefined} input Switch entries, with or without leading dashes
+ * @returns {ChromiumSwitch[]} Parsed switches, skipping entries without a name
+ */
+export const parseChromiumSwitches = (input: string | string[] | undefined): ChromiumSwitch[] => {
+  const entries = typeof input === 'string' ? input.split(/\s+/) : input ?? []
+  return entries
+    .map((entry) => {
+      const normalized = entry.trim().replace(/^-+/, '')
+      const separatorIndex = normalized.indexOf('=')
+      if (separatorIndex === -1) return { name: normalized }
+      return { name: normalized.slice(0, separatorIndex), value: normalized.slice(separatorIndex + 1) }
+    })
+    .filter(({ name }) => name !== '')
+}

--- a/src/libs/cosmos.ts
+++ b/src/libs/cosmos.ts
@@ -1,5 +1,6 @@
 import { isBrowser } from 'browser-or-node'
 
+import type { ChromiumSwitchesState } from '@/types/chromium-switches'
 import { type ElectronLog } from '@/types/electron-general'
 import { ElectronStorageDB } from '@/types/general'
 import type { ElectronSDLJoystickControllerStateEventData } from '@/types/joystick'
@@ -481,6 +482,22 @@ declare global {
        * @returns {Promise<TelemetrySystemHardwareInfo>} Serializable hardware fields
        */
       getHardwareTelemetryInfo: () => Promise<TelemetrySystemHardwareInfo>
+      /**
+       * Get the custom Chromium switches applied at launch
+       * @returns {Promise<ChromiumSwitchesState>} The saved switches and any disabled after a failed startup
+       */
+      getChromiumSwitches: () => Promise<ChromiumSwitchesState>
+      /**
+       * Save the custom Chromium switches, which only take effect after a restart
+       * @param {string[]} entries Switches to apply on the next launch
+       * @returns {Promise<void>} Rejects when any entry is malformed or unsafe
+       */
+      setChromiumSwitches: (entries: string[]) => Promise<void>
+      /**
+       * Restart the application
+       * @returns {Promise<void>} Resolves as the application quits
+       */
+      relaunchApp: () => Promise<void>
       /**
        * Start live video streaming process with FFmpeg
        * @param firstChunk - The first video chunk blob

--- a/src/tests/electron/gpu.test.ts
+++ b/src/tests/electron/gpu.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { applyChromiumSwitches, markStartupAsHealthy } from '@/electron/services/gpu'
+
+const appliedSwitches: string[] = []
+const storeData = new Map<string, unknown>()
+
+vi.mock('electron', () => ({
+  app: {
+    commandLine: {
+      appendSwitch: (name: string, value?: string) => {
+        appliedSwitches.push(value === undefined ? name : `${name}=${value}`)
+      },
+    },
+  },
+  ipcMain: { handle: vi.fn() },
+}))
+
+vi.mock('@/electron/services/config-store', () => ({
+  default: {
+    get: (key: string) => storeData.get(key),
+    set: (key: string, value: unknown) => storeData.set(key, value),
+  },
+}))
+
+describe('Chromium switches boot failsafe', () => {
+  beforeEach(() => {
+    appliedSwitches.length = 0
+    storeData.clear()
+  })
+
+  it('Applies the saved switches and leaves the launch unconfirmed', () => {
+    storeData.set('chromiumSwitches', ['disable-gpu', 'use-angle=gl'])
+
+    applyChromiumSwitches()
+
+    expect(appliedSwitches).toEqual(['disable-gpu', 'use-angle=gl'])
+    expect(storeData.get('chromiumSwitchesBootPending')).toBe(true)
+  })
+
+  it('Confirms the launch once a window has loaded', () => {
+    storeData.set('chromiumSwitches', ['disable-gpu'])
+
+    applyChromiumSwitches()
+    markStartupAsHealthy()
+
+    expect(storeData.get('chromiumSwitchesBootPending')).toBe(false)
+  })
+
+  it('Disables the switches when the previous launch was never confirmed', () => {
+    storeData.set('chromiumSwitches', ['disable-gpu'])
+    applyChromiumSwitches()
+    appliedSwitches.length = 0
+
+    applyChromiumSwitches()
+
+    expect(appliedSwitches).toEqual([])
+    expect(storeData.get('chromiumSwitches')).toEqual([])
+    expect(storeData.get('chromiumSwitchesDisabled')).toEqual(['disable-gpu'])
+  })
+
+  it('Keeps starting clean on the launches that follow a failed one', () => {
+    storeData.set('chromiumSwitches', ['disable-gpu'])
+    applyChromiumSwitches()
+    applyChromiumSwitches()
+    appliedSwitches.length = 0
+
+    applyChromiumSwitches()
+
+    expect(appliedSwitches).toEqual([])
+    expect(storeData.get('chromiumSwitchesBootPending')).toBe(false)
+    expect(storeData.get('chromiumSwitchesDisabled')).toEqual(['disable-gpu'])
+  })
+
+  it('Does not guard a launch that has no saved switches', () => {
+    applyChromiumSwitches()
+
+    expect(appliedSwitches).toEqual([])
+    expect(storeData.get('chromiumSwitchesBootPending')).toBeUndefined()
+  })
+})

--- a/src/tests/libs/chromium-switches.test.ts
+++ b/src/tests/libs/chromium-switches.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseChromiumSwitches } from '@/libs/chromium-switches'
+
+describe('parseChromiumSwitches', () => {
+  it('Parses switches with and without values, ignoring leading dashes', () => {
+    expect(parseChromiumSwitches(['--disable-zero-copy-dxgi-video', 'use-angle=gl'])).toEqual([
+      { name: 'disable-zero-copy-dxgi-video' },
+      { name: 'use-angle', value: 'gl' },
+    ])
+  })
+
+  it('Keeps commas inside values, as feature lists are comma-separated', () => {
+    expect(parseChromiumSwitches('--enable-features=AcceleratedVideoDecodeLinuxGL,VaapiOnNvidiaGPUs')).toEqual([
+      { name: 'enable-features', value: 'AcceleratedVideoDecodeLinuxGL,VaapiOnNvidiaGPUs' },
+    ])
+  })
+
+  it('Splits a string on whitespace only', () => {
+    expect(parseChromiumSwitches('  --use-angle=gl   --disable-gpu-compositing ')).toEqual([
+      { name: 'use-angle', value: 'gl' },
+      { name: 'disable-gpu-compositing' },
+    ])
+  })
+
+  it('Drops empty and nameless entries', () => {
+    expect(parseChromiumSwitches(['', '   ', '--', '=orphan', 'valid'])).toEqual([{ name: 'valid' }])
+  })
+
+  it('Returns nothing when unset', () => {
+    expect(parseChromiumSwitches(undefined)).toEqual([])
+  })
+})

--- a/src/tests/libs/chromium-switches.test.ts
+++ b/src/tests/libs/chromium-switches.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { parseChromiumSwitches } from '@/libs/chromium-switches'
+import {
+  blockedChromiumSwitchNames,
+  parseChromiumSwitches,
+  predefinedChromiumSwitches,
+  validateChromiumSwitchEntry,
+} from '@/libs/chromium-switches'
 
 describe('parseChromiumSwitches', () => {
   it('Parses switches with and without values, ignoring leading dashes', () => {
@@ -29,5 +34,49 @@ describe('parseChromiumSwitches', () => {
 
   it('Returns nothing when unset', () => {
     expect(parseChromiumSwitches(undefined)).toEqual([])
+  })
+})
+
+describe('validateChromiumSwitchEntry', () => {
+  it('Accepts well-formed switches, with or without a value', () => {
+    expect(validateChromiumSwitchEntry('--disable-gpu')).toBeUndefined()
+    expect(validateChromiumSwitchEntry('enable-features=SomeFeature,OtherFeature')).toBeUndefined()
+  })
+
+  it('Accepts switches Chromium may not know, since unknown switches are ignored', () => {
+    expect(validateChromiumSwitchEntry('not-a-real-chromium-switch')).toBeUndefined()
+  })
+
+  it('Rejects empty entries and entries containing spaces', () => {
+    expect(validateChromiumSwitchEntry('  ')).toBeDefined()
+    expect(validateChromiumSwitchEntry('--disable-gpu --disable-gpu-compositing')).toBeDefined()
+  })
+
+  it('Rejects names that cannot be Chromium switches', () => {
+    expect(validateChromiumSwitchEntry('Disable_GPU')).toBeDefined()
+    expect(validateChromiumSwitchEntry('--=value')).toBeDefined()
+  })
+
+  it('Rejects switches that would weaken security or stability', () => {
+    blockedChromiumSwitchNames.forEach((name) => {
+      expect(validateChromiumSwitchEntry(`--${name}`)).toBeDefined()
+    })
+    expect(validateChromiumSwitchEntry('--remote-debugging-port=9222')).toBeDefined()
+  })
+})
+
+describe('predefinedChromiumSwitches', () => {
+  it('Only offers switches that pass validation', () => {
+    predefinedChromiumSwitches.forEach(({ entry }) => {
+      expect(validateChromiumSwitchEntry(entry)).toBeUndefined()
+    })
+  })
+
+  it('Describes every option and targets at least one platform', () => {
+    predefinedChromiumSwitches.forEach(({ title, description, platforms }) => {
+      expect(title.length).toBeGreaterThan(0)
+      expect(description.length).toBeGreaterThan(0)
+      expect(platforms.length).toBeGreaterThan(0)
+    })
   })
 })

--- a/src/types/chromium-switches.ts
+++ b/src/types/chromium-switches.ts
@@ -1,0 +1,11 @@
+/** Persisted state of the custom Chromium switches, as seen by the renderer. */
+export interface ChromiumSwitchesState {
+  /**
+   * Switches that are currently applied on every launch
+   */
+  entries: string[]
+  /**
+   * Switches that were set aside because Cockpit failed to start with them
+   */
+  disabledAfterFailedStartup: string[]
+}

--- a/src/views/ConfigurationDevelopmentView.vue
+++ b/src/views/ConfigurationDevelopmentView.vue
@@ -36,6 +36,17 @@
               @update:model-value="onToggleSplashScreen"
             />
           </div>
+          <div v-if="isRunningInElectron" class="flex justify-start w-full mt-3">
+            <v-btn
+              variant="outlined"
+              color="white"
+              size="small"
+              prepend-icon="mdi-cog-play-outline"
+              @click="openAdvancedInitializationOptions"
+            >
+              Open advanced initialization options
+            </v-btn>
+          </div>
         </div>
         <ExpansiblePanel :is-expanded="!interfaceStore.isOnPhoneScreen" no-bottom-divider>
           <template #title>
@@ -129,6 +140,7 @@
           </template>
         </ExpansiblePanel>
       </div>
+      <AdvancedInitializationOptionsDialog v-model:show-dialog="showAdvancedInitializationOptions" />
     </template>
   </BaseConfigurationView>
 </template>
@@ -141,6 +153,7 @@ import { format, parse } from 'date-fns'
 import { saveAs } from 'file-saver'
 import { computed, onBeforeMount, onBeforeUnmount, ref } from 'vue'
 
+import AdvancedInitializationOptionsDialog from '@/components/AdvancedInitializationOptionsDialog.vue'
 import ExpansiblePanel from '@/components/ExpansiblePanel.vue'
 import { useSnackbar } from '@/composables/snackbar'
 import {
@@ -181,6 +194,13 @@ const onToggleSplashScreen = (value: boolean | null): void => {
 const openConsole = (): void => {
   logUserAction('Opened system console')
   devStore.showConsole = true
+}
+
+const showAdvancedInitializationOptions = ref(false)
+
+const openAdvancedInitializationOptions = (): void => {
+  logUserAction('Opened the advanced initialization options dialog')
+  showAdvancedInitializationOptions.value = true
 }
 
 /* eslint-disable jsdoc/require-jsdoc */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,6 +23,11 @@ const baseConfig = {
             build: {
               outDir: 'dist/electron',
             },
+            resolve: {
+              alias: {
+                '@': path.resolve(__dirname, 'src'),
+              },
+            },
           },
           onstart: () => {
             // @ts-ignore: process.electronApp exists in vite-plugin-electron but not in the types
@@ -38,6 +43,11 @@ const baseConfig = {
           vite: {
             build: {
               outDir: 'dist/electron',
+            },
+            resolve: {
+              alias: {
+                '@': path.resolve(__dirname, 'src'),
+              },
             },
           },
         },


### PR DESCRIPTION
## Why

Working around GPU and video driver bugs currently means asking users to edit their shortcut target by hand, an edit that is lost on the next update or reinstall. That is how the recent exploreHD freezing case was mitigated: `--use-angle=gl` fixed the topside rendering collapse, but nothing kept it applied.

Startup also logged nothing about the GPU, so a stall caused by the graphics stack looked exactly like a stream problem in the logs, and diagnosing it depended on a user reproducing the issue while someone watched.

Relates to #868, which asks for a warning when hardware acceleration is off. This does not implement that warning, but it adds the GPU status the warning would need.

## What

- **Advanced initialization options** in the Development configuration view: eight described switches filtered to the current platform, a field for custom ones, and Cancel / Save and restart. Standalone only, since the switches are Electron's command line; the button is not rendered in Lite.
- **A startup failsafe.** A flag is raised before the saved switches are applied and lowered once a window finishes loading. If the next launch finds it still raised, the switches are set aside and the dialog reports which ones. The worst case for any switch, including one nobody predicted, is a single failed launch that recovers on its own.
- **GPU feature status and driver info logged at startup.**
- `COCKPIT_CHROMIUM_SWITCHES` stays available as a support override, deliberately outside the failsafe.

## On validating switches

Whether a switch exists is deliberately not checked. Chromium ignores switches it does not recognize, so a typo is harmless, while a perfectly valid switch can still break rendering on specific hardware. Validation therefore covers what is actually checkable: switch-name syntax, one switch at a time, and a small blocklist that would weaken security or stability regardless of hardware (`no-sandbox`, `disable-web-security`, `remote-debugging-port`, `single-process`, `user-data-dir` and similar). The renderer validates as you type and the main process validates again before writing, since that is the boundary deciding what reaches the command line. The guarantee against breakage comes from the failsafe, not from validation.

## Test plan

- [x] `yarn lint` clean
- [x] `ELECTRON=true yarn build` passes
- [x] 17 unit tests covering the parser, the validator, the catalog, and the failsafe state machine across a successful launch, a failed one, and the launches after it
- [ ] **Not yet exercised in a running app.** The dialog has not been clicked through, so the IPC round trip and the restart are unverified by me. Worth a reviewer opening it, enabling an option, and confirming the restart applies it.
- [ ] Worth confirming the failsafe on real hardware by saving a switch known to break rendering on that machine and checking the following launch starts clean and reports it

Note that `yarn typecheck` is a no-op in this repo: `vue-tsc` exits 0 after 0.4s with `languageId not found for App.vue`, on a clean checkout too. Type coverage here came from the build instead.