### PR TITLE
Stop requiring tests or runnable checks on PRs

### DIFF
--- a/.github/claude-review/review-guidelines.md
+++ b/.github/claude-review/review-guidelines.md
@@ -219,8 +219,7 @@ Sub-check ALL of the following, but only write out the ones that produce a findi
 - Behavior changes ride alone: flag a fix or a modification to existing behavior folded into a feature commit that happens to touch the same code. It has to be reviewable on its own, and revertable or backportable without dragging the feature along. The exception is a large refactor of that same behavior, where the change genuinely belongs to the refactor commit and splitting it out would be artificial.
 
 ### 9. Tests
-- Missing coverage for new logic, brittle tests, tests that were removed/weakened, testability concerns.
-- Non-trivial logic should leave behind at least ONE runnable check (an assert-based self-check or a small test) that fails if the logic breaks. Flag non-trivial additions that ship with no such check. Trivial one-liners need none.
+- Brittle tests, tests that were removed/weakened, testability concerns. Do not ask for new tests or checks for logic the PR adds — that is not a requirement here.
 
 ### 10. Documentation
 - README updates when a feature differs between Lite and Standalone (per AGENTS.md), in-code JSDoc, user-facing docs, changelog-worthy items.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,8 +64,6 @@ Prefer deletion over addition, boring over clever, and the shortest working diff
 
 **Do not be lazy about:** understanding the problem, input validation at trust boundaries, error handling that prevents data loss, security, accessibility, and the calibration real hardware needs (clocks drift, sensors read off — the vehicle is never the spec ideal).
 
-**Leave one runnable check.** Non-trivial logic must leave behind at least ONE runnable check — the smallest thing that fails if the logic breaks (an assert-based self-check or one small test; no new frameworks or fixtures). Trivial one-liners need none.
-
 **Mark deliberate corner-cuts.** When you knowingly cut a real corner with a known ceiling (global lock, O(n²) scan, naive heuristic), leave a `ponytail:` comment naming the ceiling and the upgrade path.
 
 ## Scope discipline


### PR DESCRIPTION
Removes the rule that every non-trivial change must ship a test or an assert-based self-check, and the matching instruction in the automated reviewer's guidelines.

We don't have yet a good testing suit nor a hard decision on that, so let's keep as it is for now.

- `AGENTS.md`: drops the "Leave one runnable check" paragraph.
- `.github/claude-review/review-guidelines.md`: section 9 no longer asks for coverage of new logic or for a runnable check, and is explicitly told not to raise it. It still flags brittle tests, tests removed or weakened by the PR, and testability concerns.