### PR TITLE
feat: add Speed VGI preset for ground speed

### DIFF
--- a/src/assets/defaults.ts
+++ b/src/assets/defaults.ts
@@ -732,7 +732,7 @@ export const widgetProfiles: Profile[] = [
                 options: {
                   displayName: 'Speed (GPS)',
                   variableName: 'VFR_HUD/groundspeed',
-                  iconName: 'mdi-car-speed-limiter',
+                  iconName: 'mdi-speedometer',
                   variableUnit: 'm/s',
                   variableMultiplier: 1,
                   decimalPlaces: 1,

--- a/src/components/mini-widgets/VeryGenericIndicator.vue
+++ b/src/components/mini-widgets/VeryGenericIndicator.vue
@@ -661,6 +661,7 @@ const setIndicatorFromTemplate = (template: VeryGenericIndicatorPreset): void =>
   miniWidget.value.options.iconName = template.iconName
   miniWidget.value.options.variableUnit = template.variableUnit
   miniWidget.value.options.variableMultiplier = template.variableMultiplier
+  miniWidget.value.options.decimalPlaces = template.decimalPlaces ?? null
 }
 </script>
 

--- a/src/types/genericIndicator.ts
+++ b/src/types/genericIndicator.ts
@@ -23,6 +23,10 @@ export interface VeryGenericIndicatorPreset {
    * Value that multiplies the original value to bring it to a representative unit system
    */
   variableMultiplier: number
+  /**
+   * Fixed decimal places for the displayed value. When omitted, auto-formatting is used.
+   */
+  decimalPlaces?: number
 }
 
 export const veryGenericIndicatorPresets: VeryGenericIndicatorPreset[] = [
@@ -95,5 +99,13 @@ export const veryGenericIndicatorPresets: VeryGenericIndicatorPreset[] = [
     iconName: 'mdi-arrow-collapse-down',
     variableUnit: 'm',
     variableMultiplier: 1,
+  },
+  {
+    displayName: 'Speed',
+    variableName: 'VFR_HUD/groundspeed',
+    iconName: 'mdi-speedometer',
+    variableUnit: 'm/s',
+    variableMultiplier: 1,
+    decimalPlaces: 1,
   },
 ]


### PR DESCRIPTION
## Summary

- Adds a **Speed** Very Generic Indicator preset bound to `VFR_HUD/groundspeed`, in m/s, with one decimal place. The unprefixed (legacy) variable id is deliberate: those duplicates are only created for the connected vehicle, so the preset follows whatever MAVLink system ID the vehicle has, where a `/mavlink/1/1/...` id would pin it to system 1.
- Lets presets optionally set `decimalPlaces`, so applying Speed (or a future preset) gets the intended precision.
- Swaps the default profile's speed icon from the speed-limiter symbol to `mdi-speedometer`, which depicts a speed readout rather than a cap on speed, matching the new preset. Only fresh profiles are seeded from `defaults.ts`, so already-configured users keep the icon they have.

Review of this PR turned up two pre-existing defects in the indicator, affecting the widget generally rather than this preset. They were moved out to #2921 so this one stays scoped to the preset: applying any preset never subscribed the widget to its variable and left `useStringVariable` set (#2920), and the widget never released its data-lake listeners (#2919).

## Test plan

- [ ] Open a VGI mini-widget config and confirm a **Speed** preset appears
- [ ] Apply it and verify display name is Speed, unit is m/s, decimal places is 1, and the variable is ground speed
- [ ] Confirm other presets still apply cleanly, with decimal places falling back to auto-formatting
- [ ] Confirm the Speed preset resolves on a vehicle whose system ID is not 1
- [ ] On a fresh profile, confirm the default Speed (GPS) widget shows the speedometer icon

Closes #2901