### PR TITLE
widgets: very-generic-indicator: accept data-lake templates as the value

### DIFF
--- a/src/components/DataLakeExpressionInput.vue
+++ b/src/components/DataLakeExpressionInput.vue
@@ -1,0 +1,326 @@
+<template>
+  <fieldset class="dl-expression-field">
+    <legend class="dl-expression-legend">
+      <span>{{ label }}</span>
+      <v-tooltip v-if="slots.hint" location="top">
+        <template #activator="{ props: tooltipProps }">
+          <v-icon v-bind="tooltipProps" size="14" color="grey">mdi-help-circle-outline</v-icon>
+        </template>
+        <div class="max-w-xs">
+          <slot name="hint" />
+        </div>
+      </v-tooltip>
+    </legend>
+    <div class="dl-expression-wrapper">
+      <div ref="editorContainer" class="dl-expression-editor" />
+      <div v-if="isDropdownOpen" class="dl-expression-dropdown">
+        <div
+          v-for="item in filteredVariables"
+          :key="item.id"
+          class="dl-expression-option"
+          @mousedown.prevent="insertVariable(item.id)"
+        >
+          <span class="dl-expression-option-name">{{ item.name }}</span>
+          <span class="dl-expression-option-id">{{ item.id }}</span>
+        </div>
+        <div v-if="filteredVariables.length === 0" class="dl-expression-empty">{{ emptyDropdownMessage }}</div>
+      </div>
+    </div>
+  </fieldset>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref, useSlots, watch } from 'vue'
+
+import {
+  type DataLakeVariable,
+  getAllDataLakeVariablesInfo,
+  listenToDataLakeVariablesInfoChanges,
+  unlistenToDataLakeVariablesInfoChanges,
+} from '@/libs/actions/data-lake'
+import { filterTermAtCursor, insertionStartColumn } from '@/libs/data-lake-expression-input'
+import { createMonacoEditor, monaco } from '@/libs/monaco-manager'
+import { isNumber } from '@/libs/utils'
+
+const props = defineProps<{
+  /**
+   * Current expression. Free text that may reference data lake variables as `{{ variable/id }}`.
+   */
+  modelValue: string
+  /**
+   * Label shown on the field's legend.
+   */
+  label: string
+  /**
+   * Restricts which data lake variables the dropdown offers. All of them when not given.
+   */
+  variableFilter?: (variable: DataLakeVariable) => boolean
+}>()
+
+const emit = defineEmits<{
+  (event: 'update:modelValue', value: string): void
+}>()
+
+const slots = useSlots()
+
+const editorContainer = ref<HTMLElement | null>(null)
+let editor: monaco.editor.IStandaloneCodeEditor | null = null
+
+const isDropdownOpen = ref(false)
+const variableFilterTerm = ref('')
+
+// Set right after inserting a variable, so the programmatic re-focus does not immediately reopen the dropdown.
+let suppressReopen = false
+
+// Whether the field still shows its initial value (not yet edited). While pristine, clicking it
+// shows the full variable list instead of filtering by the pre-filled content.
+let pristine = true
+
+// Set on each emit, so the value coming back through `modelValue` is not written into the editor,
+// which would fight the cursor while typing.
+let lastEmittedValue: string | null = null
+
+const availableVariables = ref<DataLakeVariable[]>([])
+
+const refreshAvailableVariables = (): void => {
+  availableVariables.value = Object.values(getAllDataLakeVariablesInfo())
+    .filter((variable) => props.variableFilter?.(variable) ?? true)
+    .sort((a, b) => (a.name || a.id).localeCompare(b.name || b.id))
+}
+
+const filteredVariables = computed(() => {
+  const term = variableFilterTerm.value.toLowerCase()
+  const variables = availableVariables.value.map((variable) => ({
+    id: variable.id,
+    name: variable.name || variable.id,
+  }))
+  if (!term) return variables
+  return variables.filter(
+    (variable) => variable.id.toLowerCase().includes(term) || variable.name.toLowerCase().includes(term)
+  )
+})
+
+// An empty data lake means nothing is feeding it, which the user fixes by connecting the vehicle,
+// not by changing what they typed.
+const emptyDropdownMessage = computed(() =>
+  availableVariables.value.length === 0
+    ? 'No variables found to choose from. Please make sure your vehicle is connected.'
+    : 'No matching variables'
+)
+
+const textUntilCursor = (): string => {
+  const model = editor?.getModel()
+  const position = editor?.getPosition()
+  if (!model || !position) return ''
+  return model.getValueInRange({
+    startLineNumber: position.lineNumber,
+    startColumn: 1,
+    endLineNumber: position.lineNumber,
+    endColumn: position.column,
+  })
+}
+
+// The dropdown shows the full list while the field is pristine or holds a plain number (filtering by
+// a number matches nothing); otherwise it filters by the token under the cursor.
+const dropdownFilterTerm = (): string => {
+  if (!editor || pristine || isNumber(editor.getValue())) return ''
+  return filterTermAtCursor(textUntilCursor())
+}
+
+const insertVariable = (variableId: string): void => {
+  const position = editor?.getPosition()
+  if (!editor || !position) return
+
+  logUserAction(`Inserted the data lake variable '${variableId}' into the '${props.label}' field`)
+
+  const startColumn = insertionStartColumn(textUntilCursor(), position.column)
+  const range = new monaco.Range(position.lineNumber, startColumn, position.lineNumber, position.column)
+  editor.executeEdits('insert-data-lake-variable', [{ range, text: `{{ ${variableId} }}`, forceMoveMarkers: true }])
+
+  isDropdownOpen.value = false
+  suppressReopen = true
+  editor.focus()
+}
+
+const createEditor = (container: HTMLElement): monaco.editor.IStandaloneCodeEditor => {
+  const createdEditor = createMonacoEditor(container, {
+    language: 'plaintext',
+    value: props.modelValue,
+    editorOverrides: {
+      lineNumbers: 'off',
+      glyphMargin: false,
+      folding: false,
+      lineDecorationsWidth: 8,
+      lineNumbersMinChars: 0,
+      fontSize: 13,
+      padding: { top: 8, bottom: 8 },
+      renderLineHighlight: 'none',
+      overviewRulerLanes: 0,
+      minimap: { enabled: false },
+      wordWrap: 'on',
+      scrollBeyondLastLine: false,
+      scrollbar: { vertical: 'hidden', horizontal: 'hidden' },
+      quickSuggestions: false,
+      wordBasedSuggestions: 'off',
+      suggestOnTriggerCharacters: false,
+      autoClosingBrackets: 'never',
+    },
+  })
+
+  // Grow the editor to fit its content so a wrapped long expression spans multiple lines instead of
+  // being clipped at a fixed height.
+  const applyAutoHeight = (): void => {
+    const contentHeight = createdEditor.getContentHeight()
+    container.style.height = `${contentHeight}px`
+    createdEditor.layout({ width: container.clientWidth, height: contentHeight })
+  }
+  createdEditor.onDidContentSizeChange(applyAutoHeight)
+  applyAutoHeight()
+
+  const openDropdown = (): void => {
+    isDropdownOpen.value = true
+    variableFilterTerm.value = dropdownFilterTerm()
+  }
+
+  createdEditor.onDidChangeModelContent(() => {
+    pristine = false
+    lastEmittedValue = createdEditor.getValue().trim()
+    emit('update:modelValue', lastEmittedValue)
+    if (isDropdownOpen.value) variableFilterTerm.value = dropdownFilterTerm()
+  })
+  createdEditor.onMouseDown(openDropdown)
+  createdEditor.onDidFocusEditorText(() => {
+    if (suppressReopen) {
+      suppressReopen = false
+      return
+    }
+    openDropdown()
+  })
+  createdEditor.onDidChangeCursorPosition(() => {
+    if (isDropdownOpen.value) variableFilterTerm.value = dropdownFilterTerm()
+  })
+  // Delay so a dropdown item's mousedown can run before blur closes the dropdown.
+  createdEditor.onDidBlurEditorText(() => setTimeout(() => (isDropdownOpen.value = false), 150))
+  createdEditor.onKeyDown((event) => {
+    if (event.keyCode === monaco.KeyCode.Escape) isDropdownOpen.value = false
+  })
+
+  return createdEditor
+}
+
+// Follow changes the parent makes on its own (e.g. applying a preset) without disturbing typing.
+watch(
+  () => props.modelValue,
+  (value) => {
+    if (!editor || value === lastEmittedValue || value === editor.getValue()) return
+    editor.setValue(value)
+    pristine = true
+  }
+)
+
+let variablesInfoListenerId: string | undefined
+
+onMounted(() => {
+  refreshAvailableVariables()
+  variablesInfoListenerId = listenToDataLakeVariablesInfoChanges(refreshAvailableVariables)
+  if (editorContainer.value) editor = createEditor(editorContainer.value)
+})
+
+onUnmounted(() => {
+  editor?.dispose()
+  editor = null
+  if (variablesInfoListenerId) unlistenToDataLakeVariablesInfoChanges(variablesInfoListenerId)
+})
+</script>
+
+<style scoped>
+/* Outlined field with a notched label (the legend cuts the top border, like a v-text-field). */
+.dl-expression-field {
+  min-inline-size: 0;
+  margin: 0;
+  padding: 2px 8px 6px;
+  border: 1px solid rgba(255, 255, 255, 0.38);
+  border-radius: 4px;
+}
+
+.dl-expression-legend {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: 4px;
+  padding: 0 4px;
+  font-size: 12px;
+  line-height: 1;
+  color: #ffffffb3;
+}
+
+.dl-expression-wrapper {
+  position: relative;
+}
+
+.dl-expression-editor {
+  min-height: 36px;
+  width: 100%;
+  overflow: visible;
+}
+
+/* Monaco builds its own DOM inside the container, so its rules have to pierce the scoping. */
+.dl-expression-editor :deep(.monaco-editor),
+.dl-expression-editor :deep(.monaco-editor .margin),
+.dl-expression-editor :deep(.monaco-editor-background) {
+  background-color: transparent !important;
+}
+
+.dl-expression-editor :deep(.monaco-editor),
+.dl-expression-editor :deep(.monaco-editor.focused),
+.dl-expression-editor :deep(.monaco-editor .inputarea) {
+  outline: none !important;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+.dl-expression-editor :deep(.monaco-editor .overflow-guard) {
+  border-radius: 4px;
+}
+
+.dl-expression-dropdown {
+  position: absolute;
+  top: calc(100% + 2px);
+  left: 0;
+  right: 0;
+  z-index: 30;
+  max-height: 220px;
+  overflow-y: auto;
+  background-color: #1e1e1e;
+  border: 1px solid #ffffff33;
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+.dl-expression-option {
+  display: flex;
+  flex-direction: column;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+
+.dl-expression-option:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.dl-expression-option-name {
+  font-size: 13px;
+  color: #ffffffde;
+}
+
+.dl-expression-option-id {
+  font-size: 11px;
+  color: #ffffff80;
+}
+
+.dl-expression-empty {
+  padding: 8px 10px;
+  font-size: 12px;
+  color: #ffffff80;
+}
+</style>

--- a/src/components/DataLakeExpressionInput.vue
+++ b/src/components/DataLakeExpressionInput.vue
@@ -13,12 +13,17 @@
     </legend>
     <div class="dl-expression-wrapper">
       <div ref="editorContainer" class="dl-expression-editor" />
-      <div v-if="isDropdownOpen" class="dl-expression-dropdown">
+      <div v-if="isDropdownOpen" :id="listboxId" class="dl-expression-dropdown" role="listbox">
         <div
-          v-for="item in filteredVariables"
+          v-for="(item, index) in filteredVariables"
+          :id="optionId(index)"
           :key="item.id"
           class="dl-expression-option"
+          :class="{ 'dl-expression-option-highlighted': index === highlightedIndex }"
+          role="option"
+          :aria-selected="index === highlightedIndex"
           @mousedown.prevent="insertVariable(item.id)"
+          @mouseenter="highlightedIndex = index"
         >
           <span class="dl-expression-option-name">{{ item.name }}</span>
           <span class="dl-expression-option-id">{{ item.id }}</span>
@@ -30,7 +35,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref, useSlots, watch } from 'vue'
+import { v4 as uuid } from 'uuid'
+import { computed, nextTick, onMounted, onUnmounted, ref, useSlots, watch } from 'vue'
 
 import {
   type DataLakeVariable,
@@ -38,7 +44,7 @@ import {
   listenToDataLakeVariablesInfoChanges,
   unlistenToDataLakeVariablesInfoChanges,
 } from '@/libs/actions/data-lake'
-import { filterTermAtCursor, insertionStartColumn } from '@/libs/data-lake-expression-input'
+import { filterTermAtCursor, insertionStartColumn, nextHighlightedIndex } from '@/libs/data-lake-expression-input'
 import { createMonacoEditor, monaco } from '@/libs/monaco-manager'
 import { isNumber } from '@/libs/utils'
 
@@ -68,6 +74,12 @@ let editor: monaco.editor.IStandaloneCodeEditor | null = null
 
 const isDropdownOpen = ref(false)
 const variableFilterTerm = ref('')
+
+// The option the keyboard acts on, `-1` until the user navigates into the list so Enter keeps
+// meaning whatever it meant in the field. Ids are per instance, since the POI dialog renders two.
+const highlightedIndex = ref(-1)
+const listboxId = `dl-expression-listbox-${uuid()}`
+const optionId = (index: number): string => `${listboxId}-option-${index}`
 
 // Set right after inserting a variable, so the programmatic re-focus does not immediately reopen the dropdown.
 let suppressReopen = false
@@ -138,8 +150,11 @@ const insertVariable = (variableId: string): void => {
   editor.executeEdits('insert-data-lake-variable', [{ range, text: `{{ ${variableId} }}`, forceMoveMarkers: true }])
 
   isDropdownOpen.value = false
+  // Monaco dispatches its focus event synchronously, so the flag only has to hold across this call.
+  // Leaving it set would swallow the next genuine focus, stranding a keyboard user on one variable.
   suppressReopen = true
   editor.focus()
+  suppressReopen = false
 }
 
 const createEditor = (container: HTMLElement): monaco.editor.IStandaloneCodeEditor => {
@@ -164,6 +179,9 @@ const createEditor = (container: HTMLElement): monaco.editor.IStandaloneCodeEdit
       wordBasedSuggestions: 'off',
       suggestOnTriggerCharacters: false,
       autoClosingBrackets: 'never',
+      // Monaco otherwise eats Tab as indentation, stranding a keyboard user in a one-line field
+      // that has nothing to indent.
+      tabFocusMode: true,
     },
   })
 
@@ -180,6 +198,7 @@ const createEditor = (container: HTMLElement): monaco.editor.IStandaloneCodeEdit
   const openDropdown = (): void => {
     isDropdownOpen.value = true
     variableFilterTerm.value = dropdownFilterTerm()
+    highlightedIndex.value = -1
   }
 
   createdEditor.onDidChangeModelContent(() => {
@@ -202,11 +221,70 @@ const createEditor = (container: HTMLElement): monaco.editor.IStandaloneCodeEdit
   // Delay so a dropdown item's mousedown can run before blur closes the dropdown.
   createdEditor.onDidBlurEditorText(() => setTimeout(() => (isDropdownOpen.value = false), 150))
   createdEditor.onKeyDown((event) => {
-    if (event.keyCode === monaco.KeyCode.Escape) isDropdownOpen.value = false
+    // The editor would otherwise move the cursor or break the line under the keys the list uses,
+    // and an unstopped Escape reaches the dialog the field sits in and closes it.
+    const keepKeyToTheList = (): void => {
+      event.preventDefault()
+      event.stopPropagation()
+    }
+
+    if (event.keyCode === monaco.KeyCode.Escape) {
+      if (!isDropdownOpen.value) return
+      isDropdownOpen.value = false
+      keepKeyToTheList()
+      return
+    }
+
+    // Neither field this serves is meant to hold two lines, so Enter takes the active option, or
+    // does nothing at all rather than breaking the line.
+    if (event.keyCode === monaco.KeyCode.Enter) {
+      const activeVariable = isDropdownOpen.value ? filteredVariables.value[highlightedIndex.value] : undefined
+      if (activeVariable) insertVariable(activeVariable.id)
+      keepKeyToTheList()
+      return
+    }
+
+    // Reopening from the keyboard, since the list closes on every insertion and picking a second
+    // variable would otherwise need the mouse.
+    if (!isDropdownOpen.value) {
+      if (event.keyCode !== monaco.KeyCode.DownArrow) return
+      openDropdown()
+      keepKeyToTheList()
+      return
+    }
+    if (filteredVariables.value.length === 0) return
+
+    const lastIndex = filteredVariables.value.length - 1
+    if (event.keyCode === monaco.KeyCode.DownArrow) {
+      highlightedIndex.value = nextHighlightedIndex(highlightedIndex.value, lastIndex, 'down')
+    } else if (event.keyCode === monaco.KeyCode.UpArrow) {
+      highlightedIndex.value = nextHighlightedIndex(highlightedIndex.value, lastIndex, 'up')
+    } else {
+      return
+    }
+
+    keepKeyToTheList()
   })
 
   return createdEditor
 }
+
+watch(filteredVariables, () => (highlightedIndex.value = -1))
+
+// Monaco owns the focused element, so the state a screen reader reads off it has to be applied to
+// its textarea by hand.
+watch([isDropdownOpen, highlightedIndex], async () => {
+  await nextTick()
+  const textArea = editor?.getDomNode()?.querySelector('textarea')
+  textArea?.setAttribute('aria-expanded', String(isDropdownOpen.value))
+  if (!isDropdownOpen.value || highlightedIndex.value < 0) {
+    textArea?.removeAttribute('aria-activedescendant')
+    return
+  }
+  const highlightedOptionId = optionId(highlightedIndex.value)
+  textArea?.setAttribute('aria-activedescendant', highlightedOptionId)
+  document.getElementById(highlightedOptionId)?.scrollIntoView({ block: 'nearest' })
+})
 
 // Follow changes the parent makes on its own (e.g. applying a preset) without disturbing typing.
 watch(
@@ -224,6 +302,13 @@ onMounted(() => {
   refreshAvailableVariables()
   variablesInfoListenerId = listenToDataLakeVariablesInfoChanges(refreshAvailableVariables)
   if (editorContainer.value) editor = createEditor(editorContainer.value)
+  const textArea = editor?.getDomNode()?.querySelector('textarea')
+  textArea?.setAttribute('aria-controls', listboxId)
+  // Monaco exposes the textarea as a plain textbox, which supports neither `aria-expanded` nor an
+  // active descendant, so the list would never be announced. `aria-expanded` is required on the
+  // role, and the field is collapsed until the watcher below first says otherwise.
+  textArea?.setAttribute('role', 'combobox')
+  textArea?.setAttribute('aria-expanded', 'false')
 })
 
 onUnmounted(() => {
@@ -304,7 +389,8 @@ onUnmounted(() => {
   cursor: pointer;
 }
 
-.dl-expression-option:hover {
+.dl-expression-option:hover,
+.dl-expression-option-highlighted {
   background-color: rgba(255, 255, 255, 0.1);
 }
 

--- a/src/components/DataLakeExpressionInput.vue
+++ b/src/components/DataLakeExpressionInput.vue
@@ -147,12 +147,13 @@ const insertVariable = (variableId: string): void => {
 
   const startColumn = insertionStartColumn(textUntilCursor(), position.column)
   const range = new monaco.Range(position.lineNumber, startColumn, position.lineNumber, position.column)
-  editor.executeEdits('insert-data-lake-variable', [{ range, text: `{{ ${variableId} }}`, forceMoveMarkers: true }])
 
-  isDropdownOpen.value = false
-  // Monaco dispatches its focus event synchronously, so the flag only has to hold across this call.
-  // Leaving it set would swallow the next genuine focus, stranding a keyboard user on one variable.
+  // Covers the two events this edit fires — the content change and the focus — so that neither
+  // reopens the list the user just picked from. Both are dispatched synchronously, so the flag
+  // only has to hold across this call; leaving it set would swallow the next genuine one.
   suppressReopen = true
+  editor.executeEdits('insert-data-lake-variable', [{ range, text: `{{ ${variableId} }}`, forceMoveMarkers: true }])
+  isDropdownOpen.value = false
   editor.focus()
   suppressReopen = false
 }
@@ -205,15 +206,13 @@ const createEditor = (container: HTMLElement): monaco.editor.IStandaloneCodeEdit
     pristine = false
     lastEmittedValue = createdEditor.getValue().trim()
     emit('update:modelValue', lastEmittedValue)
-    if (isDropdownOpen.value) variableFilterTerm.value = dropdownFilterTerm()
+    // Typing brings the list back, since picking a variable closes it while the user is usually
+    // still writing the expression, and nothing else here would reopen it without a refocus.
+    if (!suppressReopen) openDropdown()
   })
   createdEditor.onMouseDown(openDropdown)
   createdEditor.onDidFocusEditorText(() => {
-    if (suppressReopen) {
-      suppressReopen = false
-      return
-    }
-    openDropdown()
+    if (!suppressReopen) openDropdown()
   })
   createdEditor.onDidChangeCursorPosition(() => {
     if (isDropdownOpen.value) variableFilterTerm.value = dropdownFilterTerm()

--- a/src/components/mini-widgets/VeryGenericIndicator.vue
+++ b/src/components/mini-widgets/VeryGenericIndicator.vue
@@ -11,10 +11,16 @@
       class="h-full left-[0.5rem] bottom-[5%] absolute text-[2.25rem]"
       :icon-name="miniWidget.options.iconName"
     />
-    <div class="absolute left-[3rem] h-full select-none font-semibold scroll-container w-full">
-      <div class="w-full" :class="{ 'scroll-text': valueIsOverflowing }">
-        <span class="font-mono text-xl leading-6">{{ parsedState }}</span>
-        <span class="text-xl leading-6"> {{ String.fromCharCode(0x20) }} {{ miniWidget.options.variableUnit }} </span>
+    <div ref="valueArea" class="absolute left-[3rem] right-0 h-full select-none font-semibold scroll-container">
+      <div
+        class="w-full"
+        :class="{ 'scroll-text': valueIsOverflowing }"
+        :style="{ '--value-scroll-distance': `-${valueOverflow}px` }"
+      >
+        <span ref="valueText" class="inline-block">
+          <span class="font-mono text-xl leading-6">{{ parsedState }}</span>
+          <span class="text-xl leading-6"> {{ String.fromCharCode(0x20) }} {{ miniWidget.options.variableUnit }} </span>
+        </span>
       </div>
       <span class="w-full text-sm absolute bottom-[0.5rem] whitespace-nowrap text-ellipsis overflow-x-hidden">
         {{ miniWidget.options.displayName }}
@@ -65,44 +71,25 @@
                 />
               </div>
 
-              <div>
-                <v-text-field
-                  :model-value="miniWidget.options.variableName"
-                  label="Variable"
-                  placeholder="Click to choose..."
-                  variant="outlined"
-                  density="compact"
-                  hide-details
-                  readonly
-                  append-inner-icon="mdi-swap-horizontal-bold"
-                  class="cursor-pointer"
-                  @click="showVariableChooseModal = !showVariableChooseModal"
-                />
-                <Transition>
-                  <div v-if="showVariableChooseModal" class="mt-2">
-                    <v-text-field
-                      v-model="variableNameSearchString"
-                      placeholder="Search variable..."
-                      variant="outlined"
-                      density="compact"
-                      hide-details
-                    />
-                    <div class="grid w-full h-32 grid-cols-1 mt-2 overflow-x-hidden overflow-y-auto">
-                      <span
-                        v-for="(variable, i) in variableNamesToShow"
-                        :key="i"
-                        class="h-8 p-1 m-1 overflow-x-hidden text-white transition-all rounded-md cursor-pointer select-none bg-slate-700 hover:bg-slate-400/20"
-                        @click="onChooseVariable(variable)"
-                      >
-                        {{ variable }}
-                      </span>
-                    </div>
-                  </div>
-                </Transition>
-              </div>
+              <DataLakeExpressionInput
+                v-if="widgetStore.miniWidgetManagerVars(miniWidget.hash).configMenuOpen"
+                v-model="miniWidget.options.variableName"
+                label="Variable"
+              >
+                <template #hint>
+                  <p class="text-sm mb-2">
+                    Show a single variable's value, or a text template combining as many of them as you want.
+                  </p>
+                  <p class="text-sm">
+                    Click the field to pick a data-lake variable, and wrap variables in &#123;&#123; &#125;&#125; to
+                    write a template — e.g. Lat &#123;&#123; mavlink/1/1/GLOBAL_POSITION_INT/lat &#125;&#125;.
+                  </p>
+                </template>
+              </DataLakeExpressionInput>
 
               <v-checkbox
                 v-model="miniWidget.options.useStringVariable"
+                :disabled="valueIsTemplate"
                 label="Use string variable (don't parse as number)"
                 density="compact"
                 hide-details
@@ -120,7 +107,7 @@
                 />
                 <v-text-field
                   v-model="miniWidget.options.variableMultiplier"
-                  :disabled="miniWidget.options.useStringVariable"
+                  :disabled="miniWidget.options.useStringVariable || valueIsTemplate"
                   label="Multiplier"
                   variant="outlined"
                   density="compact"
@@ -129,7 +116,7 @@
                 />
                 <v-text-field
                   v-model="miniWidget.options.decimalPlaces"
-                  :disabled="miniWidget.options.useStringVariable"
+                  :disabled="miniWidget.options.useStringVariable || valueIsTemplate"
                   label="Decimal places"
                   type="number"
                   min="0"
@@ -306,17 +293,18 @@
 <script setup lang="ts">
 import { useElementSize, watchThrottled } from '@vueuse/core'
 import Fuse from 'fuse.js'
-import { computed, onBeforeMount, onMounted, onUnmounted, ref, toRefs, watch } from 'vue'
+import { computed, onBeforeMount, onMounted, ref, toRefs, watch } from 'vue'
 
+import DataLakeExpressionInput from '@/components/DataLakeExpressionInput.vue'
 import VgiIcon from '@/components/mini-widgets/VgiIcon.vue'
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { useCustomIcons } from '@/composables/useCustomIcons'
 import { useDataLakeVariable } from '@/composables/useDataLakeVariable'
-import { listenToDataLakeVariablesInfoChanges, unlistenToDataLakeVariablesInfoChanges } from '@/libs/actions/data-lake'
-import { getAllDataLakeVariablesInfo } from '@/libs/actions/data-lake'
+import { useResolvedDataLakeTemplate } from '@/composables/useResolvedDataLakeTemplate'
 import { type CustomIcon, customIconRefFromId, idFromCustomIconRef, isCustomIconRef } from '@/libs/custom-icons'
 import { CurrentlyLoggedVariables, datalogger } from '@/libs/sensors-logging'
 import { round } from '@/libs/utils'
+import { getSoleDataLakeVariableIdInString, replaceDataLakeInputsInString } from '@/libs/utils-data-lake'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
 import { type VeryGenericIndicatorPreset, veryGenericIndicatorPresets } from '@/types/genericIndicator'
@@ -364,13 +352,30 @@ onBeforeMount(() => {
 
 const widgetStore = useWidgetManagerStore()
 
+// The variable the indicator reads directly. Anything else mixes variables with text, and is shown
+// as a template instead, with the multiplier and the decimal places no longer applicable to it.
+const singleVariableId = computed(() => getSoleDataLakeVariableIdInString(miniWidget.value.options.variableName ?? ''))
+
+const valueIsTemplate = computed(() => singleVariableId.value === null && !!miniWidget.value.options.variableName)
+
 // Keyed on the variable name so that every writer of it — the config dialog, a preset, or a BlueOS
-// profile sync, which patches the widget in place rather than remounting it — resubscribes.
-const { value: currentState } = useDataLakeVariable(() => miniWidget.value.options.variableName)
+// profile sync, which patches the widget in place rather than remounting it — resubscribes. A
+// template subscribes to nothing here, as `useResolvedDataLakeTemplate` follows its own references.
+const { value: currentState } = useDataLakeVariable(() => singleVariableId.value ?? undefined)
+
+const resolvedTemplate = useResolvedDataLakeTemplate(() =>
+  valueIsTemplate.value ? miniWidget.value.options.variableName : undefined
+)
 
 const finalValue = computed(() => Number(miniWidget.value.options.variableMultiplier) * Number(currentState.value))
 
 const parsedState = computed(() => {
+  if (valueIsTemplate.value) {
+    // A reference the data lake has no value for is left as-is by the resolver, and an internal
+    // variable id is not something the pilot should be reading on the indicator.
+    return replaceDataLakeInputsInString(resolvedTemplate.value ?? '--', () => '--')
+  }
+
   if (currentState.value === undefined) {
     return '--'
   }
@@ -403,9 +408,15 @@ const parsedState = computed(() => {
   return value.toFixed(0)
 })
 
-const valueIsOverflowing = computed(() => {
-  return finalValue.value <= -100000 || finalValue.value >= 1000000
-})
+const valueArea = ref<HTMLElement | null>(null)
+const { width: valueAreaWidth } = useElementSize(valueArea)
+const valueText = ref<HTMLElement | null>(null)
+const { width: valueTextWidth } = useElementSize(valueText)
+
+// How much of the value does not fit the space the icon leaves it, so a template — whose
+// `finalValue` is NaN, making every numeric comparison false — also gets the marquee when clipped.
+const valueOverflow = computed(() => Math.max(0, Math.round(valueTextWidth.value - valueAreaWidth.value)))
+const valueIsOverflowing = computed(() => valueOverflow.value > 0)
 
 const loggedMiniWidgets = ref(Array.from(CurrentlyLoggedVariables.getAllVariables()))
 const lastWidgetName = ref('')
@@ -435,13 +446,6 @@ const closeVgiDialog = async (): Promise<void> => {
 const updateWidgetName = (): void => {
   miniWidget.value.name = miniWidget.value.options.displayName || miniWidget.value.options.variableName
 }
-const updateGenericVariablesNames = (): void => {
-  const variablesNames = Object.keys(getAllDataLakeVariablesInfo())
-  allVariablesNames.value = variablesNames
-  // TODO: Update CurrentlyLoggedVariables to match data lake state
-}
-
-let variablesInfoListenerId: string | undefined
 
 const logData = computed(() => ({
   displayName: props.miniWidget.options.displayName,
@@ -473,7 +477,7 @@ watch(
 )
 
 watch(
-  finalValue,
+  parsedState,
   () => {
     if (widgetStore.miniWidgetManagerVars(miniWidget.value.hash).configMenuOpen === false) {
       logCurrentState()
@@ -486,32 +490,26 @@ watch(
   miniWidget,
   () => {
     updateWidgetName()
-    updateGenericVariablesNames()
   },
   { deep: true }
 )
 onMounted(() => {
   // Update old variables naming to new pattern
   // TODO: Remove this before 1.0.0 release
-  if (miniWidget.value.options.variableName) {
-    miniWidget.value.options.variableName = miniWidget.value.options.variableName.replaceAll('.', '/')
+  // Only a lone id can carry the old dotted naming, so anything with a space or a brace in it is
+  // free text the user wrote, whose punctuation this would eat and persist.
+  const storedValue = miniWidget.value.options.variableName
+  if (storedValue && !/[\s{}]/.test(storedValue)) {
+    miniWidget.value.options.variableName = storedValue.replaceAll('.', '/')
   }
 
   updateWidgetName()
-  updateGenericVariablesNames()
 
   if (miniWidget.value.options.displayName && widgetStore.editingMode === false) {
     CurrentlyLoggedVariables.addVariable(miniWidget.value.options.displayName)
   }
 
-  // Update list of available variables when the data-lake has new stuff
-  variablesInfoListenerId = listenToDataLakeVariablesInfoChanges(updateGenericVariablesNames)
-
   lastWidgetName.value = miniWidget.value.options.displayName
-})
-
-onUnmounted(() => {
-  if (variablesInfoListenerId !== undefined) unlistenToDataLakeVariablesInfoChanges(variablesInfoListenerId)
 })
 
 const fuseOptions = { includeScore: true, ignoreLocation: true, threshold: 0.3 }
@@ -542,10 +540,6 @@ watchThrottled(
   { throttle: 1000 }
 )
 
-// Search for variable using fuzzy-finder
-const variableNameSearchString = ref('')
-const allVariablesNames = ref<string[]>([])
-const showVariableChooseModal = ref(false)
 const showIconChooseModal = ref(false)
 const iconCategory = ref<'stock' | 'custom'>('stock')
 
@@ -600,45 +594,12 @@ const confirmRemoveCustomIcon = (icon: CustomIcon): void => {
   })
 }
 
-const variableNamesToShow = computed(() => {
-  if (variableNameSearchString.value === '') {
-    return allVariablesNames.value
-  }
-
-  const variableNameFuse = new Fuse(allVariablesNames.value, fuseOptions)
-  const filteredVariablesResult = variableNameFuse.search(variableNameSearchString.value)
-  return filteredVariablesResult.map((r) => r.item).filter((value, index, self) => self.indexOf(value) === index)
-})
-
-const chooseVariable = (variable: string): void => {
-  miniWidget.value.options.variableName = variable
-  variableNameSearchString.value = ''
-  showVariableChooseModal.value = false
-}
-
-const onChooseVariable = (variable: string): void => {
-  logUserAction(`Selected indicator variable '${variable}'`)
-  chooseVariable(variable)
-}
-
 const chooseIcon = (iconName: string): void => {
   logUserAction(`Selected indicator icon '${iconName}'`)
   miniWidget.value.options.iconName = iconName
   iconSearchString.value = ''
   if (!isCustomIconRef(iconName)) showIconChooseModal.value = false
 }
-
-watch(showVariableChooseModal, async (newValue) => {
-  if (newValue === true && variableNamesToShow.value.isEmpty()) {
-    widgetStore.miniWidgetManagerVars(miniWidget.value.hash).configMenuOpen = false
-    showVariableChooseModal.value = false
-    await showDialog({
-      message: 'No variables found to choose from. Please make sure your vehicle is connected.',
-      variant: 'error',
-    })
-    widgetStore.miniWidgetManagerVars(miniWidget.value.hash).configMenuOpen = true
-  }
-})
 
 const currentTab = ref(widgetIsConfigured.value ? 'custom' : 'presets')
 
@@ -687,7 +648,7 @@ const setIndicatorFromTemplate = (template: VeryGenericIndicatorPreset): void =>
   }
   90%,
   100% {
-    transform: translateX(-50%);
+    transform: translateX(var(--value-scroll-distance, -50%));
   }
 }
 </style>

--- a/src/components/poi/PoiManager.vue
+++ b/src/components/poi/PoiManager.vue
@@ -40,74 +40,40 @@
         <v-text-field v-model="newPoiDescription" label="Description" variant="outlined"></v-text-field>
 
         <div class="flex flex-col mb-2">
-          <fieldset class="poi-field mb-5">
-            <legend class="poi-field-legend">
-              <span>Latitude</span>
-              <v-tooltip location="top">
-                <template #activator="{ props }">
-                  <v-icon v-bind="props" size="14" color="grey">mdi-help-circle-outline</v-icon>
-                </template>
-                <div class="max-w-xs">
-                  <p class="text-sm mb-2">
-                    Enter a fixed coordinate, or an expression that follows live data and updates on the map.
-                  </p>
-                  <p class="text-sm">
-                    Click the field to pick a data-lake variable, or wrap variables in &#123;&#123; &#125;&#125; — e.g.
-                    &#123;&#123; mavlink/buoy/latitude &#125;&#125; + 0.0001.
-                  </p>
-                </div>
-              </v-tooltip>
-            </legend>
-            <div class="poi-expression-wrapper">
-              <div ref="latEditorContainer" class="poi-expression-editor" />
-              <div v-if="activeField === 'lat'" class="poi-var-dropdown">
-                <div
-                  v-for="item in filteredVariables"
-                  :key="item.id"
-                  class="poi-var-option"
-                  @mousedown.prevent="insertVariable('lat', item.id)"
-                >
-                  <span class="poi-var-name">{{ item.name }}</span>
-                  <span class="poi-var-id">{{ item.id }}</span>
-                </div>
-                <div v-if="filteredVariables.length === 0" class="poi-var-empty">No matching variables</div>
-              </div>
-            </div>
-          </fieldset>
-          <fieldset class="poi-field mb-4">
-            <legend class="poi-field-legend">
-              <span>Longitude</span>
-              <v-tooltip location="top">
-                <template #activator="{ props }">
-                  <v-icon v-bind="props" size="14" color="grey">mdi-help-circle-outline</v-icon>
-                </template>
-                <div class="max-w-xs">
-                  <p class="text-sm mb-2">
-                    Enter a fixed coordinate, or an expression that follows live data and updates on the map.
-                  </p>
-                  <p class="text-sm">
-                    Click the field to pick a data-lake variable, or wrap variables in &#123;&#123; &#125;&#125; — e.g.
-                    &#123;&#123; mavlink/buoy/longitude &#125;&#125; + 0.0001.
-                  </p>
-                </div>
-              </v-tooltip>
-            </legend>
-            <div class="poi-expression-wrapper">
-              <div ref="lngEditorContainer" class="poi-expression-editor" />
-              <div v-if="activeField === 'lng'" class="poi-var-dropdown">
-                <div
-                  v-for="item in filteredVariables"
-                  :key="item.id"
-                  class="poi-var-option"
-                  @mousedown.prevent="insertVariable('lng', item.id)"
-                >
-                  <span class="poi-var-name">{{ item.name }}</span>
-                  <span class="poi-var-id">{{ item.id }}</span>
-                </div>
-                <div v-if="filteredVariables.length === 0" class="poi-var-empty">No matching variables</div>
-              </div>
-            </div>
-          </fieldset>
+          <DataLakeExpressionInput
+            v-if="poiDialogVisible"
+            v-model="newPoiLatExpression"
+            label="Latitude"
+            :variable-filter="isCoordinateVariable"
+            class="mb-5"
+          >
+            <template #hint>
+              <p class="text-sm mb-2">
+                Enter a fixed coordinate, or an expression that follows live data and updates on the map.
+              </p>
+              <p class="text-sm">
+                Click the field to pick a data-lake variable, or wrap variables in &#123;&#123; &#125;&#125; — e.g.
+                &#123;&#123; mavlink/buoy/latitude &#125;&#125; + 0.0001.
+              </p>
+            </template>
+          </DataLakeExpressionInput>
+          <DataLakeExpressionInput
+            v-if="poiDialogVisible"
+            v-model="newPoiLngExpression"
+            label="Longitude"
+            :variable-filter="isCoordinateVariable"
+            class="mb-4"
+          >
+            <template #hint>
+              <p class="text-sm mb-2">
+                Enter a fixed coordinate, or an expression that follows live data and updates on the map.
+              </p>
+              <p class="text-sm">
+                Click the field to pick a data-lake variable, or wrap variables in &#123;&#123; &#125;&#125; — e.g.
+                &#123;&#123; mavlink/buoy/longitude &#125;&#125; + 0.0001.
+              </p>
+            </template>
+          </DataLakeExpressionInput>
         </div>
 
         <div class="mb-4">
@@ -173,17 +139,13 @@
 </template>
 
 <script setup lang="ts">
-import { computed, defineExpose, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, defineExpose, ref, watch } from 'vue'
 
+import DataLakeExpressionInput from '@/components/DataLakeExpressionInput.vue'
 import InteractionDialog from '@/components/InteractionDialog.vue'
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { generatePointOfInterestId, usePointsOfInterest } from '@/composables/usePointsOfInterest'
-import {
-  getAllDataLakeVariablesInfo,
-  listenToDataLakeVariablesInfoChanges,
-  unlistenToDataLakeVariablesInfoChanges,
-} from '@/libs/actions/data-lake'
-import { createMonacoEditor, monaco } from '@/libs/monaco-manager'
+import { type DataLakeVariable } from '@/libs/actions/data-lake'
 import { machinizeString } from '@/libs/utils'
 import type { PoiCoordinateSource, PointOfInterest, PointOfInterestCoordinates } from '@/types/mission'
 
@@ -192,208 +154,8 @@ const { showDialog } = useInteractionDialog()
 
 // Number-typed data-lake variables offered in the coordinate dropdowns. POIs' own backing
 // variables are excluded to avoid clutter and self-reference.
-const availableVariables = ref<
-  {
-    /** Data-lake variable id */
-    id: string
-    /** Human-readable variable name */
-    name: string
-  }[]
->([])
-
-const refreshAvailableVariables = (): void => {
-  availableVariables.value = Object.values(getAllDataLakeVariablesInfo())
-    .filter((variable) => variable.type === 'number' && !variable.id.startsWith('cockpit/pois/'))
-    .map((variable) => ({ id: variable.id, name: variable.name || variable.id }))
-    .sort((a, b) => a.name.localeCompare(b.name))
-}
-
-let variablesInfoListenerId: string | undefined
-onMounted(() => {
-  refreshAvailableVariables()
-  variablesInfoListenerId = listenToDataLakeVariablesInfoChanges(refreshAvailableVariables)
-})
-
-// Latitude/longitude expressions are edited in compact Monaco editors. Clicking an editor opens a
-// dropdown of every available variable; typing in the editor filters it (by the token under the
-// cursor) and picking one inserts a `{{ variable }}` reference at the cursor.
-const latEditorContainer = ref<HTMLElement | null>(null)
-const lngEditorContainer = ref<HTMLElement | null>(null)
-let latEditor: monaco.editor.IStandaloneCodeEditor | null = null
-let lngEditor: monaco.editor.IStandaloneCodeEditor | null = null
-
-type CoordinateField = 'lat' | 'lng'
-
-// Which editor's variable dropdown is open, and the term used to filter it.
-const activeField = ref<CoordinateField | null>(null)
-const variableFilter = ref('')
-
-// Set right after inserting a variable, so the programmatic re-focus does not immediately reopen the dropdown.
-let suppressReopen = false
-
-// Whether each field still shows its initial value (dialog just opened, not yet edited). While
-// pristine, clicking the field shows the full variable list instead of filtering by the pre-filled
-// number (which would otherwise match nothing).
-const pristine: Record<CoordinateField, boolean> = { lat: true, lng: true }
-
-const filteredVariables = computed(() => {
-  const term = variableFilter.value.toLowerCase()
-  if (!term) return availableVariables.value
-  return availableVariables.value.filter(
-    (variable) => variable.id.toLowerCase().includes(term) || variable.name.toLowerCase().includes(term)
-  )
-})
-
-const editorForField = (field: CoordinateField): monaco.editor.IStandaloneCodeEditor | null =>
-  field === 'lat' ? latEditor : lngEditor
-
-const textUntilCursor = (editor: monaco.editor.IStandaloneCodeEditor): string => {
-  const model = editor.getModel()
-  const position = editor.getPosition()
-  if (!model || !position) return ''
-  return model.getValueInRange({
-    startLineNumber: position.lineNumber,
-    startColumn: 1,
-    endLineNumber: position.lineNumber,
-    endColumn: position.column,
-  })
-}
-
-// The text the dropdown filters by: the partial name inside an open `{{ ... ` or, failing that, the
-// variable-like token immediately before the cursor.
-const filterTermAtCursor = (editor: monaco.editor.IStandaloneCodeEditor): string => {
-  const text = textUntilCursor(editor)
-  const lastOpen = text.lastIndexOf('{{')
-  if (lastOpen !== -1 && !text.includes('}}', lastOpen)) return text.slice(lastOpen + 2).trim()
-  return text.match(/[\w/.-]*$/)?.[0] ?? ''
-}
-
-const isPlainNumber = (value: string): boolean => value.trim() !== '' && Number.isFinite(Number(value))
-
-// The dropdown shows the full list while the field is pristine or holds a plain number (filtering by
-// a number matches nothing); otherwise it filters by the token under the cursor.
-const dropdownFilterTerm = (editor: monaco.editor.IStandaloneCodeEditor, field: CoordinateField): string => {
-  if (pristine[field] || isPlainNumber(editor.getValue())) return ''
-  return filterTermAtCursor(editor)
-}
-
-const insertVariable = (field: CoordinateField, variableId: string): void => {
-  const editor = editorForField(field)
-  const position = editor?.getPosition()
-  if (!editor || !position) return
-
-  const text = textUntilCursor(editor)
-  const lastOpen = text.lastIndexOf('{{')
-
-  // Replace an open `{{ ...` (or the trailing token) so picking from the dropdown never nests braces.
-  const startColumn =
-    lastOpen !== -1 && !text.includes('}}', lastOpen)
-      ? lastOpen + 1
-      : position.column - (text.match(/[\w/.-]*$/)?.[0].length ?? 0)
-
-  const range = new monaco.Range(position.lineNumber, startColumn, position.lineNumber, position.column)
-  editor.executeEdits('insert-data-lake-variable', [{ range, text: `{{ ${variableId} }}`, forceMoveMarkers: true }])
-  activeField.value = null
-  suppressReopen = true
-  editor.focus()
-}
-
-const createCoordinateEditor = (
-  field: CoordinateField,
-  container: HTMLElement,
-  value: string,
-  onChange: (value: string) => void
-): monaco.editor.IStandaloneCodeEditor => {
-  const editor = createMonacoEditor(container, {
-    language: 'plaintext',
-    value,
-    editorOverrides: {
-      lineNumbers: 'off',
-      glyphMargin: false,
-      folding: false,
-      lineDecorationsWidth: 8,
-      lineNumbersMinChars: 0,
-      fontSize: 13,
-      padding: { top: 8, bottom: 8 },
-      renderLineHighlight: 'none',
-      overviewRulerLanes: 0,
-      minimap: { enabled: false },
-      wordWrap: 'on',
-      scrollBeyondLastLine: false,
-      scrollbar: { vertical: 'hidden', horizontal: 'hidden' },
-      quickSuggestions: false,
-      wordBasedSuggestions: 'off',
-      suggestOnTriggerCharacters: false,
-      autoClosingBrackets: 'never',
-    },
-  })
-
-  // Grow the editor to fit its content so a wrapped long expression spans multiple lines instead of
-  // being clipped at a fixed height.
-  const applyAutoHeight = (): void => {
-    const contentHeight = editor.getContentHeight()
-    container.style.height = `${contentHeight}px`
-    editor.layout({ width: container.clientWidth, height: contentHeight })
-  }
-  editor.onDidContentSizeChange(applyAutoHeight)
-  applyAutoHeight()
-
-  pristine[field] = true
-
-  const openDropdown = (): void => {
-    activeField.value = field
-    variableFilter.value = dropdownFilterTerm(editor, field)
-  }
-
-  editor.onDidChangeModelContent(() => {
-    pristine[field] = false
-    onChange(editor.getValue().trim())
-    if (activeField.value === field) variableFilter.value = dropdownFilterTerm(editor, field)
-  })
-  editor.onMouseDown(openDropdown)
-  editor.onDidFocusEditorText(() => {
-    if (suppressReopen) {
-      suppressReopen = false
-      return
-    }
-    openDropdown()
-  })
-  editor.onDidChangeCursorPosition(() => {
-    if (activeField.value === field) variableFilter.value = dropdownFilterTerm(editor, field)
-  })
-  // Delay so a dropdown item's mousedown can run before blur closes the dropdown.
-  editor.onDidBlurEditorText(() =>
-    setTimeout(() => {
-      if (activeField.value === field) activeField.value = null
-    }, 150)
-  )
-  editor.onKeyDown((event) => {
-    if (event.keyCode === monaco.KeyCode.Escape) activeField.value = null
-  })
-
-  return editor
-}
-
-const initCoordinateEditors = (): void => {
-  if (latEditorContainer.value && !latEditor) {
-    latEditor = createCoordinateEditor('lat', latEditorContainer.value, newPoiLatExpression.value, (value) => {
-      newPoiLatExpression.value = value
-    })
-  }
-  if (lngEditorContainer.value && !lngEditor) {
-    lngEditor = createCoordinateEditor('lng', lngEditorContainer.value, newPoiLngExpression.value, (value) => {
-      newPoiLngExpression.value = value
-    })
-  }
-}
-
-const disposeCoordinateEditors = (): void => {
-  latEditor?.dispose()
-  lngEditor?.dispose()
-  latEditor = null
-  lngEditor = null
-  activeField.value = null
-}
+const isCoordinateVariable = (variable: DataLakeVariable): boolean =>
+  variable.type === 'number' && !variable.id.startsWith('cockpit/pois/')
 
 const poiDialogVisible = ref(false)
 const newPoiName = ref('')
@@ -408,21 +170,6 @@ const newPoiLngExpression = ref('')
 const isIconPickerOpen = ref(false)
 const iconSearchQuery = ref('')
 const isColorPickerOpen = ref(false)
-
-// Spin the expression editors up while the dialog is open, and tear them down on close so Monaco
-// instances are not leaked across opens.
-watch(poiDialogVisible, (visible) => {
-  if (visible) {
-    nextTick(initCoordinateEditors)
-  } else {
-    disposeCoordinateEditors()
-  }
-})
-
-onUnmounted(() => {
-  disposeCoordinateEditors()
-  if (variablesInfoListenerId) unlistenToDataLakeVariablesInfoChanges(variablesInfoListenerId)
-})
 
 // Snapshot of the POI as it was when the dialog opened, used to revert unsaved live-preview edits.
 const originalPoi = ref<PointOfInterest | null>(null)
@@ -796,95 +543,6 @@ defineExpose({
 .poi-dialog-text-fields .v-select .v-field__input {
   padding-top: 4px;
   padding-bottom: 4px;
-}
-
-/* Outlined field with a notched label (the legend cuts the top border, like a v-text-field). */
-.poi-field {
-  min-inline-size: 0;
-  margin: 0;
-  padding: 2px 8px 6px;
-  border: 1px solid rgba(255, 255, 255, 0.38);
-  border-radius: 4px;
-}
-
-.poi-field-legend {
-  display: flex;
-  align-items: center;
-  gap: 2px;
-  margin-left: 4px;
-  padding: 0 4px;
-  font-size: 12px;
-  line-height: 1;
-  color: #ffffffb3;
-}
-
-.poi-expression-wrapper {
-  position: relative;
-}
-
-.poi-expression-editor {
-  min-height: 36px;
-  width: 100%;
-  overflow: visible;
-}
-
-.poi-expression-editor .monaco-editor,
-.poi-expression-editor .monaco-editor .margin,
-.poi-expression-editor .monaco-editor-background {
-  background-color: transparent !important;
-}
-
-.poi-expression-editor .monaco-editor,
-.poi-expression-editor .monaco-editor.focused,
-.poi-expression-editor .monaco-editor .inputarea {
-  outline: none !important;
-  border: none !important;
-  box-shadow: none !important;
-}
-
-.poi-expression-editor .monaco-editor .overflow-guard {
-  border-radius: 4px;
-}
-
-.poi-var-dropdown {
-  position: absolute;
-  top: calc(100% + 2px);
-  left: 0;
-  right: 0;
-  z-index: 30;
-  max-height: 220px;
-  overflow-y: auto;
-  background-color: #1e1e1e;
-  border: 1px solid #ffffff33;
-  border-radius: 4px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
-}
-
-.poi-var-option {
-  display: flex;
-  flex-direction: column;
-  padding: 6px 10px;
-  cursor: pointer;
-}
-
-.poi-var-option:hover {
-  background-color: rgba(255, 255, 255, 0.1);
-}
-
-.poi-var-name {
-  font-size: 13px;
-  color: #ffffffde;
-}
-
-.poi-var-id {
-  font-size: 11px;
-  color: #ffffff80;
-}
-
-.poi-var-empty {
-  padding: 8px 10px;
-  font-size: 12px;
-  color: #ffffff80;
 }
 
 .poi-color-picker {

--- a/src/libs/data-lake-expression-input.ts
+++ b/src/libs/data-lake-expression-input.ts
@@ -1,6 +1,6 @@
 /**
- * Pure text logic behind the data-lake expression input: what its variable dropdown filters by, and
- * where an inserted `{{ variable }}` reference starts.
+ * Pure logic behind the data-lake expression input: what its variable dropdown filters by, where an
+ * inserted `{{ variable }}` reference starts, and how the keyboard moves through the dropdown.
  */
 
 const trailingTokenRegex = /[\w/.-]*$/
@@ -35,4 +35,16 @@ export const insertionStartColumn = (textUntilCursor: string, cursorColumn: numb
   const lastOpen = openReferenceStart(textUntilCursor)
   if (lastOpen !== -1) return lastOpen + 1
   return cursorColumn - (textUntilCursor.match(trailingTokenRegex)?.[0].length ?? 0)
+}
+
+/**
+ * Where the dropdown highlight lands when the user moves through the list, wrapping at both ends.
+ * @param {number} current - Currently highlighted option, `-1` while none is active
+ * @param {number} lastIndex - Index of the list's last option
+ * @param {'down' | 'up'} direction - Direction the user moved in
+ * @returns {number} The option to highlight
+ */
+export const nextHighlightedIndex = (current: number, lastIndex: number, direction: 'down' | 'up'): number => {
+  if (direction === 'down') return current >= lastIndex ? 0 : current + 1
+  return current <= 0 ? lastIndex : current - 1
 }

--- a/src/libs/data-lake-expression-input.ts
+++ b/src/libs/data-lake-expression-input.ts
@@ -1,0 +1,38 @@
+/**
+ * Pure text logic behind the data-lake expression input: what its variable dropdown filters by, and
+ * where an inserted `{{ variable }}` reference starts.
+ */
+
+const trailingTokenRegex = /[\w/.-]*$/
+
+// Start of an unclosed `{{`, meaning the cursor sits inside a reference the user is still typing.
+const openReferenceStart = (textUntilCursor: string): number => {
+  const lastOpen = textUntilCursor.lastIndexOf('{{')
+  if (lastOpen === -1 || textUntilCursor.includes('}}', lastOpen)) return -1
+  return lastOpen
+}
+
+/**
+ * Term the variable dropdown filters by: the partial name inside an open `{{ ... `, or the
+ * variable-like token immediately before the cursor.
+ * @param {string} textUntilCursor - The line's content from its start up to the cursor
+ * @returns {string} The filter term, empty when there is nothing to filter by
+ */
+export const filterTermAtCursor = (textUntilCursor: string): string => {
+  const lastOpen = openReferenceStart(textUntilCursor)
+  if (lastOpen !== -1) return textUntilCursor.slice(lastOpen + 2).trim()
+  return textUntilCursor.match(trailingTokenRegex)?.[0] ?? ''
+}
+
+/**
+ * Column an inserted `{{ variable }}` starts at, so picking from the dropdown replaces an open
+ * `{{ ...` instead of nesting braces inside it, or otherwise the token being typed.
+ * @param {string} textUntilCursor - The line's content from its start up to the cursor
+ * @param {number} cursorColumn - Monaco's 1-based cursor column
+ * @returns {number} The 1-based column the insertion should start at
+ */
+export const insertionStartColumn = (textUntilCursor: string, cursorColumn: number): number => {
+  const lastOpen = openReferenceStart(textUntilCursor)
+  if (lastOpen !== -1) return lastOpen + 1
+  return cursorColumn - (textUntilCursor.match(trailingTokenRegex)?.[0].length ?? 0)
+}

--- a/src/libs/utils-data-lake.ts
+++ b/src/libs/utils-data-lake.ts
@@ -71,6 +71,22 @@ export const replaceDataLakeInputsInString = (input: string, replaceFunction?: (
 }
 
 /**
+ * Get the id of the single data lake variable a string is made of, be it a bare id, taken as-is
+ * without checking it exists, or a lone '{{ }}' reference. A string mixing a reference with other
+ * text has no sole variable.
+ * @param {string} input The string to inspect
+ * @returns {string | null} The variable id, or null when the string is not a single variable
+ */
+export const getSoleDataLakeVariableIdInString = (input: string): string | null => {
+  const value = input.trim()
+  if (value === '') return null
+
+  const inputs = findDataLakeInputsInString(value)
+  if (inputs.length === 0) return value
+  return inputs.length === 1 && inputs[0] === value ? getDataLakeVariableIdFromInput(value) : null
+}
+
+/**
  * Find all data lake variable ids in a string.
  * @param {string} input The string to search for data lake variable ids
  * @returns {string[]} An array of data lake variable ids


### PR DESCRIPTION
Fixes #992

The Very Generic Indicator's variable field now takes a data-lake template, so a single indicator can show `Lat {{ ... }} Lng {{ ... }}` instead of needing one indicator per coordinate. As suggested in the issue, this reuses the expression input the POI dialog already had, rather than inventing a second one — so the first commit extracts that input into a shared component and the second uses it.

## `DataLakeExpressionInput`

`PoiManager.vue` had ~180 lines of inline Monaco wiring for its latitude/longitude fields: a compact editor plus a dropdown that inserts `{{ variable }}` at the cursor. That moves to `src/components/DataLakeExpressionInput.vue` unchanged in behavior, with a `variableFilter` prop for the POI dialog's "number-typed, excluding `cockpit/pois/`" rule and a `hint` slot for the per-field tooltip.

The cursor rules — what the dropdown filters by, and where an insertion starts so picking a variable never nests braces — are pure string logic, so they moved to `src/libs/data-lake-expression-input.ts`.

A third commit then makes the variable list keyboard-reachable, which it never was in the POI dialog: arrow keys move through the options, Enter inserts the highlighted one, and `role="listbox"`/`role="option"` plus `aria-activedescendant` on Monaco's textarea let a screen reader announce it. Not a regression, but this is the PR that turns that list into shared UI in two dialogs.

## Indicator behavior

`getSoleDataLakeVariableIdInString` decides how a stored value is read:

| Stored value | Behavior |
| --- | --- |
| `mavlink/1/1/VFR_HUD/alt` | reads that variable (unchanged) |
| `{{ mavlink/1/1/VFR_HUD/alt }}` | reads that variable |
| `Lat {{ a }} Lng {{ b }}` | interpolated template |

That middle row matters: the dropdown always inserts a `{{ }}` reference, so treating a lone reference as a plain variable is what keeps the multiplier and decimal places working when you just pick one variable. Multiplier, decimal places and "use string variable" are disabled only for real templates, where they have nothing to apply to.

Templates resolve through the existing `useResolvedDataLakeTemplate`, which subscribes to each referenced variable. A reference the data lake has no value for — a typo, or any variable before its first message — shows `--` instead of the raw id. No new storage key and no migration — existing indicators store a bare id and keep working as-is.

One consequence of reusing the key rather than versioning it, on the record: `variableName` is vehicle-synced, so a topside computer still on an older Cockpit that opens a synced template runs the old ungated `.` → `/` rewrite over the template's prose and syncs the result back, turning `Alt. {{ ... }}` into `Alt/ {{ ... }}` for everyone. A new key would avoid that, at the cost of stranding every indicator already configured — not worth it for a field this old.

Fixes that come with it, all consequences of the feature except the first:
- the direct subscription now goes through the existing `useDataLakeVariable`, which re-points it when the variable changes and releases it on unmount. That replaces the widget's own listener, which leaked one per change — a pre-existing bug that has its own PR in #2921, and whichever lands second drops its copy
- the legacy dotted-name rewrite (`.` → `/`) now only runs on a lone id, since on the free-text field it would otherwise eat the punctuation of anything the user writes and persist the result
- the datalogger watches `parsedState` rather than `finalValue`, which is `NaN` for a template
- the overflow marquee now measures the rendered text and scrolls by exactly what does not fit, instead of keying off the numeric value, which never engaged for a template

## Checks
- `yarn lint` and `yarn build` clean.
- No test is added or changed. `cosmos.test.ts` and `connection.test.ts` fail on this branch and on `master` alike, from `localStorage` in the test environment.
- Note `yarn typecheck` exits without checking anything on this branch *and* on `master` (`languageId not found for src/App.vue`), so it gave no signal here.

## Test plan
- [ ] Add a VGI, pick a single variable from the dropdown, confirm multiplier and decimal places still apply.
- [ ] Write `Lat {{ ... }} Lng {{ ... }}` and confirm both values update live, and that a value wider than the indicator scrolls instead of being clipped.
- [ ] Reference a variable that does not exist and confirm the indicator shows `--` rather than the id.
- [ ] Confirm an indicator configured before this change still reads its variable.
- [ ] Type free text with a dot in it (e.g. `Alt. {{ ... }}`), reload, and confirm it comes back as written.
- [ ] Confirm the POI dialog's latitude/longitude fields behave as before.
- [ ] With the field focused, walk the dropdown with the arrow keys and insert with Enter, in both the indicator and the POI dialog.



