### PR TITLE
Name auto-created video streams after the external stream name

### DIFF
--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -207,7 +207,11 @@ export const useVideoStore = defineStore('video', () => {
     // ponytail: feeds differing only in the URL query still fall back to '[2]'; keep the query here if one shows up
     const feed = pathSegments.filter(Boolean).pop()?.split('?')[0] ?? ''
 
-    return ['RTSP', host, feed].filter(Boolean).join(' ')
+    // RadCams announce themselves over ONVIF as "UnderwaterCam", which MCM hands us as the source name
+    const sourceName = streamInformation.value.find((info) => info.rtspSourceUrl === rtspUrl)?.sourceName ?? ''
+    const prefix = sourceName.toLowerCase().includes('underwatercam') ? 'RadCam RTSP' : 'RTSP'
+
+    return [prefix, host, feed].filter(Boolean).join(' ')
   }
 
   const initializeStreamsCorrespondency = (): void => {

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -224,13 +224,14 @@ export const useVideoStore = defineStore('video', () => {
     const existingInternalNames = streamsCorrespondency.value.map((corr) => corr.name)
     const newCorrespondencies: VideoStreamCorrespondency[] = []
 
-    let i = 1
     unmappedExternalStreams.forEach((streamName) => {
-      // Find the next available internal name (Stream 1, Stream 2, etc.)
-      let internalName = `Stream ${i}`
+      // Name the stream after the external name, disambiguating collisions with a bracketed counter suffix
+      const baseName = streamName.trim() || 'Stream'
+      let internalName = baseName
+      let suffix = 2
       while (existingInternalNames.includes(internalName)) {
-        i++
-        internalName = `Stream ${i}`
+        internalName = `${baseName} [${suffix}]`
+        suffix++
       }
 
       newCorrespondencies.push({
@@ -238,7 +239,6 @@ export const useVideoStore = defineStore('video', () => {
         externalId: streamName,
       })
       existingInternalNames.push(internalName) // Track this name to avoid duplicates
-      i++
     })
 
     // Add new correspondences to the existing ones instead of replacing them

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -182,6 +182,34 @@ export const useVideoStore = defineStore('video', () => {
     }
   }
 
+  const uniqueInternalName = (baseName: string, takenNames: string[]): string => {
+    let name = baseName
+    let suffix = 2
+    while (takenNames.includes(name)) {
+      name = `${baseName} [${suffix}]`
+      suffix++
+    }
+    return name
+  }
+
+  // A bare RTSP URL tells the user nothing, so name the stream after the host serving it. Dropping
+  // the credentials keeps them out of the name, and out of the filenames and stored options derived
+  // from it. Not URL(): cameras are not consistent about the '//', and a scheme without it parses
+  // as an opaque path, leaving the hostname empty and the stream named after nothing.
+  const rtspBaseName = (rtspUrl: string): string => {
+    const [authority, ...pathSegments] = rtspUrl
+      .trim()
+      .replace(/^rtsps?:\/{0,2}/i, '')
+      .split('/')
+    const host = (authority.split('@').pop() ?? '').replace(/:\d+$/, '')
+
+    // The path is what tells two feeds of the same camera apart, like an ONVIF main and sub profile
+    // ponytail: feeds differing only in the URL query still fall back to '[2]'; keep the query here if one shows up
+    const feed = pathSegments.filter(Boolean).pop()?.split('?')[0] ?? ''
+
+    return ['RTSP', host, feed].filter(Boolean).join(' ')
+  }
+
   const initializeStreamsCorrespondency = (): void => {
     // Move already-mapped RadCam WebRTC streams to the ignored list
     // TODO: This whole logic around auto-ignoring RadCam WebRTC streams should be removed once the MCM stutter problem is fixed
@@ -225,14 +253,7 @@ export const useVideoStore = defineStore('video', () => {
     const newCorrespondencies: VideoStreamCorrespondency[] = []
 
     unmappedExternalStreams.forEach((streamName) => {
-      // Name the stream after the external name, disambiguating collisions with a bracketed counter suffix
-      const baseName = streamName.trim() || 'Stream'
-      let internalName = baseName
-      let suffix = 2
-      while (existingInternalNames.includes(internalName)) {
-        internalName = `${baseName} [${suffix}]`
-        suffix++
-      }
+      const internalName = uniqueInternalName(streamName.trim() || 'Stream', existingInternalNames)
 
       newCorrespondencies.push({
         name: internalName,
@@ -268,13 +289,8 @@ export const useVideoStore = defineStore('video', () => {
     const existingInternalNames = streamsCorrespondency.value.map((corr) => corr.name)
     const newCorrespondencies: VideoStreamCorrespondency[] = []
 
-    let i = 1
     for (const rtspUrl of unmappedRtspUrls) {
-      let internalName = `RTSP Stream ${i}`
-      while (existingInternalNames.includes(internalName)) {
-        i++
-        internalName = `RTSP Stream ${i}`
-      }
+      const internalName = uniqueInternalName(rtspBaseName(rtspUrl), existingInternalNames)
 
       newCorrespondencies.push({
         name: internalName,
@@ -284,7 +300,6 @@ export const useVideoStore = defineStore('video', () => {
         autoDiscovered: true,
       })
       existingInternalNames.push(internalName)
-      i++
     }
 
     streamsCorrespondency.value = [...streamsCorrespondency.value, ...newCorrespondencies]
@@ -1306,12 +1321,7 @@ export const useVideoStore = defineStore('video', () => {
     }
 
     const existingInternalNames = streamsCorrespondency.value.map((corr) => corr.name)
-    let i = 1
-    let internalName = `RTSP Stream ${i}`
-    while (existingInternalNames.includes(internalName)) {
-      i++
-      internalName = `RTSP Stream ${i}`
-    }
+    const internalName = uniqueInternalName(rtspBaseName(normalizedRtspUrl), existingInternalNames)
 
     const newCorrespondency: VideoStreamCorrespondency = {
       name: internalName,

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -1226,17 +1226,7 @@ export const useVideoStore = defineStore('video', () => {
     const streamCorr = streamsCorrespondency.value.find((stream) => stream.externalId === streamID)
 
     if (streamCorr) {
-      const oldInternalName = streamCorr.name
       streamCorr.name = newInternalName
-
-      const streamData = activeStreams.value[oldInternalName]
-      if (streamData) {
-        activeStreams.value = {
-          ...activeStreams.value,
-          [newInternalName]: streamData,
-        }
-        delete activeStreams.value[oldInternalName]
-      }
       lastRenamedStreamName.value = newInternalName
     } else {
       throw new Error(`Stream with ID '${streamID}' not found.`)


### PR DESCRIPTION
Closes #2903

### Problem

Auto-created stream correspondencies got generic sequential internal names. A WebRTC camera the vehicle publishes as `Main Camera` was shown as `Stream 1`, and every RTSP camera was `RTSP Stream 1`, `RTSP Stream 2`, and so on. Those names show up in the video widget dropdown, the mini video recorder, the snapshot tool, the camera replacement dialog and in recording filenames, and none of them said which camera you were looking at. The only fix was renaming each one by hand on the video configuration page.

### Change

Four commits:

1. **WebRTC streams are named after the external stream name.** `Main Camera` instead of `Stream 1`. Collisions are disambiguated with a bracketed counter suffix (`Main Camera [2]`, `Main Camera [3]`, ...), reusing the dedup loop that was already there.
2. **RTSP streams are named after the camera serving them.** `RTSP 192.168.0.10 stream_0` instead of `RTSP Stream 1`. The external ID of an RTSP correspondency is the raw source URL, which is unusable as a display name, so the name is built from the host plus the last path segment: the host says which camera box it is, and the path is what tells two feeds of the same box apart (an ONVIF main and sub profile). The authority is split off by hand instead of through `URL`, because cameras are not consistent about the `//` and a scheme without it parses as an opaque path with an empty hostname. Dropping everything up to the `@` keeps any credentials embedded in the URL out of the name, and therefore out of the snapshot filenames and stored widget options derived from it. This covers both auto-discovery and manually added RTSP URLs.
3. **RadCams are labelled as such.** They announce themselves over ONVIF as `UnderwaterCam`, which MCM reports as the source name, so those streams become `RadCam RTSP 192.168.0.10 stream_0`.
4. **Renaming a stream no longer moves its active-stream entry.** A pre-existing bug in `renameStreamInternalNameById` that commit 1 makes reachable: `activeStreams` is keyed by external stream id everywhere else, so re-keying it by internal name hid the live entry from every lookup, the widget then built a second WebRTC session, the first one leaked for the rest of the session, and a recording in progress could no longer be stopped or finalized. The external id does not change on a rename, so there is nothing to move.

Checked against a real vehicle: an ONVIF RadCam at `rtsp://192.168.0.10:554/stream_0` reports `"UnderwaterCam - IPCamera (UnderwaterCam)"` as its source name, so it is named `RadCam RTSP 192.168.0.10 stream_0`, while an unknown camera at `rtsp://10.0.0.7:554/h264` becomes `RTSP 10.0.0.7 h264`.

### Scope

Only affects newly created correspondencies. Streams already persisted in `cockpit-streams-correspondency` keep their names, so nothing users renamed themselves gets clobbered and no migration is needed.

### Testing

- Connect to a vehicle with a fresh `cockpit-streams-correspondency` and confirm WebRTC streams are named after the camera instead of `Stream 1`/`Stream 2`.
- Confirm a RadCam RTSP stream shows up as `RadCam RTSP <ip> <feed>` and a non-RadCam RTSP stream as `RTSP <ip> <feed>`.
- Confirm two feeds of the same camera (`/stream_0` and `/stream_1`) get names that say which is which, instead of one of them getting a `[2]` suffix.
- Add an RTSP URL by hand on the video configuration page and confirm it gets the same treatment.
- Connect to a vehicle publishing two cameras with the same name and confirm the second one becomes `<name> [2]`.
- Confirm streams already mapped keep their existing names after the update.
- Rename a stream while a video widget is showing it, and confirm the picture keeps running instead of reconnecting, and that a recording started before the rename can still be stopped and saved.
