### PR TITLE
Map: Fix crash when switching from mission-planning and executing, while having a draft mission

### DIFF
--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -410,3 +410,14 @@ export const tryACoupleOfTimes = async <T>(
 export const messageFromError = (error: unknown): string => {
   return error instanceof Error ? error.message : String(error)
 }
+
+/**
+ * Deep-clone a JSON-representable value into plain data, dropping any Vue reactivity proxy on it or
+ * nested inside it. Prefer this over `structuredClone`, which throws on reactive proxies. Functions
+ * and `undefined` values are dropped, as JSON cannot represent them. The walk reads through proxies,
+ * so unwrap with `toRaw` first when calling from a `computed` or a render function, or every nested
+ * read becomes a dependency of it.
+ * @param {T} value The value to flatten.
+ * @returns {T} A detached copy holding no proxies.
+ */
+export const toPlain = <T>(value: T): T => JSON.parse(JSON.stringify(value))

--- a/src/migration/default-profile-importer.ts
+++ b/src/migration/default-profile-importer.ts
@@ -9,12 +9,13 @@ import {
 } from '@/assets/joystick-profiles'
 import { MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import { OtherProtocol } from '@/libs/joystick/protocols/other'
+import { toPlain } from '@/libs/utils'
 import type { JoystickProtocolActionsMapping } from '@/types/joystick'
 import type { Profile, View } from '@/types/widgets'
 
-// Proxy-safe deep clone; structuredClone can't handle Vue reactivity wrappers or function references that
-// may end up inside the stored mappings/views (seen in the wild when importing defaults crashes the renderer).
-const safeClone = <T>(value: T): T => JSON.parse(JSON.stringify(toRaw(value)))
+// toRaw keeps the JSON walk untracked: buildViewsGroupAfterImport runs inside a computed
+// (useVehicleDefaultsViewsImport.ts), which would otherwise depend on every widget in the layout.
+const safeClone = <T>(value: T): T => toPlain(toRaw(value))
 
 /**
  * Proxy-safe deep clone of a joystick mapping. Use this whenever the import flow needs a detached

--- a/src/stores/mission.ts
+++ b/src/stores/mission.ts
@@ -18,6 +18,7 @@ import {
 } from '@/libs/mission/automatic-name'
 import { generateMissionThumbnailSvg } from '@/libs/mission/library'
 import { eventCategoriesDefaultMapping } from '@/libs/slide-to-confirm'
+import { toPlain } from '@/libs/utils'
 import {
   AltitudeReferenceType,
   CockpitMission,
@@ -234,8 +235,8 @@ export const useMissionStore = defineStore('mission', () => {
   }
 
   const takeSnapshot = (): MissionSnapshot => ({
-    waypoints: JSON.parse(JSON.stringify(currentPlanningWaypoints)) as Waypoint[],
-    surveys: JSON.parse(JSON.stringify(currentPlanningSurveys)) as Survey[],
+    waypoints: toPlain(currentPlanningWaypoints),
+    surveys: toPlain(currentPlanningSurveys),
   })
 
   /**

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -733,7 +733,7 @@ import {
   polygonAreaSquareMeters,
 } from '@/libs/mission/general-estimates'
 import { PLANNABLE_VEHICLE_TYPES, vehicleTypeLabel } from '@/libs/mission/library'
-import { degrees, messageFromError } from '@/libs/utils'
+import { degrees, messageFromError, toPlain } from '@/libs/utils'
 import router from '@/router'
 import { SubMenuComponentName, SubMenuName, useAppInterfaceStore } from '@/stores/appInterface'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
@@ -828,7 +828,7 @@ const uploadMissionToVehicle = async (): Promise<void> => {
   logUserAction('Uploaded mission to vehicle')
   uploadingMission.value = true
   missionUploadProgress.value = 0
-  const missionItemsToUpload: Waypoint[] = JSON.parse(JSON.stringify(missionStore.currentPlanningWaypoints))
+  const missionItemsToUpload = toPlain(missionStore.currentPlanningWaypoints)
 
   const loadingCallback = async (loadingPerc: number): Promise<void> => {
     missionUploadProgress.value = loadingPerc

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -3801,20 +3801,21 @@ const loadDraftMission = async (mission: CockpitMission): Promise<void> => {
 
 // Backed by a debounced watcher so the deep clone runs at most once per change burst, instead of
 // firing on every reactive read of the prop while the library modal is open.
-const buildCurrentMissionSnapshot = (): CockpitMission => ({
-  version: 0,
-  settings: {
-    mapCenter: mapCenter.value,
-    zoom: zoom.value,
-    currentWaypointAltitude: currentWaypointAltitude.value,
-    currentWaypointAltitudeRefType: currentWaypointAltitudeRefType.value,
-    // Use the local (in-input) cruise speed so library saves capture pending changes the user
-    // typed but hasn't committed back to the store yet (e.g. by uploading the mission).
-    defaultCruiseSpeed: localCruiseSpeed.value,
-  },
-  waypoints: structuredClone(toRaw(missionStore.currentPlanningWaypoints)),
-  surveys: structuredClone(toRaw(missionStore.currentPlanningSurveys)),
-})
+const buildCurrentMissionSnapshot = (): CockpitMission =>
+  toPlain({
+    version: 0,
+    settings: {
+      mapCenter: mapCenter.value,
+      zoom: zoom.value,
+      currentWaypointAltitude: currentWaypointAltitude.value,
+      currentWaypointAltitudeRefType: currentWaypointAltitudeRefType.value,
+      // Use the local (in-input) cruise speed so library saves capture pending changes the user
+      // typed but hasn't committed back to the store yet (e.g. by uploading the mission).
+      defaultCruiseSpeed: localCruiseSpeed.value,
+    },
+    waypoints: missionStore.currentPlanningWaypoints,
+    surveys: missionStore.currentPlanningSurveys,
+  })
 
 const currentMissionSnapshot = ref<CockpitMission>(buildCurrentMissionSnapshot())
 


### PR DESCRIPTION
**Problem:**

- Opening Mission Planning with a persisted draft throws `Failed to execute 'structuredClone' on 'Window': [object Array] could not be cloned.` from `buildCurrentMissionSnapshot`, and keeps throwing on every pan, zoom and switch between Mission Planning and Flight Mode.
- `useBlueOsStorage` is backed by `ref(...)`, so the draft arrives deeply reactive and the waypoints that reach `currentPlanningWaypoints` carry reactive `coordinates` arrays.
- The snapshot cloned them with `structuredClone(toRaw(...))`, and `toRaw` is shallow, so those nested proxies survive it and `structuredClone` rejects them with exactly that `[object Array]` message.
- `cockpit-draft-mission` is BlueOS-synced, so a topside computer reset to defaults still hits it as soon as it connects to a vehicle holding a draft.
- `handleLoadMissionFromLibrary` reaches the same snapshot from `cockpit-mission-library`, another reactive storage ref.

**Fix:**

- `buildCurrentMissionSnapshot` (`src/views/MissionPlanningView.vue:3804`) now builds the whole mission through `toPlain`, a JSON round-trip that reads through proxies instead of rejecting them, so waypoints, surveys and settings all come out plain.
- Fixes the single consumer that could not cope, rather than the eleven store writers that can put proxies there: the store is left as it is, and every other consumer already round-trips through JSON (undo/redo snapshots, the vehicle upload, draft persistence).
- `settings.mapCenter` comes out detached as well, where the stored snapshot previously shared the live `mapCenter` ref.
- `toPlain` lands in `src/libs/utils.ts` and replaces three hand-rolled copies of the same idiom (`takeSnapshot`, `uploadMissionToVehicle`, the joystick-defaults import), so the reason to prefer it over `structuredClone` is stated once.
- Nothing new runs on pointer paths: the snapshot stays behind the existing 100 ms `watchDebounced`.

**Test plan:**

- [ ] With a draft mission of several waypoints (or a vehicle syncing one), open Mission Planning: no `structuredClone` error, and panning, zooming and switching to Flight Mode and back stay clean
- [ ] Drag a waypoint, then pan the map: still no error
- [ ] Load a mission from the mission library at its original location, then pan: still no error
- [ ] Create a survey, rotate its lines and remove one of its waypoints, then pan: still no error
- [ ] Save a mission to the library and confirm the stored snapshot still holds the current waypoints

Closes #2899
