### PR TITLE
fix: video: apply the configured jitter buffer target to RTSP streams

### DIFF
--- a/src/components/VideoPlayerStatsForNerds.vue
+++ b/src/components/VideoPlayerStatsForNerds.vue
@@ -8,6 +8,7 @@
 import { WebRTCStats } from '@peermetrics/webrtc-stats'
 import { onBeforeUnmount, onMounted, onUnmounted, ref, watch } from 'vue'
 
+import { monitorStreamPeerConnection } from '@/libs/webrtc/stats'
 import { useVideoStore } from '@/stores/video'
 import type { Go2RTCStreamInfo } from '@/types/video'
 import { WebRTCStatsEvent } from '@/types/video'
@@ -30,7 +31,8 @@ const props = defineProps({
   },
   height: {
     type: Number,
-    default: 200,
+    // Tall enough to keep the longest stats list (WebRTC, 12 rows) clear of the plot area at the bottom
+    default: 212,
   },
   updateInterval: {
     type: Number,
@@ -68,6 +70,9 @@ let processingDelayDelta = 0
 let freezes = 0
 let frozenTime = 0
 let framedrops = 0
+let jitterBufferDelay = 0
+let jitterBufferEmittedCount = 0
+let jitterBufferDelayPerFrame = 0
 
 let packetLossPercentage = 0
 let framerate = 0
@@ -144,6 +149,8 @@ function draw(): void {
       { label: 'Bitrate', value: bitrateStr, color: 'rgb(255, 165, 0)' },
       { label: 'Packets', value: ppsStr, color: 'rgb(100, 200, 255)' },
       { label: 'Stalls', value: rtspStallCount, color: rtspStallCount > 0 ? 'rgb(255, 0, 0)' : 'white' },
+      { label: 'Buffer', value: `${jitterBufferDelayPerFrame.toFixed(0)}ms`, color: statusColor },
+      { label: 'Frame drops', value: framedrops, color: statusColor },
     ]
 
     stats.forEach((stat, index) => {
@@ -165,6 +172,7 @@ function draw(): void {
       { label: 'Pli', value: pliCount, color: color },
       { label: 'Fir', value: firCount, color: color },
       { label: 'Processing ', value: `${processingDelayDelta.toFixed(0)}ms`, color: color },
+      { label: 'Buffer', value: `${jitterBufferDelayPerFrame.toFixed(0)}ms`, color: color },
       { label: 'Freezes', value: `${freezes}(${frozenTime.toFixed(1)}s)`, color: color },
       { label: 'Bitrate', value: `${bitrate.toFixed(0)}kbps`, color: 'rgb(255, 165, 0)' },
       { label: 'FPS', value: framerate.toFixed(2), color: 'rgb(0, 255, 0)' },
@@ -201,12 +209,7 @@ watch(videoStore.activeStreams, (streams): void => {
     const pcInfo = videoStore.getStreamPeerConnection(streamName)
     if (!pcInfo) return
     if (webrtcStats.peersToMonitor[pcInfo.peerId]) return
-    webrtcStats.addConnection({
-      pc: pcInfo.peerConnection,
-      peerId: pcInfo.peerId,
-      connectionId: pcInfo.sessionId,
-      remote: false,
-    })
+    monitorStreamPeerConnection(webrtcStats, pcInfo)
   })
 })
 
@@ -247,6 +250,8 @@ onMounted(() => {
 
   webrtcStats.on('stats', (ev: WebRTCStatsEvent) => {
     try {
+      if (!webrtcStats.peersToMonitor[ev.peerId]) return
+
       const videoData = ev.data.video.inbound[0]
       if (videoData === undefined) return
       connectionLost = videoData.bitrate === 0
@@ -269,6 +274,14 @@ onMounted(() => {
       freezes = videoData.freezeCount
       frozenTime = videoData.totalFreezesDuration
       framedrops = videoData.framesDropped
+      // Both stats are cumulative, so only their deltas tell how much the last frames actually waited in the buffer
+      const jitterBufferDelayDelta = videoData.jitterBufferDelay - jitterBufferDelay
+      const jitterBufferEmittedDelta = videoData.jitterBufferEmittedCount - jitterBufferEmittedCount
+      if (jitterBufferEmittedDelta > 0) {
+        jitterBufferDelayPerFrame = (1000 * jitterBufferDelayDelta) / jitterBufferEmittedDelta
+      }
+      jitterBufferDelay = videoData.jitterBufferDelay
+      jitterBufferEmittedCount = videoData.jitterBufferEmittedCount
       framerate = videoData.framesPerSecond ?? 0
       videoHeight = videoData.frameHeight
     } catch (e) {

--- a/src/composables/go2rtc.ts
+++ b/src/composables/go2rtc.ts
@@ -1,5 +1,7 @@
 import { type Ref, ref } from 'vue'
 
+import { setJitterBufferTarget } from '@/libs/webrtc/jitter-buffer'
+
 const RECONNECT_DELAY_MS = 3000
 // Time we give the peer connection to reach 'connected' before assuming go2rtc is stuck waiting for an
 // unavailable source (e.g. camera not yet on the network) and forcing a reconnect.
@@ -25,8 +27,9 @@ export class Go2RTCManager {
   /**
    * @param {number} go2rtcPort - The port go2rtc is listening on
    * @param {string} streamName - The stream name registered in go2rtc
+   * @param {number} jitterBufferTarget - RTP receiver jitter buffer target in milliseconds
    */
-  constructor(private go2rtcPort: number, private streamName: string) {}
+  constructor(private go2rtcPort: number, private streamName: string, private jitterBufferTarget: number) {}
 
   /**
    * Start the WebRTC connection to go2rtc.
@@ -80,6 +83,8 @@ export class Go2RTCManager {
       const [remoteStream] = event.streams
       if (!remoteStream) return
       this.mediaStream.value = remoteStream
+
+      setJitterBufferTarget(pc, this.jitterBufferTarget)
 
       const videoTracks = remoteStream.getVideoTracks()
       videoTracks.forEach((track) => {

--- a/src/composables/go2rtc.ts
+++ b/src/composables/go2rtc.ts
@@ -1,3 +1,4 @@
+import { v4 as uuid } from 'uuid'
 import { type Ref, ref } from 'vue'
 
 import { setJitterBufferTarget } from '@/libs/webrtc/jitter-buffer'
@@ -17,6 +18,8 @@ export class Go2RTCManager {
   public connected = ref(false)
   public signallerStatus: Ref<string> = ref('Disconnected')
   public streamStatus: Ref<string> = ref('Waiting...')
+  // Changes on every (re)connection, so stats consumers can tell a fresh peer connection from the previous one
+  public connectionId = ''
 
   private pc: RTCPeerConnection | null = null
   private ws: WebSocket | null = null
@@ -30,6 +33,14 @@ export class Go2RTCManager {
    * @param {number} jitterBufferTarget - RTP receiver jitter buffer target in milliseconds
    */
   constructor(private go2rtcPort: number, private streamName: string, private jitterBufferTarget: number) {}
+
+  /**
+   * The current peer connection, exposed for stats monitoring
+   * @returns {RTCPeerConnection | null} The active peer connection, or null if there is none
+   */
+  public get peerConnection(): RTCPeerConnection | null {
+    return this.pc
+  }
 
   /**
    * Start the WebRTC connection to go2rtc.
@@ -76,6 +87,7 @@ export class Go2RTCManager {
 
     const pc = new RTCPeerConnection()
     this.pc = pc
+    this.connectionId = uuid()
 
     pc.addTransceiver('video', { direction: 'recvonly' })
 

--- a/src/composables/go2rtc.ts
+++ b/src/composables/go2rtc.ts
@@ -108,7 +108,12 @@ export class Go2RTCManager {
       console.debug(`[go2rtc] Track added for stream '${this.streamName}'`)
     }
 
-    pc.onconnectionstatechange = () => {
+    // A listener rather than the single-slot pc.onconnectionstatechange, which anything else holding the peer
+    // connection (the stats library, for one) can overwrite, silently taking the reconnection with it
+    pc.addEventListener('connectionstatechange', () => {
+      // A superseded connection must not write the status refs, which by then describe the one that replaced it
+      if (this.pc !== pc) return
+
       const state = pc.connectionState
       console.debug(`[go2rtc] Connection state for '${this.streamName}': ${state}`)
       this.streamStatus.value = state
@@ -127,7 +132,7 @@ export class Go2RTCManager {
           this.connected.value = false
           break
       }
-    }
+    })
 
     this.armConnectWatchdog()
 
@@ -266,7 +271,6 @@ export class Go2RTCManager {
 
     if (this.pc) {
       this.pc.ontrack = null
-      this.pc.onconnectionstatechange = null
       this.pc.onicecandidate = null
       this.pc.close()
       this.pc = null

--- a/src/composables/webRTC.ts
+++ b/src/composables/webRTC.ts
@@ -3,6 +3,7 @@
 import { type Ref, ref, watch } from 'vue'
 
 import * as Connection from '@/libs/connection/connection'
+import { setJitterBufferTarget } from '@/libs/webrtc/jitter-buffer'
 import { Session } from '@/libs/webrtc/session'
 import { Signaller } from '@/libs/webrtc/signaller'
 import type { Stream } from '@/libs/webrtc/signalling_protocol'
@@ -236,7 +237,9 @@ export class WebRTCManager {
     const [remoteStream] = event.streams
     this.mediaStream.value = remoteStream
 
-    this.session?.setJitterBufferTarget(this.JitterBufferTarget)
+    if (this.session?.peerConnection) {
+      setJitterBufferTarget(this.session.peerConnection, this.JitterBufferTarget)
+    }
 
     // Assign 'motion' contentHint to media stream video tracks, so it performs better on low bandwith situations
     // More on that here: https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/contentHint

--- a/src/libs/webrtc/jitter-buffer.ts
+++ b/src/libs/webrtc/jitter-buffer.ts
@@ -1,0 +1,43 @@
+/**
+ * Sets the RTP receiver jitter buffer target of every video receiver of a peer connection.
+ * When left unset the browser uses its own adaptive buffer, which grows on CPU or network starvation and does not
+ * shrink back afterwards, so any low-resource event leaves a permanent latency increase behind.
+ * @param {RTCPeerConnection} peerConnection - Connection whose video receivers should be configured
+ * @param {number} jitterBufferTarget - Target buffer time in milliseconds
+ */
+export const setJitterBufferTarget = (peerConnection: RTCPeerConnection, jitterBufferTarget: number): void => {
+  peerConnection.getReceivers().forEach((receiver: RTCRtpReceiver) => {
+    if (receiver.track.kind !== 'video') {
+      return
+    }
+
+    let playoutDelayHint = null
+    if (jitterBufferTarget) {
+      if (jitterBufferTarget > 4000) {
+        jitterBufferTarget = 4000
+      } else if (jitterBufferTarget < 0) {
+        jitterBufferTarget = 0
+      }
+
+      playoutDelayHint = jitterBufferTarget / 1000 // in seconds, legacy Chrome API
+    }
+
+    console.debug(
+      `RTCRtpReceiver jitterBufferTarget attribute set from ${
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (receiver as any).jitterBufferTarget
+      } to ${jitterBufferTarget}`
+    )
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(receiver as any).jitterBufferTarget = jitterBufferTarget // in milliseconds (DOMHighResTimeStamp)
+
+    console.debug(
+      `RTCRtpReceiver playoutDelayHint attribute set from ${
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (receiver as any).playoutDelayHint
+      } to ${playoutDelayHint}`
+    )
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(receiver as any).playoutDelayHint = playoutDelayHint
+  })
+}

--- a/src/libs/webrtc/session.ts
+++ b/src/libs/webrtc/session.ts
@@ -130,47 +130,6 @@ export class Session {
   }
 
   /**
-   * Sets jitterBufferTarget (milliseconds)
-   * @param {number} jitterBufferTarget - Target RTP receiver jitter buffer time in milliseconds
-   */
-  public setJitterBufferTarget(jitterBufferTarget: number): void {
-    this.peerConnection.getReceivers().forEach((receiver: RTCRtpReceiver) => {
-      if (receiver.track.kind !== 'video') {
-        return
-      }
-
-      let playoutDelayHint = null
-      if (jitterBufferTarget) {
-        if (jitterBufferTarget > 4000) {
-          jitterBufferTarget = 4000
-        } else if (jitterBufferTarget < 0) {
-          jitterBufferTarget = 0
-        }
-
-        playoutDelayHint = jitterBufferTarget / 1000 // in seconds, legacy Chrome API
-      }
-
-      console.debug(
-        `RTCRtpReceiver jitterBufferTarget attribute set from ${
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (receiver as any).jitterBufferTarget
-        } to ${jitterBufferTarget}`
-      )
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ;(receiver as any).jitterBufferTarget = jitterBufferTarget // in milliseconds (DOMHighResTimeStamp)
-
-      console.debug(
-        `RTCRtpReceiver playoutDelayHint attribute set from ${
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (receiver as any).playoutDelayHint
-        } to ${playoutDelayHint}`
-      )
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ;(receiver as any).playoutDelayHint = playoutDelayHint
-    })
-  }
-
-  /**
    * Defines the behavior for when a remote SDP is received from the signalling server
    * @param {RTCSessionDescription} description - The SDP received from the signalling server
    */

--- a/src/libs/webrtc/stats.ts
+++ b/src/libs/webrtc/stats.ts
@@ -1,0 +1,27 @@
+import { WebRTCStats } from '@peermetrics/webrtc-stats'
+
+import { StreamPeerConnectionInfo } from '@/types/video'
+
+/**
+ * Register a stream's current peer connection for stats monitoring, dropping the monitors of the previous ones
+ * Expects a stats instance dedicated to a single stream, as every other peer registered on it is dropped
+ * @param {ReturnType<typeof WebRTCStats>} stats - Stats instance monitoring the stream
+ * @param {StreamPeerConnectionInfo} pcInfo - The peer connection the stream is currently using, and its ids
+ */
+export const monitorStreamPeerConnection = (
+  stats: ReturnType<typeof WebRTCStats>,
+  pcInfo: StreamPeerConnectionInfo
+): void => {
+  const stalePeerIds = Object.keys(stats.peersToMonitor).filter((peerId) => peerId !== pcInfo.peerId)
+
+  stats.addConnection({
+    pc: pcInfo.peerConnection,
+    peerId: pcInfo.peerId,
+    connectionId: pcInfo.sessionId,
+    remote: false,
+  })
+
+  // Dropped only once the new peer is in, as the library restarts its monitoring intervals whenever the peer
+  // count rises from zero, leaking the interval it was already running
+  stalePeerIds.forEach((peerId) => stats.removePeer(peerId))
+}

--- a/src/stores/omniscientLogger.ts
+++ b/src/stores/omniscientLogger.ts
@@ -11,6 +11,7 @@ import {
 } from '@/libs/actions/data-lake'
 import eventTracker from '@/libs/external-telemetry/event-tracking'
 import { isElectron } from '@/libs/utils'
+import { monitorStreamPeerConnection } from '@/libs/webrtc/stats'
 import { WebRTCStatsEvent, WebRTCVideoStat } from '@/types/video'
 
 import { useMainVehicleStore } from './mainVehicle'
@@ -189,21 +190,16 @@ export const useOmniscientLoggerStore = defineStore('omniscient-logger', () => {
   // Monitor the active streams to add the connections to the WebRTC statistics
   watch(videoStore.activeStreams, (streams) => {
     Object.keys(streams).forEach((streamName) => {
-      const session = streams[streamName]?.webRtcManager?.session
-      if (!session || !session.peerConnection) return
+      const pcInfo = videoStore.getStreamPeerConnection(streamName)
+      if (!pcInfo) return
 
       if (webrtcStreamStats[streamName] === undefined) {
         webrtcStreamStats[streamName] = new WebRTCStats({ getStatsInterval: 100 })
       }
 
-      if (webrtcStreamStats[streamName].peersToMonitor[session.consumerId]) return
+      if (webrtcStreamStats[streamName].peersToMonitor[pcInfo.peerId]) return
 
-      webrtcStreamStats[streamName].addConnection({
-        pc: session.peerConnection, // RTCPeerConnection instance
-        peerId: session.consumerId, // any string that helps you identify this peer,
-        connectionId: session.id, // optional, an id that you can use to keep track of this connection
-        remote: false, // optional, override the global remote flag
-      })
+      monitorStreamPeerConnection(webrtcStreamStats[streamName], pcInfo)
 
       storedKeys.forEach((key) => {
         if (getDataLakeVariableInfo(streamRateVariableId(streamName, key)) === undefined) {
@@ -222,6 +218,9 @@ export const useOmniscientLoggerStore = defineStore('omniscient-logger', () => {
 
       webrtcStreamStats[streamName].on('stats', (ev: WebRTCStatsEvent) => {
         try {
+          // Stats for a peer we no longer monitor describe a connection that has already been replaced
+          if (!webrtcStreamStats[streamName].peersToMonitor[ev.peerId]) return
+
           const videoData = ev.data.video.inbound[0]
           if (videoData === undefined) return
 

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -624,6 +624,14 @@ export const useVideoStore = defineStore('video', () => {
     if (session?.peerConnection) {
       return { peerConnection: session.peerConnection, peerId: session.consumerId, sessionId: session.id }
     }
+
+    const go2rtcManager = data?.go2rtcManager
+    if (go2rtcManager?.peerConnection) {
+      // Fresh id per connection, so a reconnect registers the new peer connection and drops the monitor of the old one.
+      const { peerConnection, connectionId } = go2rtcManager
+      return { peerConnection, peerId: connectionId, sessionId: connectionId }
+    }
+
     return undefined
   }
 

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -440,7 +440,7 @@ export const useVideoStore = defineStore('video', () => {
           const port = await window.electronAPI!.go2rtcGetPort()
           await window.electronAPI!.go2rtcAddStream(streamName, rtspUrl)
 
-          const manager = new Go2RTCManager(port, streamName)
+          const manager = new Go2RTCManager(port, streamName, jitterBufferTarget.value)
           const { mediaStream, connected } = manager.start()
 
           activeStreams.value[streamName] = {

--- a/src/tests/libs/webrtc/jitter-buffer.test.ts
+++ b/src/tests/libs/webrtc/jitter-buffer.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from 'vitest'
+
+import { setJitterBufferTarget } from '@/libs/webrtc/jitter-buffer'
+
+const fakeReceivers = (kinds: string[]): Record<string, unknown>[] =>
+  kinds.map((kind) => ({ track: { kind } } as Record<string, unknown>))
+
+const fakePeerConnection = (receivers: Record<string, unknown>[]): RTCPeerConnection =>
+  ({ getReceivers: () => receivers } as never)
+
+test('Applies the target to video receivers only', () => {
+  const receivers = fakeReceivers(['video', 'audio'])
+
+  setJitterBufferTarget(fakePeerConnection(receivers), 250)
+
+  expect(receivers[0].jitterBufferTarget).toBe(250)
+  expect(receivers[0].playoutDelayHint).toBe(0.25)
+  expect(receivers[1].jitterBufferTarget).toBeUndefined()
+})
+
+test('Clamps the target to the range accepted by browsers', () => {
+  const tooHigh = fakeReceivers(['video'])
+  const negative = fakeReceivers(['video'])
+
+  setJitterBufferTarget(fakePeerConnection(tooHigh), 10000)
+  setJitterBufferTarget(fakePeerConnection(negative), -1)
+
+  expect(tooHigh[0].jitterBufferTarget).toBe(4000)
+  expect(negative[0].jitterBufferTarget).toBe(0)
+})
+
+test('Zero target leaves the legacy hint unset', () => {
+  const receivers = fakeReceivers(['video'])
+
+  setJitterBufferTarget(fakePeerConnection(receivers), 0)
+
+  expect(receivers[0].jitterBufferTarget).toBe(0)
+  expect(receivers[0].playoutDelayHint).toBeNull()
+})

--- a/src/tests/libs/webrtc/stats.test.ts
+++ b/src/tests/libs/webrtc/stats.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from 'vitest'
+
+import { monitorStreamPeerConnection } from '@/libs/webrtc/stats'
+
+test('Registers the new peer connection before dropping the previous one', () => {
+  const calls: string[] = []
+  const peersToMonitor: Record<string, boolean> = { old: true }
+  const stats = {
+    peersToMonitor,
+    addConnection: (options: Record<string, unknown>): void => {
+      calls.push(`add:${options.peerId}`)
+      peersToMonitor[options.peerId as string] = true
+    },
+    removePeer: (peerId: string): void => {
+      calls.push(`remove:${peerId}`)
+      delete peersToMonitor[peerId]
+    },
+  }
+
+  monitorStreamPeerConnection(stats, {
+    peerConnection: {} as RTCPeerConnection,
+    peerId: 'new',
+    sessionId: 'new',
+  })
+
+  expect(calls).toEqual(['add:new', 'remove:old'])
+  expect(Object.keys(peersToMonitor)).toEqual(['new'])
+})
+
+test('Keeps the peer monitored when the same connection is registered again', () => {
+  const peersToMonitor: Record<string, boolean> = { same: true }
+  const stats = {
+    peersToMonitor,
+    addConnection: (options: Record<string, unknown>): void => {
+      peersToMonitor[options.peerId as string] = true
+    },
+    removePeer: (peerId: string): void => {
+      delete peersToMonitor[peerId]
+    },
+  }
+
+  monitorStreamPeerConnection(stats, { peerConnection: {} as RTCPeerConnection, peerId: 'same', sessionId: 'same' })
+
+  expect(Object.keys(peersToMonitor)).toEqual(['same'])
+})


### PR DESCRIPTION
## Summary

**This is not a latency fix — it changes nothing at the default setting.** It closes a configuration gap and makes RTSP streams observable. Please read the section below before assuming it helps with RTSP lag.

The "RTP Jitter Buffer (Target) duration" setting was only ever applied to mavlink-camera-manager streams: `Session` pushes it onto its receivers on every track, while `Go2RTCManager` builds its own `RTCPeerConnection` and never did. So a user who raises the target gets it on WebRTC streams and is silently ignored on RTSP ones. Separately, RTSP streams report nothing about what the browser does with their frames, which makes any latency investigation on that path guesswork.

- **The receiver tuning became a free function** (`src/libs/webrtc/jitter-buffer.ts`), moved out of `Session` so both managers can reach the same code. No behavior change for WebRTC streams.
- **RTSP streams now apply the configured target**, so a nonzero value behaves the same on both protocols.
- **RTSP streams report their client-side receive stats.** The stats overlay and the data-lake stream variables only ever saw the mavlink-camera-manager peer connection, so for RTSP they showed go2rtc's ingest bitrate and packet rate and nothing about the browser's receive side. Their peer connection is now exposed through the same store accessor, keyed by a fresh id per connection so a reconnect re-registers instead of leaving the stats pinned to a closed one, and both protocols show the average jitter buffer delay so they can be compared directly.

The target is read when a stream is activated, so changing the setting requires restarting the stream. That matches the existing WebRTC behavior.

## Why this cannot affect the default case

Worth writing down, because it is counter-intuitive and it took reading the Chromium and libwebrtc sources to establish:

- Cockpit's default is `0` (`cockpit-jitter-buffer-target`), and clearing the field snaps it back to `0` rather than leaving it empty, so in practice every user is on `0`.
- At `0` the code sends `playoutDelayHint = null`, which means "no hint, use the browser default". So the WebRTC path, at the default, explicitly asks for the same adaptive behavior that the RTSP path was getting by not asking for anything.
- `RTCRtpReceiver.jitterBufferTarget` only shipped in Chrome 124. Electron 29.4.6 pins Chromium 122, so in this build that assignment is a dead property on a JS object and reaches no WebRTC code at all. Only the legacy `playoutDelayHint` does anything here.
- Even where the attribute is live, both funnel into `SetJitterBufferMinimumDelay`, which sets `min_playout_delay_` in libwebrtc's `VCMTiming`, and the target is `max(min_playout_delay_, jitter_delay_ + RequiredDecodeTime() + render_delay_)`. It is a floor, not a ceiling: it can only add delay on top of the adaptive estimate, and it cannot make Chromium drop frames. Zero means no floor, which is already the default. The genuine "render frames as they arrive" mode needs `max_playout_delay <= 500ms` as well, and that has no JavaScript API — only the sender-side RTP playout-delay extension, which go2rtc does not send.

So the parity is real and worth having, but the RTSP latency that prompted this (on a 1.1GHz Celeron topside machine, where RTSP takes a permanent latency step on every resource spike and never recovers) is not explained by it. That investigation continues, and the stats added here are what it needs: if the new `Buffer` line climbs during a spike and stays up, the delay is on the browser's receive side; if it stays at a few tens of milliseconds while the picture is seconds behind, the delay is accumulating upstream in go2rtc or its socket, which is where I would now look first.

## Test plan

- [ ] Set the RTP jitter buffer target to something large (e.g. 2000ms) in Configuration → Video, restart an RTSP stream, and confirm its latency grows accordingly. Before this PR the setting had no effect on RTSP streams.
- [ ] Set it back to 0, restart, and confirm RTSP latency returns to what it was.
- [ ] Confirm a WebRTC stream responds to the same setting exactly as it did before.
- [ ] With stats for nerds enabled on an RTSP stream, confirm the overlay still shows the go2rtc ingest numbers (codec, size, bitrate, packets, stalls) and now also shows `Buffer` and `Frame drops`.
- [ ] Let an RTSP stream reconnect (take the source down and bring it back) and confirm the stats keep updating instead of freezing on the old connection.
- [ ] Confirm WebRTC streams connect, record and report stats as before.

## Checks

- `src/tests/libs/webrtc/jitter-buffer.test.ts` covers the video-only receiver filter, the 0–4000ms clamp, and that a zero target leaves the legacy hint unset.
- `yarn lint` clean with `--max-warnings=0`, `yarn test:unit` passing.
- Note for whoever reviews the types: `yarn typecheck` exits early in this repo with `languageId not found for src/App.vue` and checks nothing. I ran plain `tsc` instead; the only errors in the touched files are two pre-existing `URI | undefined` complaints on untouched `new WebRTCManager(...)` lines.

