### PR TITLE
Mission Control Panel: Show cruise speed also on the mini-widget

### DIFF
--- a/src/components/mini-widgets/MiniMissionControlPanel.vue
+++ b/src/components/mini-widgets/MiniMissionControlPanel.vue
@@ -50,7 +50,7 @@
           />
         </template>
       </v-tooltip>
-      <CruiseSpeedControl icon-class="text-[16px]" :show-speed-value="false" />
+      <CruiseSpeedControl compact />
       <v-tooltip location="top" open-delay="800" text="Return to home">
         <template #activator="{ props: homeProps }">
           <v-btn

--- a/src/components/mission-planning/CruiseSpeedControl.vue
+++ b/src/components/mission-planning/CruiseSpeedControl.vue
@@ -9,7 +9,7 @@
               size="x-small"
               icon="mdi-speedometer"
               variant="text"
-              :class="iconClass"
+              :class="compact ? 'text-[16px]' : 'text-[18px]'"
               :disabled="!vehicleStore.isVehicleOnline"
             />
           </template>
@@ -33,8 +33,12 @@
       </div>
     </v-menu>
     <span
-      v-if="showSpeedValue"
-      class="absolute left-1/2 top-full -translate-x-1/2 mt-[-5px] px-[3px] rounded-[2px] bg-white text-[#333333] text-[8px] font-bold leading-[11px] select-none pointer-events-none"
+      class="absolute left-1/2 top-full -translate-x-1/2 px-[3px] rounded-[2px] bg-white text-[#333333] font-bold select-none pointer-events-none"
+      :class="
+        compact
+          ? 'text-[7.2px] leading-[10px] mt-[-11px] border-2 border-slate-800'
+          : 'text-[8px] leading-[11px] mt-[-5px]'
+      "
       aria-hidden="true"
     >
       {{ liveCruiseSpeed.toFixed(1) }}
@@ -50,19 +54,12 @@ import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useMissionStore } from '@/stores/mission'
 
-withDefaults(
-  defineProps<{
-    /**
-     * Classes applied to the speedometer icon button
-     */
-    iconClass?: string
-    /**
-     * Whether the commanded speed is shown as a tag under the button
-     */
-    showSpeedValue?: boolean
-  }>(),
-  { iconClass: 'text-[18px]', showSpeedValue: true }
-)
+defineProps<{
+  /**
+   * Render the compact variant sized for the mini-widget bar (smaller icon, bordered speed tag)
+   */
+  compact?: boolean
+}>()
 
 const interfaceStore = useAppInterfaceStore()
 const missionStore = useMissionStore()


### PR DESCRIPTION
**Problem:**

- The compact mission control panel in the bottom bar showed only the speedometer icon, so the commanded cruise speed was readable only after opening the speed menu.

**Fix:**

- The commanded cruise speed now sits under the speedometer icon on the compact panel too, matching the full panel.
- The compact tag is drawn slightly smaller and closer to the icon, with a dark border that separates it from the icon, so it fits the short bar and stays legible.

Image 1 - The mini mission control panel now shows the commanded cruise speed under the speedometer icon,
<img width="757" height="312" alt="image" src="https://github.com/user-attachments/assets/76c750ed-cdbf-4f5b-8c33-6de8f2f60909" />

Closes #2916