### PR TITLE
fix: data-lake: reject unusable transforming functions instead of saving them

### DIFF
--- a/src/components/TransformingFunctionDialog.vue
+++ b/src/components/TransformingFunctionDialog.vue
@@ -199,7 +199,8 @@ const toggleManualIdEditing = (): void => {
 }
 
 const isValidForm = computed(() => {
-  return newFunction.value.name && newFunction.value.expression && newFunction.value.type && newFunction.value.id
+  const { name, expression, type, id } = newFunction.value
+  return name && expression && type && id.trim()
 })
 
 const saveTransformingFunction = (): void => {
@@ -207,22 +208,31 @@ const saveTransformingFunction = (): void => {
     openSnackbar({ message: 'Please fill in all fields', variant: 'error' })
     return
   }
-  logUserAction('Saved data-lake transforming function')
 
-  if (editingExistingFunction.value && props.editFunction) {
-    const { ...otherProps } = newFunction.value
-    updateTransformingFunction({
-      id: props.editFunction.id,
-      ...otherProps,
-    })
-  } else {
-    createTransformingFunction(
-      newFunction.value.id,
-      newFunction.value.name,
-      newFunction.value.type,
-      newFunction.value.expression,
-      newFunction.value.description
-    )
+  // Both writers reject a variable they cannot evaluate, so the dialog stays open on a rejection
+  // instead of closing on an edit that was never stored. The save itself is logged by the view's
+  // `saved` handler, which only runs once a write went through.
+  try {
+    if (editingExistingFunction.value && props.editFunction) {
+      const { ...otherProps } = newFunction.value
+      updateTransformingFunction({
+        id: props.editFunction.id,
+        ...otherProps,
+      })
+    } else {
+      createTransformingFunction(
+        newFunction.value.id,
+        newFunction.value.name,
+        newFunction.value.type,
+        newFunction.value.expression,
+        newFunction.value.description
+      )
+    }
+  } catch (error) {
+    console.error('Refused to save the compound variable.', error)
+    const message = 'Could not save this compound variable. Close the dialog, open it again and retry.'
+    openSnackbar({ message, variant: 'error' })
+    return
   }
 
   emit('saved')

--- a/src/libs/actions/data-lake-transformations.ts
+++ b/src/libs/actions/data-lake-transformations.ts
@@ -25,7 +25,20 @@ let unusableTransformingFunctions: TransformingFunction[] = []
 // either one throws somewhere far from here (`getDataLakeVariableIdFromInput` on load, the POI
 // coordinate sync while pruning), and such an entry can back no variable anyway.
 const isUsableTransformingFunction = (func: TransformingFunction): boolean =>
-  typeof func?.id === 'string' && typeof func.expression === 'string'
+  typeof func?.id === 'string' && func.id.trim() !== '' && typeof func.expression === 'string'
+
+// The id is trimmed rather than taken as given because surrounding whitespace survives every check
+// here but makes the entry unreferenceable: `getDataLakeVariableIdFromInput` trims what an
+// expression's `{{ }}` captures, so `{{ my id }}` would never find an id stored as ' my id '.
+const withTrimmedId = (func: TransformingFunction): TransformingFunction =>
+  typeof func?.id === 'string' ? { ...func, id: func.id.trim() } : func
+
+const usableTransformingFunctionOrThrow = (func: TransformingFunction): TransformingFunction => {
+  const trimmedFunc = withTrimmedId(func)
+  if (isUsableTransformingFunction(trimmedFunc)) return trimmedFunc
+  const got = `Got id '${func?.id}' and expression '${func?.expression}'.`
+  throw new Error(`A transforming function needs a non-empty id and a string expression. ${got}`)
+}
 
 const loadTransformingFunctions = (): void => {
   const transformingFunctions = settingsManager.getKeyValue(transformingFunctionsKey)
@@ -41,7 +54,9 @@ const loadTransformingFunctions = (): void => {
     return
   }
   const storedFunctions = transformingFunctions as TransformingFunction[]
-  globalTransformingFunctions = storedFunctions.filter((func) => isUsableTransformingFunction(func))
+  // Stored ids are normalised on the way in too, so an entry a previous version wrote as ' my id ' still
+  // matches the trimmed id an update carries, instead of silently saving nothing.
+  globalTransformingFunctions = storedFunctions.filter((func) => isUsableTransformingFunction(func)).map(withTrimmedId)
   unusableTransformingFunctions = storedFunctions.filter((func) => !isUsableTransformingFunction(func))
   const droppedCount = unusableTransformingFunctions.length
   if (droppedCount > 0) {
@@ -254,6 +269,7 @@ export interface TransformingFunction {
  * @param {'string' | 'number' | 'boolean'} type - Type of the new variable
  * @param {string} expression - Expression to calculate the variable's value
  * @param {string?} description - Description of the new variable
+ * @throws {Error} If the id is empty or the expression is not a string
  */
 export const createTransformingFunction = (
   id: string,
@@ -262,9 +278,9 @@ export const createTransformingFunction = (
   expression: string,
   description?: string
 ): void => {
-  const transformingFunction: TransformingFunction = { name, id, type, expression, description }
+  const transformingFunction = usableTransformingFunctionOrThrow({ name, id, type, expression, description })
   globalTransformingFunctions.push(transformingFunction)
-  createDataLakeVariable({ id, name, type, description })
+  createDataLakeVariable({ id: transformingFunction.id, name, type, description })
   saveTransformingFunctions()
 }
 
@@ -279,13 +295,17 @@ export const getAllTransformingFunctions = (): TransformingFunction[] => {
 /**
  * Updates a transforming function
  * @param {TransformingFunction} func - The function to update
+ * @throws {Error} If the id is empty, the expression is not a string, or no stored function has that id
  */
 export const updateTransformingFunction = (func: TransformingFunction): void => {
-  const index = globalTransformingFunctions.findIndex((f) => f.id === func.id)
-  if (index !== -1) {
-    globalTransformingFunctions[index] = func
-    saveTransformingFunctions()
+  const transformingFunction = usableTransformingFunctionOrThrow(func)
+  const index = globalTransformingFunctions.findIndex((f) => f.id === transformingFunction.id)
+  // Returning quietly here would discard the caller's update while looking like it worked.
+  if (index === -1) {
+    throw new Error(`There is no transforming function with id '${transformingFunction.id}' to update.`)
   }
+  globalTransformingFunctions[index] = transformingFunction
+  saveTransformingFunctions()
 }
 
 /**


### PR DESCRIPTION
## Summary

The fix is on the write side of the transforming-functions list, plus the read path that seeds it. Loading already skips entries that cannot be evaluated (`056907b`, merged in #2912), but nothing stopped one from being written, so a corrupt entry stayed permanently in the vehicle-synced key.

- **Validate before persisting** (#2910). A user's `cockpit-transforming-functions` held an entry with no id and a `{{undefined}}` expression. `createTransformingFunction` and `updateTransformingFunction` now check the same `isUsableTransformingFunction` predicate the loader uses and throw, so a caller that cannot produce an evaluable function fails at the call site instead of leaving an entry behind. The predicate also rejects an all-whitespace id.
- **Trim the id wherever an entry enters the list.** An id with surrounding whitespace passes every check but can never be referenced: `getDataLakeVariableIdFromInput` trims what an expression's `{{ }}` captures, so `{{ my id }}` never finds an id stored as `' my id '`. Both writers normalise the id before validating it, and `loadTransformingFunctions` normalises what it reads, so all four producers land on the same representation: an entry a previous version stored as `' my id '` matches the trimmed id an update carries instead of the update finding nothing and silently saving nothing, and its data-lake variable is registered under the referenceable id. The compound-variable dialog also trims the id before enabling Save, so a whitespace-only id disables the button rather than relying on the throw being surfaced.
- **Fail loudly when there is nothing to update.** `updateTransformingFunction` returned having saved nothing when no entry carried the id, and the dialog closed reporting success on the edit it had just discarded. It now throws, and the dialog's Save handler catches both writers into an error snackbar and stays open, so a rejected write is never presented as a saved one.

Two paths in master can reach the new throw. The dialog gates on a truthy id, and every programmatic caller uses a hardcoded or templated id, so an undefined id is not reachable from the UI — but `coordinateExpression` (`poi-data-lake.ts:42-43`) returns its argument unchanged when it is neither number nor string, so a POI synced from another topside with a `null` coordinate source reaches `createTransformingFunction` with a non-string expression. That now throws into the `catch` the POI watcher already has (`usePointsOfInterest.ts:209-221`) instead of being persisted and failing later. Existing corrupt entries are left untouched — the loader already ignores them and `saveTransformingFunctions` round-trips them.

## Test plan

- [ ] Tools → Data Lake → **Add compound variable**: type a name and expression, then a whitespace-only id, and confirm Save stays disabled. A real id still saves, and the variable shows up in the list with its value.
- [ ] Enable manual ID editing and save an id typed with a leading/trailing space, then reference it from a second compound variable as `{{ that-id }}` and confirm the second one resolves.
- [ ] Edit an existing compound variable, change the expression, save, and confirm the new value is computed and survives a reload. Repeat it on a variable whose stored id was written with a leading/trailing space by a previous version, and confirm the edit is kept.
- [ ] Confirm the joystick axis variables still register on connecting a joystick (they go through `createTransformingFunction` with templated ids).

## Checks

- Launch with the reported entry present: no retry spam, since the loader fix already in master drops the entry from the evaluated set before any listener is built. This PR does not change that; it closes the write path so no new entry of that shape can be stored, and the log line quoted in #2910 interpolates `func.id`, so the reported entry is the missing-id shape that fix covers.
- The rejected shapes (missing, empty and whitespace id, non-string expression) were exercised manually: nothing is persisted for them, a failed update does not overwrite the stored expression, an update for an id that is not stored throws instead of silently discarding it, a padded id is stored trimmed, and a padded id already in the stored key loads trimmed and can still be updated.
- `yarn lint` and `yarn typecheck` are clean.

Closes #2910
Closes #2929