### PR TITLE
modes: name the vehicle modes as ArduPilot does, and let the user rename them

### DIFF
--- a/src/components/ExternalFeaturesDiscoveryModal.vue
+++ b/src/components/ExternalFeaturesDiscoveryModal.vue
@@ -792,6 +792,7 @@ import {
 } from '@/libs/actions/mavlink-message-actions'
 import { getActionsFromBlueOS, getJoystickSuggestionsFromBlueOS } from '@/libs/blueos'
 import { allAvailableButtons } from '@/libs/joystick/protocols'
+import { actionDisplayName } from '@/libs/joystick/protocols/cockpit-actions'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useControllerStore } from '@/stores/controller'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
@@ -995,7 +996,7 @@ const getCurrentActionNameForSuggestion = (suggestion: JoystickMapSuggestion): s
   if (!mapping) return 'No function'
 
   const currentAction = mapping.buttonsCorrespondencies?.[suggestion.modifier]?.[suggestion.button]?.action
-  return currentAction?.name ?? 'No function'
+  return currentAction ? actionDisplayName(currentAction) : 'No function'
 }
 
 /**

--- a/src/components/configuration/FlightModeNamesConfig.vue
+++ b/src/components/configuration/FlightModeNamesConfig.vue
@@ -1,0 +1,105 @@
+<template>
+  <div class="flex flex-col w-full px-2 pt-3 pb-4">
+    <div class="flex flex-row items-center justify-between w-full mb-4">
+      <v-select
+        :model-value="selectedVehicleType"
+        :items="vehicleTypesWithNames"
+        label="Vehicle"
+        variant="filled"
+        density="compact"
+        hide-details
+        theme="dark"
+        class="max-w-[200px]"
+        @update:model-value="setSelectedVehicleType"
+      />
+      <v-btn variant="text" size="small" :disabled="!hasCustomNames" @click="resetModeNamesToDefault">
+        Reset names to ArduPilot defaults
+      </v-btn>
+    </div>
+    <div class="grid gap-x-8 gap-y-2" :class="interfaceStore.isOnPhoneScreen ? 'grid-cols-1' : 'grid-cols-2'">
+      <div v-for="modeName in modeNamesToShow" :key="modeName" class="flex flex-row items-center">
+        <div class="w-[45%] text-sm opacity-70 truncate">{{ modeName }}</div>
+        <v-text-field
+          :model-value="editedNames[modeName] ?? displayNameOf(modeName)"
+          variant="filled"
+          density="compact"
+          hide-details
+          theme="dark"
+          class="w-[55%]"
+          @update:model-value="(value: string) => (editedNames[modeName] = value)"
+          @change="setModeName(modeName)"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+import { humanizeString } from '@/libs/utils'
+import { defaultFlightModeNames, flightModeName } from '@/libs/vehicle/ardupilot/mode-names'
+import { Type as VehicleType } from '@/libs/vehicle/vehicle'
+import { useAppInterfaceStore } from '@/stores/appInterface'
+import { useMainVehicleStore } from '@/stores/mainVehicle'
+
+const interfaceStore = useAppInterfaceStore()
+const mainVehicleStore = useMainVehicleStore()
+
+const vehicleTypesWithNames = Object.keys(defaultFlightModeNames).map((type) => ({
+  title: humanizeString(type),
+  value: type as VehicleType,
+}))
+
+const selectedVehicleType = ref<VehicleType>(mainVehicleStore.ardupilotVehicleType ?? VehicleType.Sub)
+
+// What is being typed on each name field, dropped once saved so the field goes back to showing the resolved name
+const editedNames = ref<Record<string, string>>({})
+
+const modeNamesToShow = computed(() => Object.keys(defaultFlightModeNames[selectedVehicleType.value] ?? {}))
+
+const customNamesForSelectedVehicle = computed(
+  () => mainVehicleStore.customFlightModeNames[selectedVehicleType.value] ?? {}
+)
+
+const hasCustomNames = computed(() => Object.keys(customNamesForSelectedVehicle.value).length > 0)
+
+const displayNameOf = (modeName: string): string => {
+  return flightModeName(modeName, selectedVehicleType.value, mainVehicleStore.customFlightModeNames)
+}
+
+const saveCustomNames = (customNames: Record<string, string>): void => {
+  const allCustomNames = { ...mainVehicleStore.customFlightModeNames, [selectedVehicleType.value]: customNames }
+  if (Object.keys(customNames).length === 0) delete allCustomNames[selectedVehicleType.value]
+  mainVehicleStore.customFlightModeNames = allCustomNames
+  editedNames.value = {}
+}
+
+const setSelectedVehicleType = (value: unknown): void => {
+  logUserAction(`Switched the flight mode names to the ones of the ${humanizeString(value as string)}`)
+  selectedVehicleType.value = value as VehicleType
+  editedNames.value = {}
+}
+
+const setModeName = (modeName: string): void => {
+  const newName = (editedNames.value[modeName] ?? '').trim()
+  const isArdupilotName = newName === '' || newName === defaultFlightModeNames[selectedVehicleType.value]?.[modeName]
+  const customNames = { ...customNamesForSelectedVehicle.value }
+
+  if (isArdupilotName) {
+    delete customNames[modeName]
+    logUserAction(`Reset the name of the '${modeName}' flight mode`)
+  } else {
+    customNames[modeName] = newName
+    logUserAction(`Renamed the '${modeName}' flight mode to '${newName}'`)
+  }
+
+  saveCustomNames(customNames)
+}
+
+const resetModeNamesToDefault = (): void => {
+  const vehicleName = humanizeString(selectedVehicleType.value)
+  logUserAction(`Reset the flight mode names of the ${vehicleName} to the ArduPilot ones`)
+  saveCustomNames({})
+}
+</script>

--- a/src/components/joysticks/JoystickPS.vue
+++ b/src/components/joysticks/JoystickPS.vue
@@ -32,6 +32,7 @@ import { v4 as uuid4 } from 'uuid'
 import { computed, onBeforeUnmount, ref, toRefs, watch } from 'vue'
 
 import { JoystickModel } from '@/libs/joystick/manager'
+import { actionDisplayName } from '@/libs/joystick/protocols/cockpit-actions'
 import { scale } from '@/libs/utils'
 import {
   type JoystickButtonActionCorrespondency,
@@ -390,7 +391,7 @@ const updateLabelsState = (): void => {
     if (isNaN(Number(button))) return
     const buttonActionCorrespondency = buttonsActionsCorrespondency.value[button as JoystickButton] || undefined
     const functionName =
-      buttonActionCorrespondency === undefined ? 'unassigned' : buttonActionCorrespondency.action.name
+      buttonActionCorrespondency === undefined ? 'unassigned' : actionDisplayName(buttonActionCorrespondency.action)
     // @ts-ignore: we already check if button is a number and so if button is a valid index
     const labelId = buttonPath[button].replace('path', 'text')
     const overlay = labelOverlays.value.find((l) => l.id === labelId)

--- a/src/components/mini-widgets/ModeSelector.vue
+++ b/src/components/mini-widgets/ModeSelector.vue
@@ -9,18 +9,52 @@
       @update:model-value="onModeSelected"
     />
   </div>
+  <v-dialog v-model="widgetStore.miniWidgetManagerVars(miniWidget.hash).configMenuOpen" width="700">
+    <v-card class="pa-4 text-white" style="border-radius: 15px" :style="interfaceStore.globalGlassMenuStyles">
+      <v-card-title class="text-center">Mode names</v-card-title>
+      <v-card-text class="max-h-[60vh] overflow-y-auto">
+        <div class="absolute top-2 right-2 z-10">
+          <v-btn
+            icon
+            size="30"
+            variant="text"
+            class="text-white text-[22px]"
+            aria-label="Close"
+            @click="widgetStore.miniWidgetManagerVars(miniWidget.hash).configMenuOpen = false"
+          >
+            <i class="mdi mdi-close"></i>
+          </v-btn>
+        </div>
+        <FlightModeNamesConfig />
+      </v-card-text>
+    </v-card>
+  </v-dialog>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref, toRefs } from 'vue'
 
+import FlightModeNamesConfig from '@/components/configuration/FlightModeNamesConfig.vue'
 import { datalogger, DatalogVariable } from '@/libs/sensors-logging'
+import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
+import { useWidgetManagerStore } from '@/stores/widgetManager'
+import type { MiniWidget } from '@/types/widgets'
 
 import Dropdown from '../Dropdown.vue'
 
+const props = defineProps<{
+  /**
+   * Configuration of the widget
+   */
+  miniWidget: MiniWidget
+}>()
+const miniWidget = toRefs(props).miniWidget
+
 datalogger.registerUsage(DatalogVariable.mode)
 const vehicleStore = useMainVehicleStore()
+const interfaceStore = useAppInterfaceStore()
+const widgetStore = useWidgetManagerStore()
 const currentMode = ref()
 
 const modeOptions = computed(() =>

--- a/src/components/mini-widgets/ModeSelector.vue
+++ b/src/components/mini-widgets/ModeSelector.vue
@@ -2,7 +2,9 @@
   <div>
     <Dropdown
       :model-value="currentMode"
-      :options="vehicleStore.modesAvailable()"
+      :options="modeOptions"
+      name-key="name"
+      value-key="value"
       class="min-w-[128px]"
       @update:model-value="onModeSelected"
     />
@@ -10,7 +12,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 
 import { datalogger, DatalogVariable } from '@/libs/sensors-logging'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
@@ -20,6 +22,10 @@ import Dropdown from '../Dropdown.vue'
 datalogger.registerUsage(DatalogVariable.mode)
 const vehicleStore = useMainVehicleStore()
 const currentMode = ref()
+
+const modeOptions = computed(() =>
+  vehicleStore.modesAvailable().map((mode) => ({ value: mode, name: vehicleStore.flightModeDisplayName(mode) }))
+)
 
 // Bound to the dropdown's user-selection event (not a watch on currentMode) so that automated mode changes
 // reflected by the polling below don't get logged or re-issued as if the user changed the mode.

--- a/src/composables/vehicleDefaults/vehicleDefaultsImportShared.ts
+++ b/src/composables/vehicleDefaults/vehicleDefaultsImportShared.ts
@@ -1,5 +1,6 @@
 import { type Ref, ref } from 'vue'
 
+import { actionDisplayName } from '@/libs/joystick/protocols/cockpit-actions'
 import { OtherProtocol } from '@/libs/joystick/protocols/other'
 import {
   type DefaultsEvaluation,
@@ -116,7 +117,7 @@ export const buildJoystickImportRows = (
       modifier: modKey,
       buttonKey: Number(btnKey),
       inputLabel: `Button ${btnKey} (${modKey})`,
-      fromActionName: currentBtn?.action.name ?? 'Unassigned',
+      fromActionName: currentBtn ? actionDisplayName(currentBtn.action) : 'Unassigned',
       toActionName: defaultBtn.action.name,
     })
   }

--- a/src/libs/joystick/protocols/cockpit-actions.ts
+++ b/src/libs/joystick/protocols/cockpit-actions.ts
@@ -144,3 +144,13 @@ export const executeActionCallback = (id: string): void => {
 }
 
 export const availableCockpitActions = cockpitActionsManager.availableActions
+
+/**
+ * Get the name to show for an action taken from a joystick mapping, which stores the whole action and thus a name that
+ * was current when the button was mapped
+ * @param {Pick<ProtocolAction, 'id' | 'name'>} action - The action as it is stored in the mapping
+ * @returns {string} The name of the registered action with that id, falling back to the stored one when there is none
+ */
+export const actionDisplayName = (action: Pick<ProtocolAction, 'id' | 'name'>): string => {
+  return availableCockpitActions[action.id as CockpitActionsFunction]?.name ?? action.name
+}

--- a/src/libs/vehicle/ardupilot/common.ts
+++ b/src/libs/vehicle/ardupilot/common.ts
@@ -7,7 +7,7 @@ import {
 } from '@/libs/joystick/protocols/cockpit-actions'
 
 import { Type as VehicleType } from '../vehicle'
-import { flightModeName } from './mode-names'
+import { type FlightModeNames, flightModeName } from './mode-names'
 import { CopterMode, PlaneMode, RoverMode, SubMode } from './types/modes'
 
 type ModeEnum = Record<string, string | number>
@@ -105,10 +105,20 @@ export function getVehicleModeActionId(vehicleType: VehicleType, modeName: strin
 export function createVehicleModeAction(vehicleType: VehicleType, modeName: string): CockpitAction {
   const actionId = getVehicleModeActionId(vehicleType, modeName)
   // TODO: Use the new MAVLink Mode microservice: https://mavlink.io/en/services/standard_modes.html#getting-all-available-modes
-  // Actions are registered once at startup, so they carry the ArduPilot names and not the ones customized by the user.
-  const displayName = flightModeName(modeName, vehicleType)
+  return new CockpitAction(actionId, vehicleModeActionName(vehicleType, modeName))
+}
+
+/**
+ * Build the name of the action that sets a vehicle mode
+ * @param {VehicleType} vehicleType - The vehicle type
+ * @param {string} modeName - The mode name
+ * @param {FlightModeNames} customNames - Names chosen by the user, which win over the ArduPilot ones
+ * @returns {string} The name to show for the action
+ */
+function vehicleModeActionName(vehicleType: VehicleType, modeName: string, customNames?: FlightModeNames): string {
+  const displayName = flightModeName(modeName, vehicleType, customNames)
   const vehicleDisplayName = vehicleType.charAt(0).toUpperCase() + vehicleType.slice(1)
-  return new CockpitAction(actionId, `${displayName} Mode (ArduPilot ${vehicleDisplayName})`)
+  return `${displayName} Mode (ArduPilot ${vehicleDisplayName})`
 }
 
 /**
@@ -191,6 +201,20 @@ function preRegisterAllModeActions(): void {
 
 // Pre-register all mode actions at module load time
 preRegisterAllModeActions()
+
+/**
+ * Rename the already registered mode actions, so a mode the user renamed is called the same everywhere it is offered
+ * @param {FlightModeNames} customNames - Names chosen by the user, which win over the ArduPilot ones
+ */
+export function renameModeActions(customNames: FlightModeNames): void {
+  for (const [vehicleType, modeEnum] of Object.entries(vehicleModeEnums)) {
+    for (const [modeName, modeValue] of getModeEntries(modeEnum)) {
+      const action = modeActionRegistry.get(getModeRegistryKey(vehicleType as VehicleType, modeValue))
+      if (action === undefined) continue
+      action.name = vehicleModeActionName(vehicleType as VehicleType, modeName, customNames)
+    }
+  }
+}
 
 /**
  * Register mode change callbacks for a connected vehicle

--- a/src/libs/vehicle/ardupilot/common.ts
+++ b/src/libs/vehicle/ardupilot/common.ts
@@ -7,6 +7,7 @@ import {
 } from '@/libs/joystick/protocols/cockpit-actions'
 
 import { Type as VehicleType } from '../vehicle'
+import { flightModeName } from './mode-names'
 import { CopterMode, PlaneMode, RoverMode, SubMode } from './types/modes'
 
 type ModeEnum = Record<string, string | number>
@@ -104,10 +105,8 @@ export function getVehicleModeActionId(vehicleType: VehicleType, modeName: strin
 export function createVehicleModeAction(vehicleType: VehicleType, modeName: string): CockpitAction {
   const actionId = getVehicleModeActionId(vehicleType, modeName)
   // TODO: Use the new MAVLink Mode microservice: https://mavlink.io/en/services/standard_modes.html#getting-all-available-modes
-  const displayName = modeName
-    .split('_')
-    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-    .join(' ')
+  // Actions are registered once at startup, so they carry the ArduPilot names and not the ones customized by the user.
+  const displayName = flightModeName(modeName, vehicleType)
   const vehicleDisplayName = vehicleType.charAt(0).toUpperCase() + vehicleType.slice(1)
   return new CockpitAction(actionId, `${displayName} Mode (ArduPilot ${vehicleDisplayName})`)
 }
@@ -123,7 +122,7 @@ function getModeName(vehicleType: VehicleType, modeValue: number): string {
   if (modeEnum?.[modeValue]) {
     return (modeEnum[modeValue] as string).toLowerCase()
   }
-  return 'unknown'
+  return 'Unknown'
 }
 
 /**

--- a/src/libs/vehicle/ardupilot/mode-names.ts
+++ b/src/libs/vehicle/ardupilot/mode-names.ts
@@ -1,0 +1,117 @@
+import { Type as VehicleType } from '../vehicle'
+
+/**
+ * Names for the modes of each vehicle type, keyed by the mode name reported by the vehicle.
+ */
+export type FlightModeNames = Partial<Record<VehicleType, Record<string, string>>>
+
+// TODO: Ask the vehicle for its modes over the MAVLink Standard Modes protocol instead of hardcoding them here: https://mavlink.io/en/services/standard_modes.html
+/**
+ * Name Cockpit shows for each mode, following the ones ArduPilot uses in its parameter metadata: the mode selection
+ * parameters (FLTMODE1 for Copter and Plane, MODE1 for Rover) and the joystick button functions (BTNx_FUNCTION) for
+ * Sub, which is where ArduPilot names the Sub modes. Names ArduPilot writes as a single word, like AltHold or QRTL,
+ * are spelled out here, since the pilot reading them mid-dive is not the one who wrote the firmware.
+ */
+export const defaultFlightModeNames: FlightModeNames = {
+  [VehicleType.Sub]: {
+    MANUAL: 'Manual',
+    STABILIZE: 'Stabilize',
+    ACRO: 'Acro',
+    ALT_HOLD: 'Depth Hold',
+    AUTO: 'Auto',
+    GUIDED: 'Guided',
+    CIRCLE: 'Circle',
+    SURFACE: 'Surface',
+    POSHOLD: 'Position Hold',
+    MOTOR_DETECT: 'Motor Detection',
+    SURFTRAK: 'Surface Track',
+  },
+  [VehicleType.Rover]: {
+    MANUAL: 'Manual',
+    ACRO: 'Acro',
+    STEERING: 'Steering',
+    HOLD: 'Hold',
+    LOITER: 'Loiter',
+    FOLLOW: 'Follow',
+    SIMPLE: 'Simple',
+    DOCK: 'Dock',
+    CIRCLE: 'Circle',
+    AUTO: 'Auto',
+    RTL: 'RTL',
+    SMART_RTL: 'Smart RTL',
+    GUIDED: 'Guided',
+    INITIALISING: 'Initialising',
+  },
+  [VehicleType.Copter]: {
+    STABILIZE: 'Stabilize',
+    ACRO: 'Acro',
+    ALT_HOLD: 'Altitude Hold',
+    AUTO: 'Auto',
+    GUIDED: 'Guided',
+    LOITER: 'Loiter',
+    RTL: 'RTL',
+    CIRCLE: 'Circle',
+    LAND: 'Land',
+    DRIFT: 'Drift',
+    SPORT: 'Sport',
+    FLIP: 'Flip',
+    AUTOTUNE: 'Auto Tune',
+    POSHOLD: 'Position Hold',
+    BRAKE: 'Brake',
+    THROW: 'Throw',
+    AVOID_ADSB: 'Avoid ADSB',
+    GUIDED_NOGPS: 'Guided No GPS',
+    SMART_RTL: 'Smart RTL',
+    FLOWHOLD: 'Flow Hold',
+    FOLLOW: 'Follow',
+    ZIGZAG: 'Zig Zag',
+    SYSTEMID: 'System ID',
+    AUTOROTATE: 'Heli Auto Rotate',
+    AUTO_RTL: 'Auto RTL',
+    TURTLE: 'Turtle',
+  },
+  [VehicleType.Plane]: {
+    MANUAL: 'Manual',
+    CIRCLE: 'Circle',
+    STABILIZE: 'Stabilize',
+    TRAINING: 'Training',
+    ACRO: 'Acro',
+    FLY_BY_WIRE_A: 'Fly-By-Wire A',
+    FLY_BY_WIRE_B: 'Fly-By-Wire B',
+    CRUISE: 'Cruise',
+    AUTOTUNE: 'Auto Tune',
+    AUTO: 'Auto',
+    RTL: 'RTL',
+    LOITER: 'Loiter',
+    TAKEOFF: 'Takeoff',
+    AVOID_ADSB: 'Avoid ADSB',
+    GUIDED: 'Guided',
+    INITIALISING: 'Initialising',
+    QSTABILIZE: 'Q-Stabilize',
+    QHOVER: 'Q-Hover',
+    QLOITER: 'Q-Loiter',
+    QLAND: 'Q-Land',
+    QRTL: 'Q-RTL',
+    QAUTOTUNE: 'Q-Auto Tune',
+    QACRO: 'Q-Acro',
+    THERMAL: 'Thermal',
+    LOITER_ALT_QLAND: 'Loiter to Q-Land',
+  },
+}
+
+/**
+ * Get the name to show the user for a vehicle mode
+ * @param {string} modeName - Mode name as reported by the vehicle, e.g. 'ALT_HOLD'
+ * @param {VehicleType | undefined} vehicleType - Type of the vehicle the mode belongs to
+ * @param {FlightModeNames} customNames - Names chosen by the user, which win over the ArduPilot ones
+ * @returns {string} The name to display, falling back to the mode name itself when no name is known for it
+ */
+export const flightModeName = (
+  modeName: string,
+  vehicleType?: VehicleType,
+  customNames: FlightModeNames = {}
+): string => {
+  if (vehicleType === undefined) return modeName
+  const mode = modeName.toUpperCase()
+  return customNames[vehicleType]?.[mode] ?? defaultFlightModeNames[vehicleType]?.[mode] ?? modeName
+}

--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -30,8 +30,8 @@ import { MavlinkManualControlManager } from '@/libs/joystick/protocols/mavlink-m
 import { canByPassCategory, EventCategory, slideToConfirm } from '@/libs/slide-to-confirm'
 import type { ArduPilot } from '@/libs/vehicle/ardupilot/ardupilot'
 import { CustomMode } from '@/libs/vehicle/ardupilot/ardurover'
-import { getVehicleTypeFromMavType } from '@/libs/vehicle/ardupilot/common'
-import { flightModeName } from '@/libs/vehicle/ardupilot/mode-names'
+import { getVehicleTypeFromMavType, renameModeActions } from '@/libs/vehicle/ardupilot/common'
+import { type FlightModeNames, flightModeName } from '@/libs/vehicle/ardupilot/mode-names'
 import { defaultMessageIntervalsOptions } from '@/libs/vehicle/mavlink/defaults'
 import type { MAVLinkParameterSetData, MessageIntervalOptions } from '@/libs/vehicle/mavlink/types'
 import { MAVLINK_MESSAGE_INTERVALS_STORAGE_KEY } from '@/libs/vehicle/mavlink/vehicle'
@@ -171,6 +171,11 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const modes = ref<Map<string, any>>()
 
+  const customFlightModeNames = useBlueOsStorage<FlightModeNames>('cockpit-custom-flight-mode-names', {})
+
+  // The joystick mode actions are registered once at startup, so they have to be renamed when the names change
+  watch(customFlightModeNames, (names) => renameModeActions(names), { deep: true, immediate: true })
+
   const ardupilotVehicleType = computed(() =>
     vehicleType.value === undefined ? undefined : getVehicleTypeFromMavType(vehicleType.value)
   )
@@ -178,10 +183,10 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
   /**
    * Name to show the user for one of the modes of the connected vehicle
    * @param {string} modeName - Mode name as reported by the vehicle, e.g. 'ALT_HOLD'
-   * @returns {string} The name ArduPilot gives the mode, or the mode name itself
+   * @returns {string} The name chosen by the user, the ArduPilot one, or the mode name itself
    */
   function flightModeDisplayName(modeName: string): string {
-    return flightModeName(modeName, ardupilotVehicleType.value)
+    return flightModeName(modeName, ardupilotVehicleType.value, customFlightModeNames.value)
   }
 
   // Store custom message intervals in BlueOS storage
@@ -1096,6 +1101,7 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     mode,
     modes,
     ardupilotVehicleType,
+    customFlightModeNames,
     flightModeDisplayName,
     isArmed,
     flying,

--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -30,6 +30,8 @@ import { MavlinkManualControlManager } from '@/libs/joystick/protocols/mavlink-m
 import { canByPassCategory, EventCategory, slideToConfirm } from '@/libs/slide-to-confirm'
 import type { ArduPilot } from '@/libs/vehicle/ardupilot/ardupilot'
 import { CustomMode } from '@/libs/vehicle/ardupilot/ardurover'
+import { getVehicleTypeFromMavType } from '@/libs/vehicle/ardupilot/common'
+import { flightModeName } from '@/libs/vehicle/ardupilot/mode-names'
 import { defaultMessageIntervalsOptions } from '@/libs/vehicle/mavlink/defaults'
 import type { MAVLinkParameterSetData, MessageIntervalOptions } from '@/libs/vehicle/mavlink/types'
 import { MAVLINK_MESSAGE_INTERVALS_STORAGE_KEY } from '@/libs/vehicle/mavlink/vehicle'
@@ -168,6 +170,19 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
   const mode = ref<string | undefined>(undefined)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const modes = ref<Map<string, any>>()
+
+  const ardupilotVehicleType = computed(() =>
+    vehicleType.value === undefined ? undefined : getVehicleTypeFromMavType(vehicleType.value)
+  )
+
+  /**
+   * Name to show the user for one of the modes of the connected vehicle
+   * @param {string} modeName - Mode name as reported by the vehicle, e.g. 'ALT_HOLD'
+   * @returns {string} The name ArduPilot gives the mode, or the mode name itself
+   */
+  function flightModeDisplayName(modeName: string): string {
+    return flightModeName(modeName, ardupilotVehicleType.value)
+  }
 
   // Store custom message intervals in BlueOS storage
   const mavlinkMessageIntervalOptions = useBlueOsStorage(
@@ -1080,6 +1095,8 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     statusGPS,
     mode,
     modes,
+    ardupilotVehicleType,
+    flightModeDisplayName,
     isArmed,
     flying,
     isVehicleOnline,

--- a/src/stores/vehicleAlerter.ts
+++ b/src/stores/vehicleAlerter.ts
@@ -16,7 +16,11 @@ export const useVehicleAlerterStore = defineStore('vehicle-alerter', () => {
 
   watch(
     () => vehicleStore.mode,
-    () => alertStore.pushAlert(new Alert(AlertLevel.Info, `Vehicle mode changed to ${vehicleStore.mode}.`))
+    (newMode) => {
+      if (newMode === undefined) return
+      const modeName = vehicleStore.flightModeDisplayName(newMode)
+      alertStore.pushAlert(new Alert(AlertLevel.Info, `Vehicle mode changed to ${modeName}.`))
+    }
   )
 
   watch(

--- a/src/tests/libs/vehicle/mode-names.test.ts
+++ b/src/tests/libs/vehicle/mode-names.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from 'vitest'
+
+import { defaultFlightModeNames, flightModeName } from '@/libs/vehicle/ardupilot/mode-names'
+import { CopterMode, PlaneMode, RoverMode, SubMode } from '@/libs/vehicle/ardupilot/types/modes'
+import { Type as VehicleType } from '@/libs/vehicle/vehicle'
+
+const modeEnums = {
+  [VehicleType.Sub]: SubMode,
+  [VehicleType.Rover]: RoverMode,
+  [VehicleType.Copter]: CopterMode,
+  [VehicleType.Plane]: PlaneMode,
+}
+
+test('every supported mode has a default name, and every default name belongs to a mode', () => {
+  Object.entries(modeEnums).forEach(([vehicleType, modeEnum]) => {
+    // PRE_FLIGHT is a Cockpit internal state, so it is never shown to the user.
+    const vehicleModes = Object.keys(modeEnum)
+      .filter((key) => isNaN(Number(key)))
+      .filter((key) => key !== 'PRE_FLIGHT')
+
+    const namedModes = Object.keys(defaultFlightModeNames[vehicleType as VehicleType] ?? {})
+    expect(namedModes.sort()).toEqual(vehicleModes.sort())
+  })
+})
+
+test('flightModeName', () => {
+  expect(flightModeName('ALT_HOLD', VehicleType.Sub)).toBe('Depth Hold')
+  expect(flightModeName('alt_hold', VehicleType.Sub)).toBe('Depth Hold')
+  expect(flightModeName('ALT_HOLD', VehicleType.Copter)).toBe('Altitude Hold')
+
+  const customNames = { [VehicleType.Sub]: { ALT_HOLD: 'Hold Depth' } }
+  expect(flightModeName('ALT_HOLD', VehicleType.Sub, customNames)).toBe('Hold Depth')
+  expect(flightModeName('SURFTRAK', VehicleType.Sub, customNames)).toBe('Surface Track')
+
+  // Modes and vehicles we know no name for keep the name the vehicle reported.
+  expect(flightModeName('SOME_NEW_MODE', VehicleType.Sub)).toBe('SOME_NEW_MODE')
+  expect(flightModeName('MANUAL', VehicleType.Blimp)).toBe('MANUAL')
+  expect(flightModeName('MANUAL')).toBe('MANUAL')
+})

--- a/src/tests/libs/vehicle/mode-names.test.ts
+++ b/src/tests/libs/vehicle/mode-names.test.ts
@@ -1,8 +1,11 @@
 import { expect, test } from 'vitest'
 
+import { actionDisplayName } from '@/libs/joystick/protocols/cockpit-actions'
+import { getVehicleModeActionId, renameModeActions } from '@/libs/vehicle/ardupilot/common'
 import { defaultFlightModeNames, flightModeName } from '@/libs/vehicle/ardupilot/mode-names'
 import { CopterMode, PlaneMode, RoverMode, SubMode } from '@/libs/vehicle/ardupilot/types/modes'
 import { Type as VehicleType } from '@/libs/vehicle/vehicle'
+import { JoystickProtocol } from '@/types/joystick'
 
 const modeEnums = {
   [VehicleType.Sub]: SubMode,
@@ -36,4 +39,20 @@ test('flightModeName', () => {
   expect(flightModeName('SOME_NEW_MODE', VehicleType.Sub)).toBe('SOME_NEW_MODE')
   expect(flightModeName('MANUAL', VehicleType.Blimp)).toBe('MANUAL')
   expect(flightModeName('MANUAL')).toBe('MANUAL')
+})
+
+test('a mapped mode action is named after the current names, not the one persisted with the mapping', () => {
+  const persistedMapping = {
+    protocol: JoystickProtocol.CockpitAction,
+    id: getVehicleModeActionId(VehicleType.Sub, 'alt_hold'),
+    name: 'Alt Hold Mode (ArduPilot Sub)',
+  }
+
+  expect(actionDisplayName(persistedMapping)).toBe('Depth Hold Mode (ArduPilot Sub)')
+
+  renameModeActions({ [VehicleType.Sub]: { ALT_HOLD: 'Hold Depth' } })
+  expect(actionDisplayName(persistedMapping)).toBe('Hold Depth Mode (ArduPilot Sub)')
+
+  renameModeActions({})
+  expect(actionDisplayName(persistedMapping)).toBe('Depth Hold Mode (ArduPilot Sub)')
 })

--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -898,7 +898,7 @@ export const isMiniWidgetConfigurable: Record<MiniWidgetType, boolean> = {
   [MiniWidgetType.VeryGenericIndicator]: true,
   [MiniWidgetType.JoystickCommIndicator]: true,
   [MiniWidgetType.MiniVideoRecorder]: true,
-  [MiniWidgetType.ModeSelector]: false,
+  [MiniWidgetType.ModeSelector]: true,
   [MiniWidgetType.SatelliteIndicator]: false,
   [MiniWidgetType.ViewSelector]: false,
   [MiniWidgetType.SnapshotTool]: true,

--- a/src/views/ConfigurationJoystickView.vue
+++ b/src/views/ConfigurationJoystickView.vue
@@ -437,7 +437,7 @@
                         <td class="w-[120px]">
                           <div>
                             <p class="text-center">
-                              {{ currentButtonActions[item.id as JoystickButton]?.action.name }}
+                              {{ getButtonActionName(item.id as JoystickButton) }}
                             </p>
                           </div>
                         </td>
@@ -668,6 +668,7 @@ import { getDataLakeVariableInfo } from '@/libs/actions/data-lake'
 import { getAllTransformingFunctions } from '@/libs/actions/data-lake-transformations'
 import { getArdupilotVersion, getMavlink2RestVersion } from '@/libs/blueos'
 import { JoystickModel } from '@/libs/joystick/manager'
+import { actionDisplayName } from '@/libs/joystick/protocols/cockpit-actions'
 import { MAVLinkButtonFunction } from '@/libs/joystick/protocols/mavlink-manual-control'
 import { modifierKeyActions } from '@/libs/joystick/protocols/other'
 import { mavlinkCameraFocusActionId, mavlinkCameraZoomActionId } from '@/libs/joystick/protocols/predefined-resources'
@@ -774,7 +775,7 @@ const isExtraButtonPressed = (joystick: Joystick, buttonId: number): boolean => 
 
 const getButtonActionName = (buttonId: number): string => {
   const action = currentButtonActions.value[buttonId as JoystickButton]?.action
-  return action?.name ?? 'unassigned'
+  return action === undefined ? 'unassigned' : actionDisplayName(action)
 }
 
 const getAxesNotInSvg = (joystick: Joystick): number[] => {

--- a/src/views/ConfigurationMAVLinkView.vue
+++ b/src/views/ConfigurationMAVLinkView.vue
@@ -40,7 +40,7 @@
             </div>
           </template>
         </ExpansiblePanel>
-        <ExpansiblePanel no-bottom-divider :is-expanded="!interfaceStore.isOnPhoneScreen">
+        <ExpansiblePanel :is-expanded="!interfaceStore.isOnPhoneScreen">
           <template #title>Message intervals</template>
           <template #info>
             <p>
@@ -223,6 +223,18 @@
             </div>
           </template>
         </ExpansiblePanel>
+        <ExpansiblePanel no-bottom-divider :is-expanded="!interfaceStore.isOnPhoneScreen">
+          <template #title>Flight mode names</template>
+          <template #info>
+            <p>
+              How each vehicle mode is named throughout Cockpit. The defaults are the names ArduPilot itself uses, and a
+              mode with no name of its own is shown exactly as the vehicle reports it.
+            </p>
+          </template>
+          <template #content>
+            <FlightModeNamesConfig />
+          </template>
+        </ExpansiblePanel>
       </div>
     </template>
   </BaseConfigurationView>
@@ -231,6 +243,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 
+import FlightModeNamesConfig from '@/components/configuration/FlightModeNamesConfig.vue'
 import ExpansiblePanel from '@/components/ExpansiblePanel.vue'
 import { MAVLinkType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import type { MessageIntervalOptions } from '@/libs/vehicle/mavlink/types'


### PR DESCRIPTION
## Summary

The mode selector showed the raw mode name the vehicle reports, so an ArduSub pilot read `ALT_HOLD` for what ArduPilot itself calls depth hold, and `SURFTRAK` for the mode that holds a distance from the bottom. The mode change alert repeated that name, and the joystick action list had a third spelling of its own, from title-casing the raw name.

- **Defaults follow ArduPilot, not our taste.** The name table comes from ArduPilot's parameter metadata: `FLTMODE1` for Copter and Plane, `MODE1` for Rover, and the joystick button functions (`BTNx_FUNCTION`) for Sub, which is the only place ArduPilot names the Sub modes — that is where `Depth Hold` comes from. The names ArduPilot writes as a single word are spelled out (`AltHold` reads `Altitude Hold`, `QRTL` reads `Q-RTL`), since the pilot reading them mid-dive is not the one who wrote the firmware. A mode or a vehicle type with no name there keeps the name the vehicle reported, so nothing is invented for firmware we do not know.
- **Applied on the mode selector, on the "Vehicle mode changed to …" alert and on the joystick mode actions**, which had their own prettifier.
- **The names are the user's to choose.** Naming is a matter of taste and of the team flying the vehicle, so there is a per-vehicle-type table where each mode can be renamed. Clearing a field puts the ArduPilot name back, and "Reset names to ArduPilot defaults" clears the whole vehicle type. The names live in `cockpit-custom-flight-mode-names`, so they sync with the rest of the settings.

The mode selector still sends the mode the vehicle knows; only the label changed.

The table lives in one component used from two places: the MAVLink settings page, and the mode selector mini-widget's own configuration menu (right-click the selector, or its cog in edit mode). The MAVLink page is behind pirate mode; the mini-widget menu is not, so renaming a mode is available to everyone. Everyone still gets the ArduPilot names by default.

The joystick page resolves each label when it draws it, instead of trusting the one stored with the mapping, and the mode actions are renamed whenever the names change. So a renamed mode reads the same in the action list, in the search and on a button that was mapped before the rename.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/bluerobotics/cockpit/53d54c17b5c5b58c8b0cc16aeb2259190450d2da/alert-before.png" width="420"> | <img src="https://raw.githubusercontent.com/bluerobotics/cockpit/53d54c17b5c5b58c8b0cc16aeb2259190450d2da/alert-after.png" width="420"> |

The mode selector on the same ArduSub, and the table where the names are edited:

<img src="https://raw.githubusercontent.com/bluerobotics/cockpit/53d54c17b5c5b58c8b0cc16aeb2259190450d2da/selector-after.png" width="200">

<img src="https://raw.githubusercontent.com/bluerobotics/cockpit/b59dbf1d10ffc33181b63356d05d93bac7525e68/settings-panel.png" width="620">

## Test plan

- [ ] Connect an ArduSub vehicle and open the mode selector: it reads `Depth Hold`, `Position Hold`… instead of `ALT_HOLD`, `POSHOLD`, and picking one still changes the vehicle mode.
- [ ] Change the mode from the vehicle side and check the alert names the mode the same way.
- [ ] With pirate mode on, Settings → MAVLink → Flight mode names: rename a mode and see the selector and the alert follow it; clear the field and the ArduPilot name comes back; "Reset names to ArduPilot defaults" restores the whole list.
- [ ] With pirate mode **off**, right-click the mode selector → Options: the same table opens, and a rename there shows up on the selector right away.
- [ ] Switch the vehicle dropdown to Rover/Copter/Plane and confirm the modes listed are the ones of that vehicle.
- [ ] Settings → Joystick: a mode action reads `Depth Hold Mode (ArduPilot Sub)`, and a mode renamed in the MAVLink settings reads the new name both in the action list and on a button that was already mapped to it before the rename.

## Checks

- Mode selector for a Rover, read from the DOM: `Manual | Acro | Steering | Hold | Loiter | Follow | Simple | Dock | Circle | Auto | RTL | Smart RTL | Guided | Initialising`, where `SMART_RTL` reads `Smart RTL`. Each option's value is still the raw name the vehicle reports (`SMART_RTL`), so the mode sent to the vehicle is unchanged.
- Renaming `ALT_HOLD` in the settings table to `Hold the Depth` changed the selector to `Hold the Depth` without a reload.
- Clearing a field of a mode that has no custom name leaves the ArduPilot name in the box (`Depth Hold`), rather than an empty field disagreeing with the selector.
- New unit test asserts the default table matches the mode enums of every supported vehicle type exactly, so a mode added to Cockpit cannot silently go unnamed, plus the custom → ArduPilot → raw name order, and that a mapped mode action is named after the current names rather than the one frozen into the mapping.
- `yarn lint`, `yarn typecheck` and `yarn test:unit` clean (the two failures on `cosmos.test.ts` and `connection.test.ts` are pre-existing on `master`).

Closes #1167


