### PR TITLE
Fix the /demo agent's Node version and cap what a recording can cost

### DIFF
--- a/.github/workflows/claude-pr-demo.yml
+++ b/.github/workflows/claude-pr-demo.yml
@@ -40,6 +40,11 @@ jobs:
       DEMO_BRANCH: pr-demos
       PR_NUMBER: ${{ github.event.issue.number }}
       REPO: ${{ github.repository }}
+      # claude-code-base-action runs its own setup-node, defaulting to 18.x, which replaces the
+      # version installed below by the time the agent's shell exists. Node 18 has no global
+      # WebSocket, so the recorder dies on `new WebSocket(...)` even though the smoke test — which
+      # runs before the action — passed. This is the documented way to tell the action otherwise.
+      NODE_VERSION: '22.13.0'
     steps:
       # The recorder, the guidelines and AGENTS.md all come from the base ref. The PR gets to be
       # filmed, but it does not get to choose the code that drives the browser or the agent.
@@ -154,6 +159,9 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           model: "claude-opus-4-6"
           max_turns: "100"
+          # The action's own default is 10 minutes, which does not survive recording a clip and
+          # watching the frames back, let alone the couple of retakes that usually takes.
+          timeout_minutes: "20"
           # No `curl`: nothing the agent does needs the network, and the diff it reads is untrusted,
           # so denying it removes the obvious way to exfiltrate anything it is tricked into reading.
           allowed_tools: "Bash(node:*),Bash(ffmpeg:*),Bash(ls:*),Bash(cat:*),Bash(jq:*),Bash(wc:*),Bash(head:*),Bash(tail:*),Bash(mkdir:*),Bash(cp:*),Bash(rm:*),Bash(pkill:*),View,GlobTool,GrepTool,BatchTool,Write,Edit"

--- a/.github/workflows/claude-pr-demo.yml
+++ b/.github/workflows/claude-pr-demo.yml
@@ -45,6 +45,9 @@ jobs:
       # WebSocket, so the recorder dies on `new WebSocket(...)` even though the smoke test — which
       # runs before the action — passed. This is the documented way to tell the action otherwise.
       NODE_VERSION: '22.13.0'
+      # Only reported against, never enforced on its own — `max_turns` is what actually holds
+      # spend down, so re-derive it from the cost line whenever this figure moves.
+      DEMO_BUDGET_USD: '2.00'
     steps:
       # The recorder, the guidelines and AGENTS.md all come from the base ref. The PR gets to be
       # filmed, but it does not get to choose the code that drives the browser or the agent.
@@ -151,6 +154,7 @@ jobs:
         run: node scripts/uicast/record.mjs scripts/uicast/scene-selftest.mjs /tmp/selftest.mp4
 
       - name: Record the demo
+        id: record
         uses: anthropics/claude-code-base-action@beta
         env:
           HEAD_SHA: ${{ env.HEAD_SHA }}
@@ -158,7 +162,13 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           model: "claude-opus-4-6"
-          max_turns: "100"
+          # Spend cap, expressed as turns because neither the action nor Claude Code takes a
+          # currency budget. Opus 4.6 bills $5/M in, $25/M out, $0.50/M cache read and $6.25/M
+          # cache write, and for this job almost all of it is context being re-read rather than
+          # anything generated. Measured on run 31021157391: the fixed context costs ~$1.25 over
+          # the first ten turns and ~$0.04/turn after that, so $DEMO_BUDGET_USD runs out at turn
+          # 27. Re-derive this from the cost line below if the guidelines or the model change.
+          max_turns: "26"
           # The action's own default is 10 minutes, which does not survive recording a clip and
           # watching the frames back, let alone the couple of retakes that usually takes.
           timeout_minutes: "20"
@@ -205,6 +215,42 @@ jobs:
 
             Follow the system instructions and `.github/claude-review/demo-video-guidelines.md` exactly.
             Produce either (`demo/demo.mp4` + `demo/scenario.mjs` + `demo/comment.md`) or `demo/skipped.md`.
+
+      # Runs even when the agent failed, because an expensive run that produced nothing is exactly
+      # the one worth pricing. Claude Code reports its own total only on a clean finish, so a run
+      # cut short by the turn cap or the timeout has to be priced from its usage blocks.
+      # continue-on-error because this only reports: `if: always()` makes the step run after a
+      # failure, it does not stop the step's own failure from failing the job — and this one sits
+      # in front of the publish step, so without it a hiccup here would withhold a good recording.
+      - name: Price the recording
+        if: always()
+        continue-on-error: true
+        env:
+          EXECUTION_FILE: ${{ steps.record.outputs.execution_file }}
+        run: |
+          set -euo pipefail
+          if [ -z "${EXECUTION_FILE:-}" ] || [ ! -f "$EXECUTION_FILE" ]; then
+            echo "no execution log to price"
+            exit 0
+          fi
+          # Slurped and walked recursively so this works whether the log is a JSON array or the
+          # newline-delimited stream, and regardless of how deeply usage is nested.
+          usd=$(jq -s -r '
+            ([.. | objects | select(has("total_cost_usd")) | .total_cost_usd] | last) //
+            ([.. | objects | select(has("cache_read_input_tokens"))]
+              | (map(.input_tokens // 0) | add // 0) * 5
+              + (map(.output_tokens // 0) | add // 0) * 25
+              + (map(.cache_creation_input_tokens // 0) | add // 0) * 6.25
+              + (map(.cache_read_input_tokens // 0) | add // 0) * 0.5
+              | . / 1000000) // 0
+          ' "$EXECUTION_FILE")
+          line=$(printf 'Demo recording cost $%.2f of its $%.2f budget.' "$usd" "$DEMO_BUDGET_USD")
+          echo "$line" | tee -a "$GITHUB_STEP_SUMMARY"
+          # Passed in rather than interpolated into the program text, and coerced with +0 so a
+          # value awk would otherwise treat as a string is still compared as a number.
+          if awk -v u="$usd" -v b="$DEMO_BUDGET_USD" 'BEGIN { exit !(u + 0 > b + 0) }'; then
+            echo "::warning::$line Lower max_turns, or raise DEMO_BUDGET_USD if the cap is too tight."
+          fi
 
       - name: Publish the demo and post the comment
         env:


### PR DESCRIPTION
The first real `/demo` run ([31021157391](https://github.com/bluerobotics/cockpit/actions/runs/31021157391), on #2895) failed, and cost $5.39 to produce nothing. Two separate causes.

## The Node version is silently downgraded under the agent

`claude-code-base-action` runs its **own** `actions/setup-node`, pinned to `${{ env.NODE_VERSION || '18.x' }}`. That replaces the 22.13.0 this workflow installs earlier, so by the time the agent's shell exists, `node` is 18.20.8 — which has no global `WebSocket`. The recorder dies immediately:

```
ReferenceError: WebSocket is not defined
    at .../scripts/uicast/record.mjs:95
```

This is why the failure was so confusing: the rig smoke-test at step 8 runs *before* the action re-pins Node, so it passed on 22.13.0 and everything looked healthy. Every environment assumption I flagged as unverified when this merged — the Chrome path, the bundled ffmpeg symlink, build and serve — worked correctly.

Setting `NODE_VERSION` on the job is the escape hatch the action reads.

## Ten minutes was never enough

`timeout_minutes` defaults to `"10"`. I set `timeout-minutes: 60` on the job but never the action input. The agent spent that whole budget working around the Node problem — trying 22.23.1, 24.18.0, `npx node@22`, copying the binary to `/tmp/node22`, `nvm`, `--experimental-websocket`, then `npm install ws` — and was killed at exit 124. Now 20 minutes.

## Capping the spend

Neither the action nor Claude Code takes a currency budget (`CLAUDE_CODE_BUDGET_TOKENS` appears in blog posts but is not in Anthropic's env-vars reference), so the ceiling is expressed as turns.

At Opus 4.6 rates — $5/M in, $25/M out, $0.50/M cache read, $6.25/M cache write — that run breaks down as:

| | tokens | cost |
|---|---|---|
| cache read | 7,116,850 | $3.56 |
| cache write | 276,359 | $1.73 |
| input | 19,910 | $0.10 |
| output | 3,386 | $0.09 |

Almost all of it is context being re-read, not anything generated. The curve is front-loaded: the fixed context (system prompt, guidelines, `AGENTS.md`) costs ~$1.25 over the first ten turns, then ~$0.04/turn.

| after | cumulative |
|---|---|
| 10 turns | $1.25 |
| **27 turns** | **$2.00** |
| 40 turns | $2.44 |
| 116 turns | $5.39 |

So `max_turns` drops from 100 to **26**.

**This is deliberately tight, and worth a second opinion.** A clean run with one retake fits in 26 turns; a run needing three retakes will hit the cap and report a failure instead of quietly spending more. Note that most of the 116 turns above went on the Node workaround, so a healthy run should be far shorter — but we have no sample of one yet. If demos routinely stop at the cap, the options are to raise `DEMO_BUDGET_USD`, trim the guidelines to lower the $1.25 floor, or move the recording agent to Sonnet 4.6 ($3/$15, $0.30/M cache read), where $2 buys roughly twice the turns.

The new pricing step reports what each run actually cost, so the cap can be re-derived from real data rather than this single sample. It runs on failure too, because a run that burns the budget and produces nothing is exactly the one worth pricing.

## Tests Required to Merge (by dev and/or testers)

CI-only; no Cockpit runtime code is touched.

- [ ] Comment `/demo` on a small UI PR and confirm the recorder now starts under Node 22 and a video is produced
- [ ] Confirm the "Price the recording" step reports a figure in the job summary
- [ ] Confirm a run that exceeds the budget emits the warning annotation

### Verified locally

The `jq` pricing expression is exercised against all four log shapes it can meet — a completed run with an authoritative `total_cost_usd`, a run cut short in JSON-array form, the same in newline-delimited stream form, and an empty log — returning `3.25`, `25.5`, `25.5` and `0`. The budget comparison was checked either side of the threshold, and the workflow YAML parses.

The Node fix itself cannot be verified without a real run, since it depends on the action's internal setup-node behaviour.
