### PR TITLE
Add VGI preset and data-lake alias for the Celsius 2 sensor

### DIFF
--- a/src/components/mini-widgets/VeryGenericIndicator.vue
+++ b/src/components/mini-widgets/VeryGenericIndicator.vue
@@ -271,11 +271,11 @@
           </v-window-item>
 
           <v-window-item value="presets">
-            <div class="flex flex-wrap items-center justify-around">
+            <div class="grid items-center grid-cols-3">
               <div
                 v-for="(template, i) in veryGenericIndicatorPresets"
                 :key="i"
-                class="flex items-center justify-center px-2 m-2 text-white transition-all rounded-md cursor-pointer hover:bg-slate-100/20"
+                class="flex items-center px-2 m-2 text-white transition-all rounded-md cursor-pointer hover:bg-slate-100/20"
                 @click="setIndicatorFromTemplate(template)"
               >
                 <VgiIcon class="relative w-[2rem] icon-symbol text-[34px] mx-2" :icon-name="template.iconName" />

--- a/src/libs/vehicle/mavlink/vehicle.ts
+++ b/src/libs/vehicle/mavlink/vehicle.ts
@@ -367,6 +367,17 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
         this.onAttitude.emit()
         break
       }
+      case MAVLinkType.BATTERY_STATUS: {
+        const batteryStatus = mavlink_message.message as Message.BatteryStatus
+        // The Celsius 2 reports through the battery monitor, so its reading arrives as the temperature of battery
+        // instance 0 (`TEMP2_SRC_ID: 1` on the vehicle, which ArduPilot decrements), in centidegrees. Vehicles
+        // without the sensor send INT16_MAX (32767) instead, which would otherwise read as a 327.67 °C ocean.
+        if (batteryStatus.id === 0 && batteryStatus.temperature !== 32767) {
+          const temperatureC = batteryStatus.temperature / 100
+          setDataLakeVariableData(this.preDefinedDataLakeVariables.celsius2Temperature.id, temperatureC)
+        }
+        break
+      }
       case MAVLinkType.GIMBAL_DEVICE_ATTITUDE_STATUS: {
         const attitude = mavlink_message.message as Message.GimbalDeviceAttitudeStatus
 
@@ -1485,6 +1496,7 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
       cameraTiltLegacy: { id: 'cameraTiltDeg', name: '(Legacy) Camera Tilt Degrees', type: 'number' },
       autopilotSystemId: { id: 'autopilotSystemId', name: 'Autopilot System ID', type: 'number' },
       cameraTilt: { id: `${vehiclePath}/cameraTiltDeg`, name: `Camera Tilt [degrees] (${vehicleName})`, type: 'number' },
+      celsius2Temperature: { id: 'celsius2TemperatureC', name: 'Celsius 2 Temperature [°C]', type: 'number' },
       networkLatencyMs: { id: `${vehiclePath}/networkLatencyMs`, name: `Network Latency [ms] (${vehicleName})`, type: 'number' },
     }
     /* eslint-enable vue/max-len, prettier/prettier, max-len */

--- a/src/types/genericIndicator.ts
+++ b/src/types/genericIndicator.ts
@@ -108,4 +108,14 @@ export const veryGenericIndicatorPresets: VeryGenericIndicatorPreset[] = [
     variableMultiplier: 1,
     decimalPlaces: 1,
   },
+  {
+    // The Celsius 2 reports through the battery monitor, so its reading arrives as the temperature of
+    // battery instance 0 (`TEMP2_SRC_ID: 1` on the vehicle, which ArduPilot decrements), in centidegrees.
+    displayName: 'Celsius 2',
+    variableName: 'BATTERY_STATUS/id=0/temperature',
+    iconName: 'mdi-thermometer',
+    variableUnit: '°C',
+    variableMultiplier: 0.01,
+    decimalPlaces: 1,
+  },
 ]

--- a/src/types/genericIndicator.ts
+++ b/src/types/genericIndicator.ts
@@ -109,13 +109,11 @@ export const veryGenericIndicatorPresets: VeryGenericIndicatorPreset[] = [
     decimalPlaces: 1,
   },
   {
-    // The Celsius 2 reports through the battery monitor, so its reading arrives as the temperature of
-    // battery instance 0 (`TEMP2_SRC_ID: 1` on the vehicle, which ArduPilot decrements), in centidegrees.
     displayName: 'Celsius 2',
-    variableName: 'BATTERY_STATUS/id=0/temperature',
+    variableName: 'celsius2TemperatureC',
     iconName: 'mdi-thermometer',
     variableUnit: '°C',
-    variableMultiplier: 0.01,
+    variableMultiplier: 1,
     decimalPlaces: 1,
   },
 ]


### PR DESCRIPTION
## Summary

Three commits, all about making the Blue Robotics Celsius 2 usable from Cockpit.

**1. `celsius2TemperatureC` data-lake variable.** The Celsius 2 does not report on a `SCALED_PRESSURE` message like the Bar30 and the original Celsius do. BlueOS's ArduSub defaults hand its reading to the battery monitor, so it arrives inside `BATTERY_STATUS`, in centidegrees. Nobody looking for a temperature sensor searches the data lake for a battery message, and the raw field reads `2350` for 23.5 °C — a variable named after a temperature sensor that reads 2350 is a trap. So the value is republished under a name people will actually find, already converted to °C.

This reuses the existing predefined-variable mechanism in `src/libs/vehicle/mavlink/vehicle.ts` (`preDefinedDataLakeVariables` + a `setDataLakeVariableData` call from the message handler) — the same one behind `cameraTiltDeg`, which likewise exposes a friendly, unit-converted alias of a value buried in a MAVLink message. A transforming function was the other candidate and was rejected: it would persist into `cockpit-transforming-functions`, leaving permanent, user-editable settings data on every install for a sensor most vehicles do not have.

**2. A `Celsius 2` VGI preset**, binding to `celsius2TemperatureC` with a `1` multiplier, a thermometer icon and one decimal place, which is the sensor's rated accuracy. The name says which sensor the reading comes from, so it is not confused with the existing `Water Temp` preset, which is the Bar30's reading.

**3. The presets chooser now lays its entries on a fixed grid.** It sized every entry by its own content and spread each row with `justify-around`, so the columns landed somewhere different on every row — visible in @ArturoManzoli's review screenshot, and present before this PR too. Three equal columns keep the icons lined up whatever the preset names happen to be.

| Before | After |
| --- | --- |
| ragged columns, each row offset differently | every column aligned |

Details worth checking:

- Battery instance 0 is where the reading lands, not 1: the [BlueOS parameter repository](https://github.com/bluerobotics/Blueos-Parameter-Repository/blob/master/params/ardupilot/ArduSub/hardware/tmp119.params) sets `TEMP2_SRC: 3` (battery index) with `TEMP2_SRC_ID: 1`, and ArduPilot's temperature backend [subtracts one from that id](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Backend.cpp#L110) before handing the value over, so the sensor writes to the vehicle's first configured battery.
- Vehicles with no temperature to report send `INT16_MAX` in that field, so the variable is only written when the reading is real. Without that guard, every vehicle without a Celsius 2 would advertise a 327.67 °C ocean.
- The variable id is unprefixed, for the same reason as #2902: a `/mavlink/1/1/...` id would pin the preset to system 1, while an unprefixed id follows whatever MAVLink system ID the vehicle has. It is only written for the connected vehicle.
- The alias is created as soon as a vehicle connects, so the preset resolves before any battery message arrives; until one does, the indicator shows `--` and fills in on the first reading.
- The preset name is deliberately short. The indicator's label is hard-clipped at `widgetWidth - 52` px with no ellipsis, so anything longer than about 84px is silently truncated at the default width — `Celsius 2 Temp` rendered as `Celsius 2 Te`. That clipping is a pre-existing indicator bug rather than a preset one, so it is not fixed here.

Verified by feeding a `BATTERY_STATUS` with `id=0, temperature=2350` through the real vehicle handler and mounting an indicator bound to the preset: the data-lake value reads `23.5` and the indicator renders `23.5 °C`.

## Test plan

- [ ] With a Celsius 2 on the vehicle, confirm `celsius2TemperatureC` appears in the data-lake variable list and reads a plausible water temperature in °C, not centidegrees
- [ ] On a vehicle without a Celsius 2, confirm the variable stays empty instead of reading 327.67
- [ ] Open a VGI mini-widget config and confirm a **Celsius 2** preset appears, with a thermometer icon, and that every preset column lines up
- [ ] Apply it and confirm the unit is °C and the indicator matches the data-lake value
- [ ] Confirm it resolves on a vehicle whose system ID is not 1

Closes #2923