### PR TITLE
fix: widgets: keep the Very Generic Indicator subscribed to its variable

### DIFF
--- a/src/assets/defaults.ts
+++ b/src/assets/defaults.ts
@@ -267,7 +267,7 @@ export const widgetProfiles: Profile[] = [
                 name: 'VeryGenericIndicator',
                 options: {
                   displayName: 'Water Temp',
-                  variableName: 'SCALED_PRESSURE2.temperature',
+                  variableName: 'SCALED_PRESSURE2/temperature',
                   iconName: 'mdi-thermometer',
                   variableUnit: '°C',
                   variableMultiplier: '.01',
@@ -610,7 +610,7 @@ export const widgetProfiles: Profile[] = [
                 name: 'VeryGenericIndicator',
                 options: {
                   displayName: 'Water Temp',
-                  variableName: 'SCALED_PRESSURE2.temperature',
+                  variableName: 'SCALED_PRESSURE2/temperature',
                   iconName: 'mdi-thermometer',
                   variableUnit: '°C',
                   variableMultiplier: '.01',

--- a/src/components/mini-widgets/VeryGenericIndicator.vue
+++ b/src/components/mini-widgets/VeryGenericIndicator.vue
@@ -306,16 +306,13 @@
 <script setup lang="ts">
 import { useElementSize, watchThrottled } from '@vueuse/core'
 import Fuse from 'fuse.js'
-import { computed, onBeforeMount, onMounted, ref, toRefs, watch } from 'vue'
+import { computed, onBeforeMount, onMounted, onUnmounted, ref, toRefs, watch } from 'vue'
 
 import VgiIcon from '@/components/mini-widgets/VgiIcon.vue'
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { useCustomIcons } from '@/composables/useCustomIcons'
-import {
-  getDataLakeVariableData,
-  listenDataLakeVariable,
-  listenToDataLakeVariablesInfoChanges,
-} from '@/libs/actions/data-lake'
+import { useDataLakeVariable } from '@/composables/useDataLakeVariable'
+import { listenToDataLakeVariablesInfoChanges, unlistenToDataLakeVariablesInfoChanges } from '@/libs/actions/data-lake'
 import { getAllDataLakeVariablesInfo } from '@/libs/actions/data-lake'
 import { type CustomIcon, customIconRefFromId, idFromCustomIconRef, isCustomIconRef } from '@/libs/custom-icons'
 import { CurrentlyLoggedVariables, datalogger } from '@/libs/sensors-logging'
@@ -367,7 +364,9 @@ onBeforeMount(() => {
 
 const widgetStore = useWidgetManagerStore()
 
-const currentState = ref<unknown>(0)
+// Keyed on the variable name so that every writer of it — the config dialog, a preset, or a BlueOS
+// profile sync, which patches the widget in place rather than remounting it — resubscribes.
+const { value: currentState } = useDataLakeVariable(() => miniWidget.value.options.variableName)
 
 const finalValue = computed(() => Number(miniWidget.value.options.variableMultiplier) * Number(currentState.value))
 
@@ -433,9 +432,6 @@ const closeVgiDialog = async (): Promise<void> => {
   managerVars.configMenuOpen = false
 }
 
-const updateVariableState = (): void => {
-  currentState.value = getDataLakeVariableData(miniWidget.value.options.variableName)
-}
 const updateWidgetName = (): void => {
   miniWidget.value.name = miniWidget.value.options.displayName || miniWidget.value.options.variableName
 }
@@ -444,6 +440,8 @@ const updateGenericVariablesNames = (): void => {
   allVariablesNames.value = variablesNames
   // TODO: Update CurrentlyLoggedVariables to match data lake state
 }
+
+let variablesInfoListenerId: string | undefined
 
 const logData = computed(() => ({
   displayName: props.miniWidget.options.displayName,
@@ -484,18 +482,9 @@ watch(
   { immediate: true }
 )
 
-// Watch for changes in the data lake variable
-watch(
-  () => miniWidget.value.options.variableName,
-  (newVariableName) => {
-    if (!newVariableName) return
-    updateVariableState()
-  }
-)
 watch(
   miniWidget,
   () => {
-    updateVariableState()
     updateWidgetName()
     updateGenericVariablesNames()
   },
@@ -508,7 +497,6 @@ onMounted(() => {
     miniWidget.value.options.variableName = miniWidget.value.options.variableName.replaceAll('.', '/')
   }
 
-  updateVariableState()
   updateWidgetName()
   updateGenericVariablesNames()
 
@@ -517,11 +505,13 @@ onMounted(() => {
   }
 
   // Update list of available variables when the data-lake has new stuff
-  listenToDataLakeVariablesInfoChanges(updateGenericVariablesNames)
-
-  chooseVariable(miniWidget.value.options.variableName)
+  variablesInfoListenerId = listenToDataLakeVariablesInfoChanges(updateGenericVariablesNames)
 
   lastWidgetName.value = miniWidget.value.options.displayName
+})
+
+onUnmounted(() => {
+  if (variablesInfoListenerId !== undefined) unlistenToDataLakeVariablesInfoChanges(variablesInfoListenerId)
 })
 
 const fuseOptions = { includeScore: true, ignoreLocation: true, threshold: 0.3 }
@@ -624,8 +614,6 @@ const chooseVariable = (variable: string): void => {
   miniWidget.value.options.variableName = variable
   variableNameSearchString.value = ''
   showVariableChooseModal.value = false
-
-  listenDataLakeVariable(variable, updateVariableState)
 }
 
 const onChooseVariable = (variable: string): void => {

--- a/src/components/mini-widgets/VeryGenericIndicator.vue
+++ b/src/components/mini-widgets/VeryGenericIndicator.vue
@@ -650,6 +650,8 @@ const setIndicatorFromTemplate = (template: VeryGenericIndicatorPreset): void =>
   miniWidget.value.options.variableUnit = template.variableUnit
   miniWidget.value.options.variableMultiplier = template.variableMultiplier
   miniWidget.value.options.decimalPlaces = template.decimalPlaces ?? null
+  // Every preset is numeric, and this flag would bypass both the multiplier and the decimal places.
+  miniWidget.value.options.useStringVariable = false
 }
 </script>
 

--- a/src/tests/types/genericIndicator.test.ts
+++ b/src/tests/types/genericIndicator.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+
+import { veryGenericIndicatorPresets } from '@/types/genericIndicator'
+
+describe('Very Generic Indicator presets', () => {
+  // Data-lake ids are built as `${messageName}/${field}`, so a dotted id silently never resolves
+  // and the preset shows no value until the widget's mount-time migration rewrites it.
+  it('binds every preset to a slash-separated data-lake id', () => {
+    const dotted = veryGenericIndicatorPresets.filter((preset) => preset.variableName.includes('.'))
+    expect(dotted.map((preset) => preset.displayName)).toEqual([])
+  })
+})

--- a/src/types/genericIndicator.ts
+++ b/src/types/genericIndicator.ts
@@ -46,7 +46,7 @@ export const veryGenericIndicatorPresets: VeryGenericIndicatorPreset[] = [
   },
   {
     displayName: 'Water Temp',
-    variableName: 'SCALED_PRESSURE2.temperature',
+    variableName: 'SCALED_PRESSURE2/temperature',
     iconName: 'mdi-thermometer',
     variableUnit: '°C',
     variableMultiplier: 0.01,


### PR DESCRIPTION
## Summary

Three pre-existing defects in the Very Generic Indicator, each in its own commit. All of them predate the Speed preset (#2902) and affect the widget generally.

- **The indicator only subscribed from `chooseVariable`** (#2919, #2920). It discarded the listener id, never released the previous variable and had no unmount counterpart, so listeners accumulated per variable change and outlived the widget. Registering from that one producer also missed every other writer of `options.variableName`: applying a preset assigned it directly and so never subscribed at all, freezing the value at a single reading until the widget remounted — which closing the config dialog does not do, since mini-widgets are keyed by hash. A BlueOS profile sync has the same shape, replacing the stored object wholesale while the hash stays put. `useDataLakeVariable` already watches an id getter, resubscribes on change and releases on unmount, so this uses it and drops the local bookkeeping, covering every writer at the value they all go through. Net deletion.
- **Applying a preset kept the string parse mode** (#2920). Every preset is numeric, but `useStringVariable` was left as it was, and with it set `parsedState` returns the raw value before the multiplier and the decimal places are applied — Water Temp showing raw centidegrees rather than `raw * 0.01`, with the two inputs that would explain it greyed out.
- **The Water Temp indicator asked for an id nothing produces.** The preset and both default profiles used `SCALED_PRESSURE2.temperature`, but data-lake ids are built as `${messageName}/${field}`; the dotted form only ever existed as input to the widget's mount-time dot-to-slash migration. So that preset subscribed to an id that never receives a value and sat at `--` until the app was reloaded. Fixed in the defaults too, so they stop depending on a migration marked for removal before 1.0.0.

The first commit is what fixes the symptom reported on #2902: a preset reading 0 until Cockpit is restarted.

## Test plan

- [ ] Apply a preset to a widget that already had a different variable, and confirm it starts tracking the new one immediately, with no restart
- [ ] Confirm the Water Temp preset shows a live temperature rather than `--`
- [ ] Tick "use string variable" on a VGI, then apply a preset, and confirm the value comes back scaled with the checkbox cleared
- [ ] Switch a VGI's variable several times, then delete the widget, and confirm the indicator keeps working elsewhere and nothing keeps updating in the background
- [ ] With two operators on one vehicle, change a VGI's variable on one and confirm the other tracks the new variable after the profile syncs
- [ ] Confirm an unconfigured VGI still shows `--` and every other preset still applies cleanly

Closes #2919
Closes #2920