### PR TITLE
Show tooltip when main-menu items are collapsed

### DIFF
--- a/src/components/GlassButton.vue
+++ b/src/components/GlassButton.vue
@@ -18,11 +18,9 @@
       ]"
       :style="{ width: buttonStyle.width.toString() + 'px', height: buttonStyle.height.toString() + 'px' }"
     >
-      <template v-if="tooltip">
-        <v-tooltip open-delay="600" activator="parent" location="top">
-          {{ tooltip }}
-        </v-tooltip>
-      </template>
+      <v-tooltip v-if="tooltip" activator="parent" location="right">
+        {{ tooltip }}
+      </v-tooltip>
       <template v-if="isRound || isUncontained">
         <slot v-if="$slots.default"></slot>
         <v-icon :size="props.iconSize || calculatedIconSize" :class="iconClass" class="opacity-90">

--- a/src/components/GlassButton.vue
+++ b/src/components/GlassButton.vue
@@ -9,6 +9,7 @@
   >
     <button
       :disabled="isDisabled"
+      :aria-label="label || tooltip"
       class="flex flex-col items-center justify-center mt-3 -mb-2"
       :class="[
         isUncontained ? 'no-glass' : 'frosted-button',
@@ -18,7 +19,7 @@
       ]"
       :style="{ width: buttonStyle.width.toString() + 'px', height: buttonStyle.height.toString() + 'px' }"
     >
-      <v-tooltip v-if="tooltip" activator="parent" location="right">
+      <v-tooltip v-if="tooltip" activator="parent" :location="tooltipLocation ?? 'right'">
         {{ tooltip }}
       </v-tooltip>
       <template v-if="isRound || isUncontained">
@@ -83,6 +84,10 @@ const props = defineProps<{
    * The tooltip text displayed on hover.
    */
   tooltip?: string
+  /**
+   * Where the tooltip opens relative to the button. Defaults to the right, which suits a button in a left-pinned column.
+   */
+  tooltipLocation?: 'top' | 'bottom' | 'start' | 'end' | 'left' | 'right'
   /**
    * Visual feedback for the button when toggled selected.
    */

--- a/src/components/MainMenu.vue
+++ b/src/components/MainMenu.vue
@@ -134,6 +134,7 @@
               :key="menuitem.title"
               :label="simplifiedMainMenu ? undefined : menuitem.title"
               :label-class="menuLabelSize"
+              :tooltip="simplifiedMainMenu ? menuitem.title : undefined"
               :button-class="interfaceStore.isOnSmallScreen ? '-ml-[2px]' : ''"
               :icon="menuitem.icon"
               :selected="interfaceStore.currentSubMenuComponentName === menuitem.componentName"
@@ -155,6 +156,7 @@
               <v-divider width="70%" />
               <GlassButton
                 :label-class="menuLabelSize"
+                tooltip="Back"
                 icon="mdi-arrow-left"
                 :icon-class="interfaceStore.isOnSmallScreen ? '' : '-mb-[1px]'"
                 :button-class="interfaceStore.isOnSmallScreen ? (simplifiedMainMenu ? '-mt-1' : 'mt-1') : undefined"

--- a/src/views/ConfigurationLogsView.vue
+++ b/src/views/ConfigurationLogsView.vue
@@ -6,6 +6,8 @@
           icon="mdi-help-circle-outline"
           :icon-size="interfaceStore.isOnSmallScreen ? 14 : 18"
           :icon-class="interfaceStore.isOnSmallScreen ? '-mt-[2px]' : '-mb-[3px]'"
+          tooltip="Help"
+          tooltip-location="bottom"
           variant="uncontained"
           no-effects
           @click="openHelpDialog"
@@ -332,6 +334,7 @@
                           v-bind="props"
                           icon="mdi-plus-circle-outline"
                           :icon-size="interfaceStore.isOnSmallScreen ? 16 : 20"
+                          tooltip="Add custom message element"
                           variant="uncontained"
                           no-effects
                           @click="props.click"


### PR DESCRIPTION
## Summary

Three commits, all about naming buttons that show nothing but an icon.

- **Submenu buttons get a tooltip when the menu is collapsed** (#2942). In the 45px-wide collapsed form the submenu drops every label, leaving a bare strip of icons with no way to tell them apart. The level-1 buttons already pass `tooltip` as the fallback for that case; the submenu items now do the same, so the title shows on hover exactly when the label is hidden. The submenu's back arrow, which carries no label in either form, gets one too.

- **The tooltip shows immediately and sits beside the button.** It carried `open-delay="600"`, so the label took over a second to appear, and it anchored to the top: in a column of ~21-32px rows a top-anchored label lands on the icon above the one being pointed at, hiding the very thing it is there to name. It now opens with no delay, to the side. It stays declared inside the `<button>` rather than moving to the row wrapper — the button is the focusable element, and DOM `focus` does not bubble, so a wrapper-activated tooltip opens for the pointer only and never for someone tabbing through the menu.

- **Icon-only buttons get an accessible name.** On the round and uncontained variants the label renders outside the `<button>`, and the collapsed menu drops it entirely, so the control was announced as unnamed. The tooltip cannot stand in for it: it only lends the button an `aria-describedby`, which describes a control that still has no name. `aria-label` now falls back to the tooltip text. The help and add buttons on the telemetry-logs settings screen passed neither prop, so the fallback had nothing to reach for; they get a tooltip, which names them and gives sighted users a hover label they did not have either. The help one sits 8px from the button that closes the settings panel, where a right-anchored label would open across it, so the anchor became a prop — still defaulting to the right the menu column needs — and that button passes `bottom`.

## Test plan

- [ ] Collapse the main menu (`simplifiedMainMenu`) and open a submenu.
- [ ] Hover each submenu item and confirm the title appears beside it, right away.
- [ ] Confirm the label does not cover the item above the one being hovered.
- [ ] Hover the back arrow at the bottom of the submenu and confirm it reads "Back".
- [ ] Tab through the collapsed submenu and confirm the focused item shows the same label it shows on hover.
- [ ] Expand the menu again and confirm the labels are back and no tooltip appears on the level-1 or submenu items.
- [ ] With a screen reader, move through the collapsed menu and confirm every button is announced by name, including the back arrow.
- [ ] On the telemetry-logs settings screen, hover the help icon in the header and the add button in the custom-message menu, and confirm each shows its name and is announced by it.
- [ ] Confirm the help icon's label opens below it and does not land on the panel's close button.

## Checks

- `GlassButton` is imported only by `src/components/MainMenu.vue` and `src/views/ConfigurationLogsView.vue`, so the tooltip changes reach the main menu and those two logs-view buttons and nothing else — there are no `GlassButton`s in the top bar or in any dialog.
- The `aria-label` fallback applies to every `GlassButton`, where it either repeats the label already visible inside the button or supplies the name from the tooltip. The two instances that passed neither prop now pass a tooltip, so no `GlassButton` is left unnamed.
- The new `tooltipLocation` prop is optional and defaults to `'right'`, so the main-menu instances and the add button keep the anchor they had; only the header help button passes anything.
- The tooltip's activator is the `<button>` on both `master` and this branch, so hover and keyboard focus share one entry point. Vuetify resolves `open-on-focus` from `open-on-hover` when it is not passed (`VOverlay/useActivator.mjs:36`) and binds the listener with `addEventListener('focus', …)` on the activator element (`:92`, `util/bindProps.mjs:18`); `focus` does not bubble, so any wrapper activator is pointer-only. The price of keeping it on the button is that hovering the row outside the icon does not open the label, as on `master`.

Closes #2942

