### PR TITLE
Give the PR reviewer the turns to finish a large PR

### DIFF
--- a/.github/workflows/claude-pr-review-continue.yml
+++ b/.github/workflows/claude-pr-review-continue.yml
@@ -179,8 +179,11 @@ jobs:
           model: ${{ vars.CLAUDE_AGENT_MODEL || 'claude-opus-5' }}
           # The investigation passes are search-heavy — tracing callers out to an entry point is
           # several greps per changed function — and at 40 the budget was spent before they started.
-          max_turns: "80"
-          timeout_minutes: "25"
+          # 80 then died mid-investigation on a rebased PR, where the compare covers the whole diff
+          # again and every file has to be re-read: the run ended having written no review at all.
+          # 120 turns measured out at ~22min, so the timeout has to clear that with room to spare.
+          max_turns: "120"
+          timeout_minutes: "35"
           allowed_tools: "Bash(jq:*),Bash(wc:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(rg:*),View,GlobTool,GrepTool,BatchTool,Write"
           system_prompt: |
             You are the automated code review agent for `bluerobotics/cockpit`, running inside a GitHub Actions workflow.
@@ -251,9 +254,9 @@ jobs:
         continue-on-error: true
         env:
           EXECUTION_FILE: ${{ steps.review.outputs.execution_file }}
-          # An estimate until the first runs land: re-derive it from the cost line this step prints,
-          # the way DEMO_BUDGET_USD was. max_turns is what actually caps spend; this only reports.
-          REVIEW_BUDGET_USD: '4.00'
+          # Derived from the cost line this step prints: 80 turns landed at $3.83-$4.02, so 120 turns
+          # sits near $6. max_turns is what actually caps spend; this only reports.
+          REVIEW_BUDGET_USD: '6.00'
         run: .github/scripts/price-agent-run.sh "$EXECUTION_FILE" "$REVIEW_BUDGET_USD" 'PR re-review'
 
       # Always a new comment, never an update — the history of re-reviews is the point. The token

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -63,8 +63,10 @@ jobs:
           model: ${{ vars.CLAUDE_AGENT_MODEL || 'claude-opus-5' }}
           # The investigation passes are search-heavy — tracing callers out to an entry point is
           # several greps per changed function — and at 40 the budget was spent before they started.
-          max_turns: "80"
-          timeout_minutes: "25"
+          # Kept in step with the re-review, which ran out of turns at 80 on a large PR and published
+          # nothing; a first review of the same PR does the same reading.
+          max_turns: "120"
+          timeout_minutes: "35"
           allowed_tools: "Bash(jq:*),Bash(wc:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(rg:*),View,GlobTool,GrepTool,BatchTool,Write"
           system_prompt: |
             You are the automated code review agent for `bluerobotics/cockpit`, running inside a GitHub Actions workflow.
@@ -116,9 +118,9 @@ jobs:
         continue-on-error: true
         env:
           EXECUTION_FILE: ${{ steps.review.outputs.execution_file }}
-          # An estimate until the first runs land: re-derive it from the cost line this step prints,
-          # the way DEMO_BUDGET_USD was. max_turns is what actually caps spend; this only reports.
-          REVIEW_BUDGET_USD: '4.00'
+          # Derived from the cost line this step prints: 80 turns landed at $3.83-$4.02, so 120 turns
+          # sits near $6. max_turns is what actually caps spend; this only reports.
+          REVIEW_BUDGET_USD: '6.00'
         run: .github/scripts/price-agent-run.sh "$EXECUTION_FILE" "$REVIEW_BUDGET_USD" 'PR review'
 
       # Sticky by the seq=1 marker, so a re-run of this workflow replaces its own comment rather


### PR DESCRIPTION
## Problem

Every `/review` on #2907 since its last push failed, three runs in a row, each burning ~15 minutes and ~$4 to publish nothing:

```
"subtype": "error_max_turns", "num_turns": 80, "total_cost_usd": 3.83
##[error]the agent produced no review
```

The agent spends all 80 turns on the investigation passes and never reaches `review.md`, so `Publish the re-review` fails on an empty file. Runs [31434477591](https://github.com/bluerobotics/cockpit/actions/runs/31434477591) ($4.02) and [31436032362](https://github.com/bluerobotics/cockpit/actions/runs/31436032362) ($3.83) are the same failure.

What makes a re-review exceed what a first review needed: the branch was rebased, so `compare` returns the whole PR again, `incremental.diff` carries no signal, and the guidelines require the Change map and sections 0-11 to be rebuilt over all of `pr.diff` anyway. Every file gets re-read, and the status table for the previous findings comes on top of that.

## Change

`max_turns` 80 → 120 on both review workflows, and `timeout_minutes` 25 → 35 with it: 80 turns measured 883s, so 120 turns is ~22min and would have sat uncomfortably close to the old timeout — trading a turn-cap failure for a timeout failure, which produces an empty `review.md` just the same.

`REVIEW_BUDGET_USD` 4.00 → 6.00 to match, since 80 turns landed at $3.83-$4.02. It stays advisory, as its own comment says: it prints a line and warns, and `max_turns` is the only thing that actually holds spend down. This is a per-run number, not a per-PR one — nothing accumulates across runs.

The first-review workflow is raised in step even though it has not failed yet. It does the same reading of the same PR, so leaving the pair to diverge just moves the same silent failure to the first review of the next big PR.

## Notes

`issue_comment` workflows always run from the default branch, so `/review` keeps using the 80-turn version until this lands on `master`.

## Test plan
- [ ] Merge, then `/review` on #2907 and confirm the re-review publishes a comment instead of failing.
- [ ] Check the run's cost line stays under the $6 budget.