### PR TITLE
Map: Keep pan and zoom when switching between mission planning and flight mode

### DIFF
--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -249,6 +249,7 @@ import { attachTileNoiseFallback, refreshNoiseFallbackTiles } from '@/libs/map/m
 import {
   createGridOverlay,
   fitMapToWaypoints,
+  persistLiveMapView,
   singleStepZoomMapOptions,
   TargetFollower,
   WhoToFollow,
@@ -1077,6 +1078,9 @@ watch(
 // - disable auto update for target follower
 // - remove event listeners
 onBeforeUnmount(() => {
+  // Debounced saves may still be pending; write the live view now so Mission Planning mounts with it.
+  persistLiveMapView(missionStore.saveLastMapPosition, map.value, zoom.value, mapCenter.value)
+
   targetFollower.disableAutoUpdate()
   stopUnFollowOnUserDrag?.()
   window.removeEventListener('keydown', onKeydown)

--- a/src/libs/map/utils-map.ts
+++ b/src/libs/map/utils-map.ts
@@ -263,6 +263,29 @@ export const fitMapToWaypoints = (
 }
 
 /**
+ * Persist the live map view into the shared last-position store.
+ * Prefer the Leaflet instance when present so a leave mid-gesture still records the real center/zoom.
+ * @param { (zoom: number, center: WaypointCoordinates) => void } save Writer for the shared last-view keys.
+ * @param { L.Map | undefined } map Live Leaflet map, when still mounted.
+ * @param { number } zoom Fallback zoom from the local ref.
+ * @param { WaypointCoordinates } center Fallback center from the local ref.
+ * @returns { void }
+ */
+export const persistLiveMapView = (
+  save: (zoom: number, center: WaypointCoordinates) => void,
+  map: L.Map | undefined,
+  zoom: number,
+  center: WaypointCoordinates
+): void => {
+  if (map) {
+    const { lat, lng } = map.getCenter()
+    save(map.getZoom(), [lat, lng])
+    return
+  }
+  save(zoom, center)
+}
+
+/**
  * Generates a survey path based on the given polygon and parameters.
  * @param {L.LatLng[]} polygonPoints - The points of the polygon.
  * @param {number} distanceBetweenLines - The distance between survey lines in meters.

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -717,6 +717,7 @@ import { attachTileNoiseFallback, refreshNoiseFallbackTiles } from '@/libs/map/m
 import {
   createGridOverlay,
   fitMapToWaypoints,
+  persistLiveMapView,
   singleStepZoomMapOptions,
   TargetFollower,
   WhoToFollow,
@@ -4123,6 +4124,9 @@ watch(
 )
 
 onUnmounted(() => {
+  // Debounced saves may still be pending; write the live view now so Flight Mode mounts with it.
+  persistLiveMapView(missionStore.saveLastMapPosition, planningMap.value, zoom.value, mapCenter.value)
+
   targetFollower.disableAutoUpdate()
   stopUnFollowOnUserDrag?.()
   if (planningMap.value) {


### PR DESCRIPTION
## Summary
- Fixes #2897: switching between Mission Planning and Flight Mode no longer jumps the map back to a stale pan/zoom.
- Both maps already shared `cockpit-user-last-map-center` / `cockpit-user-last-map-zoom`, but the write was debounced 3s and never flushed on leave, so the next view remounted with the previous stored view.
- On unmount, flush the pending debounce and persist the live Leaflet center/zoom via `persistLiveMapView` in `utils-map`.

## Test plan
- [ ] In Flight Mode, pan and zoom the map somewhere distinctive, then open Mission Planning within ~1s — planning map should open at that same place/zoom
- [ ] In Mission Planning, pan/zoom somewhere else, then switch to Flight Mode within ~1s — flight map should match
- [ ] Repeat both directions after waiting >3s (debounce already written) — still matches