### PR TITLE
fix: video: stop reopening the RTSP failure dialog on every poll

### DIFF
--- a/src/libs/stream-activation-backoff.ts
+++ b/src/libs/stream-activation-backoff.ts
@@ -1,0 +1,42 @@
+const retryDelayMs = 5000
+
+/**
+ * Backoff bookkeeping for stream activations that failed.
+ *
+ * Stream consumers (video player widget, snapshot tool, recorder) re-request their stream about once a second
+ * and read a missing stream as "not activated yet", so without this a failed activation is retried, and
+ * reported to the user, on every tick. Retries are kept, since the source may still come back, but they are
+ * spaced out and only the failure that starts a streak is worth telling the user about.
+ */
+export class StreamActivationBackoff {
+  private lastFailureTime = new Map<string, number>()
+
+  /**
+   * Whether a stream failed too recently for another activation attempt to be worth making
+   * @param {string} streamName - External stream identifier
+   * @returns {boolean} True while the stream is still inside its retry delay
+   */
+  public isBackingOff(streamName: string): boolean {
+    const lastFailure = this.lastFailureTime.get(streamName)
+    return lastFailure !== undefined && Date.now() - lastFailure < retryDelayMs
+  }
+
+  /**
+   * Record a failed activation attempt, and decide whether this one is worth telling the user about
+   * @param {string} streamName - External stream identifier
+   * @returns {boolean} True when this failure starts a streak, i.e. the user has not been told about it yet
+   */
+  public registerFailure(streamName: string): boolean {
+    const isFirstFailure = !this.lastFailureTime.has(streamName)
+    this.lastFailureTime.set(streamName, Date.now())
+    return isFirstFailure
+  }
+
+  /**
+   * Forget a stream's failure streak, so a later failure is retried right away and reported to the user again
+   * @param {string} streamName - External stream identifier
+   */
+  public forget(streamName: string): void {
+    this.lastFailureTime.delete(streamName)
+  }
+}

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -26,6 +26,7 @@ import {
   LiveVideoProcessorInitializationError,
 } from '@/libs/live-video-processor'
 import { datalogger } from '@/libs/sensors-logging'
+import { StreamActivationBackoff } from '@/libs/stream-activation-backoff'
 import { isElectron, isEqual, sanitizeFilenameComponent, sleep } from '@/libs/utils'
 import { tempVideoStorage, videoStorage } from '@/libs/videoStorage'
 import type { Stream } from '@/libs/webrtc/signalling_protocol'
@@ -464,6 +465,7 @@ export const useVideoStore = defineStore('video', () => {
   }, 300)
 
   const rtspActivating = new Set<string>()
+  const rtspActivationBackoff = new StreamActivationBackoff()
   let rtspUnsupportedWarned = false
   const unreceivableVideoWarned = new Set<string>()
   let unreceivableVideoDialogOpened = false
@@ -478,10 +480,19 @@ export const useVideoStore = defineStore('video', () => {
     if (getStreamProtocol(streamName) === 'rtsp') {
       if (rtspActivating.has(streamName)) return
       if (activeStreams.value[streamName]?.go2rtcManager) return
+      if (rtspActivationBackoff.isBackingOff(streamName)) return
+
+      // The external id of an RTSP stream is its URL, credentials included, so never show it to the user
+      const displayName = internalStreamNameFromExternal(streamName) ?? streamName
 
       const rtspUrl = getRtspUrl(streamName)
       if (!rtspUrl) {
-        showDialog({ message: `RTSP URL for stream '${streamName}' is missing.`, variant: 'error' })
+        if (rtspActivationBackoff.registerFailure(streamName)) {
+          const msg =
+            `Video stream '${displayName}' has no address configured.` +
+            ' Delete it and add it again in the video configuration page.'
+          showDialog({ message: msg, variant: 'error' })
+        }
         return
       }
       if (!window.electronAPI) {
@@ -521,10 +532,17 @@ export const useVideoStore = defineStore('video', () => {
             mediaRecorder: undefined,
             timeRecordingStart: undefined,
           }
+          rtspActivationBackoff.forget(streamName)
           console.debug(`Activated RTSP stream '${streamName}' via go2rtc.`)
         } catch (error) {
           console.error(`Failed to activate RTSP stream '${streamName}':`, error)
-          showDialog({ message: `Failed to start RTSP stream '${streamName}'.`, variant: 'error' })
+          if (rtspActivationBackoff.registerFailure(streamName)) {
+            // Nothing in the try above reaches the camera, so a failure here is always local to Cockpit
+            const msg =
+              `Could not start video stream '${displayName}'. Cockpit's video service is not responding.` +
+              ' Restart Cockpit and try again.'
+            showDialog({ message: msg, variant: 'error' })
+          }
         } finally {
           rtspActivating.delete(streamName)
         }
@@ -1353,6 +1371,7 @@ export const useVideoStore = defineStore('video', () => {
 
       // Clean up all resources for the stream, and any consumer bookkeeping tied to it
       streamConsumers.delete(externalId)
+      rtspActivationBackoff.forget(externalId)
       if (activeStreams.value[externalId]) {
         teardownStreamResources(externalId, `External stream '${externalId}' was ignored by user`)
       }

--- a/src/tests/libs/stream-activation-backoff.test.ts
+++ b/src/tests/libs/stream-activation-backoff.test.ts
@@ -1,0 +1,34 @@
+import { expect, test, vi } from 'vitest'
+
+import { StreamActivationBackoff } from '@/libs/stream-activation-backoff'
+
+test('StreamActivationBackoff', () => {
+  vi.useFakeTimers()
+
+  const backoff = new StreamActivationBackoff()
+  const stream = 'rtsp://192.168.2.10:554/stream_1'
+
+  // The regression this guards: consumers re-request their stream about once a second, so a stream that never
+  // activates used to be retried, and reported to the user, on every one of these ticks.
+  let attempts = 0
+  let dialogs = 0
+  for (let tick = 0; tick < 30; tick++) {
+    if (!backoff.isBackingOff(stream)) {
+      attempts++
+      if (backoff.registerFailure(stream)) dialogs++
+    }
+    vi.advanceTimersByTime(1000)
+  }
+  expect(dialogs).toBe(1)
+  expect(attempts).toBe(6) // 30s of polling, one attempt per 5s of retry delay
+
+  // Other streams are unaffected by this one's failures
+  expect(backoff.isBackingOff('rtsp://192.168.2.11:554/stream_1')).toBe(false)
+
+  // Once it activates, or the user deletes it, a later failure is worth reporting again
+  backoff.forget(stream)
+  expect(backoff.isBackingOff(stream)).toBe(false)
+  expect(backoff.registerFailure(stream)).toBe(true)
+
+  vi.useRealTimers()
+})


### PR DESCRIPTION
## Summary

Stream consumers ask the video store for their stream about once a second and read a missing entry as "not activated yet", so an RTSP stream whose activation kept failing was retried on every tick. Every retry reported the same failure through `showDialog`, and the dedup added in `composables: interaction-dialog: don't remount a dialog that is already open` only holds while the dialog is on screen, so a dialog the user had just dismissed came straight back and the application became unusable.

The problem happens if go2rtc does not respond on time (still starting, or the sidecar binary missing). An unreachable camera URL is not enough: go2rtc just registers the address, and a down camera is a silent reconnect. This PR does not change the happy path — it only guards the failure path (one dialog per streak) and spaces retries to 5s so we don't hammer go2rtc while it's starting.

- **Only the first failure of a streak reaches the user** (#2946). A new `StreamActivationBackoff` (`src/libs/stream-activation-backoff.ts`) tracks the last failure per stream: attempts are spaced five seconds apart, and only the failure that starts a streak opens a dialog. A successful activation forgets the streak, so a later failure is reported again. The retries themselves are kept rather than dropped, because go2rtc is started on demand by the very call that fails, which makes the first attempt the one most likely to fail transiently.
- **The failure dialogs say what to check, and name the stream the user knows.** Both messages interpolated the external stream id, which for an RTSP stream is the URL itself, credentials included; they now use the internal name, and each points at the step that actually fixes it — restarting Cockpit when its video service does not come up, and deleting and re-adding the stream when it has no address, since the configuration page cannot edit one.

The store's accessors used to throw on this same path, and this PR carried that fix too. `video: tolerate streams that are not active yet` landed it on master in the meantime, so it is no longer part of this diff.

## Test plan

- [ ] On master: leave an RTSP player on the view, quit, rename `binaries/go2rtc/go2rtc` to something else, and start again. The dialog opens every second until you put the binary back.
- [ ] Same steps on this branch: the failure dialog appears once, and dismissing it keeps it dismissed — the app stays usable. Put the binary back afterwards.
- [ ] Two RTSP widgets and a restart can also storm it on a slow computer. On this branch that should be one dialog per stream streak.
- [ ] Regular WebRTC streams still connect and record as before.

## Checks

- Failure dialogs while go2rtc is missing or still starting: one per second, forever → one per failure streak. Activation attempts: one per second → one per five seconds.
- `src/tests/libs/stream-activation-backoff.test.ts` covers the regression directly, simulating 30 seconds of one-second polling.
- `yarn lint`, `yarn typecheck` and `yarn test:unit` clean.

Closes #2946

