### PR TITLE
Allow receiving data from other vehicles on the network

### DIFF
--- a/src/components/TransformingFunctionDialog.vue
+++ b/src/components/TransformingFunctionDialog.vue
@@ -69,6 +69,9 @@
                 • Return is optional, but should be included in complex expressions
                 <br />
                 • Remember to set the type accordingly
+                <br />
+                • Each variable enters the expression with its own type, so a text value stays text even when it looks
+                like a number
               </div>
             </v-expand-transition>
             <div

--- a/src/components/configuration/ConnectionsList.vue
+++ b/src/components/configuration/ConnectionsList.vue
@@ -14,14 +14,17 @@
           <span class="text-xs opacity-60">({{ row.statusLabel }})</span>
           <span v-if="row.details" class="text-xs opacity-60 truncate">{{ row.details }}</span>
         </div>
-        <v-btn
-          v-tooltip.bottom="removeTooltip"
-          :aria-label="removeTooltip"
-          icon="mdi-delete"
-          size="x-small"
-          variant="text"
-          @click="emit('remove', row.key)"
-        />
+        <div class="flex items-center">
+          <slot name="row-actions" :row="row" />
+          <v-btn
+            v-tooltip.bottom="removeTooltip"
+            :aria-label="removeTooltip"
+            icon="mdi-delete"
+            size="x-small"
+            variant="text"
+            @click="emit('remove', row.key)"
+          />
+        </div>
       </div>
     </div>
     <div v-else class="text-sm opacity-60 mb-4">{{ emptyMessage }}</div>

--- a/src/components/configuration/ConnectionsList.vue
+++ b/src/components/configuration/ConnectionsList.vue
@@ -1,0 +1,128 @@
+<template>
+  <div class="flex flex-col w-full mt-2 pb-8">
+    <div v-if="rows.length > 0" class="mb-4">
+      <div
+        v-for="row in rows"
+        :key="row.key"
+        class="flex items-center justify-between py-2 px-3 mb-2 rounded bg-[#FFFFFF11]"
+      >
+        <div class="flex items-center gap-2 flex-1 min-w-0">
+          <v-icon :color="getLoadingStatusColor(row.status)" size="small">
+            {{ getLoadingStatusIcon(row.status) }}
+          </v-icon>
+          <span class="truncate text-sm" :title="row.title ?? row.address">{{ row.address }}</span>
+          <span class="text-xs opacity-60">({{ row.statusLabel }})</span>
+          <span v-if="row.details" class="text-xs opacity-60 truncate">{{ row.details }}</span>
+        </div>
+        <v-btn
+          v-tooltip.bottom="removeTooltip"
+          :aria-label="removeTooltip"
+          icon="mdi-delete"
+          size="x-small"
+          variant="text"
+          @click="emit('remove', row.key)"
+        />
+      </div>
+    </div>
+    <div v-else class="text-sm opacity-60 mb-4">{{ emptyMessage }}</div>
+    <slot name="warning" />
+    <div class="flex justify-start items-center">
+      <v-text-field
+        :model-value="modelValue"
+        variant="outlined"
+        type="input"
+        density="compact"
+        :label="addressLabel"
+        :placeholder="addressPlaceholder"
+        hide-details
+        @update:model-value="emit('update:modelValue', $event)"
+        @keyup.enter="emit('add')"
+      />
+      <v-btn
+        :size="interfaceStore.isOnSmallScreen ? 'small' : 'default'"
+        :disabled="!modelValue.trim()"
+        class="bg-transparent"
+        :class="interfaceStore.isOnSmallScreen ? 'ml-1' : 'ml-5'"
+        variant="text"
+        @click="emit('add')"
+      >
+        {{ addButtonLabel }}
+      </v-btn>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { ConnectionStatus } from '@/libs/utils/ui'
+import { getLoadingStatusColor, getLoadingStatusIcon } from '@/libs/utils/ui'
+import { useAppInterfaceStore } from '@/stores/appInterface'
+
+/**
+ * One configured connection, as shown in the list.
+ */
+interface ConnectionRow {
+  /**
+   * Identifier passed back on removal.
+   */
+  key: string
+  /**
+   * Address shown to the user.
+   */
+  address: string
+  /**
+   * Full address for the hover title, when the shown one is abbreviated.
+   */
+  title?: string
+  /**
+   * Status the icon and its color come from.
+   */
+  status: ConnectionStatus
+  /**
+   * Status as shown to the user.
+   */
+  statusLabel: string
+  /**
+   * Extra information shown after the status.
+   */
+  details?: string
+}
+
+const interfaceStore = useAppInterfaceStore()
+
+defineProps<{
+  /**
+   * Connections currently configured.
+   */
+  rows: ConnectionRow[]
+  /**
+   * Address being typed into the new-connection field.
+   */
+  modelValue: string
+  /**
+   * Line shown when nothing is configured.
+   */
+  emptyMessage: string
+  /**
+   * Label of the new-connection field.
+   */
+  addressLabel: string
+  /**
+   * Example address shown while the new-connection field is empty.
+   */
+  addressPlaceholder: string
+  /**
+   * Label of the button that adds what was typed.
+   */
+  addButtonLabel: string
+  /**
+   * Accessible name and tooltip of each row's remove button.
+   */
+  removeTooltip: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string): void
+  (e: 'add'): void
+  (e: 'remove', key: string): void
+}>()
+</script>

--- a/src/composables/secondaryVehicles.ts
+++ b/src/composables/secondaryVehicles.ts
@@ -2,6 +2,7 @@ import { useStorage } from '@vueuse/core'
 import { computed, ref, watch } from 'vue'
 
 import { openSnackbar } from '@/composables/snackbar'
+import { generatePointOfInterestId, usePointsOfInterest } from '@/composables/usePointsOfInterest'
 import { getDataLakeVariableData } from '@/libs/actions/data-lake'
 import * as Connection from '@/libs/connection/connection'
 import { ConnectionManager } from '@/libs/connection/connection-manager'
@@ -12,6 +13,7 @@ import {
   syncSecondaryVehicleConnections,
 } from '@/libs/vehicle/mavlink/secondary-connections'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
+import type { PointOfInterestCoordinates } from '@/types/mission'
 
 const storedUris = useStorage<string[]>(secondaryVehicleUrisKey, [])
 
@@ -96,6 +98,97 @@ export const removeSecondaryVehicle = (uri: string): void => {
   storedUris.value = secondaryVehicleUris.value.filter((entry) => entry !== uri)
   logUserAction(`Removed the secondary vehicle at '${uri}'`)
   openSnackbar({ message: 'Vehicle removed.', variant: 'success', duration: 3000 })
+}
+
+// The autopilot is component 1, as in every other place the vehicle position is read from, and it reports
+// degrees scaled by 1e7.
+const vehicleCoordinateVariable = (systemId: number, field: 'lat' | 'lon'): string =>
+  `/mavlink/${systemId}/1/GLOBAL_POSITION_INT/${field}`
+
+const vehiclePosition = (systemId: number): PointOfInterestCoordinates | undefined => {
+  const latitude = getDataLakeVariableData(vehicleCoordinateVariable(systemId, 'lat'))
+  const longitude = getDataLakeVariableData(vehicleCoordinateVariable(systemId, 'lon'))
+  if (typeof latitude !== 'number' || typeof longitude !== 'number') return undefined
+  return [latitude / 1e7, longitude / 1e7]
+}
+
+/**
+ * Whether any of the given vehicles can be placed on the map, which takes a position having arrived from
+ * it: the marker is stored with a fallback location for whoever has no live data for it, and there is no
+ * honest one to store before the vehicle says where it is.
+ * @param {number[]} systemIds System IDs of the vehicles to check
+ * @returns {boolean} Whether at least one of them reported a position
+ */
+export const canPlaceSecondaryVehiclesOnMap = (systemIds: number[]): boolean =>
+  systemIds.some((systemId) => vehiclePosition(systemId) !== undefined)
+
+/**
+ * Places a point of interest following the live position of each given vehicle, so the user gets it on the
+ * map without writing its coordinate expressions by hand.
+ * @param {number[]} systemIds System IDs of the vehicles to place
+ * @returns {void}
+ */
+export const placeSecondaryVehiclesOnMap = (systemIds: number[]): void => {
+  const { pointsOfInterest, addPointOfInterest } = usePointsOfInterest()
+
+  const placedNames: string[] = []
+  const alreadyPlacedNames: string[] = []
+  const waitingNames: string[] = []
+
+  systemIds.forEach((systemId) => {
+    const name = `Vehicle ${systemId}`
+
+    const position = vehiclePosition(systemId)
+    if (position === undefined) {
+      waitingNames.push(name)
+      return
+    }
+
+    const latitude = `{{ ${vehicleCoordinateVariable(systemId, 'lat')} }} / 1e7`
+    const longitude = `{{ ${vehicleCoordinateVariable(systemId, 'lon')} }} / 1e7`
+    // The coordinate expression is what marks a POI as this vehicle's, unlike an id the user can also
+    // produce by naming a POI after the vehicle.
+    if (pointsOfInterest.value.some((poi) => poi.latitude === latitude)) {
+      alreadyPlacedNames.push(name)
+      return
+    }
+
+    addPointOfInterest({
+      id: generatePointOfInterestId(
+        name,
+        pointsOfInterest.value.map((poi) => poi.id)
+      ),
+      name,
+      description: `Live position of the vehicle with system ID ${systemId}.`,
+      latitude,
+      longitude,
+      fallbackCoordinates: position,
+      icon: 'mdi-map-marker',
+      color: '#87CEEB',
+      timestamp: Date.now(),
+    })
+    placedNames.push(name)
+  })
+
+  // An address can carry several vehicles, so each outcome is reported on its own instead of letting the
+  // ones that were skipped, and why, go unmentioned.
+  const outcomes: string[] = []
+  if (placedNames.length > 0) outcomes.push(`${placedNames.join(', ')} placed on the map, tracking the live position.`)
+  if (alreadyPlacedNames.length > 0) {
+    outcomes.push(`${alreadyPlacedNames.join(', ')} ${alreadyPlacedNames.length === 1 ? 'was' : 'were'} already there.`)
+  }
+  if (waitingNames.length > 0) {
+    const verb = waitingNames.length === 1 ? 'has' : 'have'
+    outcomes.push(`${waitingNames.join(', ')} ${verb} not reported a position yet, and stayed off the map.`)
+  }
+  if (outcomes.length === 0) return
+
+  if (placedNames.length > 0) logUserAction(`Placed ${placedNames.join(', ')} on the map`)
+  openSnackbar({
+    message: outcomes.join(' '),
+    variant: placedNames.length > 0 ? 'success' : 'info',
+    duration: 5000,
+  })
 }
 
 /**

--- a/src/composables/secondaryVehicles.ts
+++ b/src/composables/secondaryVehicles.ts
@@ -1,0 +1,117 @@
+import { useStorage } from '@vueuse/core'
+import { computed, ref, watch } from 'vue'
+
+import { openSnackbar } from '@/composables/snackbar'
+import { getDataLakeVariableData } from '@/libs/actions/data-lake'
+import * as Connection from '@/libs/connection/connection'
+import { ConnectionManager } from '@/libs/connection/connection-manager'
+import {
+  type SecondaryConnectionState,
+  getSecondaryConnectionState,
+  secondaryVehicleUrisKey,
+  syncSecondaryVehicleConnections,
+} from '@/libs/vehicle/mavlink/secondary-connections'
+import { useMainVehicleStore } from '@/stores/mainVehicle'
+
+const storedUris = useStorage<string[]>(secondaryVehicleUrisKey, [])
+
+/** Configured addresses, always read as a list even when the stored value is not one */
+export const secondaryVehicleUris = computed<string[]>(() => (Array.isArray(storedUris.value) ? storedUris.value : []))
+
+/** Runtime state of each configured address, as of the last {@link refreshSecondaryVehicleStates} call */
+export const secondaryVehicleStates = ref<Record<string, SecondaryConnectionState>>({})
+
+/** System IDs claimed by more than one other vehicle, so all but the first to announce each are being ignored */
+export const duplicatedSecondaryVehicleSystemIds = computed<number[]>(() => {
+  const systemIds = Object.values(secondaryVehicleStates.value).flatMap((state) => state.systemIds)
+  return [...new Set(systemIds.filter((systemId, index) => systemIds.indexOf(systemId) !== index))]
+})
+
+/** Whether another vehicle uses the piloted vehicle's system ID, in which case it is dropped instead of ignored */
+export const secondaryVehicleUsesMainVehicleSystemId = computed<boolean>(() => {
+  const mainVehicleSystemId = getDataLakeVariableData('autopilotSystemId')
+  if (typeof mainVehicleSystemId !== 'number') return false
+  return Object.values(secondaryVehicleStates.value).some((state) => state.systemIds.includes(mainVehicleSystemId))
+})
+
+/**
+ * Re-reads the runtime state of every connection, which the connections do not push on their own.
+ * @returns {void}
+ */
+export const refreshSecondaryVehicleStates = (): void => {
+  const states = secondaryVehicleUris.value.map((uri) => [uri, getSecondaryConnectionState(uri)] as const)
+  secondaryVehicleStates.value = Object.fromEntries(states)
+}
+
+const refuse = (message: string): false => {
+  openSnackbar({ message, variant: 'error', closeButton: true })
+  return false
+}
+
+/**
+ * Adds a vehicle by the address of its MAVLink stream, telling the user why it was refused when it cannot be
+ * used.
+ * @param {string} uri Address of the vehicle
+ * @returns {boolean} Whether the vehicle was added
+ */
+export const addSecondaryVehicle = (uri: string): boolean => {
+  const trimmedUri = uri.trim()
+  if (trimmedUri === '') return false
+
+  let normalizedUri: string
+  try {
+    const parsedUri = new Connection.URI(trimmedUri)
+    if (parsedUri.type() !== Connection.Type.WebSocket) {
+      throw new Error('the address should start with ws:// or wss://')
+    }
+    normalizedUri = parsedUri.toString()
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error)
+    return refuse(`Could not add the vehicle: ${reason}.`)
+  }
+
+  if (secondaryVehicleUris.value.includes(normalizedUri)) {
+    return refuse('That vehicle has already been added.')
+  }
+  if (normalizedUri === ConnectionManager.mainConnection()?.uri().toString()) {
+    return refuse('That is the address of the main vehicle, which is already connected.')
+  }
+
+  storedUris.value = [...secondaryVehicleUris.value, normalizedUri]
+  logUserAction(`Added the secondary vehicle at '${normalizedUri}'`)
+  openSnackbar({
+    message: 'Vehicle added. Its telemetry will show up as data-lake variables once it starts arriving.',
+    variant: 'success',
+    duration: 5000,
+  })
+  return true
+}
+
+/**
+ * Removes a vehicle and closes its connection.
+ * @param {string} uri Address of the vehicle
+ * @returns {void}
+ */
+export const removeSecondaryVehicle = (uri: string): void => {
+  storedUris.value = secondaryVehicleUris.value.filter((entry) => entry !== uri)
+  logUserAction(`Removed the secondary vehicle at '${uri}'`)
+  openSnackbar({ message: 'Vehicle removed.', variant: 'success', duration: 3000 })
+}
+
+/**
+ * Keeps the open connections matching the configured addresses, so the telemetry mirroring runs without any
+ * UI mounted.
+ * @returns {void}
+ */
+export const initSecondaryVehicleConnections = (): void => {
+  const mainVehicleStore = useMainVehicleStore()
+
+  watch(
+    secondaryVehicleUris,
+    (uris) => {
+      syncSecondaryVehicleConnections(uris, () => mainVehicleStore.vehicleConnectionWatchdogTimeoutMs)
+      refreshSecondaryVehicleStates()
+    },
+    { immediate: true }
+  )
+}

--- a/src/libs/actions/data-lake-transformations.ts
+++ b/src/libs/actions/data-lake-transformations.ts
@@ -3,7 +3,7 @@ import {
   findDataLakeInputsInString,
   findDataLakeVariablesIdsInString,
   getDataLakeVariableIdFromInput,
-  replaceDataLakeInputsInString,
+  replaceDataLakeInputsInStringAsLiterals,
 } from '../utils-data-lake'
 import {
   createDataLakeVariable,
@@ -65,7 +65,7 @@ const saveTransformingFunctions = (): void => {
  * @returns {string | number | boolean} The evaluated value
  */
 export const evaluateDataLakeExpression = (expression: string): string | number | boolean => {
-  const expressionWithValues = replaceDataLakeInputsInString(expression)
+  const expressionWithValues = replaceDataLakeInputsInStringAsLiterals(expression)
 
   // Inputs whose variables have no value yet are left as literal '{{ ... }}' placeholders by the replacement.
   // Bail out with a clear error instead of letting eval fail with a cryptic "Unexpected token '{'" SyntaxError.

--- a/src/libs/utils-data-lake.ts
+++ b/src/libs/utils-data-lake.ts
@@ -51,10 +51,13 @@ export const getDataLakeVariableIdFromInput = (input: string): string | null => 
  * Replace all data lake inputs in a string with values from the data lake.
  * If a possible input is not found in the data lake, it will be left unchanged.
  * @param {string} input The string to replace data lake inputs in
- * @param {Function} replaceFunction The function to use to replace the data lake inputs. If not provided, the default function will be used.
+ * @param {Function} replaceFunction The function to use to replace the data lake inputs, taking the match and the position it was found at. If not provided, the default function will be used.
  * @returns {string} The string with data lake inputs replaced
  */
-export const replaceDataLakeInputsInString = (input: string, replaceFunction?: (match: string) => string): string => {
+export const replaceDataLakeInputsInString = (
+  input: string,
+  replaceFunction?: (match: string, offset: number) => string
+): string => {
   if (typeof input !== 'string') return input
 
   const defaultReplaceFunction = (match: string): string => {
@@ -67,7 +70,85 @@ export const replaceDataLakeInputsInString = (input: string, replaceFunction?: (
 
   const replaceFunctionToUse = replaceFunction || defaultReplaceFunction
 
-  return input.toString().replace(dataLakeInputRegex, (match) => replaceFunctionToUse(match))
+  return input.toString().replace(dataLakeInputRegex, (match, _id, offset) => replaceFunctionToUse(match, offset))
+}
+
+/**
+ * Tell, for each position of a JavaScript expression, whether it sits inside a string literal.
+ * Comments are skipped, so an apostrophe in one does not open a literal the evaluation never sees.
+ * A template literal's '${ ... }' is an expression the evaluation runs, so it counts as code and not as
+ * part of the literal holding it.
+ * @param {string} code The expression to scan
+ * @returns {boolean[]} Whether the character at each position is inside a string literal
+ */
+const stringLiteralPositions = (code: string): boolean[] => {
+  // ponytail: quotes, comments and template substitutions only, so a quote or a brace inside a regex literal
+  // still shifts what follows it. Two of those balance out and can hand a code position the unquoted form;
+  // tokenize if that ever matters.
+  const positions = new Array<boolean>(code.length).fill(false)
+  // What is currently open, innermost last: a quote for each string literal, '${' for each template
+  // substitution and '{' for each brace nested in one, which is how the substitution's own '}' is found.
+  const open: string[] = []
+
+  for (let index = 0; index < code.length; index++) {
+    const character = code[index]
+    const enclosing = open[open.length - 1]
+    const insideLiteral = enclosing === "'" || enclosing === '"' || enclosing === '`'
+    const commentOpener = insideLiteral ? '' : code.slice(index, index + 2)
+    if (commentOpener === '//' || commentOpener === '/*') {
+      const commentEnd =
+        commentOpener === '//' ? code.indexOf('\n', index) : code.indexOf('*/', index + commentOpener.length)
+      if (commentEnd === -1) break
+      index = commentOpener === '//' ? commentEnd : commentEnd + 1
+    } else if (insideLiteral && character === '\\') {
+      positions[index] = true
+      if (index + 1 < code.length) positions[index + 1] = true
+      index++
+    } else if (enclosing === '`' && character === '$' && code[index + 1] === '{') {
+      open.push('${')
+      index++
+    } else if (insideLiteral) {
+      positions[index] = character !== enclosing
+      if (character === enclosing) open.pop()
+    } else if (["'", '"', '`'].includes(character)) {
+      open.push(character)
+    } else if (enclosing !== undefined && character === '{') {
+      open.push('{')
+    } else if (enclosing !== undefined && character === '}') {
+      open.pop()
+    }
+  }
+
+  // Anything left open means the scan lost track of which positions are code, and the unquoted form in a
+  // code position is exactly the injection this exists to prevent, so no position is trusted as text.
+  return open.length === 0 ? positions : positions.fill(false)
+}
+
+// Escaped for all three kinds of string literal at once, since the value has to be unable to close the one
+// it lands in, whichever that is, nor open a template substitution inside it.
+const asStringLiteralContent = (value: unknown): string =>
+  JSON.stringify(String(value)).slice(1, -1).replace(/['`]/g, '\\$&').replace(/\$\{/g, '\\${')
+
+/**
+ * Replace all data lake inputs in a string with their values written as JavaScript literals, for strings
+ * that are going to be evaluated as code. Substituting a string value raw would let it be read as syntax
+ * instead of as a value, so whatever wrote the variable would be choosing what the evaluation runs.
+ * An input inside a string literal is text being built rather than a value being read, so it gets the value
+ * escaped instead of quoted, which keeps templates like `'Mode: {{ /x }}'` meaning what they always did.
+ * If a possible input is not found in the data lake, it will be left unchanged.
+ * @param {string} input The string to replace data lake inputs in
+ * @returns {string} The string with data lake inputs replaced by their literals
+ */
+export const replaceDataLakeInputsInStringAsLiterals = (input: string): string => {
+  const insideStringLiteral = typeof input === 'string' ? stringLiteralPositions(input) : []
+
+  return replaceDataLakeInputsInString(input, (match, offset) => {
+    const variableId = getDataLakeVariableIdFromInput(match)
+    if (!variableId) return match
+    const variableData = getDataLakeVariableData(variableId)
+    if (variableData === undefined) return match
+    return insideStringLiteral[offset] ? asStringLiteralContent(variableData) : JSON.stringify(variableData)
+  })
 }
 
 /**

--- a/src/libs/vehicle/mavlink/data-lake-injection.ts
+++ b/src/libs/vehicle/mavlink/data-lake-injection.ts
@@ -3,7 +3,13 @@ import type { Package } from '@/libs/connection/m2r/messages/mavlink2rest'
 
 import { flattenData } from '../common/data-flattener'
 
+// A secondary link's message body is remote JSON, and the variable picker splices a chosen id straight into an
+// expression that gets evaluated, so an id is only minted when it holds what a MAVLink path can hold.
+const validVariableIdRegex = /^[\w/=.-]+$/
+
 const setVariable = (id: string, name: string, value: string | number): void => {
+  if (!validVariableIdRegex.test(id)) return
+
   if (getDataLakeVariableInfo(id) === undefined) {
     createDataLakeVariable({ id, name, type: typeof value === 'string' ? 'string' : 'number' })
   }

--- a/src/libs/vehicle/mavlink/data-lake-injection.ts
+++ b/src/libs/vehicle/mavlink/data-lake-injection.ts
@@ -1,0 +1,53 @@
+import { createDataLakeVariable, getDataLakeVariableInfo, setDataLakeVariableData } from '@/libs/actions/data-lake'
+import type { Package } from '@/libs/connection/m2r/messages/mavlink2rest'
+
+import { flattenData } from '../common/data-flattener'
+
+const setVariable = (id: string, name: string, value: string | number): void => {
+  if (getDataLakeVariableInfo(id) === undefined) {
+    createDataLakeVariable({ id, name, type: typeof value === 'string' ? 'string' : 'number' })
+  }
+  setDataLakeVariableData(id, value)
+}
+
+/**
+ * Inject variable(s) from a MAVLink package into the DataLake, under
+ * `/mavlink/<system id>/<component id>/<message>/<field>`.
+ * @param {Package} mavlinkPackage The package to take the variables from
+ * @param {number} [legacyVariablesSystemId] System that also gets the legacy, unprefixed variable names (e.g.
+ * 'ATTITUDE/roll'), for its component 1 only. Omit to create the prefixed variables alone.
+ * @returns {void}
+ */
+export const injectMavlinkPackageIntoDataLake = (mavlinkPackage: Package, legacyVariablesSystemId?: number): void => {
+  const messageType = mavlinkPackage.message.type
+  const { system_id: messageSystemId, component_id: messageComponentId } = mavlinkPackage.header
+  const prefix = `/mavlink/${messageSystemId}/${messageComponentId}`
+  const suffix = `(MAVLink / System: ${messageSystemId} / Component: ${messageComponentId})`
+  const shouldCreateLegacyVariables =
+    legacyVariablesSystemId !== undefined && legacyVariablesSystemId === messageSystemId && messageComponentId === 1
+
+  // Inject variables from the MAVLink messages into the DataLake
+  if (['NAMED_VALUE_FLOAT', 'NAMED_VALUE_INT'].includes(messageType)) {
+    // Special handling for NAMED_VALUE_FLOAT/NAMED_VALUE_INT messages
+    const name = `${(mavlinkPackage.message.name as string[]).join('').replace(/\0/g, '')}`
+    setVariable(`${prefix}/${messageType}/${name}`, `${name} ${suffix}`, mavlinkPackage.message.value)
+
+    if (shouldCreateLegacyVariables) {
+      // Create duplicated variables for legacy purposes (that was how they were stored in the old generic-variables system)
+      setVariable(name, `(Legacy) ${name}`, mavlinkPackage.message.value)
+    }
+  } else {
+    // For all other messages, use the flattener
+    flattenData(mavlinkPackage.message).forEach(({ path, value }) => {
+      if (typeof value !== 'string' && typeof value !== 'number') return
+
+      if (shouldCreateLegacyVariables) {
+        // Create the variable in the old style path for legacy purposes (that was how they were stored in the old generic-variables system)
+        setVariable(path, `(Legacy) ${path}`, value)
+      }
+
+      // Create the variable in the new style path
+      setVariable(`${prefix}/${path}`, `${path} ${suffix}`, value)
+    })
+  }
+}

--- a/src/libs/vehicle/mavlink/secondary-connections.ts
+++ b/src/libs/vehicle/mavlink/secondary-connections.ts
@@ -1,0 +1,187 @@
+/**
+ * Manages the secondary MAVLink2Rest connections: extra vehicles on the network whose telemetry is mirrored
+ * into the data lake, so widgets and live-tracked points of interest can follow them without any of them
+ * becoming the main vehicle.
+ *
+ * These links are read-only by design, so no command can ever reach a vehicle the user is not piloting.
+ * They also bypass `ConnectionManager`, since adding a connection there replaces the main connection (and
+ * disconnects the previous one), and its `onRead` is what feeds the main vehicle and the vehicle factory.
+ *
+ * This module has no Vue dependencies; reactive orchestration lives in the `secondaryVehicles` composable.
+ */
+
+import { getDataLakeVariableData } from '@/libs/actions/data-lake'
+import * as Connection from '@/libs/connection/connection'
+import type { Package } from '@/libs/connection/m2r/messages/mavlink2rest'
+import { MavAutopilot, MAVLinkType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
+import type { Message } from '@/libs/connection/m2r/messages/mavlink2rest-message'
+import { WebSocketConnection } from '@/libs/connection/websocket-connection'
+import type { ConnectionStatus } from '@/libs/utils/ui'
+import { injectMavlinkPackageIntoDataLake } from '@/libs/vehicle/mavlink/data-lake-injection'
+import * as Protocol from '@/libs/vehicle/protocol/protocol'
+
+/** Persistence key for the configured secondary connection addresses. Machine-local: these are addresses on the local network. */
+export const secondaryVehicleUrisKey = 'cockpit-secondary-mavlink2rest-uris'
+
+const LOG_PREFIX = '[SecondaryVehicles]'
+
+/**
+ * Runtime state of a secondary connection, used for UI feedback.
+ */
+export interface SecondaryConnectionState {
+  /**
+   * Whether the underlying websocket is currently open.
+   */
+  isConnected: boolean
+  /**
+   * Epoch of the last message received, or undefined while nothing has arrived yet.
+   */
+  lastMessageAt: number | undefined
+  /**
+   * System IDs of the vehicles announced on this link, which is what names their data-lake variables.
+   */
+  systemIds: number[]
+}
+
+const connections = new Map<string, WebSocketConnection>()
+const lastMessageAt = new Map<string, number>()
+const systemIds = new Map<string, Set<number>>()
+
+// A data-lake id names exactly one system, so the first link to announce a vehicle with a given system ID is
+// the only one allowed to write that system's variables.
+const systemIdOwners = new Map<number, string>()
+
+const textDecoder = new TextDecoder()
+
+// A MAVLink stream carries every system on the vehicle's network, including BlueOS services and other ground
+// stations, so a vehicle is only counted when it announces a real autopilot, as the vehicle factory does.
+const isVehicleHeartbeat = (mavlinkPackage: Package): boolean =>
+  mavlinkPackage.message.type === MAVLinkType.HEARTBEAT &&
+  (mavlinkPackage.message as Message.Heartbeat).autopilot?.type !== MavAutopilot.MAV_AUTOPILOT_INVALID
+
+/**
+ * Whether a value announced as a MAVLink system or component ID really is one. A secondary link's payload is
+ * remote JSON whose header is only typed by assertion, and an ID that is not a number would still name
+ * data-lake variables, slip past the numeric guards in `onSecondaryData`, and reach the coordinate
+ * expressions generated from it.
+ * @param {unknown} id Value announced in the package header
+ * @returns {boolean} Whether it is a valid identifier
+ */
+export const isValidMavlinkId = (id: unknown): id is number =>
+  typeof id === 'number' && Number.isInteger(id) && id >= 1 && id <= 255
+
+const onSecondaryData = (uri: string, data: Uint8Array): void => {
+  let mavlinkPackage: Package
+  try {
+    mavlinkPackage = JSON.parse(textDecoder.decode(data)) as Package
+  } catch {
+    return
+  }
+  const systemId = mavlinkPackage?.header?.system_id
+  if (!isValidMavlinkId(systemId) || !isValidMavlinkId(mavlinkPackage.header?.component_id)) return
+  if (mavlinkPackage.message?.type === undefined) return
+
+  lastMessageAt.set(uri, Date.now())
+  if (isVehicleHeartbeat(mavlinkPackage)) {
+    systemIds.get(uri)?.add(systemId)
+    if (!systemIdOwners.has(systemId)) systemIdOwners.set(systemId, uri)
+  }
+
+  // Only mirror systems this link announced as a vehicle, and never one using the piloted vehicle's ID, so no
+  // other system can overwrite the variables the flight view reads. The main vehicle can also claim an ID
+  // after a link did, which is why it is checked on every message instead of only when the ID is claimed.
+  if (systemIdOwners.get(systemId) !== uri) return
+
+  // ponytail: the piloted vehicle's ID is only known once it has connected, so a link using that ID can write
+  // its variables until then. Listen to 'autopilotSystemId' and clear what it wrote if the window ever matters.
+  if (systemId === getDataLakeVariableData('autopilotSystemId')) return
+
+  // ponytail: every message of every secondary link is turned into data-lake variables at whatever rate the
+  // vehicle streams, so the cost grows with vehicles x message rate. Filter by message type here if needed.
+  injectMavlinkPackageIntoDataLake(mavlinkPackage)
+}
+
+/**
+ * Returns the current state of a secondary connection. Pull-based, so nothing polls in the background: the
+ * UI reads it while it is on screen.
+ * @param {string} uri Address of the secondary connection
+ * @returns {SecondaryConnectionState} The connection's current state
+ */
+export const getSecondaryConnectionState = (uri: string): SecondaryConnectionState => ({
+  isConnected: connections.get(uri)?.isConnected() ?? false,
+  lastMessageAt: lastMessageAt.get(uri),
+  systemIds: [...(systemIds.get(uri) ?? [])],
+})
+
+/**
+ * Maps a connection's state to a status, distinguishing an open socket that is delivering data from one that
+ * has gone silent. Silence is measured against the same timeout that recycles the socket, so the reported
+ * status cannot contradict what the connection is about to do.
+ * @param {SecondaryConnectionState} state State of the connection
+ * @param {number} watchdogTimeoutMs How long the socket may stay silent before being recycled
+ * @returns {ConnectionStatus} The corresponding status
+ */
+export const secondaryConnectionStatus = (
+  state: SecondaryConnectionState,
+  watchdogTimeoutMs: number
+): ConnectionStatus => {
+  if (!state.isConnected) return 'disconnected'
+  const isReceiving = state.lastMessageAt !== undefined && Date.now() - state.lastMessageAt < watchdogTimeoutMs
+  return isReceiving ? 'connected' : 'connecting'
+}
+
+const statusLabels: Record<ConnectionStatus, string> = {
+  connected: 'receiving data',
+  connecting: 'connected, waiting for data',
+  disconnected: 'disconnected',
+}
+
+/**
+ * Maps a connection's state to a human-readable status label.
+ * @param {SecondaryConnectionState} state State of the connection
+ * @param {number} watchdogTimeoutMs How long the socket may stay silent before being recycled
+ * @returns {string} The label
+ */
+export const secondaryConnectionStatusLabel = (state: SecondaryConnectionState, watchdogTimeoutMs: number): string =>
+  statusLabels[secondaryConnectionStatus(state, watchdogTimeoutMs)]
+
+/**
+ * Opens and closes secondary connections so the open ones match the given addresses. Data-lake variables
+ * already created by a removed connection are left in place, since widgets may still reference them; they
+ * simply stop updating, as they do for any vehicle that goes away.
+ * @param {string[]} uris Addresses that should be connected
+ * @param {() => number} getWatchdogTimeoutMs Returns the user-configured vehicle connection watchdog timeout
+ * @returns {void}
+ */
+export const syncSecondaryVehicleConnections = (uris: string[], getWatchdogTimeoutMs: () => number): void => {
+  const wantedUris = new Set(uris)
+
+  connections.forEach((connection, uri) => {
+    if (wantedUris.has(uri)) return
+    connection.disconnect()
+    connections.delete(uri)
+    lastMessageAt.delete(uri)
+    systemIds.delete(uri)
+    systemIdOwners.forEach((owner, systemId) => {
+      if (owner === uri) systemIdOwners.delete(systemId)
+    })
+    console.info(`${LOG_PREFIX} Closed the connection to '${uri}'.`)
+  })
+
+  wantedUris.forEach((uri) => {
+    if (connections.has(uri)) return
+    try {
+      const parsedUri = new Connection.URI(uri)
+      if (parsedUri.type() !== Connection.Type.WebSocket) {
+        throw new Error('the address should start with ws:// or wss://')
+      }
+      systemIds.set(uri, new Set())
+      const connection = new WebSocketConnection(parsedUri, Protocol.Type.MAVLink, { getWatchdogTimeoutMs })
+      connection.onRead.add((data: Uint8Array) => onSecondaryData(uri, data))
+      connections.set(uri, connection)
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error)
+      console.error(`${LOG_PREFIX} Could not connect to '${uri}': ${reason}.`)
+    }
+  })
+}

--- a/src/libs/vehicle/mavlink/secondary-connections.ts
+++ b/src/libs/vehicle/mavlink/secondary-connections.ts
@@ -10,7 +10,12 @@
  * This module has no Vue dependencies; reactive orchestration lives in the `secondaryVehicles` composable.
  */
 
-import { getDataLakeVariableData } from '@/libs/actions/data-lake'
+import {
+  createDataLakeVariable,
+  getDataLakeVariableData,
+  getDataLakeVariableInfo,
+  setDataLakeVariableData,
+} from '@/libs/actions/data-lake'
 import * as Connection from '@/libs/connection/connection'
 import type { Package } from '@/libs/connection/m2r/messages/mavlink2rest'
 import { MavAutopilot, MAVLinkType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
@@ -51,6 +56,13 @@ const systemIds = new Map<string, Set<number>>()
 // the only one allowed to write that system's variables.
 const systemIdOwners = new Map<number, string>()
 
+// Per vehicle instead of per link, since one link carries every system on the vehicle's network.
+const lastMessageAtBySystemId = new Map<number, number>()
+
+const isReceivingDataPollIntervalMs = 1000
+
+let isReceivingDataPoll: ReturnType<typeof setInterval> | undefined
+
 const textDecoder = new TextDecoder()
 
 // A MAVLink stream carries every system on the vehicle's network, including BlueOS services and other ground
@@ -58,6 +70,40 @@ const textDecoder = new TextDecoder()
 const isVehicleHeartbeat = (mavlinkPackage: Package): boolean =>
   mavlinkPackage.message.type === MAVLinkType.HEARTBEAT &&
   (mavlinkPackage.message as Message.Heartbeat).autopilot?.type !== MavAutopilot.MAV_AUTOPILOT_INVALID
+
+/**
+ * Whether a system still counts as being received, from when it was last heard and how long it may stay
+ * silent. Pure, so the same decision serves both the per-link status and the per-vehicle data-lake variables.
+ * @param {number | undefined} lastMessageEpoch Epoch of the last message from the system, or undefined if it
+ * has never been heard from
+ * @param {number} nowEpoch Epoch to measure the silence against
+ * @param {number} timeoutMs How long the system may stay silent before it stops counting as received
+ * @returns {boolean} Whether data from the system is currently arriving
+ */
+export const isReceivingData = (lastMessageEpoch: number | undefined, nowEpoch: number, timeoutMs: number): boolean =>
+  lastMessageEpoch !== undefined && nowEpoch - lastMessageEpoch < timeoutMs
+
+// Created on the first message of each system, since the systems on a link are only discovered from its
+// stream, as the '/mavlink/<system id>/...' variables are.
+const setIsReceivingDataVariable = (systemId: number, isReceiving: boolean): void => {
+  const id = `/vehicles/mavlink/${systemId}/isReceivingData`
+  if (getDataLakeVariableInfo(id) === undefined) {
+    createDataLakeVariable({
+      id,
+      name: `Receiving data from vehicle ${systemId}`,
+      type: 'boolean',
+      description: `Whether data from the vehicle with system ID ${systemId} is currently arriving, so widgets can tell live values from the last ones received.`,
+    })
+  }
+  setDataLakeVariableData(id, isReceiving)
+}
+
+const refreshIsReceivingDataVariables = (watchdogTimeoutMs: number): void => {
+  const now = Date.now()
+  lastMessageAtBySystemId.forEach((systemLastMessageAt, systemId) => {
+    setIsReceivingDataVariable(systemId, isReceivingData(systemLastMessageAt, now, watchdogTimeoutMs))
+  })
+}
 
 /**
  * Whether a value announced as a MAVLink system or component ID really is one. A secondary link's payload is
@@ -96,14 +142,18 @@ const onSecondaryData = (uri: string, data: Uint8Array): void => {
   // its variables until then. Listen to 'autopilotSystemId' and clear what it wrote if the window ever matters.
   if (systemId === getDataLakeVariableData('autopilotSystemId')) return
 
+  // Tracked past the guards above so a vehicle only reports as received while its variables are being written.
+  if (!lastMessageAtBySystemId.has(systemId)) setIsReceivingDataVariable(systemId, true)
+  lastMessageAtBySystemId.set(systemId, Date.now())
+
   // ponytail: every message of every secondary link is turned into data-lake variables at whatever rate the
   // vehicle streams, so the cost grows with vehicles x message rate. Filter by message type here if needed.
   injectMavlinkPackageIntoDataLake(mavlinkPackage)
 }
 
 /**
- * Returns the current state of a secondary connection. Pull-based, so nothing polls in the background: the
- * UI reads it while it is on screen.
+ * Returns the current state of a secondary connection. Pull-based: this state is not pushed, the UI reads it
+ * while it is on screen.
  * @param {string} uri Address of the secondary connection
  * @returns {SecondaryConnectionState} The connection's current state
  */
@@ -126,8 +176,7 @@ export const secondaryConnectionStatus = (
   watchdogTimeoutMs: number
 ): ConnectionStatus => {
   if (!state.isConnected) return 'disconnected'
-  const isReceiving = state.lastMessageAt !== undefined && Date.now() - state.lastMessageAt < watchdogTimeoutMs
-  return isReceiving ? 'connected' : 'connecting'
+  return isReceivingData(state.lastMessageAt, Date.now(), watchdogTimeoutMs) ? 'connected' : 'connecting'
 }
 
 const statusLabels: Record<ConnectionStatus, string> = {
@@ -148,7 +197,8 @@ export const secondaryConnectionStatusLabel = (state: SecondaryConnectionState, 
 /**
  * Opens and closes secondary connections so the open ones match the given addresses. Data-lake variables
  * already created by a removed connection are left in place, since widgets may still reference them; they
- * simply stop updating, as they do for any vehicle that goes away.
+ * simply stop updating, as they do for any vehicle that goes away, after a final `false` on the vehicle's
+ * `isReceivingData` variable.
  * @param {string[]} uris Addresses that should be connected
  * @param {() => number} getWatchdogTimeoutMs Returns the user-configured vehicle connection watchdog timeout
  * @returns {void}
@@ -163,7 +213,11 @@ export const syncSecondaryVehicleConnections = (uris: string[], getWatchdogTimeo
     lastMessageAt.delete(uri)
     systemIds.delete(uri)
     systemIdOwners.forEach((owner, systemId) => {
-      if (owner === uri) systemIdOwners.delete(systemId)
+      if (owner !== uri) return
+      systemIdOwners.delete(systemId)
+      // Only for the systems actually mirrored: one dropped by the guards in `onSecondaryData` never reported
+      // as being received, so it has no variable to close out.
+      if (lastMessageAtBySystemId.delete(systemId)) setIsReceivingDataVariable(systemId, false)
     })
     console.info(`${LOG_PREFIX} Closed the connection to '${uri}'.`)
   })
@@ -184,4 +238,16 @@ export const syncSecondaryVehicleConnections = (uris: string[], getWatchdogTimeo
       console.error(`${LOG_PREFIX} Could not connect to '${uri}': ${reason}.`)
     }
   })
+
+  // A vehicle going quiet sends no message to notice it by, so the per-vehicle variables are recomputed on a
+  // timer, which only exists while at least one link does.
+  if (connections.size === 0) {
+    clearInterval(isReceivingDataPoll)
+    isReceivingDataPoll = undefined
+    return
+  }
+  isReceivingDataPoll ??= setInterval(
+    () => refreshIsReceivingDataVariables(getWatchdogTimeoutMs()),
+    isReceivingDataPollIntervalMs
+  )
 }

--- a/src/libs/vehicle/mavlink/vehicle.ts
+++ b/src/libs/vehicle/mavlink/vehicle.ts
@@ -5,7 +5,6 @@ import {
   type DataLakeVariable,
   createDataLakeVariable,
   getAllDataLakeVariablesInfo,
-  getDataLakeVariableInfo,
   setDataLakeVariableData,
 } from '@/libs/actions/data-lake'
 import { createTransformingFunction, getAllTransformingFunctions } from '@/libs/actions/data-lake-transformations'
@@ -30,6 +29,7 @@ import { type Message } from '@/libs/connection/m2r/messages/mavlink2rest-messag
 import { settingsManager } from '@/libs/settings-management'
 import { Signal, SignalTyped } from '@/libs/signal'
 import { degrees, frequencyHzToIntervalUs, isEqual, round, sleep } from '@/libs/utils'
+import { injectMavlinkPackageIntoDataLake } from '@/libs/vehicle/mavlink/data-lake-injection'
 import { defaultMessageIntervalsOptions } from '@/libs/vehicle/mavlink/defaults'
 import {
   type MAVLinkParameterSetData,
@@ -54,7 +54,6 @@ import {
 } from '@/libs/vehicle/types'
 import { type MissionLoadingCallback, type Waypoint, defaultLoadingCallback } from '@/types/mission'
 
-import { flattenData } from '../common/data-flattener'
 import * as Vehicle from '../vehicle'
 
 export const MAVLINK_MESSAGE_INTERVALS_STORAGE_KEY = 'cockpit-mavlink-message-intervals'
@@ -1536,69 +1535,8 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
    * @param { Package } mavlinkPackage
    */
   private addPackageVariablesToDataLake(mavlinkPackage: Package): void {
-    const messageType = mavlinkPackage.message.type
-    const { system_id: messageSystemId, component_id: messageComponentId } = mavlinkPackage.header
-    const prefix = `/mavlink/${messageSystemId}/${messageComponentId}`
-    const suffix = `(MAVLink / System: ${messageSystemId} / Component: ${messageComponentId})`
-
-    // Inject variables from the MAVLink messages into the DataLake
-    if (['NAMED_VALUE_FLOAT', 'NAMED_VALUE_INT'].includes(messageType)) {
-      // Special handling for NAMED_VALUE_FLOAT/NAMED_VALUE_INT messages
-      const name = `${(mavlinkPackage.message.name as string[]).join('').replace(/\0/g, '')}`
-      const path = `${prefix}/${messageType}/${name}`
-      if (getDataLakeVariableInfo(path) === undefined) {
-        createDataLakeVariable({ id: path, name: `${name} ${suffix}`, type: 'number' })
-      }
-      setDataLakeVariableData(path, mavlinkPackage.message.value)
-
-      if (
-        this.shouldCreateLegacyDataLakeVariables &&
-        messageSystemId === this.currentSystemId &&
-        messageComponentId === 1
-      ) {
-        // Create duplicated variables for legacy purposes (that was how they were stored in the old generic-variables system)
-        const oldVariablePath = mavlinkPackage.message.name.join('').replaceAll('\x00', '')
-        if (getDataLakeVariableInfo(oldVariablePath) === undefined) {
-          createDataLakeVariable({ id: oldVariablePath, name: `(Legacy) ${oldVariablePath}`, type: 'number' })
-        }
-        setDataLakeVariableData(oldVariablePath, mavlinkPackage.message.value)
-      }
-    } else {
-      // For all other messages, use the flattener
-      const flattened = flattenData(mavlinkPackage.message)
-      flattened.forEach(({ path, value }) => {
-        if (value === null) return
-        if (typeof value !== 'string' && typeof value !== 'number') return
-
-        if (
-          this.shouldCreateLegacyDataLakeVariables &&
-          messageSystemId === this.currentSystemId &&
-          messageComponentId === 1
-        ) {
-          // Create the variable in the old style path for legacy purposes (that was how they were stored in the old generic-variables system)
-          const oldStylePath = `${path}`
-          if (getDataLakeVariableInfo(oldStylePath) === undefined) {
-            createDataLakeVariable({
-              id: oldStylePath,
-              name: `(Legacy) ${path}`,
-              type: typeof value === 'string' ? 'string' : 'number',
-            })
-          }
-          setDataLakeVariableData(oldStylePath, value)
-        }
-
-        // Create the variable in the new style path
-        const newStylePath = `${prefix}/${path}`
-        if (getDataLakeVariableInfo(newStylePath) === undefined) {
-          createDataLakeVariable({
-            id: newStylePath,
-            name: `${path} ${suffix}`,
-            type: typeof value === 'string' ? 'string' : 'number',
-          })
-        }
-        setDataLakeVariableData(newStylePath, value)
-      })
-    }
+    const legacySystemId = this.shouldCreateLegacyDataLakeVariables ? this.currentSystemId : undefined
+    injectMavlinkPackageIntoDataLake(mavlinkPackage, legacySystemId)
   }
 
   /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import { createApp } from 'vue'
 import VueDraggableResizable from 'vue-draggable-resizable'
 import VueVirtualScroller from 'vue-virtual-scroller'
 
+import { initSecondaryVehicleConnections } from '@/composables/secondaryVehicles'
 import { initializeActionAutoRun } from '@/libs/actions/auto-run'
 import { app_version } from '@/libs/cosmos'
 import { dataLakeLogger } from '@/libs/data-lake-logging'
@@ -100,6 +101,9 @@ initializeActionAutoRun()
 
 // Boot the GNSS reading pipeline so configured devices post to the data lake independently of the UI
 initGnss()
+
+// Boot the secondary vehicle connections so their telemetry reaches the data lake independently of the UI
+initSecondaryVehicleConnections()
 
 // Start logging as soon as the app is loaded to always have telemetry for videos
 datalogger.startLogging('cockpit-telemetry-logging')

--- a/src/tests/libs/utils-data-lake.test.ts
+++ b/src/tests/libs/utils-data-lake.test.ts
@@ -1,0 +1,102 @@
+import { expect, test, vi } from 'vitest'
+
+import { getDataLakeVariableData } from '@/libs/actions/data-lake'
+import { replaceDataLakeInputsInStringAsLiterals } from '@/libs/utils-data-lake'
+
+// The real data lake pulls in the settings manager, which needs a working localStorage the test environment
+// does not provide, so the value each input resolves to is set per test.
+vi.mock('@/libs/actions/data-lake', () => ({
+  getDataLakeVariableData: vi.fn(),
+  getDataLakeVariableInfo: vi.fn(),
+}))
+
+const evaluate = (expression: string): unknown => eval(`(function() { return ${expression} })()`)
+
+// The form 'evaluateDataLakeExpression' uses for an expression that returns on its own.
+const evaluateBody = (expression: string): unknown => eval(`(function() { ${expression} })()`)
+
+const codePayload = '0 })(); globalThis.pwned = true; (function() { return 0'
+
+// A template substitution needs no quote, brace nor backtick to run, so the escaping that keeps a value
+// out of syntax in a text position leaves this payload untouched.
+const templateSubstitutionPayload = '(globalThis.pwned = true)'
+
+test('A string value is substituted as a literal, so it cannot become code', () => {
+  vi.mocked(getDataLakeVariableData).mockReturnValue('0); globalThis.pwned = true; (0')
+
+  const expression = replaceDataLakeInputsInStringAsLiterals('{{ /mavlink/3/1/GLOBAL_POSITION_INT/lat }} / 1e7')
+
+  expect(evaluate(expression)).toBeNaN()
+  expect('pwned' in globalThis).toBe(false)
+})
+
+test('A number value is still substituted as a number', () => {
+  vi.mocked(getDataLakeVariableData).mockReturnValue(-278899760)
+
+  const expression = replaceDataLakeInputsInStringAsLiterals('{{ /mavlink/3/1/GLOBAL_POSITION_INT/lat }} / 1e7')
+
+  expect(evaluate(expression)).toBeCloseTo(-27.889976)
+})
+
+test('A string value inside a string literal stays text, so a saved template keeps its meaning', () => {
+  vi.mocked(getDataLakeVariableData).mockReturnValue('GUIDED')
+
+  expect(evaluate(replaceDataLakeInputsInStringAsLiterals("'Mode: {{ /vehicle/mode }}'"))).toBe('Mode: GUIDED')
+  expect(evaluate(replaceDataLakeInputsInStringAsLiterals("'{{ /vehicle/mode }}' === 'GUIDED'"))).toBe(true)
+})
+
+test('A string value cannot close the literal it is substituted into', () => {
+  vi.mocked(getDataLakeVariableData).mockReturnValue("'; globalThis.pwned = true; '`${globalThis.pwned = true}`")
+
+  const expression = replaceDataLakeInputsInStringAsLiterals("'{{ /vehicle/mode }}'")
+
+  expect(evaluate(expression)).toBe("'; globalThis.pwned = true; '`${globalThis.pwned = true}`")
+  expect('pwned' in globalThis).toBe(false)
+})
+
+test('A quote inside a comment does not make the value on the next line be read as code', () => {
+  vi.mocked(getDataLakeVariableData).mockReturnValue(codePayload)
+
+  const expression = replaceDataLakeInputsInStringAsLiterals(
+    "// Show the vehicle's last message\nreturn {{ /mavlink/3/1/STATUSTEXT/text }}.length"
+  )
+
+  expect(evaluateBody(expression)).toBe(codePayload.length)
+  expect('pwned' in globalThis).toBe(false)
+})
+
+test('A literal the scan leaves open makes every value quoted, since it can no longer tell code from text', () => {
+  vi.mocked(getDataLakeVariableData).mockReturnValue(codePayload)
+
+  const expression = replaceDataLakeInputsInStringAsLiterals("/'/.test({{ /mavlink/3/1/STATUSTEXT/text }})")
+
+  expect(evaluate(expression)).toBe(false)
+  expect('pwned' in globalThis).toBe(false)
+})
+
+test('A value inside a template substitution is a value being read, so it cannot become code', () => {
+  vi.mocked(getDataLakeVariableData).mockReturnValue(templateSubstitutionPayload)
+
+  const expression = replaceDataLakeInputsInStringAsLiterals(
+    '`Depth: ${ {{ /mavlink/3/1/STATUSTEXT/text }} / 1000 } m`'
+  )
+
+  expect(evaluate(expression)).toBe('Depth: NaN m')
+  expect('pwned' in globalThis).toBe(false)
+})
+
+test('A value in the text of a template literal stays text, even when the same template substitutes one', () => {
+  vi.mocked(getDataLakeVariableData).mockReturnValue('GUIDED')
+
+  const expression = replaceDataLakeInputsInStringAsLiterals('`Mode: {{ /vehicle/mode }} (${ 1 + 1 })`')
+
+  expect(evaluate(expression)).toBe('Mode: GUIDED (2)')
+})
+
+test('An input whose variable has no value is left in place for the caller to report', () => {
+  vi.mocked(getDataLakeVariableData).mockReturnValue(undefined)
+
+  const input = '{{ /mavlink/3/1/GLOBAL_POSITION_INT/lat }} / 1e7'
+
+  expect(replaceDataLakeInputsInStringAsLiterals(input)).toBe(input)
+})

--- a/src/tests/libs/vehicle/mavlink/data-lake-injection.test.ts
+++ b/src/tests/libs/vehicle/mavlink/data-lake-injection.test.ts
@@ -33,6 +33,15 @@ test('Legacy unprefixed variables are created only for the system that asked for
   expect(variables().get('VFR_HUD/alt')).toBe(10)
 })
 
+test('A name the remote endpoint chose is not turned into a variable when it could be read as code', () => {
+  const name = 'depth}}+(globalThis.pwned=true)+{{/mavlink/42/1/NAMED_VALUE_FLOAT/depth'
+  injectMavlinkPackageIntoDataLake(mavlinkPackage(42, { type: 'NAMED_VALUE_FLOAT', name: [...name], value: 1 }))
+  injectMavlinkPackageIntoDataLake(mavlinkPackage(42, { type: 'ATTITUDE ', roll: 0.5 }))
+
+  expect([...variables().keys()].filter((id) => /[{}\s]/.test(id))).toEqual([])
+  expect(variables().get('/mavlink/42/1/NAMED_VALUE_FLOAT/depth')).toBe(undefined)
+})
+
 test('A package with no system id does not create legacy variables while they are disabled', () => {
   injectMavlinkPackageIntoDataLake(mavlinkPackage(undefined, { type: 'AHRS2', altitude: 5 }))
 

--- a/src/tests/libs/vehicle/mavlink/data-lake-injection.test.ts
+++ b/src/tests/libs/vehicle/mavlink/data-lake-injection.test.ts
@@ -1,0 +1,40 @@
+import { expect, test, vi } from 'vitest'
+
+import { setDataLakeVariableData } from '@/libs/actions/data-lake'
+import type { Package } from '@/libs/connection/m2r/messages/mavlink2rest'
+import { injectMavlinkPackageIntoDataLake } from '@/libs/vehicle/mavlink/data-lake-injection'
+
+// The real data lake pulls in the settings manager, which needs a working localStorage the test environment
+// does not provide, so the injected variables are read back from what the injection tried to write.
+vi.mock('@/libs/actions/data-lake', () => ({
+  createDataLakeVariable: vi.fn(),
+  getDataLakeVariableInfo: vi.fn(),
+  setDataLakeVariableData: vi.fn(),
+}))
+
+const variables = (): Map<string, string | number> =>
+  new Map(vi.mocked(setDataLakeVariableData).mock.calls as [string, string | number][])
+
+const mavlinkPackage = (systemId: number | undefined, message: Record<string, unknown>): Package =>
+  ({ header: { system_id: systemId, component_id: 1, sequence: 0 }, message } as unknown as Package)
+
+test('Variables are named after the system and component the package came from', () => {
+  injectMavlinkPackageIntoDataLake(mavlinkPackage(3, { type: 'ATTITUDE', roll: 0.5 }))
+
+  expect(variables().get('/mavlink/3/1/ATTITUDE/roll')).toBe(0.5)
+  expect(variables().has('ATTITUDE/roll')).toBe(false)
+})
+
+test('Legacy unprefixed variables are created only for the system that asked for them', () => {
+  injectMavlinkPackageIntoDataLake(mavlinkPackage(1, { type: 'VFR_HUD', alt: 10 }), 1)
+  expect(variables().get('VFR_HUD/alt')).toBe(10)
+
+  injectMavlinkPackageIntoDataLake(mavlinkPackage(2, { type: 'VFR_HUD', alt: 20 }), 1)
+  expect(variables().get('VFR_HUD/alt')).toBe(10)
+})
+
+test('A package with no system id does not create legacy variables while they are disabled', () => {
+  injectMavlinkPackageIntoDataLake(mavlinkPackage(undefined, { type: 'AHRS2', altitude: 5 }))
+
+  expect(variables().has('AHRS2/altitude')).toBe(false)
+})

--- a/src/tests/libs/vehicle/mavlink/secondary-connections.test.ts
+++ b/src/tests/libs/vehicle/mavlink/secondary-connections.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from 'vitest'
+
+import { isReceivingData, isValidMavlinkId } from '@/libs/vehicle/mavlink/secondary-connections'
+
+const timeoutMs = 4000
+const now = 1_700_000_000_000
+
+test('isReceivingData', () => {
+  expect(isReceivingData(now, now, timeoutMs)).toBe(true)
+  expect(isReceivingData(now - timeoutMs + 1, now, timeoutMs)).toBe(true)
+  expect(isReceivingData(now - timeoutMs, now, timeoutMs)).toBe(false)
+  expect(isReceivingData(now - 10 * timeoutMs, now, timeoutMs)).toBe(false)
+  expect(isReceivingData(undefined, now, timeoutMs)).toBe(false)
+})
+
+test('isValidMavlinkId', () => {
+  expect(isValidMavlinkId(1)).toBe(true)
+  expect(isValidMavlinkId(255)).toBe(true)
+  expect(isValidMavlinkId(0)).toBe(false)
+  expect(isValidMavlinkId(256)).toBe(false)
+  expect(isValidMavlinkId(1.5)).toBe(false)
+  expect(isValidMavlinkId(NaN)).toBe(false)
+  expect(isValidMavlinkId(undefined)).toBe(false)
+
+  // A string that stringifies to a valid ID is what an announced ID has to be rejected as: it would name the
+  // piloted vehicle's variables while never matching the numeric guard that drops that ID.
+  expect(isValidMavlinkId('1')).toBe(false)
+
+  // The shape that would otherwise be spliced into a generated coordinate expression and evaluated.
+  expect(isValidMavlinkId('42/1/GLOBAL_POSITION_INT/lat}}+(globalThis.pwned=true)+{{/mavlink/42')).toBe(false)
+})

--- a/src/views/ConfigurationGeneralView.vue
+++ b/src/views/ConfigurationGeneralView.vue
@@ -254,8 +254,8 @@
               <p>
                 Receives telemetry from other vehicles on your network, each one on its own address. Their data becomes
                 available as data-lake variables named after the vehicle's system ID, so widgets can read it and a point
-                of interest can follow it on the map. To place one on the map, create a point of interest and use the
-                vehicle's position variables as its coordinates, e.g.
+                of interest can follow it on the map. Use the map button next to a vehicle to place it on the map, or
+                reference its position variables yourself, e.g.
                 <span class="font-mono">{{ exampleSecondaryVehicleCoordinate }}</span>
               </p>
               <p class="mt-2">
@@ -278,6 +278,18 @@
               @add="addNewSecondaryVehicle"
               @remove="removeSecondaryVehicle"
             >
+              <template #row-actions="{ row }">
+                <v-btn
+                  v-tooltip.bottom="placeOnMapTooltip(row.key)"
+                  :aria-label="placeOnMapTooltip(row.key)"
+                  :class="canPlaceOnMap(row.key) ? '' : '!pointer-events-auto'"
+                  :disabled="!canPlaceOnMap(row.key)"
+                  icon="mdi-map-marker-plus"
+                  size="x-small"
+                  variant="text"
+                  @click="placeSecondaryVehiclesOnMap(secondaryVehicleSystemIds(row.key))"
+                />
+              </template>
               <template #warning>
                 <div v-if="secondaryVehicleUsesMainVehicleSystemId" class="text-sm text-yellow-400 mb-4">
                   A vehicle is using the same system ID as the vehicle you are piloting, so it is not being received.
@@ -547,7 +559,9 @@ import VehicleDiscoveryDialog from '@/components/VehicleDiscoveryDialog.vue'
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import {
   addSecondaryVehicle,
+  canPlaceSecondaryVehiclesOnMap,
   duplicatedSecondaryVehicleSystemIds,
+  placeSecondaryVehiclesOnMap,
   refreshSecondaryVehicleStates,
   removeSecondaryVehicle,
   secondaryVehicleStates,
@@ -994,6 +1008,18 @@ const showDiscoveryDialog = ref(false)
 const exampleSecondaryVehicleUri = 'ws://192.168.2.4/mavlink2rest/ws/mavlink'
 const exampleSecondaryVehicleCoordinate = '{{ /mavlink/3/1/GLOBAL_POSITION_INT/lat }} / 1e7'
 const newSecondaryVehicleUri = ref('')
+
+const secondaryVehicleSystemIds = (uri: string): number[] => secondaryVehicleStates.value[uri]?.systemIds ?? []
+
+const canPlaceOnMap = (uri: string): boolean => canPlaceSecondaryVehiclesOnMap(secondaryVehicleSystemIds(uri))
+
+const placeOnMapTooltip = (uri: string): string => {
+  const isPlural = secondaryVehicleSystemIds(uri).length > 1
+  if (canPlaceOnMap(uri)) return isPlural ? 'Place these vehicles on the map' : 'Place this vehicle on the map'
+  return isPlural
+    ? 'Waiting for these vehicles to report their positions'
+    : 'Waiting for this vehicle to report its position'
+}
 
 const secondaryVehicleRows = computed(() =>
   secondaryVehicleUris.value.map((uri) => {

--- a/src/views/ConfigurationGeneralView.vue
+++ b/src/views/ConfigurationGeneralView.vue
@@ -371,49 +371,17 @@
             </div>
           </template>
           <template #content>
-            <div class="flex flex-col w-full mt-2 pb-8">
-              <!-- Existing connections list -->
-              <div v-if="Object.keys(genericWebSocketConnections).length > 0" class="mb-4">
-                <div
-                  v-for="(conn, url) in genericWebSocketConnections"
-                  :key="url"
-                  class="flex items-center justify-between py-2 px-3 mb-2 rounded bg-[#FFFFFF11]"
-                >
-                  <div class="flex items-center gap-2 flex-1 min-w-0">
-                    <v-icon :color="getLoadingStatusColor(conn.status)" size="small">
-                      {{ getLoadingStatusIcon(conn.status) }}
-                    </v-icon>
-                    <span class="truncate text-sm" :title="url">{{ replaceDataLakeInputsInString(url) }}</span>
-                    <span class="text-xs opacity-60">({{ conn.status }})</span>
-                  </div>
-                  <v-btn icon="mdi-close" size="x-small" variant="text" @click="removeGenericWebSocket(url)" />
-                </div>
-              </div>
-              <div v-else class="text-sm opacity-60 mb-4">No connections configured.</div>
-
-              <!-- Add new connection -->
-              <div class="flex justify-start items-center">
-                <v-text-field
-                  v-model="newGenericWebSocketUrl"
-                  variant="outlined"
-                  type="input"
-                  density="compact"
-                  :hint="exampleGenericWebSocketUrl"
-                  hide-details
-                  @keyup.enter="addGenericWebSocket"
-                />
-                <v-btn
-                  :size="interfaceStore.isOnSmallScreen ? 'small' : 'default'"
-                  :disabled="!newGenericWebSocketUrl.trim()"
-                  class="bg-transparent"
-                  :class="interfaceStore.isOnSmallScreen ? 'ml-1' : 'ml-5'"
-                  variant="text"
-                  @click="addGenericWebSocket"
-                >
-                  Add connection
-                </v-btn>
-              </div>
-            </div>
+            <ConnectionsList
+              v-model="newGenericWebSocketUrl"
+              :rows="genericWebSocketRows"
+              empty-message="No connections configured."
+              address-label="WebSocket address"
+              :address-placeholder="exampleGenericWebSocketUrl"
+              add-button-label="Add connection"
+              remove-tooltip="Remove connection"
+              @add="addGenericWebSocket"
+              @remove="removeGenericWebSocket"
+            />
           </template>
         </ExpansiblePanel>
         <ExpansiblePanel no-bottom-divider :is-expanded="!interfaceStore.isOnPhoneScreen">
@@ -527,6 +495,7 @@ import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 
 import { defaultGlobalAddress } from '@/assets/defaults'
 import ManageCockpitSettings from '@/components/configuration/CockpitSettingsManager.vue'
+import ConnectionsList from '@/components/configuration/ConnectionsList.vue'
 import ExpansiblePanel from '@/components/ExpansiblePanel.vue'
 import VehicleDiscoveryDialog from '@/components/VehicleDiscoveryDialog.vue'
 import { useInteractionDialog } from '@/composables/interactionDialog'
@@ -540,7 +509,6 @@ import {
   removeGenericWebSocketConnection,
 } from '@/libs/generic-websocket'
 import { isElectron, isValidNetworkAddress } from '@/libs/utils'
-import { getLoadingStatusColor, getLoadingStatusIcon } from '@/libs/utils/ui'
 import { replaceDataLakeInputsInString } from '@/libs/utils-data-lake'
 import { reloadCockpitAndWarnUser } from '@/libs/utils-vue'
 import * as Protocol from '@/libs/vehicle/protocol/protocol'
@@ -967,6 +935,16 @@ const exampleGenericWebSocketUrl = 'ws://{{ vehicle-address }}:1234'
 const genericWebSocketConnections = ref<Record<string, GenericWebSocketConnection>>({})
 const newGenericWebSocketUrl = ref(exampleGenericWebSocketUrl)
 let unsubscribeGenericWebSocket: (() => void) | null = null
+
+const genericWebSocketRows = computed(() =>
+  Object.entries(genericWebSocketConnections.value).map(([url, connection]) => ({
+    key: url,
+    address: replaceDataLakeInputsInString(url),
+    title: url,
+    status: connection.status,
+    statusLabel: connection.status,
+  }))
+)
 
 onMounted(() => {
   loadCockpitFolderPath()

--- a/src/views/ConfigurationGeneralView.vue
+++ b/src/views/ConfigurationGeneralView.vue
@@ -246,6 +246,51 @@
             </v-form>
           </template>
         </ExpansiblePanel>
+        <ExpansiblePanel no-top-divider :is-expanded="!interfaceStore.isOnPhoneScreen">
+          <template #title>Other vehicles (telemetry only)</template>
+          <template #subtitle>{{ secondaryVehicleUris.length }} configured</template>
+          <template #info>
+            <div class="w-full">
+              <p>
+                Receives telemetry from other vehicles on your network, each one on its own address. Their data becomes
+                available as data-lake variables named after the vehicle's system ID, so widgets can read it and a point
+                of interest can follow it on the map. To place one on the map, create a point of interest and use the
+                vehicle's position variables as its coordinates, e.g.
+                <span class="font-mono">{{ exampleSecondaryVehicleCoordinate }}</span>
+              </p>
+              <p class="mt-2">
+                These vehicles cannot be controlled or armed from here, and no command is ever sent to them. Give each
+                one a different system ID, otherwise only the first one to announce each ID is received, and one using
+                the piloted vehicle's ID is ignored entirely. To change it, set the autopilot's SYSID_THISMAV parameter
+                on the vehicle's autopilot parameters page in BlueOS, then reboot the autopilot.
+              </p>
+            </div>
+          </template>
+          <template #content>
+            <ConnectionsList
+              v-model="newSecondaryVehicleUri"
+              :rows="secondaryVehicleRows"
+              empty-message="No other vehicles configured."
+              address-label="Vehicle telemetry address"
+              :address-placeholder="exampleSecondaryVehicleUri"
+              add-button-label="Add vehicle"
+              remove-tooltip="Remove vehicle"
+              @add="addNewSecondaryVehicle"
+              @remove="removeSecondaryVehicle"
+            >
+              <template #warning>
+                <div v-if="secondaryVehicleUsesMainVehicleSystemId" class="text-sm text-yellow-400 mb-4">
+                  A vehicle is using the same system ID as the vehicle you are piloting, so it is not being received.
+                  Change its system ID.
+                </div>
+                <div v-if="duplicatedSecondaryVehicleSystemIds.length > 0" class="text-sm text-yellow-400 mb-4">
+                  More than one vehicle is using system ID {{ duplicatedSecondaryVehicleSystemIds.join(', ') }}, so only
+                  the first one to announce it is being received. Give each vehicle a different system ID.
+                </div>
+              </template>
+            </ConnectionsList>
+          </template>
+        </ExpansiblePanel>
         <ExpansiblePanel no-top-divider no-bottom-divider :is-expanded="!interfaceStore.isOnPhoneScreen">
           <template #title>Video connection (WebRTC)</template>
           <template #subtitle>Current address: {{ mainVehicleStore.webRTCSignallingURI?.toString() ?? '' }}</template>
@@ -491,6 +536,7 @@
 </template>
 
 <script setup lang="ts">
+import { useIntervalFn } from '@vueuse/core'
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 
 import { defaultGlobalAddress } from '@/assets/defaults'
@@ -499,6 +545,15 @@ import ConnectionsList from '@/components/configuration/ConnectionsList.vue'
 import ExpansiblePanel from '@/components/ExpansiblePanel.vue'
 import VehicleDiscoveryDialog from '@/components/VehicleDiscoveryDialog.vue'
 import { useInteractionDialog } from '@/composables/interactionDialog'
+import {
+  addSecondaryVehicle,
+  duplicatedSecondaryVehicleSystemIds,
+  refreshSecondaryVehicleStates,
+  removeSecondaryVehicle,
+  secondaryVehicleStates,
+  secondaryVehicleUris,
+  secondaryVehicleUsesMainVehicleSystemId,
+} from '@/composables/secondaryVehicles'
 import { useSnackbar } from '@/composables/snackbar'
 import * as Connection from '@/libs/connection/connection'
 import { ConnectionManager } from '@/libs/connection/connection-manager'
@@ -511,6 +566,11 @@ import {
 import { isElectron, isValidNetworkAddress } from '@/libs/utils'
 import { replaceDataLakeInputsInString } from '@/libs/utils-data-lake'
 import { reloadCockpitAndWarnUser } from '@/libs/utils-vue'
+import {
+  getSecondaryConnectionState,
+  secondaryConnectionStatus,
+  secondaryConnectionStatusLabel,
+} from '@/libs/vehicle/mavlink/secondary-connections'
 import * as Protocol from '@/libs/vehicle/protocol/protocol'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
@@ -929,6 +989,36 @@ const openExternalFeaturesModal = (): void => {
 watch(customRtcConfiguration, () => tryToPrettifyRtcConfig())
 
 const showDiscoveryDialog = ref(false)
+
+// Other vehicles, connected for telemetry only
+const exampleSecondaryVehicleUri = 'ws://192.168.2.4/mavlink2rest/ws/mavlink'
+const exampleSecondaryVehicleCoordinate = '{{ /mavlink/3/1/GLOBAL_POSITION_INT/lat }} / 1e7'
+const newSecondaryVehicleUri = ref('')
+
+const secondaryVehicleRows = computed(() =>
+  secondaryVehicleUris.value.map((uri) => {
+    const state = secondaryVehicleStates.value[uri] ?? getSecondaryConnectionState(uri)
+    const watchdogTimeoutMs = mainVehicleStore.vehicleConnectionWatchdogTimeoutMs
+    const systemIds = state.systemIds.join(', ')
+    return {
+      key: uri,
+      address: uri,
+      status: secondaryConnectionStatus(state, watchdogTimeoutMs),
+      statusLabel: secondaryConnectionStatusLabel(state, watchdogTimeoutMs),
+      details: systemIds === '' ? undefined : `System ID ${systemIds}`,
+    }
+  })
+)
+
+// The connections keep no reactive state of their own, so their status is polled while this view is open
+// instead of being pushed on every incoming message.
+useIntervalFn(refreshSecondaryVehicleStates, 1000, { immediateCallback: true })
+
+const addNewSecondaryVehicle = (): void => {
+  if (addSecondaryVehicle(newSecondaryVehicleUri.value)) {
+    newSecondaryVehicleUri.value = ''
+  }
+}
 
 // Generic WebSocket connections
 const exampleGenericWebSocketUrl = 'ws://{{ vehicle-address }}:1234'


### PR DESCRIPTION
Adds "get" support for extra vehicles in the network by pointing their address in the General settings. Each one's telemetry is mirrored into the data lake under `/mavlink/<system id>/...`, so widgets can read it and a point of interest can follow each vehicle on the map.

Example below showing my vehicle in Brazil and Tony's vehicle in Hawaii:

<img width="1556" height="1024" alt="image" src="https://github.com/user-attachments/assets/f1a56904-f4b8-4e39-8df8-9e64541ebb7d" />


These links are read-only and bypass the `ConnectionManager`, since adding a connection there replaces the main one and its `onRead` is what feeds the main vehicle and the vehicle factory. So none of the extra vehicles can be commanded, or become the vehicle being piloted.

The first commit is a behavior-preserving refactor: turning a MAVLink package into data-lake variables never needed the vehicle instance, only the system id that also gets the legacy unprefixed names, so it moves out of `MAVLinkVehicle` into a module any connection can call.

Only systems that announce themselves as a vehicle are mirrored, and only from the first link to claim each system ID, so neither two vehicles sharing an ID nor one using the piloted vehicle's can write over each other's variables. The panel warns when that happens, so the user knows why a vehicle is not showing up. The configured addresses are stored machine-local, since they are addresses on the local network, and no migration is involved.

Each mirrored vehicle also gets `/vehicles/mavlink/<system id>/isReceivingData`, a boolean data-lake variable saying whether data from that vehicle is currently arriving. Without it, a vehicle dropping mid-flight is invisible: its variables just stop updating and widgets keep rendering the last value received. It is kept up to date app-wide with no UI mounted, uses the same silence threshold as the link status in the panel, and is written `false` once when the address is removed.

A behavior change rides along in its own commit: a `{{ variable }}` in a transforming function's expression is now substituted as a value instead of being pasted into the code that gets evaluated, so no vehicle on the network can choose what an expression runs. Each value keeps its own type, so a saved expression that adds up a variable which arrives as text (a Generic WebSocket supplier can force that by quoting the value it sends) now concatenates the digits where it used to add them, and a strict comparison against a number stops matching. Placeholders inside a string literal are unaffected, and the expression info popup states that a variable enters with its own type.

Fixes #1098.

