### PR TITLE
src: format standalone as a descriptor, not a variant

### DIFF
--- a/src/components/VideoLibraryModal.vue
+++ b/src/components/VideoLibraryModal.vue
@@ -391,7 +391,7 @@
                             <div class="text-white/80 text-sm space-y-1">
                               <p>
                                 These are raw video chunks that need to be processed. The processing can be done
-                                exclusively in Cockpit Standalone. Cockpit Lite can only record the video chunks.
+                                exclusively in Cockpit standalone. Cockpit Lite can only record the video chunks.
                               </p>
                               <div>
                                 <p class="font-medium mb-2">To process your videos:</p>
@@ -402,7 +402,7 @@
                                   </li>
                                   <li class="flex items-start gap-2">
                                     <span class="text-white font-bold">2.</span>
-                                    <span>Open Cockpit Standalone</span>
+                                    <span>Open Cockpit standalone</span>
                                   </li>
                                   <li class="flex items-start gap-2">
                                     <span class="text-white font-bold">3.</span>
@@ -831,7 +831,7 @@ const videoSubTabs = [
     label: 'Processed',
     icon: 'mdi-video',
     disabled: !isElectron(),
-    tooltip: isElectron() ? '' : 'Only available in Cockpit Standalone',
+    tooltip: isElectron() ? '' : 'Only available in Cockpit standalone',
   },
   {
     name: 'raw',
@@ -845,7 +845,7 @@ const videoSubTabs = [
     label: 'Processing',
     icon: 'mdi-cog-outline',
     disabled: !isElectron(),
-    tooltip: isElectron() ? 'Process ZIP files with raw video chunks' : 'Only available in Cockpit Standalone',
+    tooltip: isElectron() ? 'Process ZIP files with raw video chunks' : 'Only available in Cockpit standalone',
   },
 ]
 
@@ -854,7 +854,7 @@ const openElectronFolder = (opener: () => void): void => {
     opener()
   } else {
     openSnackbar({
-      message: 'This feature is only available in Cockpit Standalone.',
+      message: 'This feature is only available in Cockpit standalone.',
       duration: 3000,
       variant: 'error',
       closeButton: true,
@@ -876,7 +876,7 @@ const playVideoInDefaultPlayer = (fileName: string): void => {
   if (isElectron() && window.electronAPI) {
     window.electronAPI?.openVideoFile(fileName)
   } else {
-    openSnackbar({ message: 'This feature is only available in Cockpit Standalone.', variant: 'error' })
+    openSnackbar({ message: 'This feature is only available in Cockpit standalone.', variant: 'error' })
   }
 }
 

--- a/src/components/configuration/HttpRequestActionConfig.vue
+++ b/src/components/configuration/HttpRequestActionConfig.vue
@@ -171,7 +171,7 @@
             class="mt-2"
           >
             <div class="text-body-2">
-              <strong>Note:</strong> Specifying the User-Agent header only works in Cockpit Standalone, not in Cockpit
+              <strong>Note:</strong> Specifying the User-Agent header only works in Cockpit standalone, not in Cockpit
               Lite.
             </div>
           </v-alert>

--- a/src/components/map/MapOverlaysDialog.vue
+++ b/src/components/map/MapOverlaysDialog.vue
@@ -12,7 +12,7 @@
             <v-icon icon="mdi-information-outline" size="16" class="mt-[2px]" />
             <span>
               In Cockpit Lite, overlays are stored in limited browser storage that the browser may clear, so very large
-              surveys may fail to save or not persist. For large datasets or reliable storage, use Cockpit Standalone.
+              surveys may fail to save or not persist. For large datasets or reliable storage, use Cockpit standalone.
             </span>
           </div>
 

--- a/src/components/mini-widgets/SnapshotTool.vue
+++ b/src/components/mini-widgets/SnapshotTool.vue
@@ -77,7 +77,7 @@
             />
           </template>
 
-          <span> Some features like “Capturing Cockpit work area” are only available in Cockpit Standalone. </span>
+          <span> Some features like “Capturing Cockpit work area” are only available in Cockpit standalone. </span>
         </v-tooltip>
       </div>
       <div class="flex items-center justify-start w-[90%] -mb-2">
@@ -154,7 +154,7 @@
           @update:model-value="(val) => (miniWidget.options.captureWorkspace = val)"
         />
         <p class="ml-[4px] -mb-[2px] text-sm" :class="{ 'opacity-20 pointer-events-none': !isElectronEnv }">
-          Capture Cockpit work area (Standalone-only feature)
+          Capture Cockpit work area (standalone-only feature)
         </p>
       </div>
       <v-text-field

--- a/src/composables/videoChunkManager.ts
+++ b/src/composables/videoChunkManager.ts
@@ -581,7 +581,7 @@ export const useVideoChunkManager = (): {
    */
   const processChunkGroup = async (group: ChunkGroup): Promise<void> => {
     if (!isElectron() || !window.electronAPI) {
-      openSnackbar({ message: 'Manual processing is only available in Cockpit Standalone', variant: 'error' })
+      openSnackbar({ message: 'Manual processing is only available in Cockpit standalone', variant: 'error' })
       return
     }
 

--- a/src/libs/connection/electron-connection.ts
+++ b/src/libs/connection/electron-connection.ts
@@ -34,7 +34,7 @@ class ElectronConnectionIPC {
    */
   async initialize(): Promise<void> {
     if (!window.electronAPI) {
-      throw new Error('This connection is only available in Cockpit Standalone')
+      throw new Error('This connection is only available in Cockpit standalone')
     }
 
     this._isOpen = await window.electronAPI.linkOpen(this.path)

--- a/src/libs/electron/vehicle-discovery.ts
+++ b/src/libs/electron/vehicle-discovery.ts
@@ -264,7 +264,7 @@ class VehicleDiscover {
     signal?: AbortSignal
   ): Promise<NetworkVehicle[]> {
     if (!isElectron()) {
-      throw new Error('For technical reasons, finding vehicles is only available in Cockpit Standalone.')
+      throw new Error('For technical reasons, finding vehicles is only available in Cockpit standalone.')
     }
 
     if (this.currentSearch !== undefined) {
@@ -283,7 +283,7 @@ class VehicleDiscover {
       try {
         if (!window.electronAPI?.getInfoOnSubnets) {
           const msg =
-            'For technical reasons, getting information about the local subnet is only available in Cockpit Standalone.'
+            'For technical reasons, getting information about the local subnet is only available in Cockpit standalone.'
           throw new Error(msg)
         }
 

--- a/src/libs/live-video-processor.ts
+++ b/src/libs/live-video-processor.ts
@@ -71,7 +71,7 @@ export class LiveVideoProcessor {
    */
   async startProcessing(): Promise<void> {
     if (!isElectron()) {
-      throw new Error('Live video processing is only available in Cockpit Standalone')
+      throw new Error('Live video processing is only available in Cockpit standalone')
     }
 
     this.isProcessing = true
@@ -232,7 +232,7 @@ export class LiveVideoProcessor {
     onProgress?: (progress: number, message: string) => void
   ): Promise<string> {
     if (!isElectron() || !window.electronAPI) {
-      throw new Error('ZIP processing is only available in Cockpit Standalone')
+      throw new Error('ZIP processing is only available in Cockpit standalone')
     }
 
     if (!zipFilePaths || zipFilePaths.length === 0) {

--- a/src/libs/map/overlay-import.ts
+++ b/src/libs/map/overlay-import.ts
@@ -15,7 +15,7 @@ const GEOTIFF_EXTENSIONS = ['tif', 'tiff', 'gtiff']
 
 /**
  * Error thrown when a GeoTIFF cannot be stored because the browser's IndexedDB quota would be exceeded.
- * More likely in the Lite (Web) build; Standalone (Electron) has a much larger IndexedDB quota.
+ * More likely in the Lite (Web) build; standalone (Electron) has a much larger IndexedDB quota.
  */
 export class OverlayStorageQuotaError extends Error {
   /**
@@ -29,7 +29,7 @@ export class OverlayStorageQuotaError extends Error {
 
 /**
  * Opens a file picker for the user to choose one or more GeoTIFF files. Uses a hidden file input so it works
- * identically in Standalone (Electron) and Lite (Web), where the bytes are read in-renderer.
+ * identically in standalone (Electron) and Lite (Web), where the bytes are read in-renderer.
  * @returns {Promise<File[]>} The selected files, or an empty array if the dialog was dismissed.
  */
 export const pickGeoTiffFiles = (): Promise<File[]> => {
@@ -78,7 +78,7 @@ export const importGeoTiffFile = async (file: File): Promise<MapOverlayMeta> => 
   const available = await getOverlayStorageBytesAvailable()
   if (available !== undefined && file.size > available) {
     throw new OverlayStorageQuotaError(
-      `Not enough browser storage to save "${file.name}". Free up space or use Cockpit Standalone.`
+      `Not enough browser storage to save "${file.name}". Free up space or use Cockpit standalone.`
     )
   }
 
@@ -90,7 +90,7 @@ export const importGeoTiffFile = async (file: File): Promise<MapOverlayMeta> => 
   } catch (error) {
     if (error instanceof DOMException && error.name === 'QuotaExceededError') {
       throw new OverlayStorageQuotaError(
-        `Browser storage is full, so "${file.name}" could not be saved. Free up space or use Cockpit Standalone.`
+        `Browser storage is full, so "${file.name}" could not be saved. Free up space or use Cockpit standalone.`
       )
     }
     throw error

--- a/src/libs/map/overlay-storage.ts
+++ b/src/libs/map/overlay-storage.ts
@@ -7,7 +7,7 @@ import type { MapOverlayBounds, MapOverlayRenderMode } from '@/types/mission'
 /**
  * Persistent storage for GeoTIFF overlay raster bytes, in IndexedDB for both builds. Overlays are imported
  * input data (not generated output like videos/snapshots), so they are not written to the user's filesystem.
- * In Lite (browser) IndexedDB is origin-quota-limited and evictable; in Standalone (Electron) it has a much
+ * In Lite (browser) IndexedDB is origin-quota-limited and evictable; in standalone (Electron) it has a much
  * larger quota and is effectively durable.
  */
 export const mapOverlayStorage: StorageDB = new LocalForageStorage(

--- a/src/libs/sensors/gnss.ts
+++ b/src/libs/sensors/gnss.ts
@@ -455,7 +455,7 @@ export const stopGnssDevice = async (deviceId: string): Promise<void> => {
  */
 export const startGnssDevice = async (device: GnssDeviceInfo, publish = true): Promise<void> => {
   if (!isElectron() || !window.electronAPI) {
-    throw new Error('GNSS reading is only available in Cockpit Standalone.')
+    throw new Error('GNSS reading is only available in Cockpit standalone.')
   }
 
   await stopGnssDevice(device.id)
@@ -517,7 +517,7 @@ export const autodetectBaud = async (
   perBaudMs = 1500
 ): Promise<number | null> => {
   if (!isElectron() || !window.electronAPI) {
-    throw new Error('GNSS reading is only available in Cockpit Standalone.')
+    throw new Error('GNSS reading is only available in Cockpit standalone.')
   }
 
   await stopDevicesOnPort(port)

--- a/src/stores/omniscientLogger.ts
+++ b/src/stores/omniscientLogger.ts
@@ -39,38 +39,38 @@ export const useOmniscientLoggerStore = defineStore('omniscient-logger', () => {
     // Separate memory metrics for different process types
     cockpitMainMemoryVariable = {
       id: 'cockpit-main-memory',
-      name: 'Cockpit Main Memory (Standalone)',
+      name: 'Cockpit Main Memory (standalone)',
       type: 'number',
       description:
-        'The memory usage of the main process in Cockpit Standalone, in MB. This value is updated every 100ms. Only available in Cockpit Standalone.',
+        'The memory usage of the main process, in MB. This value is updated every 100ms. Only available in standalone application.',
     } as DataLakeVariable
     createDataLakeVariable(cockpitMainMemoryVariable)
 
     cockpitRenderersMemoryVariable = {
       id: 'cockpit-renderers-memory',
-      name: 'Cockpit Renderers Memory (Standalone)',
+      name: 'Cockpit Renderers Memory (standalone)',
       type: 'number',
       description:
-        'The total memory usage of the renderer processes in Cockpit Standalone, in MB. This value is updated every 100ms. Only available in Cockpit Standalone.',
+        'The total memory usage of the renderer processes, in MB. This value is updated every 100ms. Only available in standalone application.',
     } as DataLakeVariable
     createDataLakeVariable(cockpitRenderersMemoryVariable)
 
     cockpitGpuMemoryVariable = {
       id: 'cockpit-gpu-memory',
-      name: 'Cockpit GPU Memory (Standalone)',
+      name: 'Cockpit GPU Memory (standalone)',
       type: 'number',
       description:
-        'The memory usage of the GPU in Cockpit Standalone, in MB. This value is updated every 100ms. Only available in Cockpit Standalone.',
+        'The memory usage of the GPU, in MB. This value is updated every 100ms. Only available in standalone application.',
     } as DataLakeVariable
     createDataLakeVariable(cockpitGpuMemoryVariable)
 
     // CPU usage tracking
     cockpitCpuUsageVariable = {
       id: 'cockpit-cpu-usage',
-      name: 'Cockpit CPU Usage (Standalone)',
+      name: 'Cockpit CPU Usage (standalone)',
       type: 'number',
       description:
-        'The CPU usage of Cockpit Standalone as a percentage. This value is updated every 100ms. Only available in Cockpit Standalone.',
+        'The CPU usage of Cockpit as a percentage. This value is updated every 100ms. Only available in standalone application.',
     } as DataLakeVariable
     createDataLakeVariable(cockpitCpuUsageVariable)
   }

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -407,7 +407,7 @@ export const useVideoStore = defineStore('video', () => {
             message:
               'It looks like some of your video-related widgets (e.g.: video player, mini video recorder, snapshot tool)' +
               ' are connected to RTSP streams, which are not supported in Cockpit Lite. To make sure those widgets work,' +
-              ' re-configure them to only use WebRTC, or upgrade to Cockpit Standalone, which supports both WebRTC and RTSP streams.',
+              ' re-configure them to only use WebRTC, or upgrade to Cockpit standalone, which supports both WebRTC and RTSP streams.',
             variant: 'error',
           })
         }
@@ -1285,7 +1285,7 @@ export const useVideoStore = defineStore('video', () => {
    */
   const addRtspStreamCorrespondency = (rtspUrl: string): VideoStreamCorrespondency => {
     if (!window.electronAPI) {
-      throw new Error('RTSP streams are only available in Cockpit Standalone.')
+      throw new Error('RTSP streams are only available in Cockpit standalone.')
     }
 
     let parsedUrl: URL

--- a/src/types/tts.ts
+++ b/src/types/tts.ts
@@ -1,5 +1,5 @@
 /**
- * A curated Piper voice offered for alert speech on the Standalone build.
+ * A curated Piper voice offered for alert speech on the standalone build.
  */
 export interface PiperVoice {
   /** Stable speaker key used in dropdown option values and IPC (e.g. `amy`). */

--- a/src/views/ConfigurationGeneralView.vue
+++ b/src/views/ConfigurationGeneralView.vue
@@ -1002,7 +1002,7 @@ const openCockpitFolder = (): void => {
     window.electronAPI?.openCockpitFolder()
   } else {
     openSnackbar({
-      message: 'This feature is only available in Cockpit Standalone.',
+      message: 'This feature is only available in Cockpit standalone.',
       duration: 3000,
       variant: 'error',
       closeButton: true,

--- a/src/views/ConfigurationSourcesView.vue
+++ b/src/views/ConfigurationSourcesView.vue
@@ -28,7 +28,7 @@
                   <div>
                     <h4 class="text-amber-200 font-medium mb-2">Cockpit Lite</h4>
                     <p class="text-amber-100 text-sm">
-                      Reading external serial GNSS receivers is only available in Cockpit Standalone. Browsers cannot
+                      Reading external serial GNSS receivers is only available in Cockpit standalone. Browsers cannot
                       access serial devices outside of a secure context, so this feature is disabled here.
                     </p>
                   </div>

--- a/src/views/ConfigurationVideoView.vue
+++ b/src/views/ConfigurationVideoView.vue
@@ -154,7 +154,7 @@
                 </span>
               </div>
               <div v-if="isElectron()" class="mt-4 mr-2 mb-2 w-[95%]">
-                <div class="text-sm text-gray-300 mb-2">Add direct RTSP stream (Standalone)</div>
+                <div class="text-sm text-gray-300 mb-2">Add direct RTSP stream (standalone)</div>
                 <div class="flex items-end gap-2 w-full">
                   <v-text-field
                     v-model="rtspUrlInput"
@@ -271,7 +271,7 @@
           <template #info>
             <li>
               Configure live video processing to process videos in real-time during recording for instant availability
-              when recording stops. This is only available in Cockpit Standalone.
+              when recording stops. This is only available in Cockpit standalone.
             </li>
             <li>
               Choose whether to save backup raw chunks alongside the final video file. This provides safety for video
@@ -306,7 +306,7 @@
                   <h4 class="text-amber-200 font-medium mb-2">Cockpit Lite</h4>
                   <p class="text-amber-100 text-sm">
                     Video processing is not available in Cockpit Lite. Your recordings will be saved as raw chunks that
-                    can be downloaded and processed using Cockpit Standalone.
+                    can be downloaded and processed using Cockpit standalone.
                   </p>
                 </div>
               </div>
@@ -315,7 +315,7 @@
             <div class="flex items-center justify-start w-[96%] ml-2">
               <v-checkbox
                 v-model="videoStore.enableLiveProcessing"
-                label="Live video processing (Standalone)"
+                label="Live video processing (standalone)"
                 class="text-sm mx-2"
                 hide-details
                 :disabled="!isElectron()"
@@ -324,7 +324,7 @@
                 :text="
                   isElectron()
                     ? 'Process videos in real-time during recording for instant availability when recording stops'
-                    : 'Live video processing is only available in Cockpit Standalone'
+                    : 'Live video processing is only available in Cockpit standalone'
                 "
               >
                 <template #activator="{ props }">


### PR DESCRIPTION
Cockpit has two variants: the standalone desktop application "Cockpit", and the browser-based web application "Cockpit Lite". We currently have capitalised "Standalone" instances dotted around, but "standalone" is just an adjective we have chosen to use consistently for differentiating the Cockpit desktop application from the Lite variant. Adjectives are distinct from the proper noun (name/title) they're describing, so shouldn't be capitalised &rightarrow; this PR corrects those usages to lowercase.