### PR TITLE
Flag RTSP as the preferred option on the camera replacement dialog

### DIFF
--- a/src/components/CameraReplacementDialog.vue
+++ b/src/components/CameraReplacementDialog.vue
@@ -122,6 +122,14 @@
           </template>
         </div>
 
+        <div v-if="showRtspPreferenceNote" class="flex items-start gap-2">
+          <v-icon size="16" color="grey-lighten-1" class="mt-[2px]">mdi-information-outline</v-icon>
+          <span class="text-xs text-gray-400">
+            Cockpit Standalone can pull RTSP streams directly from the camera, which performs better than WebRTC and
+            uses less of the vehicle's computing resources.
+          </span>
+        </div>
+
         <p class="text-xs text-gray-500 mt-1">
           {{ affectedWidgetCount }} widget{{ affectedWidgetCount === 1 ? '' : 's' }} will be updated.
         </p>
@@ -134,6 +142,7 @@
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 
 import { useBlueOsStorage } from '@/composables/settingsSyncer'
+import { isElectron } from '@/libs/utils'
 import { useVideoStore } from '@/stores/video'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
 import type { VideoStreamCorrespondency } from '@/types/video'
@@ -146,6 +155,7 @@ const videoStore = useVideoStore()
 const widgetStore = useWidgetManagerStore()
 
 const STABILIZATION_DELAY_MS = 15000
+const isStandalone = isElectron()
 
 const showDialog = ref(false)
 const dialogTriggered = ref(false)
@@ -274,11 +284,19 @@ const unusedAvailableStreams = computed(() => {
 const replacementItems = computed(() => {
   return unusedAvailableStreams.value.map((corr) => {
     const info = videoStore.getStreamDisplayInfo(corr.externalId)
+    const preferredSuffix = isStandalone && info.protocolLabel === 'RTSP' ? ' [Preferred]' : ''
     return {
       internalName: corr.name,
-      label: `${corr.name} (${info.protocolLabel} - ${info.resolution})`,
+      label: `${corr.name} (${info.protocolLabel} - ${info.resolution})${preferredSuffix}`,
     }
   })
+})
+
+const showRtspPreferenceNote = computed((): boolean => {
+  if (!isStandalone) return false
+  return unusedAvailableStreams.value.some(
+    (corr) => videoStore.getStreamDisplayInfo(corr.externalId).protocolLabel === 'RTSP'
+  )
 })
 
 const affectedWidgetCount = computed((): number => {


### PR DESCRIPTION
Closes #2904

### Problem

`CameraReplacementDialog.vue` lists RTSP and WebRTC replacement candidates side by side with no hint that, on the Standalone (Electron) build, RTSP is the better pick. RTSP streams are pulled straight from the camera instead of round-tripping through the vehicle's WebRTC pipeline, so they use noticeably less of the vehicle's computing resources. That guidance previously only existed on the video configuration page and in the Lite-build error dialog, so a user picking a replacement here had no way to know.

### Change

When running on Standalone:

- RTSP entries in the "Replace with" dropdown get a `[Preferred]` suffix, e.g. `Main Camera (RTSP - 1920x1080) [Preferred]`.
- An info note with an `mdi-information-outline` icon appears below the stream cards explaining that Standalone pulls RTSP directly from the camera and that it uses less of the vehicle's computing resources. It only shows when at least one available candidate is actually RTSP.

On Lite (browser) nothing changes: `isElectron()` gates both, and RTSP is not usable there anyway. The note also shows in the single-candidate layout, where there is no dropdown but the stream card already carries the RTSP chip.

Protocol comes from the existing `videoStore.getStreamDisplayInfo(corr.externalId).protocolLabel`, so no new plumbing was needed. No new user interaction was introduced, so there is nothing new to send through `logUserAction`.

### Testing

- On Standalone, with an orphaned stream plus both an RTSP and a WebRTC replacement candidate available, confirm the RTSP entry shows `[Preferred]` and the note is visible.
- With only WebRTC candidates, confirm no suffix and no note.
- On Lite, confirm the dialog is unchanged.