### PR TITLE
Show the Celsius 2 VGI preset with two decimal places

### DIFF
--- a/src/types/genericIndicator.ts
+++ b/src/types/genericIndicator.ts
@@ -114,6 +114,6 @@ export const veryGenericIndicatorPresets: VeryGenericIndicatorPreset[] = [
     iconName: 'mdi-thermometer',
     variableUnit: '°C',
     variableMultiplier: 1,
-    decimalPlaces: 1,
+    decimalPlaces: 2,
   },
 ]


### PR DESCRIPTION
Asked by Zach.

Bumps the `decimalPlaces` of the Celsius 2 very-generic-indicator preset from 1 to 2, so the displayed temperature keeps the resolution the sensor actually provides.

Only the preset default changes; widgets already configured by users keep whatever value they have, and no migration is involved.
