### PR TITLE
Add serial GNSS connection wizard to the Base Station configuration panel

### DIFF
--- a/src/components/BaseStationConfigPanel.vue
+++ b/src/components/BaseStationConfigPanel.vue
@@ -54,8 +54,42 @@
                 @blur="onCoordinateBlur"
               />
             </div>
+            <div v-if="!hasLocalGnssSource" class="config-row">
+              <v-btn
+                class="config-serial-gnss-btn bg-[#FFFFFF22] text-white"
+                variant="elevated"
+                size="small"
+                prepend-icon="mdi-usb-port"
+                :disabled="!gnss.isSupported"
+                title="Find a connected GNSS receiver and let it set the base station position"
+                @click="openGnssSetup"
+              >
+                Use serial/USB device
+              </v-btn>
+            </div>
+            <p v-if="!gnss.isSupported" class="px-1 pt-1 text-[10px] leading-tight opacity-70">
+              Serial devices cannot be read from a browser. Install Cockpit Standalone to set the base station position
+              from a connected GNSS receiver.
+            </p>
             <div class="config-row config-gps-row" :class="{ 'config-row-with-source': store.trackByGps }">
-              <p class="config-label">Track by GPS</p>
+              <div class="config-label-with-info">
+                <p class="config-label">Track by GPS</p>
+                <v-tooltip v-if="hasLocalGnssSource" location="top">
+                  <template #activator="{ props }">
+                    <button
+                      type="button"
+                      class="config-info-btn"
+                      title="Set up a serial GNSS receiver"
+                      aria-label="Set up a serial GNSS receiver"
+                      v-bind="props"
+                      @click="openGnssSetup"
+                    >
+                      <v-icon icon="mdi-cog" size="14" />
+                    </button>
+                  </template>
+                  Set up a serial GNSS receiver
+                </v-tooltip>
+              </div>
               <v-checkbox
                 :model-value="store.trackByGps"
                 hide-details
@@ -711,6 +745,8 @@
           </v-card-actions>
         </v-card>
       </v-dialog>
+
+      <BaseStationGnssSetupDialog v-model="gnssSetupDialogOpen" />
     </div>
   </div>
 </template>
@@ -718,11 +754,13 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 
+import BaseStationGnssSetupDialog from '@/components/BaseStationGnssSetupDialog.vue'
 import ExpansiblePanel from '@/components/ExpansiblePanel.vue'
 import { confirmRemoveBaseStation, useBaseStation } from '@/composables/baseStation/useBaseStation'
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { goToMenuPage } from '@/composables/menuRouting'
 import { useBarsAwarePanelStyle } from '@/composables/useBarsAwarePanelStyle'
+import { useGnss } from '@/composables/useGnss'
 import { bearingBetween, centroidOf, rangeAfterGainChange, rangeAfterTxPowerChange } from '@/libs/baseStation/coverage'
 import { isElectron } from '@/libs/utils'
 import { useAppInterfaceStore } from '@/stores/appInterface'
@@ -733,6 +771,7 @@ import {
   AntennaType,
   BaseStationCommsType,
   BLUE_ROBOTICS_TX_POWER_MW,
+  BROWSER_GEOLOCATION_SOURCE_ID,
   DEFAULT_BASE_STATION_ANTENNA_HEIGHT_METERS,
   DEFAULT_BASE_STATION_CONFIG,
   MOBILE_COVERAGE_FETCH_DROP_MIME,
@@ -761,6 +800,7 @@ const getMarginsFromBarsHeight = useBarsAwarePanelStyle(600)
 const vehicleStore = useMainVehicleStore()
 const missionStore = useMissionStore()
 const interfaceStore = useAppInterfaceStore()
+const gnss = useGnss()
 
 const config = computed(() => store.config)
 
@@ -893,6 +933,14 @@ const onGpsSourceChange = (event: Event): void => {
 
 const onNameBlur = (): void => {
   logUserAction(`Set the base station name to "${config.value.name}"`)
+}
+
+const gnssSetupDialogOpen = ref(false)
+const hasLocalGnssSource = computed(() => store.gpsSource !== BROWSER_GEOLOCATION_SOURCE_ID)
+
+const openGnssSetup = (): void => {
+  logUserAction('Opened the serial GNSS setup from the base station panel')
+  gnssSetupDialogOpen.value = true
 }
 
 const onCoordinateBlur = (): void => {
@@ -1375,15 +1423,18 @@ const snapBearingToMission = (): void => {
   min-height: auto;
 }
 
+/* Labelless row: the button spans the full width instead of sitting in the right-hand control slot. */
+.config-serial-gnss-btn {
+  flex: 1 1 auto;
+  font-size: 12px;
+  text-transform: none;
+  letter-spacing: normal;
+}
+
 /* Fixed height so showing the source select on toggle doesn't shift the rows below, while the inherited
    padding keeps the contents aligned with the other rows. */
 .config-gps-row {
   height: 36px;
-}
-
-/* The source select takes the row's right slot, so the label frees the space it needs. */
-.config-row-with-source .config-label {
-  width: auto;
 }
 
 .config-row-with-source .config-checkbox {

--- a/src/components/BaseStationGnssSetupDialog.vue
+++ b/src/components/BaseStationGnssSetupDialog.vue
@@ -386,7 +386,17 @@ const confirmDevice = async (): Promise<void> => {
 
   const name = deviceName.value.trim()
   draft.name = name
-  const id = await gnss.commitCreate()
+
+  // Saving reopens the port, and tracking must not be turned on for a device that did not come back: it
+  // takes manual coordinate entry away while never reporting a position.
+  let id: string | null
+  try {
+    id = await gnss.commitCreate()
+  } catch (error) {
+    probeError.value = `Added "${name}", but could not connect to it: ${(error as Error).message}`
+    resetToSelection()
+    return
+  }
   if (id === null) return
 
   trackDevice(id, name)

--- a/src/components/BaseStationGnssSetupDialog.vue
+++ b/src/components/BaseStationGnssSetupDialog.vue
@@ -1,0 +1,395 @@
+<template>
+  <InteractionDialog
+    :show-dialog="modelValue"
+    title="Use a serial/USB device"
+    variant="text-only"
+    max-width="560"
+    @update:show-dialog="onDialogUpdate"
+  >
+    <template #content>
+      <div class="flex gap-x-2 absolute top-0 right-0 py-2 pr-3">
+        <v-btn icon :width="34" :height="34" variant="text" aria-label="Close" class="bg-transparent" @click="close">
+          <v-icon :size="22">mdi-close</v-icon>
+        </v-btn>
+      </div>
+      <div class="flex flex-col gap-y-4 -mt-7 text-white">
+        <template v-if="step === 'select'">
+          <p class="text-body-2">
+            Pick the device you believe is your GNSS receiver and we will check it for you. Nothing is saved until you
+            confirm.
+          </p>
+
+          <div v-if="probeError" class="flex items-start gap-x-3 rounded-lg bg-[#FFFFFF11] p-3">
+            <v-icon size="20" color="amber">mdi-alert-outline</v-icon>
+            <span class="text-body-2">{{ probeError }}</span>
+          </div>
+
+          <div class="flex items-center justify-between">
+            <span class="text-caption">{{ ports.length }} device(s) found</span>
+            <v-btn variant="text" size="small" prepend-icon="mdi-refresh" @click="onRefreshPorts">Refresh</v-btn>
+          </div>
+
+          <div v-if="ports.length === 0" class="flex flex-col items-center gap-y-2 rounded-lg bg-[#FFFFFF11] p-6">
+            <v-icon size="28">mdi-usb-port</v-icon>
+            <span class="text-body-2">No serial devices found. Plug the receiver in and refresh the list.</span>
+          </div>
+          <v-list v-else theme="dark" class="bg-transparent py-0 max-h-[40vh] overflow-y-auto select-none">
+            <v-list-item
+              v-for="port in ports"
+              :key="port.path"
+              :active="port.path === selectedPort?.path"
+              rounded="lg"
+              class="mb-1 bg-[#FFFFFF11]"
+              prepend-icon="mdi-usb-port"
+              @click="selectPort(port)"
+            >
+              <v-list-item-title class="font-mono text-body-2">{{ port.path }}</v-list-item-title>
+              <v-list-item-subtitle class="text-caption">{{ portDescription(port) }}</v-list-item-subtitle>
+            </v-list-item>
+          </v-list>
+
+          <div v-if="claimingDevice" class="rounded-lg bg-[#FFFFFF11] p-3 text-body-2">
+            This device is already set up as "{{ claimingDevice.name }}". You can use it directly instead of adding it
+            again.
+          </div>
+        </template>
+
+        <template v-else-if="step === 'testing'">
+          <div class="flex flex-col items-center gap-y-4 py-8">
+            <v-progress-circular indeterminate size="42" width="3" />
+            <p class="text-body-2">
+              Checking <span class="font-mono">{{ selectedPort?.path }}</span> for GNSS data...
+            </p>
+            <p class="text-caption">Every common speed is tried, so this can take up to 15 seconds.</p>
+          </div>
+        </template>
+
+        <template v-else>
+          <div class="flex items-start gap-x-3 rounded-lg bg-[#FFFFFF11] p-3">
+            <v-icon size="20" color="#3B7B62">mdi-check-circle-outline</v-icon>
+            <span class="text-body-2">
+              This is a GNSS receiver. Found valid data on
+              <span class="font-mono">{{ selectedPort?.path }}</span> at {{ detectedBaud }} baud.
+            </span>
+          </div>
+
+          <div v-if="!draftHasUsbModel" class="flex items-start gap-x-3 rounded-lg bg-[#FFFFFF11] p-3">
+            <v-icon size="20" color="amber">mdi-alert-outline</v-icon>
+            <span class="text-body-2">
+              This device reports no USB model id, so auto-connect won't follow it to other computers.
+            </span>
+          </div>
+
+          <div class="flex items-center gap-x-2">
+            <v-icon :color="statusColor" size="small">{{ statusIcon }}</v-icon>
+            <span class="text-body-2 capitalize">{{ statusLabel }}</span>
+          </div>
+
+          <div class="grid gap-2" :class="interfaceStore.isOnPhoneScreen ? 'grid-cols-1' : 'grid-cols-2'">
+            <div
+              v-for="item in previewItems"
+              :key="item.key"
+              class="flex justify-between rounded bg-[#FFFFFF11] px-3 py-1 text-body-2"
+            >
+              <span>{{ item.label }}</span>
+              <span class="font-mono">{{ item.value }}</span>
+            </div>
+          </div>
+
+          <v-text-field
+            v-model="deviceName"
+            label="Name"
+            theme="dark"
+            variant="outlined"
+            density="compact"
+            hint="How this receiver shows up in the sources list and in the data lake."
+            persistent-hint
+            @blur="onNameEdited"
+          />
+        </template>
+      </div>
+    </template>
+
+    <template #actions>
+      <template v-if="step === 'select'">
+        <v-btn variant="text" size="small" @click="close">Cancel</v-btn>
+        <v-spacer />
+        <v-btn v-if="claimingDevice" size="small" class="bg-[#FFFFFF33] text-white" @click="useExistingDevice">
+          Use "{{ claimingDevice.name }}"
+        </v-btn>
+        <v-btn
+          v-else
+          size="small"
+          class="bg-[#FFFFFF33] text-white"
+          :disabled="!selectedPort"
+          @click="testSelectedPort"
+        >
+          Test device
+        </v-btn>
+      </template>
+      <template v-else-if="step === 'testing'">
+        <v-spacer />
+        <v-btn variant="text" size="small" @click="close">Cancel</v-btn>
+      </template>
+      <template v-else>
+        <v-btn variant="text" size="small" @click="backToSelection">Back</v-btn>
+        <v-spacer />
+        <v-btn
+          size="small"
+          class="bg-[#FFFFFF33] text-white"
+          :disabled="!deviceName.trim() || draftStatus !== 'connected'"
+          @click="confirmDevice"
+        >
+          Use this device
+        </v-btn>
+      </template>
+    </template>
+  </InteractionDialog>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
+
+import InteractionDialog from '@/components/InteractionDialog.vue'
+import { useBaseStation } from '@/composables/baseStation/useBaseStation'
+import { openSnackbar } from '@/composables/snackbar'
+import { useGnss } from '@/composables/useGnss'
+import {
+  autodetectBaud,
+  deviceUsingPort,
+  gnssFixItems,
+  gnssStatusColor,
+  gnssStatusIcon,
+  gnssStatusLabel,
+} from '@/libs/sensors/gnss'
+import { useAppInterfaceStore } from '@/stores/appInterface'
+import type { GnssDevice } from '@/types/gnss'
+import type { SerialPortInfo } from '@/types/serial'
+
+// Matches the base station's purpose rather than the receiver's model, since that is what the user is
+// setting up here. Suffixed when a device already carries the name.
+const preferredDeviceName = 'Base Station'
+
+const props = defineProps<{
+  /** Whether the dialog is open. */
+  modelValue: boolean
+}>()
+
+const emit = defineEmits<{
+  /** Emitted when the open state changes. */
+  (event: 'update:modelValue', value: boolean): void
+}>()
+
+const gnss = useGnss()
+const baseStation = useBaseStation()
+const interfaceStore = useAppInterfaceStore()
+
+const step = ref<'select' | 'testing' | 'confirm'>('select')
+const selectedPort = ref<SerialPortInfo | null>(null)
+const detectedBaud = ref<number | null>(null)
+const probeError = ref('')
+const deviceName = ref('')
+
+const ports = computed(() => gnss.availablePorts.value)
+
+const claimingDevice = computed<GnssDevice | undefined>(() =>
+  selectedPort.value ? deviceUsingPort(gnss.devices.value, selectedPort.value) : undefined
+)
+
+const draftId = computed(() => gnss.draft.value?.id ?? '')
+const draftFix = computed(() => gnss.latestFixes[draftId.value])
+const draftHasUsbModel = computed(() => Boolean(gnss.draft.value?.usbMatch?.vendorId))
+
+// The preview keeps rendering the last fix after the receiver goes away, so the readout alone cannot tell
+// the operator whether what they are reading is still live.
+const draftStatus = computed(() => gnss.statuses[draftId.value] ?? 'disconnected')
+const statusLabel = computed(() => gnssStatusLabel(draftStatus.value))
+const statusColor = computed(() => gnssStatusColor(draftStatus.value))
+const statusIcon = computed(() => gnssStatusIcon(draftStatus.value))
+
+// A probe that is joined by a later one resolves for both callers, and this component is never unmounted
+// between a dismissal and a reopen, so a test abandoned earlier would otherwise walk the whole flow again
+// alongside the current one and leave a second draft nothing can reach.
+let probeRun = 0
+const probeIsStale = (run: number): boolean => !props.modelValue || run !== probeRun
+
+const previewKeys = ['fixQuality', 'satellitesUsed', 'latitude', 'longitude']
+
+const previewItems = computed(() => {
+  const fix = draftFix.value
+  if (!fix) return [{ key: 'data', label: 'Data', value: 'Waiting...' }]
+  const items = gnssFixItems(fix)
+  return previewKeys.flatMap((key) => items.filter((item) => item.key === key))
+})
+
+const portDescription = (port: SerialPortInfo): string => {
+  const details = [port.manufacturer, port.vendorId && port.productId ? `${port.vendorId}:${port.productId}` : null]
+  const described = details.filter(Boolean).join(' - ')
+  return described || 'No USB descriptors reported'
+}
+
+const discardDraft = async (): Promise<void> => {
+  if (gnss.draft.value) await gnss.cancelCreate()
+}
+
+const resetToSelection = (): void => {
+  step.value = 'select'
+  detectedBaud.value = null
+  deviceName.value = ''
+}
+
+const close = async (): Promise<void> => {
+  logUserAction('Closed the base station GNSS setup')
+  await discardDraft()
+  emit('update:modelValue', false)
+}
+
+// The panel that hosts this dialog can be closed from outside it, taking the dialog down mid-flow.
+onBeforeUnmount(discardDraft)
+
+const onDialogUpdate = (value: boolean): void => {
+  if (value) return
+  close()
+}
+
+watch(
+  () => props.modelValue,
+  (isOpen) => {
+    if (!isOpen) return
+    probeRun++
+    resetToSelection()
+    selectedPort.value = null
+    probeError.value = ''
+    gnss.refreshPorts()
+  }
+)
+
+const onRefreshPorts = (): void => {
+  logUserAction('Refreshed the serial device list in the base station GNSS setup')
+  gnss.refreshPorts()
+}
+
+const selectPort = (port: SerialPortInfo): void => {
+  selectedPort.value = port
+  probeError.value = ''
+  logUserAction(`Selected the serial device ${port.path} in the base station GNSS setup`)
+}
+
+const trackDevice = (id: string, name: string): void => {
+  baseStation.gpsSourceId = id
+  baseStation.trackByGps = true
+  logUserAction(`Set the base station to be positioned by the GNSS device "${name}"`)
+  openSnackbar({
+    variant: 'success',
+    message: `Connected to "${name}". The base station will follow it as soon as it reports a position.`,
+    duration: 5000,
+  })
+}
+
+const useExistingDevice = async (): Promise<void> => {
+  const device = claimingDevice.value
+  if (!device) return
+
+  logUserAction(`Chose the already configured GNSS device "${device.name}" in the base station GNSS setup`)
+
+  // Tracking only watches for fixes, so a device that is configured but not reading would never move the
+  // base station, while turning tracking on takes manual entry away.
+  if (gnss.statuses[device.id] !== 'connected') {
+    try {
+      await gnss.connectDevice(device.id)
+    } catch (error) {
+      probeError.value = `Could not connect to "${device.name}": ${(error as Error).message}`
+      return
+    }
+  }
+
+  trackDevice(device.id, device.name)
+  close()
+}
+
+const testSelectedPort = async (): Promise<void> => {
+  const port = selectedPort.value
+  if (!port) return
+
+  logUserAction(`Tested the serial device ${port.path} for GNSS data`)
+  const run = ++probeRun
+  step.value = 'testing'
+  probeError.value = ''
+
+  let baud: number | null = null
+  try {
+    baud = await autodetectBaud(port.path)
+  } catch (error) {
+    if (probeIsStale(run)) return
+    probeError.value = `Could not read ${port.path}: ${(error as Error).message}`
+    step.value = 'select'
+    return
+  }
+
+  // The probe takes seconds, in which the dialog can be dismissed. Bail before claiming the port for a draft
+  // nothing would be able to reach, let alone release.
+  if (probeIsStale(run)) return
+
+  if (baud === null) {
+    const reason = 'does not look like a GNSS receiver, as no valid positioning data came out of it'
+    probeError.value = `${port.path} ${reason}. Select another device and test it.`
+    logUserAction(`Found no GNSS data on the serial device ${port.path}`)
+    step.value = 'select'
+    return
+  }
+
+  logUserAction(`Found GNSS data on the serial device ${port.path} at ${baud} baud`)
+  detectedBaud.value = baud
+
+  const draft = gnss.beginCreate()
+  draft.name = gnss.planDeviceName(preferredDeviceName)
+  draft.port = port.path
+  draft.baud = baud
+  // Only stored when the port reports a model: the device list syncs to the vehicle, and a bare path there
+  // resolves to whatever happens to be plugged into it on another machine.
+  if (port.vendorId && port.productId) {
+    draft.usbMatch = { vendorId: port.vendorId, productId: port.productId, manufacturer: port.manufacturer }
+  }
+
+  // Previews the live stream without publishing to the data lake, so the user sees real data before saving.
+  try {
+    await gnss.connectDevice(draft.id)
+  } catch (error) {
+    probeError.value = `Could not connect to the device: ${(error as Error).message}`
+    await discardDraft()
+    resetToSelection()
+    return
+  }
+
+  if (probeIsStale(run)) {
+    await discardDraft()
+    return
+  }
+
+  deviceName.value = draft.name
+  step.value = 'confirm'
+}
+
+const backToSelection = async (): Promise<void> => {
+  logUserAction('Went back to the device selection in the base station GNSS setup')
+  await discardDraft()
+  resetToSelection()
+}
+
+const onNameEdited = (): void => {
+  logUserAction(`Named the base station GNSS device "${deviceName.value}"`)
+}
+
+const confirmDevice = async (): Promise<void> => {
+  const draft = gnss.draft.value
+  if (!draft) return
+
+  const name = deviceName.value.trim()
+  draft.name = name
+  const id = await gnss.commitCreate()
+  if (id === null) return
+
+  trackDevice(id, name)
+  close()
+}
+</script>

--- a/src/components/sources/GnssDeviceDialog.vue
+++ b/src/components/sources/GnssDeviceDialog.vue
@@ -242,7 +242,16 @@ const onAutodetect = async (): Promise<void> => {
 }
 
 const onAdd = async (): Promise<void> => {
-  await gnss.commitCreate()
+  const name = device.value?.name ?? 'device'
+  try {
+    await gnss.commitCreate()
+  } catch (error) {
+    openSnackbar({
+      variant: 'error',
+      message: `Added "${name}", but could not connect to it: ${(error as Error).message}`,
+      duration: 5000,
+    })
+  }
   emit('update:modelValue', false)
 }
 

--- a/src/components/sources/GnssDeviceDialog.vue
+++ b/src/components/sources/GnssDeviceDialog.vue
@@ -102,7 +102,7 @@
             <div v-if="fix" class="grid grid-cols-2 gap-2 w-full text-sm mt-2">
               <div
                 v-for="item in statusItems"
-                :key="item.label"
+                :key="item.key"
                 class="flex justify-between px-3 py-1 rounded bg-[#FFFFFF11]"
               >
                 <span class="opacity-70">{{ item.label }}</span>
@@ -161,12 +161,12 @@ import { useGnss } from '@/composables/useGnss'
 import {
   commonBaudRates,
   getRecentSerialLines,
+  gnssFixItems,
   gnssStatusColor,
   gnssStatusIcon,
   gnssStatusLabel,
   subscribeToSerialLines,
 } from '@/libs/sensors/gnss'
-import { fixQualityLabel } from '@/libs/sensors/nmea'
 
 const props = defineProps<{
   /** Whether the dialog is open. */
@@ -210,31 +210,7 @@ const statusLabel = computed(() => gnssStatusLabel(status.value))
 const statusColor = computed(() => gnssStatusColor(status.value))
 const statusIcon = computed(() => gnssStatusIcon(status.value))
 
-const formatNumber = (value: number | undefined, digits: number): string =>
-  value === undefined ? '-' : value.toFixed(digits)
-
-const statusItems = computed(() => {
-  const current = fix.value
-  if (!current) return []
-  return [
-    { label: 'Fix', value: current.fixQualityLabel ?? fixQualityLabel(current.fixQuality ?? 0) },
-    { label: 'Fix mode', value: current.fixMode === undefined ? '-' : `${current.fixMode}D`.replace('1D', 'No fix') },
-    { label: 'Latitude', value: formatNumber(current.latitude, 7) },
-    { label: 'Longitude', value: formatNumber(current.longitude, 7) },
-    {
-      label: 'Altitude (MSL)',
-      value: current.altitudeMslM === undefined ? '-' : `${formatNumber(current.altitudeMslM, 1)} m`,
-    },
-    { label: 'Satellites used', value: current.satellitesUsed?.toString() ?? '-' },
-    { label: 'Satellites in view', value: current.satellitesInView?.toString() ?? '-' },
-    { label: 'HDOP', value: formatNumber(current.hdop, 2) },
-    {
-      label: 'Speed',
-      value: current.speedOverGroundMps === undefined ? '-' : `${formatNumber(current.speedOverGroundMps, 2)} m/s`,
-    },
-    { label: 'UTC time', value: current.utcTime ?? '-' },
-  ]
-})
+const statusItems = computed(() => (fix.value ? gnssFixItems(fix.value) : []))
 
 const onRefreshPorts = (): void => {
   logUserAction('Refreshed GNSS serial port list')

--- a/src/composables/useGnss.ts
+++ b/src/composables/useGnss.ts
@@ -16,7 +16,7 @@ import {
   stopGnssDevice,
   subscribeToDeviceState,
 } from '@/libs/sensors/gnss'
-import { isElectron, machinizeString } from '@/libs/utils'
+import { isElectron, machinizeString, uniqueString } from '@/libs/utils'
 import type { GnssDevice, GnssState } from '@/types/gnss'
 import type { SerialPortInfo } from '@/types/serial'
 
@@ -28,13 +28,8 @@ let state: GnssState | undefined
  * @param {string[]} existingIds - Ids already in use, which the result must not collide with.
  * @returns {string} A unique machinized id (falls back to `gnss` when the name has no usable characters).
  */
-const generateDeviceId = (name: string, existingIds: string[]): string => {
-  const base = machinizeString(name) || 'gnss'
-  if (!existingIds.includes(base)) return base
-  let suffix = 2
-  while (existingIds.includes(`${base}-${suffix}`)) suffix++
-  return `${base}-${suffix}`
-}
+const generateDeviceId = (name: string, existingIds: string[]): string =>
+  uniqueString(machinizeString(name) || 'gnss', existingIds, '-')
 
 /**
  * Builds the shared GNSS UI state: persisted devices, an optional in-progress draft, reactive per-device

--- a/src/composables/useGnss.ts
+++ b/src/composables/useGnss.ts
@@ -80,7 +80,7 @@ const createState = (): GnssState => {
   const connectDevice = async (id: string): Promise<void> => {
     const isDraft = draft.value?.id === id
     const device = findDeviceOrDraft(id)
-    if (!isSupported || !device || !device.port) return
+    if (!isSupported || !device) return
     device.enabled = true
     // Drafts preview the stream without registering/publishing data-lake variables until saved.
     await startGnssDevice(device, !isDraft)

--- a/src/composables/useGnss.ts
+++ b/src/composables/useGnss.ts
@@ -66,6 +66,13 @@ const createState = (): GnssState => {
       devices.value.map((device) => device.id)
     )
 
+  const planDeviceName = (name: string): string =>
+    uniqueString(
+      name,
+      devices.value.map((device) => device.name),
+      ' '
+    )
+
   const refreshPorts = async (): Promise<void> => {
     availablePorts.value = await listSerialPorts()
   }
@@ -93,7 +100,8 @@ const createState = (): GnssState => {
     draft.value = device
     statuses[device.id] = 'disconnected'
     logUserAction('Started GNSS device creation')
-    return device
+    // The ref's proxy, not the raw target: mutations through the returned object have to notify watchers.
+    return draft.value as GnssDevice
   }
 
   const clearDeviceRuntimeState = async (id: string): Promise<void> => {
@@ -188,6 +196,7 @@ const createState = (): GnssState => {
     cancelCreate,
     commitCreate,
     planDeviceId,
+    planDeviceName,
     removeDevice,
     connectDevice,
     disconnectDevice,

--- a/src/composables/useGnss.ts
+++ b/src/composables/useGnss.ts
@@ -147,9 +147,9 @@ const createState = (): GnssState => {
     statuses[id] = 'disconnected'
     logUserAction(`Added GNSS device "${device.name}"`)
 
-    if (wasConnected) {
-      connectDevice(id).catch((error) => console.error('[GNSS] Failed to connect after creation:', error))
-    }
+    // Reopening the port right after releasing the preview can fail (busy, or the receiver was unplugged),
+    // and the caller is the only one that can tell the user their brand new device is not reading.
+    if (wasConnected) await connectDevice(id)
     return id
   }
 

--- a/src/composables/usePointsOfInterest.ts
+++ b/src/composables/usePointsOfInterest.ts
@@ -9,7 +9,7 @@ import {
   poiLongitudeVariableId,
   syncPoiCoordinateVariables,
 } from '@/libs/poi/poi-data-lake'
-import { machinizeString } from '@/libs/utils'
+import { machinizeString, uniqueString } from '@/libs/utils'
 import { normalizePoiHeading, poiHasHeading } from '@/libs/utils-poi'
 import type {
   PointOfInterest,
@@ -27,13 +27,8 @@ const pointsOfInterestKey = 'cockpit-points-of-interest'
  * @param {string[]} existingIds - Ids already in use, which the result must not collide with
  * @returns {string} A machinized, unique id (falls back to `poi` when the name has no usable characters)
  */
-export const generatePointOfInterestId = (name: string, existingIds: string[]): string => {
-  const base = machinizeString(name) || 'poi'
-  if (!existingIds.includes(base)) return base
-  let suffix = 2
-  while (existingIds.includes(`${base}-${suffix}`)) suffix++
-  return `${base}-${suffix}`
-}
+export const generatePointOfInterestId = (name: string, existingIds: string[]): string =>
+  uniqueString(machinizeString(name) || 'poi', existingIds, '-')
 
 /**
  * Legacy POI shapes that may exist in persisted storage and need migrating to the current model.

--- a/src/libs/sensors/gnss.ts
+++ b/src/libs/sensors/gnss.ts
@@ -461,12 +461,18 @@ const handleDeviceBytes = (deviceId: string, bytes: number[]): void => {
   }
 }
 
+const pendingStarts = new Map<string, Promise<void>>()
+
 /**
  * Stops the reader for a device and closes its serial port, if open.
  * @param {string} deviceId - The device id.
  * @returns {Promise<void>} Resolves once the port is closed.
  */
 export const stopGnssDevice = async (deviceId: string): Promise<void> => {
+  // A start registers its runtime only once the port is open, so a stop landing before that would find
+  // nothing to stop and leave the reader it could not see holding the port until the app restarts.
+  await pendingStarts.get(deviceId)?.catch(() => undefined)
+
   const runtime = runtimes.get(deviceId)
   if (runtime) {
     stopWatchdog(runtime)
@@ -477,23 +483,7 @@ export const stopGnssDevice = async (deviceId: string): Promise<void> => {
   setStatus(deviceId, 'disconnected')
 }
 
-/**
- * Starts reading a device's GNSS receiver from its serial port.
- *
- * When `publish` is true (the default) the device's data-lake variables are registered and updated; pass
- * `publish: false` to preview an unsaved draft (parses and surfaces status/fix/serial lines without touching
- * the data lake).
- * @param {GnssDeviceInfo} device - The device to read from.
- * @param {boolean} [publish] - Whether to register/update data-lake variables (false to preview a draft).
- * @returns {Promise<void>} Resolves once the port is open.
- * @throws {Error} When not running in Electron, or when the port cannot be opened.
- */
-export const startGnssDevice = async (device: GnssDeviceInfo, publish = true): Promise<void> => {
-  if (!isElectron() || !window.electronAPI) {
-    throw new Error('GNSS reading is only available in Cockpit standalone.')
-  }
-
-  await stopGnssDevice(device.id)
+const openGnssDevice = async (device: GnssDeviceInfo, publish: boolean): Promise<void> => {
   if (publish) registerDeviceVariables(device)
   ensureLinkListener()
 
@@ -515,7 +505,7 @@ export const startGnssDevice = async (device: GnssDeviceInfo, publish = true): P
   runtimes.set(device.id, runtime)
   setStatus(device.id, 'connecting')
 
-  const opened = await window.electronAPI.linkOpen(path)
+  const opened = await window.electronAPI?.linkOpen(path)
   if (!opened) {
     runtimes.delete(device.id)
     setStatus(device.id, 'disconnected')
@@ -525,6 +515,33 @@ export const startGnssDevice = async (device: GnssDeviceInfo, publish = true): P
   pathHandlers.set(path, (bytes) => handleDeviceBytes(device.id, bytes))
   setStatus(device.id, 'no-data')
   startWatchdog(device.id)
+}
+
+/**
+ * Starts reading a device's GNSS receiver from its serial port.
+ *
+ * When `publish` is true (the default) the device's data-lake variables are registered and updated; pass
+ * `publish: false` to preview an unsaved draft (parses and surfaces status/fix/serial lines without touching
+ * the data lake).
+ * @param {GnssDeviceInfo} device - The device to read from.
+ * @param {boolean} [publish] - Whether to register/update data-lake variables (false to preview a draft).
+ * @returns {Promise<void>} Resolves once the port is open.
+ * @throws {Error} When not running in Electron, or when the port cannot be opened.
+ */
+export const startGnssDevice = async (device: GnssDeviceInfo, publish = true): Promise<void> => {
+  if (!isElectron() || !window.electronAPI) {
+    throw new Error('GNSS reading is only available in Cockpit standalone.')
+  }
+
+  await stopGnssDevice(device.id)
+
+  const start = openGnssDevice(device, publish)
+  pendingStarts.set(device.id, start)
+  try {
+    await start
+  } finally {
+    if (pendingStarts.get(device.id) === start) pendingStarts.delete(device.id)
+  }
 }
 
 const stopDevicesOnPort = async (port: string): Promise<void> => {

--- a/src/libs/sensors/gnss.ts
+++ b/src/libs/sensors/gnss.ts
@@ -17,7 +17,7 @@ import {
   setDataLakeVariableData,
   updateDataLakeVariableInfo,
 } from '@/libs/actions/data-lake'
-import { NmeaAggregator, parseNmeaSentence } from '@/libs/sensors/nmea'
+import { fixQualityLabel, NmeaAggregator, parseNmeaSentence } from '@/libs/sensors/nmea'
 import { settingsManager } from '@/libs/settings-management'
 import { isElectron } from '@/libs/utils'
 import type {
@@ -28,6 +28,7 @@ import type {
   GnssDeviceStateListener,
   GnssField,
   GnssFix,
+  GnssFixItem,
   GnssStatus,
   SerialLineEvent,
 } from '@/types/gnss'
@@ -243,6 +244,40 @@ export const gnssStatusIcon = (status: GnssStatus): string => {
  * @returns {string} The label.
  */
 export const gnssStatusLabel = (status: GnssStatus): string => (status === 'no-data' ? 'connected (no data)' : status)
+
+const formatFixNumber = (value: number | undefined, digits: number): string =>
+  value === undefined ? '-' : value.toFixed(digits)
+
+/**
+ * Formats a fix into the labelled rows the GNSS dialogs display, so every one of them shows the same
+ * values. Callers that only want a few rows pick them by key.
+ * @param {GnssFix} fix - The fix to format.
+ * @returns {GnssFixItem[]} One row per displayed field, in display order.
+ */
+export const gnssFixItems = (fix: GnssFix): GnssFixItem[] => [
+  { key: 'fixQuality', label: 'Fix', value: fix.fixQualityLabel ?? fixQualityLabel(fix.fixQuality ?? 0) },
+  {
+    key: 'fixMode',
+    label: 'Fix mode',
+    value: fix.fixMode === undefined ? '-' : `${fix.fixMode}D`.replace('1D', 'No fix'),
+  },
+  { key: 'latitude', label: 'Latitude', value: formatFixNumber(fix.latitude, 7) },
+  { key: 'longitude', label: 'Longitude', value: formatFixNumber(fix.longitude, 7) },
+  {
+    key: 'altitudeMslM',
+    label: 'Altitude (MSL)',
+    value: fix.altitudeMslM === undefined ? '-' : `${formatFixNumber(fix.altitudeMslM, 1)} m`,
+  },
+  { key: 'satellitesUsed', label: 'Satellites used', value: fix.satellitesUsed?.toString() ?? '-' },
+  { key: 'satellitesInView', label: 'Satellites in view', value: fix.satellitesInView?.toString() ?? '-' },
+  { key: 'hdop', label: 'HDOP', value: formatFixNumber(fix.hdop, 2) },
+  {
+    key: 'speedOverGroundMps',
+    label: 'Speed',
+    value: fix.speedOverGroundMps === undefined ? '-' : `${formatFixNumber(fix.speedOverGroundMps, 2)} m/s`,
+  },
+  { key: 'utcTime', label: 'UTC time', value: fix.utcTime ?? '-' },
+]
 
 const recordSerialLine = (deviceId: string, line: string): void => {
   const msg = line.replace(/\r$/, '').trim()

--- a/src/libs/sensors/gnss.ts
+++ b/src/libs/sensors/gnss.ts
@@ -535,22 +535,9 @@ const stopDevicesOnPort = async (port: string): Promise<void> => {
   }
 }
 
-/**
- * Probes a serial port at several baud rates and returns the first one that yields valid NMEA sentences.
- *
- * Any device currently reading from the same port is stopped first, since a serial port can only be opened
- * by one reader at a time.
- * @param {string} port - The serial port path to probe.
- * @param {number[]} [candidates] - The baud rates to try, in order.
- * @param {number} [perBaudMs] - How long to listen at each baud rate, in milliseconds.
- * @returns {Promise<number | null>} The detected baud rate, or null when none produced valid data.
- * @throws {Error} When not running in Electron.
- */
-export const autodetectBaud = async (
-  port: string,
-  candidates: number[] = commonBaudRates,
-  perBaudMs = 1500
-): Promise<number | null> => {
+const activeProbes = new Map<string, Promise<number | null>>()
+
+const probePort = async (port: string, candidates: number[], perBaudMs: number): Promise<number | null> => {
   if (!isElectron() || !window.electronAPI) {
     throw new Error('GNSS reading is only available in Cockpit standalone.')
   }
@@ -588,6 +575,33 @@ export const autodetectBaud = async (
   }
 
   return null
+}
+
+/**
+ * Probes a serial port at several baud rates and returns the first one that yields valid NMEA sentences.
+ *
+ * Any device currently reading from the same port is stopped first, since a serial port can only be opened
+ * by one reader at a time. A sweep cannot be aborted, so a second probe of a port already being probed
+ * joins the running one instead of starting a rival sweep that would starve both of sentences.
+ * @param {string} port - The serial port path to probe.
+ * @param {number[]} [candidates] - The baud rates to try, in order.
+ * @param {number} [perBaudMs] - How long to listen at each baud rate, in milliseconds.
+ * @returns {Promise<number | null>} The detected baud rate, or null when none produced valid data.
+ * @throws {Error} When not running in Electron.
+ */
+export const autodetectBaud = (
+  port: string,
+  candidates: number[] = commonBaudRates,
+  perBaudMs = 1500
+): Promise<number | null> => {
+  const running = activeProbes.get(port)
+  if (running) return running
+
+  const probe = probePort(port, candidates, perBaudMs).finally(() => {
+    if (activeProbes.get(port) === probe) activeProbes.delete(port)
+  })
+  activeProbes.set(port, probe)
+  return probe
 }
 
 /**

--- a/src/libs/sensors/gnss.ts
+++ b/src/libs/sensors/gnss.ts
@@ -588,6 +588,22 @@ export const resolveDevicePort = async (device: GnssDeviceInfo): Promise<string 
 }
 
 /**
+ * Finds the configured device that would already read from a given serial port, following the same
+ * model-then-path matching {@link resolveDevicePort} uses.
+ *
+ * A serial port takes a single reader, so a second device pointed at the same port can never connect
+ * alongside the first one.
+ * @param {T[]} devices - The configured devices to search.
+ * @param {SerialPortInfo} port - The port to look for a claimant of.
+ * @returns {T | undefined} The device already using the port, or undefined when it is free.
+ */
+export const deviceUsingPort = <T extends GnssDeviceInfo>(devices: T[], port: SerialPortInfo): T | undefined =>
+  devices.find(({ usbMatch }) => {
+    const { vendorId, productId } = usbMatch ?? {}
+    return Boolean(vendorId && productId) && vendorId === port.vendorId && productId === port.productId
+  }) ?? devices.find(({ port: devicePort }) => devicePort === port.path)
+
+/**
  * Boots the GNSS reading pipeline: registers each configured device's data-lake variables and auto-connects
  * the enabled ones. Reads the persisted configuration directly (no Vue), so the data-lake posting works
  * independently of any UI being mounted. No-op outside Electron.

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -290,6 +290,20 @@ export const machinizeString = (str: string): string => {
 }
 
 /**
+ * Makes a string unique against a list of already-taken ones by appending an incrementing suffix.
+ * @param {string} base The desired string.
+ * @param {string[]} taken The strings the result must not collide with.
+ * @param {string} separator What to put between the base and the suffix number.
+ * @returns {string} The base itself when free, otherwise the base with the first free suffix.
+ */
+export const uniqueString = (base: string, taken: string[], separator: string): string => {
+  if (!taken.includes(base)) return base
+  let suffix = 2
+  while (taken.includes(`${base}${separator}${suffix}`)) suffix++
+  return `${base}${separator}${suffix}`
+}
+
+/**
  * Sanitizes a value for use as a filename component on every supported platform.
  * Windows is the strictest target: it forbids `<`, `>`, `:`, `"`, `/`, `\`, `|`, `?`, `*`
  * and control characters, and disallows trailing dots/spaces. Without this, values like

--- a/src/tests/libs/sensors/gnss.test.ts
+++ b/src/tests/libs/sensors/gnss.test.ts
@@ -1,0 +1,46 @@
+import { expect, test, vi } from 'vitest'
+
+import { deviceUsingPort } from '@/libs/sensors/gnss'
+import type { GnssDeviceInfo } from '@/types/gnss'
+
+// The GNSS module reaches the settings manager through the data lake, and constructing the real one at
+// import time needs a working localStorage that this environment does not provide.
+vi.mock('@/libs/settings-management', () => ({
+  settingsManager: { getKeyValue: () => undefined, setKeyValue: () => undefined },
+}))
+
+const device = (overrides: Partial<GnssDeviceInfo>): GnssDeviceInfo => ({
+  id: 'gnss',
+  name: 'GNSS',
+  port: '/dev/ttyUSB0',
+  baud: 9600,
+  ...overrides,
+})
+
+test('deviceUsingPort', () => {
+  const byPath = device({ id: 'by-path', port: '/dev/ttyUSB0' })
+  const byModel = device({
+    id: 'by-model',
+    port: '/dev/ttyUSB9',
+    usbMatch: { vendorId: '1546', productId: '01a8' },
+  })
+
+  expect(deviceUsingPort([byPath], { path: '/dev/ttyUSB0' })?.id).toBe('by-path')
+  expect(deviceUsingPort([byPath], { path: '/dev/ttyUSB1' })).toBeUndefined()
+
+  // The receiver moved to another path, but is still the same USB model.
+  expect(deviceUsingPort([byModel], { path: '/dev/ttyUSB1', vendorId: '1546', productId: '01a8' })?.id).toBe('by-model')
+  expect(deviceUsingPort([byModel], { path: '/dev/ttyUSB1', vendorId: '1546', productId: 'ffff' })).toBeUndefined()
+
+  // The model match wins over the path one, as in `resolveDevicePort`.
+  const pinnedByPath = device({ id: 'pinned', port: '/dev/ttyUSB1' })
+  expect(
+    deviceUsingPort([pinnedByPath, byModel], { path: '/dev/ttyUSB1', vendorId: '1546', productId: '01a8' })?.id
+  ).toBe('by-model')
+
+  // Ports without USB descriptors must not all match each other just by both being undefined.
+  const noUsb = device({ id: 'no-usb', port: '/dev/ttyS0', usbMatch: undefined })
+  expect(deviceUsingPort([noUsb], { path: '/dev/ttyS1' })).toBeUndefined()
+
+  expect(deviceUsingPort([], { path: '/dev/ttyUSB0' })).toBeUndefined()
+})

--- a/src/tests/libs/sensors/gnss.test.ts
+++ b/src/tests/libs/sensors/gnss.test.ts
@@ -1,12 +1,18 @@
 import { expect, test, vi } from 'vitest'
 
-import { deviceUsingPort } from '@/libs/sensors/gnss'
+import { autodetectBaud, deviceUsingPort } from '@/libs/sensors/gnss'
 import type { GnssDeviceInfo } from '@/types/gnss'
 
 // The GNSS module reaches the settings manager through the data lake, and constructing the real one at
 // import time needs a working localStorage that this environment does not provide.
 vi.mock('@/libs/settings-management', () => ({
   settingsManager: { getKeyValue: () => undefined, setKeyValue: () => undefined },
+}))
+
+// The serial pipeline is Electron-only, and the race below only exists once it is reachable.
+vi.mock('@/libs/utils', async () => ({
+  ...(await vi.importActual<typeof import('@/libs/utils')>('@/libs/utils')),
+  isElectron: () => true,
 }))
 
 const device = (overrides: Partial<GnssDeviceInfo>): GnssDeviceInfo => ({
@@ -43,4 +49,20 @@ test('deviceUsingPort', () => {
   expect(deviceUsingPort([noUsb], { path: '/dev/ttyS1' })).toBeUndefined()
 
   expect(deviceUsingPort([], { path: '/dev/ttyUSB0' })).toBeUndefined()
+})
+
+test('autodetectBaud joins a probe already running on the port', async () => {
+  const linkOpen = vi.fn(async () => true)
+  window.electronAPI = {
+    serialListPorts: async () => [],
+    linkOpen,
+    linkClose: async () => true,
+    onLinkData: () => undefined,
+  } as unknown as typeof window.electronAPI
+
+  const probes = [autodetectBaud('/dev/ttyUSB0', [9600], 1), autodetectBaud('/dev/ttyUSB0', [9600], 1)]
+  expect(await Promise.all(probes)).toEqual([null, null])
+
+  // Two sweeps of one port would each starve the other of sentences and report a working receiver as dead.
+  expect(linkOpen).toHaveBeenCalledTimes(1)
 })

--- a/src/tests/libs/sensors/gnss.test.ts
+++ b/src/tests/libs/sensors/gnss.test.ts
@@ -1,7 +1,8 @@
 import { expect, test, vi } from 'vitest'
 
-import { autodetectBaud, deviceUsingPort } from '@/libs/sensors/gnss'
+import { autodetectBaud, deviceUsingPort, startGnssDevice, stopGnssDevice } from '@/libs/sensors/gnss'
 import type { GnssDeviceInfo } from '@/types/gnss'
+import type { SerialPortInfo } from '@/types/serial'
 
 // The GNSS module reaches the settings manager through the data lake, and constructing the real one at
 // import time needs a working localStorage that this environment does not provide.
@@ -9,11 +10,13 @@ vi.mock('@/libs/settings-management', () => ({
   settingsManager: { getKeyValue: () => undefined, setKeyValue: () => undefined },
 }))
 
-// The serial pipeline is Electron-only, and the race below only exists once it is reachable.
+// The serial pipeline is Electron-only, and the races below only exist once it is reachable.
 vi.mock('@/libs/utils', async () => ({
   ...(await vi.importActual<typeof import('@/libs/utils')>('@/libs/utils')),
   isElectron: () => true,
 }))
+
+const flushMicrotasks = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0))
 
 const device = (overrides: Partial<GnssDeviceInfo>): GnssDeviceInfo => ({
   id: 'gnss',
@@ -65,4 +68,30 @@ test('autodetectBaud joins a probe already running on the port', async () => {
 
   // Two sweeps of one port would each starve the other of sentences and report a working receiver as dead.
   expect(linkOpen).toHaveBeenCalledTimes(1)
+})
+
+test('stopGnssDevice releases a port whose start is still in flight', async () => {
+  let finishListing = (): void => undefined
+  const serialListPorts = vi.fn(
+    () => new Promise<SerialPortInfo[]>((resolve) => (finishListing = () => resolve([{ path: '/dev/ttyUSB0' }])))
+  )
+  const linkOpen = vi.fn(async () => true)
+  const linkClose = vi.fn(async () => true)
+  window.electronAPI = {
+    serialListPorts,
+    linkOpen,
+    linkClose,
+    onLinkData: () => undefined,
+  } as unknown as typeof window.electronAPI
+
+  const start = startGnssDevice(device({ id: 'racing' }), false)
+  await flushMicrotasks()
+
+  // The start is parked in the port listing, so no runtime exists for the stop to find yet.
+  const stop = stopGnssDevice('racing')
+  finishListing()
+  await Promise.all([start, stop])
+
+  expect(linkOpen).toHaveBeenCalledTimes(1)
+  expect(linkClose).toHaveBeenCalledWith(expect.stringContaining('/dev/ttyUSB0'))
 })

--- a/src/tests/libs/utils.test.ts
+++ b/src/tests/libs/utils.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, expect, test } from 'vitest'
 
-import { isElectron, serializeForLogging } from '@/libs/utils'
+import { isElectron, serializeForLogging, uniqueString } from '@/libs/utils'
 
 test('serializeForLogging', () => {
   // The regression this guards: `JSON.stringify(new Error('boom'))` is `'{}'`, which is what the log used to keep.
@@ -43,4 +43,17 @@ test('isElectron', () => {
 
   setUserAgent(chromeUserAgent)
   expect(isElectron()).toBe(false)
+})
+
+test('uniqueString', () => {
+  expect(uniqueString('Base Station', [], ' ')).toBe('Base Station')
+  expect(uniqueString('Base Station', ['Base Station'], ' ')).toBe('Base Station 2')
+  expect(uniqueString('Base Station', ['Base Station', 'Base Station 2'], ' ')).toBe('Base Station 3')
+
+  // Gaps are not filled: the suffix walks up from 2 until it finds a free one.
+  expect(uniqueString('gnss', ['gnss', 'gnss-3'], '-')).toBe('gnss-2')
+  expect(uniqueString('gnss', ['gnss', 'gnss-2'], '-')).toBe('gnss-3')
+
+  // A taken suffix without the bare base taken still yields the base.
+  expect(uniqueString('gnss', ['gnss-2'], '-')).toBe('gnss')
 })

--- a/src/types/gnss.ts
+++ b/src/types/gnss.ts
@@ -57,6 +57,18 @@ export interface GnssFix {
 }
 
 /**
+ * One labelled row of a formatted {@link GnssFix}, as the GNSS dialogs display it.
+ */
+export interface GnssFixItem {
+  /** Stable row identifier, so a caller can pick the rows it wants without matching on the label. */
+  key: string
+  /** Human-readable field name. */
+  label: string
+  /** Formatted value, or `-` when the receiver does not report the field. */
+  value: string
+}
+
+/**
  * A single parsed NMEA sentence, split into its talker, type and data fields.
  */
 export interface ParsedNmeaSentence {
@@ -188,6 +200,8 @@ export interface GnssState {
   commitCreate: () => Promise<string | null>
   /** Plans the persistent id a device with the given name would get (machinized, de-duplicated). */
   planDeviceId: (name: string) => string
+  /** Makes a display name unique against the existing devices, appending a numeric suffix when taken. */
+  planDeviceName: (name: string) => string
   /** Removes a device, closing its connection and deleting its data-lake variables. */
   removeDevice: (id: string) => Promise<void>
   /** Connects a device using its current port and baud rate. */

--- a/src/types/gnss.ts
+++ b/src/types/gnss.ts
@@ -196,7 +196,10 @@ export interface GnssState {
   beginCreate: () => GnssDevice
   /** Discards the current draft, closing any preview connection. */
   cancelCreate: () => Promise<void>
-  /** Persists the current draft as a real device, returning its final id (or null when no draft). */
+  /**
+   * Persists the current draft as a real device, returning its final id (or null when no draft). Rejects when
+   * the device was created but reconnecting it afterwards failed.
+   */
   commitCreate: () => Promise<string | null>
   /** Plans the persistent id a device with the given name would get (machinized, de-duplicated). */
   planDeviceId: (name: string) => string


### PR DESCRIPTION
## Summary

The base station and the serial GNSS support landed separately, and the wiring between them was already there but invisible: `useBaseStation` has listed configured GNSS devices as position sources and fed their fixes into `setPosition` since it merged. To reach it you had to know, unprompted, to open Settings > Sources, guess which `/dev/tty*` is your receiver, guess its baud rate, save a device, and only then come back to the map. This branch is that missing step — a guided flow that starts where the operator already is, typing coordinates in by hand.

A "Use serial/USB device" button now sits directly under the latitude and longitude inputs in the base-station panel. It opens a dialog listing the connected serial devices; the operator picks the one they believe is their receiver and tests it. Nothing is written until they confirm. Once this machine is pointed at a serial receiver, the button is replaced by a cog next to Track by GPS so the wizard can be run again without taking over the panel. The hide is keyed on this computer's GPS source, not on the vehicle-synced device list, so a second topside still sees the labelled button.

- **The test is the existing baud probe.** `autodetectBaud` already sweeps the common rates and only succeeds after three checksum-valid NMEA sentences, so it answers "is this a GNSS receiver" and "at what speed" in a single pass. No new probing logic. On failure the dialog says the device does not look like a receiver and returns them to the list to try another; on success it confirms it found one and reports the detected speed.
- **The operator sees real data before committing.** A successful test starts a draft device, which the GNSS composable already connects in preview mode without publishing to the data lake, so the confirm step shows live fix quality, satellite count and coordinates. Backing out or closing discards the draft and its connection.
- **The name is theirs to pick.** The field is pre-filled with `Base Station`, suffixed when that name is taken, since the name is what shows in the sources list and in the data-lake variable labels. Someone running two vehicles can make it `Blue Boat Base Station` before saving.
- **A port already in use is offered for reuse, not probed.** Probing calls `stopDevicesOnPort`, so testing a port that a configured device already reads would disconnect that device and then leave a duplicate that can never share the port with it. `deviceUsingPort` detects this and the dialog offers the existing device instead, connecting it first when it is not already reading.
- Confirming creates the device and points base-station tracking at it, with a snackbar. The position then follows the receiver on its own.

Two small helpers come first as their own commits: `uniqueString`, because the GNSS composable now needs the same append-a-suffix dedup for display names that it already did for device ids, and `deviceUsingPort` for the port-reuse case above. Both have tests.

Serial access is Electron-only, so in Lite the button renders disabled above a visible line explaining that it needs Standalone. The README already lists External Serial GNSS as desktop-only, so nothing changes there.

## Screenshots

Captured against a receiver streaming NMEA, so the preview below shows a real fix rather than an empty state.

**1. Pick the device.** Nothing is written until you confirm, so a wrong guess costs a retry and no config.

![Device selection](https://raw.githubusercontent.com/bluerobotics/cockpit/46ebedf563b13232fceddc15ba44e9578b5d5524/gnss-select.png)

**2. Test it.** The existing baud sweep runs, and the dialog says up front how long that can take.

![Probing the device](https://raw.githubusercontent.com/bluerobotics/cockpit/46ebedf563b13232fceddc15ba44e9578b5d5524/gnss-testing.png)

**3. Confirm.** The live fix is what tells you it really is your receiver, before you name it.

![Confirming the receiver](https://raw.githubusercontent.com/bluerobotics/cockpit/46ebedf563b13232fceddc15ba44e9578b5d5524/gnss-confirm.png)

**The entry point**, under the coordinate inputs, before this machine is pointed at a receiver:

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/bluerobotics/cockpit/46ebedf563b13232fceddc15ba44e9578b5d5524/panel-before.png" width="300"> | <img src="https://raw.githubusercontent.com/bluerobotics/cockpit/46ebedf563b13232fceddc15ba44e9578b5d5524/panel-after.png" width="300"> |

One open question: the review on #2815 asked for that dialog's status block to move into an `ExpansiblePanel`. Here the live fix is the evidence the operator uses to decide, so collapsing it would hide the thing they are meant to read. Left inline, happy to change it.

## Test plan

- [ ] With this machine still on browser geolocation, open the base-station panel and confirm the "Use serial/USB device" button sits under the coordinate inputs.
- [ ] Click it with a real NMEA receiver plugged in, select its port, and confirm the test reports a GNSS receiver and the detected baud rate.
- [ ] Confirm the live preview on that step shows fix quality, satellites and coordinates updating.
- [ ] Confirm the name field is pre-filled with `Base Station`, accept it, and confirm the base station starts following the receiver, the coordinate inputs go read-only, the setup button is replaced by a cog next to Track by GPS, and the cog reopens the wizard.
- [ ] Confirm the device now appears in Settings > Sources with its data-lake variables populated.
- [ ] Repeat the flow and confirm the second device is offered as `Base Station 2`.
- [ ] Change the pre-filled name before confirming and check the sources list and data-lake variable labels use it.
- [ ] Test a port that is not a GNSS receiver (a MAVLink serial link, a USB-serial adapter with nothing on it) and confirm the dialog says so and lets you pick another without leaving.
- [ ] Test a port already configured as another GNSS device and confirm the dialog offers to use that device instead of probing, and that a device that was disconnected gets connected before tracking switches to it.
- [ ] Back out from the confirm step and close the dialog mid-flow; confirm no draft device is left behind in Settings > Sources and the preview connection is released.
- [ ] Reload and confirm the base station reconnects to the receiver and resumes tracking.
- [ ] On a second Standalone talking to a vehicle that already has a GNSS device in Sources, confirm the labelled button is still there until this machine is pointed at a receiver.
- [ ] In Lite (browser), confirm the button is disabled and the explanation is readable under it without hovering, and that nothing throws.
- [ ] On the confirm step, unplug the receiver and confirm the status line stops saying "connected" instead of the readout silently freezing.
- [ ] Cancel a test mid-sweep, then test the same port again, and confirm the second attempt still reports the receiver.

## Checks

- `yarn lint` clean.
- `yarn vitest run`: 34 tests pass, including the two added here. `cosmos.test.ts` and `connection.test.ts` fail to collect on `master` as well, from the `localStorage` access at import time in `settings-management.ts` — unrelated to this branch, and the reason the new GNSS test mocks that module.
- `yarn typecheck` still exits clean in under half a second on `master` too (`languageId not found for App.vue`), so it gave no signal here; the new component's API usage was checked by hand against the type definitions.

Closes #1842


