### PR TITLE
Record uncaught errors and unhandled rejections in the system log

### DIFF
--- a/src/electron/services/electron-log.ts
+++ b/src/electron/services/electron-log.ts
@@ -6,7 +6,7 @@ import { join } from 'path'
 
 import { type ElectronLog } from '@/types/electron-general'
 
-import { sanitizeFilenameComponent } from '../../libs/utils'
+import { sanitizeFilenameComponent, serializeForLogging } from '../../libs/utils'
 
 // Import the same date format used in system-logging.ts
 const systemLogDateFormat = 'LLL dd, yyyy'
@@ -57,16 +57,7 @@ export const setupElectronLogService = (): void => {
   const tagLog = (...args: any[]): string => {
     let wholeMessage = ''
     args.forEach((m) => {
-      let msg = m
-      try {
-        if (typeof m === 'object' && m !== null) {
-          msg = JSON.stringify(m)
-        } else {
-          msg = m.toString()
-        }
-      } catch {
-        msg = ''
-      }
+      const msg = serializeForLogging(m)
       if (msg !== '') {
         wholeMessage += ' '
         wholeMessage += msg
@@ -201,16 +192,7 @@ export const setupElectronLogService = (): void => {
 
   // Add the [Renderer] tag and route a single renderer log message to the matching electron-log level.
   const logRendererMessage = (level: string, message: any): void => {
-    let processedMessage = ''
-    try {
-      if (typeof message === 'object' && message !== null) {
-        processedMessage = JSON.stringify(message)
-      } else {
-        processedMessage = message.toString()
-      }
-    } catch {
-      processedMessage = ''
-    }
+    const processedMessage = serializeForLogging(message)
     const taggedMessage = `[Renderer]${processedMessage !== '' ? ' ' + processedMessage : ''}`
 
     // Use original logger functions to avoid double tagging

--- a/src/libs/index-utils.js
+++ b/src/libs/index-utils.js
@@ -6,6 +6,24 @@
  * Handles backup, import, logs download, and reset functionality
  */
 
+// Mirrors `serializeForLogging` in `./utils`, which this module cannot import: index.html loads it as a
+// standalone asset, so a bare specifier here would 404 and take the whole pre-mount capture down with it.
+const serializeForLogging = (value) => {
+  try {
+    if (value instanceof Error) return value.stack ?? `${value.name}: ${value.message}`
+    if (typeof value === 'object' && value !== null) {
+      try {
+        return JSON.stringify(value)
+      } catch {
+        return String(value)
+      }
+    }
+    return String(value)
+  } catch {
+    return ''
+  }
+}
+
 // Global captured logs array
 let capturedLogs = []
 let isCapturing = true
@@ -28,18 +46,7 @@ const originalConsole = {
       capturedLogs.push({
         timestamp: new Date().toISOString(),
         level: method.toUpperCase(),
-        message: args
-          .map((arg) => {
-            if (typeof arg === 'object') {
-              try {
-                return JSON.stringify(arg, null, 2)
-              } catch (e) {
-                return String(arg)
-              }
-            }
-            return String(arg)
-          })
-          .join(' '),
+        message: args.map((arg) => serializeForLogging(arg)).join(' '),
       })
     } else {
       // Restore original console methods
@@ -58,10 +65,12 @@ const originalConsole = {
 // Capture uncaught errors
 window.addEventListener('error', function (event) {
   if (isCapturing) {
+    // This bundle is all the user can download when the app never mounts, so keep the stack whenever there is one.
+    const details = event.error?.stack ?? `${event.message} at ${event.filename}:${event.lineno}:${event.colno}`
     capturedLogs.push({
       timestamp: new Date().toISOString(),
       level: 'ERROR',
-      message: `Uncaught Error: ${event.message} at ${event.filename}:${event.lineno}:${event.colno}`,
+      message: `Uncaught Error: ${details}`,
     })
   }
 })
@@ -69,10 +78,11 @@ window.addEventListener('error', function (event) {
 // Capture unhandled promise rejections
 window.addEventListener('unhandledrejection', function (event) {
   if (isCapturing) {
+    const reason = serializeForLogging(event.reason)
     capturedLogs.push({
       timestamp: new Date().toISOString(),
       level: 'ERROR',
-      message: `Unhandled Promise Rejection: ${event.reason}`,
+      message: `Unhandled Promise Rejection: ${reason}`,
     })
   }
 })

--- a/src/libs/system-logging.ts
+++ b/src/libs/system-logging.ts
@@ -5,7 +5,7 @@ import localforage from 'localforage'
 import { settingsManager } from '@/libs/settings-management'
 import { systemLoggingEnablingKey } from '@/stores/development'
 
-import { isElectron, sanitizeFilenameComponent } from './utils'
+import { isElectron, sanitizeFilenameComponent, serializeForLogging } from './utils'
 
 export const systemLogDateFormat = 'LLL dd, yyyy'
 export const systemLogTimeFormat = 'HH꞉mm꞉ss O'
@@ -283,16 +283,7 @@ if (enableSystemLogging) {
     window.console[level] = (...o: any[]) => {
       let wholeMessage = ''
       o.forEach((m) => {
-        let msg = m
-        try {
-          if (typeof m === 'object' && m !== null) {
-            msg = JSON.stringify(m)
-          } else {
-            msg = m.toString()
-          }
-        } catch {
-          msg = ''
-        }
+        const msg = serializeForLogging(m)
         if (msg !== '') {
           wholeMessage += ' '
           wholeMessage += msg

--- a/src/libs/system-logging.ts
+++ b/src/libs/system-logging.ts
@@ -294,6 +294,20 @@ if (enableSystemLogging) {
     }
   })
 
+  // Crashes that never pass through `console.*` — anything thrown outside a handler, and the component errors
+  // Vue's development build rethrows instead of logging — would otherwise leave the log with the `[Vue warn]`
+  // component trace and no trace of the error that caused it.
+  window.addEventListener('error', (event) => {
+    // A thrown non-Error carries no stack, so the event's own coordinates are the only location on offer.
+    const location = `${event.filename}:${event.lineno}:${event.colno}`
+    const error = event.error instanceof Error ? event.error : `${event.message} at ${location}`
+    console.error('[UncaughtError]', error)
+  })
+
+  window.addEventListener('unhandledrejection', (event) => {
+    console.error('[UnhandledRejection]', event.reason)
+  })
+
   // Flush whatever is still buffered before the window goes away, so the last events aren't lost.
   window.addEventListener('beforeunload', () => {
     flushRepeatSummary()

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -433,3 +433,29 @@ export const messageFromError = (error: unknown): string => {
  * @returns {T} A detached copy holding no proxies.
  */
 export const toPlain = <T>(value: T): T => JSON.parse(JSON.stringify(value))
+
+/**
+ * Serialize a value into the text kept for it in a log.
+ * @param {unknown} value The value to be logged.
+ * @returns {string} The value's log representation, or an empty string when it cannot be serialized.
+ */
+export const serializeForLogging = (value: unknown): string => {
+  try {
+    // Errors are handled before the object branch because `JSON.stringify` renders one as `{}` — its name,
+    // message and stack are all non-enumerable — throwing away the only part worth logging.
+    if (value instanceof Error) return value.stack ?? `${value.name}: ${value.message}`
+    if (typeof value === 'object' && value !== null) {
+      try {
+        return JSON.stringify(value)
+      } catch {
+        // A value JSON cannot render (a circular object, most often) still deserves a placeholder, since
+        // dropping the argument leaves the entry with nothing but the message that introduced it.
+        return String(value)
+      }
+    }
+    // `String` rather than `.toString()`, which throws on the `null` and `undefined` that reach here.
+    return String(value)
+  } catch {
+    return ''
+  }
+}

--- a/src/tests/libs/utils.test.ts
+++ b/src/tests/libs/utils.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from 'vitest'
+
+import { serializeForLogging } from '@/libs/utils'
+
+test('serializeForLogging', () => {
+  // The regression this guards: `JSON.stringify(new Error('boom'))` is `'{}'`, which is what the log used to keep.
+  expect(serializeForLogging(new Error('boom'))).toContain('boom')
+  expect(serializeForLogging(Object.assign(new Error('boom'), { stack: undefined }))).toBe('Error: boom')
+
+  expect(serializeForLogging('plain message')).toBe('plain message')
+  expect(serializeForLogging({ a: 1 })).toBe('{"a":1}')
+  expect(serializeForLogging(42)).toBe('42')
+  expect(serializeForLogging(null)).toBe('null')
+  expect(serializeForLogging(undefined)).toBe('undefined')
+
+  const circular: Record<string, unknown> = {}
+  circular.self = circular
+  expect(serializeForLogging(circular)).toBe('[object Object]')
+  expect(serializeForLogging(Object.create(null))).toBe('{}')
+})


### PR DESCRIPTION
## Problem

A component that throws during setup leaves the syslog with the `[Vue warn]` component trace and nothing about the error that caused it:

```
[Vue warn]: Unhandled error during execution of watcher callback   at <CompassHUD ...>
[Vue warn]: Unhandled error during execution of setup function     at <CompassHUD ...>
```

Two independent things drop the error.

- `src/libs/system-logging.ts` only captures `console.*`, and Vue's development build rethrows a component error instead of routing it through `console.error`, so the rethrown error never reaches the log at all.
- When an error *does* reach the log, the console wrapper serializes it with `JSON.stringify`, which renders an `Error` as `{}` because its `name`, `message` and `stack` are all non-enumerable. This one is not specific to Vue: it hits every caught error handed to `console.*` in the app, around 170 call sites, including the `console.error(err)` that Vue's *production* build reports component errors through. The Electron main process carries two more copies of the same block (`src/electron/services/electron-log.ts`), writing into the same `.syslog` file.

The cost is real rather than theoretical. #2911 took two rounds of round-trips with the reporter, each one a full syslog and a rebuilt binary, and both diagnoses had to be reached by elimination — intersecting the imports of the two components that died and subtracting the ones that mounted fine — because the one line naming the failing property was never written down. The error turned out to be a one-line `TypeError` both times.

## Fix

Two commits, one per half of the problem above, plus a third for the one crash writer left outside the app.

**Serialize errors before the object branch of the console wrapper**, from a `serializeForLogging` helper next to the existing `messageFromError`, so a stack survives the trip to the log wherever it is handed to `console.*`. The two main-process copies call the same helper now, so a `[Main]` line keeps its stack too.

This is the half that covers the builds users install. `@sentry/vue` attaches `app.config.errorHandler` there (`src/main.ts`), and since Cockpit sets no handler of its own, Sentry's captures the error and then rethrows it; Vue catches that rethrow in `callWithErrorHandling` and re-enters `handleError` with no component instance, which skips the handler and falls through to `logError` — `console.error(err)` on the production build, `throw err` on the development one. So a released build reaches the log through the serializer, and a development build through the listener below.

**Listen for uncaught errors and unhandled rejections**, so the crashes that never pass through `console.*` — the development build's rethrow, and anything thrown outside a handler — land in the syslog too.

Three details worth calling out:

- This listens for the uncaught error rather than setting `app.config.errorHandler`. Setting one changes error semantics app-wide: Sentry calls a user handler instead of rethrowing, and reports the exception as `handled`. The listener observes without altering anything.
- A thrown non-`Error` carries no stack, so the event's `filename`/`lineno`/`colno` are recorded in its place. That is the only location such an entry can carry.
- `src/libs/index-utils.js` already listens for both events, but only until `cockpit-app-loaded` fires, and it writes to the pre-Vue fallback screen's "Download logs" bundle rather than to the syslog. Having the syslog carry them as well is deliberate; the two agree on the `message at file:line:col` shape for a location-only entry.

**Keep the stack in the pre-mount capture too**, since that bundle kept only `event.message` and dropped `event.error` entirely. A crash during boot is exactly the case where the app never mounts and the fallback screen's download button is the only artifact the user has, so it was the one writer still recording the crash without the line that names it. Same shape as above: the stack when there is one, the event's coordinates when there is not.

The listeners are registered inside the existing `if (enableSystemLogging)` block, after the console patch. Uncaught errors already surface natively in devtools, so the syslog was the only place they were missing.

## Test plan

- [ ] With system logging enabled, throw from a component's `setup` and confirm the syslog carries the error and its stack, not just the `[Vue warn]` trace
- [ ] Confirm a caught error logged with `console.error('...', error)` anywhere in the app now shows its stack instead of `{}`
- [ ] Confirm a main-process error in Standalone shows its stack in the `[Main]` lines of the `.syslog` file
- [ ] Reject a promise with no handler and confirm the syslog carries an `[UnhandledRejection]` entry with the reason
- [ ] Confirm a thrown non-`Error` value (e.g. a string) is still logged legibly, with its location
- [ ] Confirm normal console output is unchanged, and that a burst of errors is still subject to the existing repeat-suppression and oversized-message capping
- [ ] Confirm the Lite (web) build behaves the same, since this touches no Electron-only API
- [ ] Throw during boot so the app never mounts, and confirm the fallback screen's "Download logs" bundle carries the stack


