### PR TITLE
Warn when heavy traffic goes through the vehicle's wireless link

### DIFF
--- a/src/libs/blueos.ts
+++ b/src/libs/blueos.ts
@@ -345,6 +345,22 @@ export const isWirelessInterfaceName = (interfaceName: string): boolean => inter
 
 const isCabledInterfaceName = (interfaceName: string): boolean => interfaceName.includes('eth')
 
+const minCounterSpanMs = 6000
+
+/**
+ * Turns the progress of one of the vehicle's byte counters into a transfer rate.
+ * The vehicle refreshes those counters slower than Cockpit polls them, so the span has to cover several
+ * refreshes to mean anything: a poll-to-poll delta reads zero most of the time and spikes on the polls that
+ * catch a refresh, on an idle interface just as much as on a busy one.
+ * @param {number} deltaBytes How far the counter moved across the span.
+ * @param {number} spanMs Time the span covers, in milliseconds.
+ * @returns {number} The rate in Mbps, and zero for a span too short to cover a refresh or for a counter reset by a vehicle reboot.
+ */
+export const counterDeltaToMbps = (deltaBytes: number, spanMs: number): number => {
+  if (spanMs < minCounterSpanMs || deltaBytes < 0) return 0
+  return (deltaBytes * 8) / (1024 * 1024) / (spanMs / 1000)
+}
+
 export const getNetworkInfo = async (vehicleAddress: string): Promise<RawNetworkInfo[]> => {
   try {
     const url = `${protocol}//${vehicleAddress}/system-information/system/network`

--- a/src/libs/blueos.ts
+++ b/src/libs/blueos.ts
@@ -183,7 +183,7 @@ export const setKeyDataOnCockpitVehicleStorage = async (
 
 /* eslint-disable jsdoc/require-jsdoc */
 type RawIpInfo = { ip: string; service_type: string; interface_type: string }
-type IpInfo = { ipv4Address: string; interfaceType: string }
+export type IpInfo = { ipv4Address: string; interfaceType: string }
 
 type StreamConfiguration = {
   type: string
@@ -246,6 +246,13 @@ export const getIpsInformationFromVehicle = async (vehicleAddress: string): Prom
     throw new Error(`Could not get information about IPs on BlueOS. ${error}`)
   }
 }
+
+/**
+ * Tells if an interface type reported by the beacon means the vehicle is reached through a cable.
+ * @param {string} interfaceType Interface type as reported by the beacon service.
+ * @returns {boolean} True for wired and USB interfaces.
+ */
+export const isTetheredInterfaceType = (interfaceType: string): boolean => ['WIRED', 'USB'].includes(interfaceType)
 
 /* eslint-disable jsdoc/require-jsdoc */
 type RawM2rServiceInfo = { name: string; version: string; sha: string; build_date: string; authors: string }
@@ -329,12 +336,23 @@ export const getCpusInfo = async (vehicleAddress: string): Promise<RawCpuLoadInf
   }
 }
 
+/**
+ * Tells if a vehicle network interface is a wireless one, judging by the naming convention BlueOS follows.
+ * @param {string} interfaceName Name of the vehicle network interface.
+ * @returns {boolean} True for wireless interfaces.
+ */
+export const isWirelessInterfaceName = (interfaceName: string): boolean => interfaceName.includes('wlan')
+
+const isCabledInterfaceName = (interfaceName: string): boolean => interfaceName.includes('eth')
+
 export const getNetworkInfo = async (vehicleAddress: string): Promise<RawNetworkInfo[]> => {
   try {
     const url = `${protocol}//${vehicleAddress}/system-information/system/network`
     const networkRawInfo: RawNetworkInfo[] = await ky.get(url, { timeout: defaultTimeout }).json()
     return networkRawInfo.filter((network) => {
-      return (network.name.includes('wlan') || network.name.includes('eth')) && !network.name.startsWith('v')
+      return (
+        (isWirelessInterfaceName(network.name) || isCabledInterfaceName(network.name)) && !network.name.startsWith('v')
+      )
     })
   } catch (error) {
     throw new Error(`Could not get network information from BlueOS. ${error}`)

--- a/src/libs/wireless-traffic-warning.ts
+++ b/src/libs/wireless-traffic-warning.ts
@@ -1,0 +1,111 @@
+import { type IpInfo, isTetheredInterfaceType, isWirelessInterfaceName } from '@/libs/blueos'
+
+/**
+ * Watches the upload rate of the vehicle network interfaces and tells when heavy traffic has been
+ * flowing through a wireless link for long enough to be worth warning the user about.
+ */
+export interface WirelessTrafficWatcher {
+  /**
+   * Records a new round of readings and evaluates the traffic condition against them.
+   * @param {Record<string, number>} totalUploadedBytesPerInterface Bytes each vehicle network interface has transmitted since boot, keyed by interface name.
+   * @param {number} timestamp Moment the readings were taken, in milliseconds since the epoch.
+   * @returns {boolean} True when a wireless interface has been busy across every window-long stretch of the recent readings and no warning was shown yet.
+   */
+  shouldWarn: (totalUploadedBytesPerInterface: Record<string, number>, timestamp: number) => boolean
+  /**
+   * Silences the watcher, so a warning that reached the user is not repeated.
+   */
+  registerWarningShown: () => void
+}
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+type CounterSample = { timestamp: number; totalUploadedBytes: number }
+
+const analysisWindowMs = 10000
+const busyWirelessThresholdMbps = 5
+
+// A single large transfer — Cockpit pulls map tile archives and vehicle files over this same link — moves
+// enough bytes to clear the threshold on one window while lasting only seconds, and the once-per-session
+// warning would be spent on it. Asking every window-long stretch of the history to be busy leaves any
+// transfer shorter than a window an idle stretch to fail on, but only once the history spans three windows:
+// below that the transfer sits too close to both ends to leave a whole stretch clear of it. The fourth
+// window is what makes that span reachable at the 1 Hz poll, at the cost of warning around 31 s in.
+const analysisHistoryMs = 4 * analysisWindowMs
+
+// The readings come from a poll that shares the link being measured, so they are lost exactly when the link
+// is congested. Taking the stretches from the samples themselves, instead of from fixed timestamps, keeps a
+// lossy link from silencing the warning, as long as the readings still inside the history span this much of
+// it, which any cadence up to a third of the history guarantees.
+const minHistorySpanMs = analysisHistoryMs - analysisWindowMs
+
+// The vehicle refreshes these counters slower than we poll them, so the per-poll rate reads zero most of
+// the time and spikes on the polls that catch a refresh, on an idle interface just as much as on a busy
+// one. Taking the rate from how far the counter moved across a stretch instead of from what each poll
+// reported is immune to that, and to readings arriving late or out of order.
+const stretchUploadMbps = (from: CounterSample, to: CounterSample): number => {
+  const uploadedBytes = to.totalUploadedBytes - from.totalUploadedBytes
+  if (uploadedBytes < 0) return 0
+  return (uploadedBytes * 8) / (1024 * 1024) / ((to.timestamp - from.timestamp) / 1000)
+}
+
+// Slowest of the stretches spanning at least a window, so an idle one pulls the verdict down with it.
+const slowestSustainedUploadMbps = (samples: CounterSample[]): number => {
+  if (samples.length < 2) return 0
+  if (samples[samples.length - 1].timestamp - samples[0].timestamp < minHistorySpanMs) return 0
+  const rates = samples.flatMap((from, fromIndex) =>
+    samples
+      .slice(fromIndex + 1)
+      .filter((to) => to.timestamp - from.timestamp >= analysisWindowMs)
+      .map((to) => stretchUploadMbps(from, to))
+  )
+  return Math.min(...rates)
+}
+
+/**
+ * Tells if it makes sense to suggest the user to reach the vehicle through the cable, which is only the
+ * case when the vehicle is currently reached over a wireless link and also has a cabled address. An
+ * address that is not one of the reported ones, like an mDNS host name, leaves the current link kind
+ * undetermined, and an unsubstantiated warning is worse than none.
+ * @param {IpInfo[]} ipsInfo Addresses the vehicle is reachable on, as reported by the beacon.
+ * @param {string} currentAddress Address the vehicle is currently being reached on.
+ * @returns {boolean} True when the current link is wireless and a cabled one is available.
+ */
+export const canSuggestCabledLink = (ipsInfo: IpInfo[], currentAddress: string): boolean => {
+  const currentType = ipsInfo.find((ipInfo) => ipInfo.ipv4Address === currentAddress)?.interfaceType
+  if (currentType === undefined || isTetheredInterfaceType(currentType)) return false
+  return ipsInfo.some((ipInfo) => isTetheredInterfaceType(ipInfo.interfaceType))
+}
+
+/**
+ * Creates a watcher holding the rate history the traffic condition is evaluated against.
+ * @returns {WirelessTrafficWatcher} A watcher with no readings recorded yet.
+ */
+export const createWirelessTrafficWatcher = (): WirelessTrafficWatcher => {
+  const samplesPerInterface = new Map<string, CounterSample[]>()
+  let warningShown = false
+
+  return {
+    shouldWarn: (totalUploadedBytesPerInterface, timestamp) => {
+      const historyStart = timestamp - analysisHistoryMs
+      samplesPerInterface.forEach((samples, interfaceName) => {
+        samplesPerInterface.set(
+          interfaceName,
+          samples.filter((sample) => sample.timestamp > historyStart)
+        )
+      })
+      Object.entries(totalUploadedBytesPerInterface).forEach(([interfaceName, totalUploadedBytes]) => {
+        const samples = samplesPerInterface.get(interfaceName) ?? []
+        samples.push({ timestamp, totalUploadedBytes })
+        samplesPerInterface.set(interfaceName, samples)
+      })
+
+      // A vehicle can expose several wireless interfaces, so any of them being busy is enough.
+      const isBusy = ([interfaceName, samples]: [string, CounterSample[]]): boolean =>
+        isWirelessInterfaceName(interfaceName) && slowestSustainedUploadMbps(samples) >= busyWirelessThresholdMbps
+      return !warningShown && [...samplesPerInterface.entries()].some(isBusy)
+    },
+    registerWarningShown: () => {
+      warningShown = true
+    },
+  }
+}

--- a/src/libs/wireless-traffic-warning.ts
+++ b/src/libs/wireless-traffic-warning.ts
@@ -1,4 +1,4 @@
-import { type IpInfo, isTetheredInterfaceType, isWirelessInterfaceName } from '@/libs/blueos'
+import { type IpInfo, counterDeltaToMbps, isTetheredInterfaceType, isWirelessInterfaceName } from '@/libs/blueos'
 
 /**
  * Watches the upload rate of the vehicle network interfaces and tells when heavy traffic has been
@@ -38,17 +38,9 @@ const analysisHistoryMs = 4 * analysisWindowMs
 // it, which any cadence up to a third of the history guarantees.
 const minHistorySpanMs = analysisHistoryMs - analysisWindowMs
 
-// The vehicle refreshes these counters slower than we poll them, so the per-poll rate reads zero most of
-// the time and spikes on the polls that catch a refresh, on an idle interface just as much as on a busy
-// one. Taking the rate from how far the counter moved across a stretch instead of from what each poll
-// reported is immune to that, and to readings arriving late or out of order.
-const stretchUploadMbps = (from: CounterSample, to: CounterSample): number => {
-  const uploadedBytes = to.totalUploadedBytes - from.totalUploadedBytes
-  if (uploadedBytes < 0) return 0
-  return (uploadedBytes * 8) / (1024 * 1024) / ((to.timestamp - from.timestamp) / 1000)
-}
-
-// Slowest of the stretches spanning at least a window, so an idle one pulls the verdict down with it.
+// Taking the rate from how far the counter moved across a stretch, instead of from what each poll reported,
+// is also immune to readings arriving late or out of order. The slowest stretch spanning at least a window
+// decides, so an idle one pulls the verdict down with it.
 const slowestSustainedUploadMbps = (samples: CounterSample[]): number => {
   if (samples.length < 2) return 0
   if (samples[samples.length - 1].timestamp - samples[0].timestamp < minHistorySpanMs) return 0
@@ -56,7 +48,7 @@ const slowestSustainedUploadMbps = (samples: CounterSample[]): number => {
     samples
       .slice(fromIndex + 1)
       .filter((to) => to.timestamp - from.timestamp >= analysisWindowMs)
-      .map((to) => stretchUploadMbps(from, to))
+      .map((to) => counterDeltaToMbps(to.totalUploadedBytes - from.totalUploadedBytes, to.timestamp - from.timestamp))
   )
   return Math.min(...rates)
 }

--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -11,6 +11,7 @@ import { getAllDataLakeVariablesInfo, getDataLakeVariableInfo, setDataLakeVariab
 import { createDataLakeVariable } from '@/libs/actions/data-lake'
 import { altitude_setpoint } from '@/libs/altitude-slider'
 import {
+  counterDeltaToMbps,
   getCpusInfo,
   getCpuTempCelsius,
   getIpsInformationFromVehicle,
@@ -778,10 +779,13 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     const networkDownloadSpeedMbpsVariableId = (interfaceName: string): string =>
       `blueos/network/${interfaceName}/downloadSpeedMbps`
 
-    // Store previous network readings for speed calculation
+    // Store the recent network readings of each interface, which the published speeds are measured across
 
     // eslint-disable-next-line jsdoc/require-jsdoc, prettier/prettier
-    const previousNetworkReadings: Map<string, { bytesReceived: number; bytesTransmitted: number; timestamp: number }> = new Map()
+    const networkReadingsHistory: Map<string, { bytesReceived: number; bytesTransmitted: number; timestamp: number }[]> = new Map()
+
+    // Long enough to span several counter refreshes, which is what makes the published speed the real rate.
+    const speedAveragingWindowMs = 10000
 
     const wirelessTrafficWatcher = createWirelessTrafficWatcher()
     const cabledLinkCheckIntervalMs = 30000
@@ -921,38 +925,31 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
           setDataLakeVariableData(networkTotalTransmittedMBVariableId(networkInterface.name), totalTransmittedMB)
 
           // Calculate and update speeds
-          const previousReading = previousNetworkReadings.get(networkInterface.name)
-          if (previousReading) {
-            const timeDeltaSeconds = (currentTimestamp - previousReading.timestamp) / 1000
-            if (timeDeltaSeconds > 0) {
-              // Calculate speed in bytes per second
-              const downloadSpeedBytesPerSec =
-                (networkInterface.total_received_B - previousReading.bytesReceived) / timeDeltaSeconds
-              const uploadSpeedBytesPerSec =
-                (networkInterface.total_transmitted_B - previousReading.bytesTransmitted) / timeDeltaSeconds
-
-              // Convert to megabits per second (Mbps): bytes/s * 8 bits/byte / (1024 * 1024) = Mbps
-              const downloadSpeedMbps = (downloadSpeedBytesPerSec * 8) / (1024 * 1024)
-              const uploadSpeedMbps = (uploadSpeedBytesPerSec * 8) / (1024 * 1024)
-
-              // Set speeds (ensure they're not negative due to counter resets)
-              setDataLakeVariableData(
-                networkDownloadSpeedMbpsVariableId(networkInterface.name),
-                Math.max(0, downloadSpeedMbps)
-              )
-              setDataLakeVariableData(
-                networkUploadSpeedMbpsVariableId(networkInterface.name),
-                Math.max(0, uploadSpeedMbps)
-              )
-            }
+          const windowStart = currentTimestamp - speedAveragingWindowMs
+          const storedReadings = networkReadingsHistory.get(networkInterface.name) ?? []
+          const readings = storedReadings.filter((reading) => reading.timestamp > windowStart)
+          // A gap longer than the window leaves nothing inside it, and publishing nothing would leave the
+          // previous rate standing as if it were current, so the newest reading is measured against instead.
+          const oldestReading = readings[0] ?? storedReadings[storedReadings.length - 1]
+          if (oldestReading) {
+            const spanMs = currentTimestamp - oldestReading.timestamp
+            setDataLakeVariableData(
+              networkDownloadSpeedMbpsVariableId(networkInterface.name),
+              counterDeltaToMbps(networkInterface.total_received_B - oldestReading.bytesReceived, spanMs)
+            )
+            setDataLakeVariableData(
+              networkUploadSpeedMbpsVariableId(networkInterface.name),
+              counterDeltaToMbps(networkInterface.total_transmitted_B - oldestReading.bytesTransmitted, spanMs)
+            )
           }
 
           // Store current reading for next calculation
-          previousNetworkReadings.set(networkInterface.name, {
+          readings.push({
             bytesReceived: networkInterface.total_received_B,
             bytesTransmitted: networkInterface.total_transmitted_B,
             timestamp: currentTimestamp,
           })
+          networkReadingsHistory.set(networkInterface.name, readings)
         })
 
         // Not awaited, so a slow beacon does not hold this round nor report its failure as a data lake one.

--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -13,6 +13,7 @@ import { altitude_setpoint } from '@/libs/altitude-slider'
 import {
   getCpusInfo,
   getCpuTempCelsius,
+  getIpsInformationFromVehicle,
   getKeyDataFromCockpitVehicleStorage,
   getNetworkInfo,
   getStatus,
@@ -49,6 +50,7 @@ import type {
 import { Coordinates } from '@/libs/vehicle/types'
 import * as Vehicle from '@/libs/vehicle/vehicle'
 import { VehicleFactory } from '@/libs/vehicle/vehicle-factory'
+import { canSuggestCabledLink, createWirelessTrafficWatcher } from '@/libs/wireless-traffic-warning'
 import type { MissionLoadingCallback, Waypoint } from '@/types/mission'
 
 import { useControllerStore } from './controller'
@@ -781,6 +783,40 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     // eslint-disable-next-line jsdoc/require-jsdoc, prettier/prettier
     const previousNetworkReadings: Map<string, { bytesReceived: number; bytesTransmitted: number; timestamp: number }> = new Map()
 
+    const wirelessTrafficWatcher = createWirelessTrafficWatcher()
+    const cabledLinkCheckIntervalMs = 30000
+    let checkingCabledLinkSuggestion = false
+    let lastCabledLinkCheckTimestamp = 0
+
+    // Asking the vehicle which links it can be reached on is a request of its own, so it is only made once the
+    // traffic condition holds, and throttled from there. The answer cannot be kept for the session, as a cable
+    // plugged in or pulled changes it. A failure just waits for the next check, since a saturated wireless link
+    // is exactly what makes this request fail, and that is when the warning is most needed.
+    const suggestCabledLinkIfItMakesSense = async (timestamp: number): Promise<void> => {
+      if (checkingCabledLinkSuggestion) return
+      if (timestamp - lastCabledLinkCheckTimestamp < cabledLinkCheckIntervalMs) return
+      checkingCabledLinkSuggestion = true
+      lastCabledLinkCheckTimestamp = timestamp
+
+      try {
+        const ipsInfo = await getIpsInformationFromVehicle(globalAddress.value)
+        if (!canSuggestCabledLink(ipsInfo, globalAddress.value)) return
+      } catch (error) {
+        console.error(`Failed to get the links the vehicle can be reached on: ${error}`)
+        return
+      } finally {
+        checkingCabledLinkSuggestion = false
+      }
+
+      wirelessTrafficWatcher.registerWarningShown()
+      openSnackbar({
+        message:
+          "A lot of data is going through the vehicle's WiFi connection. Connecting through the cabled network should give you better video quality and less delay.",
+        variant: 'warning',
+        persistent: true,
+      })
+    }
+
     const cpusInfos = await getCpusInfo(globalAddress.value)
     cpusInfos.forEach((cpu) => {
       Object.assign(blueOsVariables, {
@@ -871,8 +907,11 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
       try {
         const updatedNetworkInfos = await getNetworkInfo(globalAddress.value)
         const currentTimestamp = Date.now()
+        const totalUploadedBytesPerInterface: Record<string, number> = {}
 
         updatedNetworkInfos.forEach((networkInterface) => {
+          totalUploadedBytesPerInterface[networkInterface.name] = networkInterface.total_transmitted_B
+
           // Convert total bytes to megabytes (MB)
           const totalReceivedMB = networkInterface.total_received_B / (1024 * 1024)
           const totalTransmittedMB = networkInterface.total_transmitted_B / (1024 * 1024)
@@ -915,6 +954,11 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
             timestamp: currentTimestamp,
           })
         })
+
+        // Not awaited, so a slow beacon does not hold this round nor report its failure as a data lake one.
+        if (wirelessTrafficWatcher.shouldWarn(totalUploadedBytesPerInterface, currentTimestamp)) {
+          suggestCabledLinkIfItMakesSense(currentTimestamp)
+        }
       } catch (error) {
         console.error(`Failed to update network information in data lake: ${error}`)
       }

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -12,7 +12,12 @@ import { useInteractionDialog } from '@/composables/interactionDialog'
 import { useBlueOsStorage } from '@/composables/settingsSyncer'
 import { useSnackbar } from '@/composables/snackbar'
 import { WebRTCManager } from '@/composables/webRTC'
-import { type ProcessedStreamInfo, getIpsInformationFromVehicle, getStreamInformationFromVehicle } from '@/libs/blueos'
+import {
+  type ProcessedStreamInfo,
+  getIpsInformationFromVehicle,
+  getStreamInformationFromVehicle,
+  isTetheredInterfaceType,
+} from '@/libs/blueos'
 import eventTracker from '@/libs/external-telemetry/event-tracking'
 import { availableCockpitActions, registerActionCallback } from '@/libs/joystick/protocols/cockpit-actions'
 import {
@@ -1140,11 +1145,11 @@ export const useVideoStore = defineStore('video', () => {
           ipsInfo.forEach((ipInfo) => {
             const isIceIp = availableIceIps.value.includes(ipInfo.ipv4Address)
             const alreadyAllowedIp = [...allowedIceIps.value, ...newAllowedIps].includes(ipInfo.ipv4Address)
-            const theteredInterfaceTypes = ['WIRED', 'USB']
-            if (globalAddress === ipInfo.ipv4Address && !theteredInterfaceTypes.includes(ipInfo.interfaceType)) {
+            const isTethered = isTetheredInterfaceType(ipInfo.interfaceType)
+            if (globalAddress === ipInfo.ipv4Address && !isTethered) {
               currentlyOnWirelessConnection = true
             }
-            if (!theteredInterfaceTypes.includes(ipInfo.interfaceType) || alreadyAllowedIp || !isIceIp) return
+            if (!isTethered || alreadyAllowedIp || !isIceIp) return
             console.info(`Adding the wired address '${ipInfo.ipv4Address}' to the list of allowed ICE IPs.`)
             newAllowedIps.push(ipInfo.ipv4Address)
           })

--- a/src/tests/libs/blueos.test.ts
+++ b/src/tests/libs/blueos.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from 'vitest'
+
+import { counterDeltaToMbps } from '@/libs/blueos'
+
+const megabitsToBytes = (megabits: number): number => (megabits * 1024 * 1024) / 8
+
+test('reads the real rate of a counter that only refreshes every few seconds', () => {
+  // Ten seconds of a 12 Mbps link whose counter last refreshed at second 9, so the newest reading is stale.
+  expect(counterDeltaToMbps(megabitsToBytes(12 * 9), 10000)).toBeCloseTo(10.8)
+
+  // The same link measured between two consecutive polls: one pair falls inside a refresh period and reads
+  // no traffic at all, the next catches the refresh and reads three seconds worth of it as one second.
+  expect(counterDeltaToMbps(0, 1000)).toBe(0)
+  expect(counterDeltaToMbps(megabitsToBytes(12 * 3), 1000)).toBe(0)
+})
+
+test('reports no traffic for a counter reset by a vehicle reboot, and for an empty span', () => {
+  expect(counterDeltaToMbps(-megabitsToBytes(500), 10000)).toBe(0)
+  expect(counterDeltaToMbps(megabitsToBytes(50), 0)).toBe(0)
+})

--- a/src/tests/libs/wireless-traffic-warning.test.ts
+++ b/src/tests/libs/wireless-traffic-warning.test.ts
@@ -1,0 +1,95 @@
+import { expect, test } from 'vitest'
+
+import {
+  canSuggestCabledLink,
+  createWirelessTrafficWatcher,
+  WirelessTrafficWatcher,
+} from '@/libs/wireless-traffic-warning'
+
+const megabitsToBytes = (megabits: number): number => (megabits * 1024 * 1024) / 8
+
+// Feeds one reading per second, of counters advancing at a steady rate on each interface.
+const feedSteadySeconds = (
+  watcher: WirelessTrafficWatcher,
+  seconds: number,
+  uploadMbpsPerInterface: Record<string, number>,
+  firstSecond = 0
+): boolean[] =>
+  Array.from({ length: seconds }, (_, index) => {
+    const second = firstSecond + index
+    const counters = Object.entries(uploadMbpsPerInterface).map(([name, mbps]) => [
+      name,
+      megabitsToBytes(mbps * second),
+    ])
+    return watcher.shouldWarn(Object.fromEntries(counters), second * 1000)
+  })
+
+test('warns only once the wireless link has been busy across every stretch of the history', () => {
+  const watcher = createWirelessTrafficWatcher()
+  const verdicts = feedSteadySeconds(watcher, 31, { eth0: 1, wlan0: 6 })
+
+  expect(verdicts.slice(0, 30)).not.toContain(true)
+  expect(verdicts[30]).toBe(true)
+
+  // A verdict that never made it to the user does not count, so it keeps being offered until it does.
+  expect(feedSteadySeconds(watcher, 5, { eth0: 1, wlan0: 6 }, 31)).not.toContain(false)
+
+  watcher.registerWarningShown()
+
+  // The advice cannot be acted on without reloading Cockpit, so it is given once and never repeated.
+  expect(feedSteadySeconds(watcher, 400, { eth0: 1, wlan0: 6 }, 36)).not.toContain(true)
+})
+
+test('stays quiet below the busy threshold', () => {
+  expect(feedSteadySeconds(createWirelessTrafficWatcher(), 35, { eth0: 0, wlan0: 4.9 })).not.toContain(true)
+
+  // The same run just above the threshold has to warn, or the silence above is only the history gate.
+  expect(feedSteadySeconds(createWirelessTrafficWatcher(), 35, { eth0: 0, wlan0: 5.1 })).toContain(true)
+})
+
+test('still warns when the readings arrive five seconds apart', () => {
+  const watcher = createWirelessTrafficWatcher()
+  const verdicts = Array.from({ length: 8 }, (_, index) =>
+    watcher.shouldWarn({ wlan0: megabitsToBytes(6 * index * 5) }, index * 5000)
+  )
+
+  expect(verdicts).toContain(true)
+})
+
+test('warns on a busy link whose counter only refreshes every few readings', () => {
+  const watcher = createWirelessTrafficWatcher()
+
+  // The vehicle refreshes the counter every third poll, so two out of three readings report no progress at
+  // all and the third reports three seconds worth of it. The link is carrying 12 Mbps the whole time.
+  const verdicts = Array.from({ length: 35 }, (_, second) =>
+    watcher.shouldWarn({ eth0: 0, wlan0: megabitsToBytes(12 * (second - (second % 3))) }, second * 1000)
+  )
+
+  expect(verdicts).toContain(true)
+})
+
+test('a single transfer on an otherwise idle wireless link does not warn, however big it is', () => {
+  const watcher = createWirelessTrafficWatcher()
+
+  // 200 Mbit at 50 Mbps, spread over four readings so the history can be cut between them, which is the
+  // shape a real transfer has and the one a rule made of fixed windows lets through. It starts off a window
+  // boundary, so the verdict rests on the history being long enough rather than on the alignment.
+  const uploadedMegabits = (second: number): number => Math.min(Math.max(second - 8, 0), 4) * 50
+  const verdicts = Array.from({ length: 60 }, (_, second) =>
+    watcher.shouldWarn({ eth0: 0, wlan0: megabitsToBytes(uploadedMegabits(second)) }, second * 1000)
+  )
+
+  expect(verdicts).not.toContain(true)
+})
+
+test('only suggests the cable when the vehicle is reached wirelessly and a cabled address exists', () => {
+  const wireless = { ipv4Address: '192.168.10.5', interfaceType: 'WIFI' }
+  const wired = { ipv4Address: '192.168.2.2', interfaceType: 'WIRED' }
+
+  expect(canSuggestCabledLink([wireless, wired], wireless.ipv4Address)).toBe(true)
+  expect(canSuggestCabledLink([wireless, wired], wired.ipv4Address)).toBe(false)
+  expect(canSuggestCabledLink([wireless], wireless.ipv4Address)).toBe(false)
+
+  // An mDNS host name matches none of the reported addresses, leaving the current link kind unknown.
+  expect(canSuggestCabledLink([wireless, wired], 'blueos-avahi.local')).toBe(false)
+})


### PR DESCRIPTION
## Summary

A vehicle reached over WiFi streams its video over WiFi, even with a cable attached. Cockpit cannot move the media to the cable, so it now tells the user about it.

<img width="740" height="58" alt="image" src="https://github.com/user-attachments/assets/af389e15-3981-49dc-9a9f-c59892d97578" />


Two things have to hold before the warning shows up:

- the vehicle is currently reached over a wireless address while a cabled one is also available, as reported by the beacon. This is the same source the video store already uses to pick the preferred stream routes, so an operator already on the cable, and a vehicle with no cable at all, stay quiet.
- a wireless interface has carried at least 5 Mbps of upload across *every* ten-second stretch of the last forty seconds. The stretches are taken from the readings themselves rather than from fixed timestamps, so a link that loses readings still produces a verdict, as long as the readings still inside the forty seconds span thirty of them, which any reading cadence up to a third of the history guarantees. The rate comes from how far the vehicle's transmitted-byte counter moved across each stretch, not from what each poll reported: the vehicle refreshes those counters slower than Cockpit polls them at 1 Hz, so the per-poll rate reads zero most of the time and spikes on the polls that catch a refresh, which no per-sample statistic tells apart from an idle link. Every stretch rather than the history as a whole because Cockpit pulls map tile archives and files from the vehicle's file storage over this same link, and a single large transfer moves enough bytes to clear the threshold over a long span while lasting only seconds — it would spend the session's one warning on itself. Any transfer shorter than a stretch leaves an idle stretch for the verdict to fail on, so it has to last longer than ten seconds to pass. That only holds once the history spans three stretches, which is what the first verdict waits for, so sustained traffic warns around 31 s in.

The beacon is only asked once the traffic condition holds, and at most once every 30 s from there, so a cable plugged in or pulled mid-session changes the answer.

The warning is a persistent snackbar, given once per session and dismissed by the user — acting on it means changing the vehicle address, which reloads Cockpit anyway. No UI was added — it uses the existing snackbar.

An address the beacon does not report, such as the default `blueos-avahi.local` host name, leaves the current link kind undetermined, and in that case nothing is warned.

## The plotted network speeds, fixed in the second commit

The `upload speed (Mbps)` and `download speed (Mbps)` data-lake variables were computed from a single poll-to-poll delta, which is the very thing the counter-refresh diagnosis above says is meaningless: they read as zeros and spikes on a busy link just as much as on an idle one, which is exactly what the plots earlier in this thread show.

That defect is pre-existing, but it is the number an operator reaches for to see what the link is doing, and the one anybody verifying this feature would plot, so it is fixed here rather than left for later — in its own commit, since it changes existing behaviour. Both speeds are now measured across the readings of the last ten seconds, which spans several counter refreshes, and the counter-delta-to-Mbps conversion lives in one helper shared with the warning's own history. The minimum span lives in that helper too, so the polls right after connecting publish no traffic instead of the sawtooth they have too little history to look past, and a gap in the readings is measured against the newest reading available instead of leaving the last rate published as if it were still current.

## Test plan

- [ ] Connect to a vehicle over WiFi, by IP, with a stream running, and confirm the warning shows up once and is not repeated for the rest of the session.
- [ ] Connect to the same vehicle over the cabled network and confirm no warning shows up.
- [ ] Connect to a vehicle with no cable attached and confirm no warning shows up.
- [ ] With no cable attached and a stream running, plug the cable in and confirm the warning shows up shortly after.
- [ ] Pull a large file off the vehicle over WiFi with no stream running — a custom map tile archive, which is multi-MB by design — and confirm no warning shows up.
- [ ] Plot the wireless and cabled `upload speed (Mbps)` variables with a stream running and confirm they now hold a steady rate instead of alternating between zero and a spike.

## Checks

- `yarn lint:fix` clean, and `vitest run` passes 40 tests. `cosmos.test.ts` and `connection.test.ts` fail to collect the same way on `master`.
- `yarn typecheck` is broken on my machine, on `master` as well — `vue-tsc` bails on `src/App.vue` and exits 0 even with a deliberate type error — so I checked the changed files with `tsc` directly and diffed the errors against the same run without this branch's changes. No new ones.
- `src/tests/libs/wireless-traffic-warning.test.ts` covers the trigger, the once-per-session latch, traffic below the threshold, readings arriving five seconds apart, a busy link whose counter only refreshes every few polls, a single large transfer spread over several readings on an idle wireless link, and the four link-kind cases of the beacon check.
- `src/tests/libs/blueos.test.ts` covers the shared rate helper: a counter that only refreshes every few seconds, a span too short to cover a refresh — both when it reads no progress and when it catches one — a counter reset by a vehicle reboot, and an empty span.

Closes #2953
Closes #2971

