### PR TITLE
fix: video: stop the recording health monitor from reopening its dialog

### DIFF
--- a/src/composables/interactionDialog.ts
+++ b/src/composables/interactionDialog.ts
@@ -76,7 +76,8 @@ type DialogState = DialogOptions & {
  */
 export function useInteractionDialog(): {
   /**
-   * Shows the dialog with the provided options.
+   * Shows the dialog with the provided options. If a dialog with the same options is already open, the pending
+   * promise for it is returned instead of a new dialog being mounted.
    * @param {DialogOptions} options - Options to configure the dialog.
    * @returns {Promise<{ isConfirmed: boolean }>} - A promise that resolves or rejects based on user action.
    */
@@ -104,6 +105,8 @@ export function useInteractionDialog(): {
   let mountPoint: HTMLElement | null = null
   let resolveFn: ((value: DialogResult | PromiseLike<DialogResult>) => void) | undefined
   let rejectFn: ((reason?: DialogResult) => void) | undefined
+  let openDialogKey: string | undefined
+  let openDialogPromise: Promise<DialogResult> | undefined
 
   const unmountDialog = (): void => {
     if (dialogApp) {
@@ -137,21 +140,38 @@ export function useInteractionDialog(): {
   }
 
   const showDialog = (options: DialogOptions): Promise<DialogResult> => {
+    // Callers on a poll or interval ask for the same dialog on every tick. Remounting would tear the open dialog
+    // down and build it back up under the user, so hand back the pending promise while it is still on screen. The
+    // key is the whole resolved state, so the same text with different buttons still gets its own dialog, and
+    // action callbacks drop out of the JSON so freshly built ones don't defeat the comparison.
+    const resolvedOptions = { ...defaultDialogState(), ...options }
+    const key = JSON.stringify(resolvedOptions)
+    if (openDialogPromise && openDialogKey === key) return openDialogPromise
+
     // Settle any still-pending dialog before replacing it so a caller awaiting a superseded dialog doesn't hang
     // forever. Resolve (rather than reject) to avoid unhandled rejections for the many callers that don't await.
     resolveFn?.({ isConfirmed: false })
-    return new Promise((resolve, reject) => {
+    openDialogKey = key
+    openDialogPromise = new Promise<DialogResult>((resolve, reject) => {
       // Merge over a fresh set of defaults so options the caller omits (notably `actions`) never leak from the
       // previous dialog, which would otherwise leave a stale destructive button on an unrelated dialog.
-      Object.assign(dialogProps, defaultDialogState(), options, { showDialog: true })
-      resolveFn = resolve
-      rejectFn = reject
+      Object.assign(dialogProps, resolvedOptions, { showDialog: true })
+      resolveFn = (value) => {
+        openDialogPromise = undefined
+        resolve(value)
+      }
+      rejectFn = (reason) => {
+        openDialogPromise = undefined
+        reject(reason)
+      }
       mountDialog()
     })
+    return openDialogPromise
   }
 
   const closeDialog = (): void => {
     dialogProps.showDialog = false
+    openDialogPromise = undefined
     unmountDialog()
   }
 

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -776,29 +776,22 @@ export const useVideoStore = defineStore('video', () => {
     unprocessedVideos.value = { ...unprocessedVideos.value, ...{ [recordingHash]: videoInfo } }
 
     // Common configuration for the not growing dialogs
-    let notGrowingDialogOpen = false
-    const closeNotGrowingDialog = (): void => {
-      notGrowingDialogOpen = false
-      closeDialog()
-    }
     const suppressNotGrowingDialog = (): void => {
       suppressNotGrowingDialogs.value = true
-      closeNotGrowingDialog()
+      closeDialog()
     }
     const notGrowingDialogConfig = {
       variant: 'error',
-      // Persistent so it can only be closed via the actions below, which reset notGrowingDialogOpen. A
-      // backdrop/Escape dismissal would otherwise leave the flag stuck and stop the dialog from ever reappearing.
+      // Persistent so it can only be closed via the actions below. The monitor re-checks every 15 seconds, so the
+      // opt-out action is the only way for the user to stop being told about a problem they already know about.
       persistent: true,
       actions: [
         { text: "Don't show again during this session", size: 'small', action: suppressNotGrowingDialog },
-        { text: 'Close', size: 'small', action: closeNotGrowingDialog },
+        { text: 'Close', size: 'small', action: closeDialog },
       ],
     }
-    // Only show the dialog once at a time, otherwise the timed monitor would re-open it on every tick.
     const showNotGrowingDialog = (message: string): void => {
-      if (suppressNotGrowingDialogs.value || notGrowingDialogOpen) return
-      notGrowingDialogOpen = true
+      if (suppressNotGrowingDialogs.value) return
       showDialog({ ...notGrowingDialogConfig, message })
     }
 

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -71,7 +71,64 @@ export const useVideoStore = defineStore('video', () => {
   const keepRawVideoChunksAsBackup = useBlueOsStorage('cockpit-keep-raw-video-chunks-as-backup', true)
   const userRestoredStreamIds = useBlueOsStorage<string[]>('cockpit-user-restored-stream-ids', [])
   const recordingMonitors: { [key: string]: ReturnType<typeof setInterval> | undefined } = {}
-  const suppressNotGrowingDialogs = ref(false)
+  // Keyed by the warning message, so silencing one recording health warning doesn't silence the others.
+  const suppressedRecordingHealthMessages = new Set<string>()
+  type RecordingHealthWarning = {
+    /**
+     * Text of the warning, shown in the dialog and used as the key of the session opt-out.
+     */
+    message: string
+    /**
+     * Whether the warning means the recording may already be lost, which lets it take the surface from a milder one.
+     */
+    meansDataLoss: boolean
+  }
+  // Shared by the monitors of all recording streams, since they all warn through the same single dialog surface.
+  let openRecordingHealthWarning: RecordingHealthWarning | undefined
+
+  const releaseRecordingHealthDialog = (warning: RecordingHealthWarning): void => {
+    // Compared by identity, not by text: closing the dialog leaves its promise pending, so the release can run a
+    // tick later, once a warning with the very same wording has claimed the surface again.
+    if (openRecordingHealthWarning === warning) openRecordingHealthWarning = undefined
+  }
+  const suppressRecordingHealthDialog = (warning: RecordingHealthWarning): void => {
+    logUserAction(`Silenced the recording health warning "${warning.message}" for this session`)
+    suppressedRecordingHealthMessages.add(warning.message)
+    releaseRecordingHealthDialog(warning)
+    closeDialog()
+  }
+  const closeRecordingHealthDialog = (warning: RecordingHealthWarning): void => {
+    logUserAction(`Closed the recording health warning "${warning.message}"`)
+    releaseRecordingHealthDialog(warning)
+    closeDialog()
+  }
+  const showRecordingHealthDialog = (message: string, meansDataLoss = false): void => {
+    if (suppressedRecordingHealthMessages.has(message)) return
+    // The warning on screen owns the single dialog surface until it is settled, be it by the actions below or by an
+    // unrelated dialog replacing it. Nothing but the user settles it, so a warning about a recording that may
+    // already be lost takes the surface from a milder one instead of waiting behind it forever.
+    // ponytail: warnings that mean the same for the recording queue behind whichever showed first, so a second
+    // unhealthy stream can wait as long as the user leaves the first dialog up. Queue the surface if that bites.
+    if (openRecordingHealthWarning && (openRecordingHealthWarning.meansDataLoss || !meansDataLoss)) return
+    const warning = { message, meansDataLoss }
+    openRecordingHealthWarning = warning
+    const release = (): void => releaseRecordingHealthDialog(warning)
+    showDialog({
+      message,
+      variant: 'error',
+      // Persistent so it can only be closed via the actions below. The monitor re-checks every 15 seconds, so the
+      // opt-out action is the only way for the user to stop being told about a problem they already know about.
+      persistent: true,
+      actions: [
+        {
+          text: "Don't show again during this session",
+          size: 'small',
+          action: () => suppressRecordingHealthDialog(warning),
+        },
+        { text: 'Close', size: 'small', action: () => closeRecordingHealthDialog(warning) },
+      ],
+    }).then(release, release)
+  }
 
   const streamInformation = ref<ProcessedStreamInfo[]>([])
   const go2rtcStreamInfo = ref<Record<string, Go2RTCStreamInfo>>({})
@@ -775,32 +832,15 @@ export const useVideoStore = defineStore('video', () => {
     }
     unprocessedVideos.value = { ...unprocessedVideos.value, ...{ [recordingHash]: videoInfo } }
 
-    // Common configuration for the not growing dialogs
-    const suppressNotGrowingDialog = (): void => {
-      suppressNotGrowingDialogs.value = true
-      closeDialog()
-    }
-    const notGrowingDialogConfig = {
-      variant: 'error',
-      // Persistent so it can only be closed via the actions below. The monitor re-checks every 15 seconds, so the
-      // opt-out action is the only way for the user to stop being told about a problem they already know about.
-      persistent: true,
-      actions: [
-        { text: "Don't show again during this session", size: 'small', action: suppressNotGrowingDialog },
-        { text: 'Close', size: 'small', action: closeDialog },
-      ],
-    }
-    const showNotGrowingDialog = (message: string): void => {
-      if (suppressNotGrowingDialogs.value) return
-      showDialog({ ...notGrowingDialogConfig, message })
-    }
-
     // On Electron, we can get the size of the video output file in real time
     // This is useful to detect if the output file is growing, which is an indication that the recording is still ongoing.
     // On Web, we can only know if the number of chunks is growing, which is an indication that the recording is still ongoing.
     // We also need to clear the interval if it already exists, to avoid multiple intervals running at the same time.
     clearInterval(recordingMonitors[streamName])
     delete recordingMonitors[streamName]
+    // The internal name, since the external id of an RTSP stream is its URL, credentials included, and these warnings
+    // are both shown to the user and written to the logs they share with us.
+    const streamLabel = internalStreamNameFromExternal(streamName) ?? streamName
     if (window.electronAPI) {
       console.info(`Starting electron recording monitor for stream '${streamName}'.`)
       recordingMonitors[streamName] = setInterval(async () => {
@@ -814,14 +854,17 @@ export const useVideoStore = defineStore('video', () => {
         }
         const fileStats = await window.electronAPI?.getFileStats(fileName, ['videos'])
         if (!fileStats || !fileStats.exists) {
-          // eslint-disable-next-line
-          const msg = 'Cannot get size of the video output file. Please check if the file exists. This can indicate a problem with the recording.'
-          showDialog({ message: msg, variant: 'error' })
+          showRecordingHealthDialog(
+            `Cockpit cannot find the file for the recording of stream '${streamLabel}', which means the recording may be lost. We recommend stopping it and starting a new one.`,
+            true
+          )
           return
         }
         const lastKnownFileSize = unprocessedVideos.value[recordingHash].lastKnownFileSize
         if (fileStats.size! <= lastKnownFileSize!) {
-          showNotGrowingDialog('The video output file is not growing. This can indicate a problem with the recording.')
+          showRecordingHealthDialog(
+            `The video output file for stream '${streamLabel}' is not growing. This can indicate a problem with the recording.`
+          )
           return
         }
         unprocessedVideos.value[recordingHash].lastKnownFileSize = fileStats.size
@@ -842,8 +885,8 @@ export const useVideoStore = defineStore('video', () => {
         const numberOfChunks = await tempVideoStorage.localForage.length()
         const lastKnownNumberOfChunks = unprocessedVideos.value[recordingHash].lastKnownNumberOfChunks
         if (numberOfChunks <= lastKnownNumberOfChunks!) {
-          showNotGrowingDialog(
-            'The number of video chunks is not growing. This can indicate a problem with the recording.'
+          showRecordingHealthDialog(
+            `The number of video chunks for stream '${streamLabel}' is not growing. This can indicate a problem with the recording.`
           )
           return
         }

--- a/src/tests/composables/interactionDialog.test.ts
+++ b/src/tests/composables/interactionDialog.test.ts
@@ -1,0 +1,35 @@
+import { expect, test, vi } from 'vitest'
+
+let mounts = 0
+
+vi.mock('@/plugins/vuetify', () => ({ default: () => undefined }))
+vi.mock('@/router', () => ({ default: () => undefined }))
+vi.mock('@/components/InteractionDialog.vue', () => ({
+  default: { template: '<div />', mounted: () => (mounts += 1) },
+}))
+
+import { useInteractionDialog } from '@/composables/interactionDialog'
+
+test('an already open dialog is not remounted by repeated calls with the same options', async () => {
+  const { showDialog, closeDialog } = useInteractionDialog()
+  const problem = { message: 'The recording may be broken.', variant: 'error' }
+
+  const first = showDialog(problem)
+  const second = showDialog(problem)
+  const third = showDialog(problem)
+  expect(mounts).toBe(1)
+  expect(second).toBe(first)
+  expect(third).toBe(first)
+
+  showDialog({ message: 'A different problem.', variant: 'error' })
+  expect(mounts).toBe(2)
+  expect(await first).toEqual({ isConfirmed: false })
+
+  // Same wording, different options, so the caller gets its own dialog instead of the open one's promise.
+  showDialog({ message: 'A different problem.', variant: 'warning' })
+  expect(mounts).toBe(3)
+
+  closeDialog()
+  showDialog({ message: 'A different problem.', variant: 'warning' })
+  expect(mounts).toBe(4)
+})


### PR DESCRIPTION
## Summary

A recording with a missing output file made the 15 s health monitor call `showDialog` on every tick, and since `showDialog` unmounts and mounts a fresh dialog on each call, the warning kept popping back with no way to dismiss it for good. The fix lands in the shared dialog composable rather than in the caller.

- **`showDialog` no longer remounts a dialog that is already on screen** (`src/composables/interactionDialog.ts`). While a dialog with the same resolved options is open, the pending promise is returned instead of the dialog being rebuilt under the user. `useInteractionDialog` is a factory, so this dedupes per composable instance, and it covers only the dialog shown last — which is what a caller repeating one request needs, the interval case. Callers that share an instance and alternate between *different* requests still have to arbitrate among themselves, which the recording monitors now do (below). Keying on the whole resolved state (not just the message) keeps a caller asking for the same text with different buttons from silently inheriting the open dialog's promise. It replaces the hand-rolled "is it already open" flag the sibling not-growing-file check carried in `src/stores/video.ts`.
- **The missing-file branch now uses the same guarded dialog as the other recording health warnings** (`src/stores/video.ts`). It gets the "Don't show again during this session" opt-out, and its message says the recording may be lost and that the user should stop it and start a new one, rather than talking about a file size that could not be read. The session opt-out is keyed by message, so silencing the mild not-growing nag does not silence the serious missing-file warning.
- **Every recording health warning names its stream, and the monitors take turns on the one dialog surface** (`src/stores/video.ts`). Cockpit records several streams at once, so "stop this recording" pointed at nothing the user could act on. Naming the stream makes each stream's warning a distinct dialog request, which the composable's most-recent-only guard cannot deduplicate, so the store tracks which warning owns the surface: the one on screen holds it until it is settled, and the monitors of the other unhealthy streams retry on later ticks. Nothing but the user settles one of these dialogs, so the wait is as long as the user leaves it up — a warning about a recording that may already be lost therefore takes the surface from a milder one instead of queueing behind it. The Close action's log entry now names the warning it closed, matching the opt-out's.

## Test plan

- [ ] On Standalone, start a recording, then delete or rename the output file under the videos folder while it runs. The warning appears once, names the stream, and stays put across the following 15 s ticks.
- [ ] Press "Close" on it. It comes back on the next tick (the problem is still there), still only one dialog at a time.
- [ ] Press "Don't show again during this session". It stays gone for the rest of the session.
- [ ] Force the not-growing warning, silence it with the opt-out, then make the file disappear. The missing-file warning still shows.
- [ ] Record two streams and break both, one with a missing file and one that stops growing. One warning is shown at a time and is not replaced under the user every 15 s; acting on it lets the other through on a later tick.
- [ ] With the not-growing warning left on screen, make the other stream's file disappear. The missing-file warning replaces it on the next tick, and the not-growing one does not take the surface back while it is up.
- [ ] Confirm unrelated dialogs still open normally while one is on screen, and that a second, different message replaces the open one as before.

## Checks

- Unit test `src/tests/composables/interactionDialog.test.ts` counts dialog mounts: three identical `showDialog` calls mount once, a different message mounts again, the same message with a different variant mounts its own dialog, and mounting resumes after `closeDialog`.
- `yarn lint` and `yarn test:unit` clean.

Closes #2950

