### PR TITLE
Video: Fix crashes caused by RTSP streams

### DIFF
--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -4,7 +4,7 @@ import { differenceInSeconds } from 'date-fns'
 import { saveAs } from 'file-saver'
 import { defineStore } from 'pinia'
 import { v4 as uuid } from 'uuid'
-import { computed, ref, watch } from 'vue'
+import { computed, markRaw, ref, watch } from 'vue'
 import adapter from 'webrtc-adapter'
 
 import { Go2RTCManager } from '@/composables/go2rtc'
@@ -424,8 +424,7 @@ export const useVideoStore = defineStore('video', () => {
       if (!activeStreams.value[streamName]?.webRtcManager) return
 
       // Update the list of available remote ICE Ips with those available for each stream
-      // @ts-ignore: availableICEIPs is not reactive here, for some yet to know reason
-      const newIps = activeStreams.value[streamName].webRtcManager.availableICEIPs.filter(
+      const newIps = activeStreams.value[streamName]!.webRtcManager!.availableICEIPs.value.filter(
         (ip: string) => !availableIceIps.value.includes(ip)
       )
       availableIceIps.value = [...availableIceIps.value, ...newIps]
@@ -508,7 +507,8 @@ export const useVideoStore = defineStore('video', () => {
 
           activeStreams.value[streamName] = {
             stream: undefined,
-            go2rtcManager: manager,
+            // A reactive-proxied manager gets its internal refs unwrapped, breaking its own '.value' writes.
+            go2rtcManager: markRaw(manager),
             // @ts-ignore: This is actually not reactive
             mediaStream: mediaStream,
             // @ts-ignore: This is actually not reactive
@@ -557,7 +557,7 @@ export const useVideoStore = defineStore('video', () => {
     activeStreams.value[streamName] = {
       // @ts-ignore: This is actually not reactive
       stream: stream,
-      webRtcManager: webRtcManager,
+      webRtcManager: markRaw(webRtcManager),
       // @ts-ignore: This is actually not reactive
       mediaStream: mediaStream,
       // @ts-ignore: This is actually not reactive
@@ -578,44 +578,49 @@ export const useVideoStore = defineStore('video', () => {
     const externalStreamData = activeStreams.value[externalId]
     if (!externalStreamData) return
 
-    // Stop recording if it's active
-    if (externalStreamData.mediaRecorder?.state === 'recording') {
-      externalStreamData.mediaRecorder.stop()
-    }
-
-    // Stop all tracks in the media stream
-    if (externalStreamData.mediaStream) {
-      externalStreamData.mediaStream.getTracks().forEach((track) => {
-        track.stop()
-        console.log(`Stopped track: ${track.kind} for external stream '${externalId}'`)
-      })
-    }
-
-    // Close WebRTC connection
-    if (externalStreamData.webRtcManager) {
-      try {
-        const session = externalStreamData.webRtcManager.session
-        if (session?.peerConnection) {
-          session.peerConnection.close()
-        }
-        externalStreamData.webRtcManager.close(reason)
-        console.log(`Stopped WebRTC manager for external stream '${externalId}'`)
-      } catch (error) {
-        console.warn(`Error stopping WebRTC manager for external stream '${externalId}':`, error)
+    // A stream left in the map after a failed teardown is unrecoverable: its manager is already
+    // half-closed, and registerStreamConsumer skips activation for a key that exists.
+    try {
+      // Stop recording if it's active
+      if (externalStreamData.mediaRecorder?.state === 'recording') {
+        externalStreamData.mediaRecorder.stop()
       }
-    }
 
-    if (externalStreamData.go2rtcManager) {
-      externalStreamData.go2rtcManager.close(reason)
-      if (window.electronAPI) {
-        void window.electronAPI.go2rtcRemoveStream(externalId).catch((error) => {
-          console.warn(`Error removing go2rtc stream '${externalId}':`, error)
+      // Stop all tracks in the media stream
+      if (externalStreamData.mediaStream) {
+        externalStreamData.mediaStream.getTracks().forEach((track) => {
+          track.stop()
+          console.log(`Stopped track: ${track.kind} for external stream '${externalId}'`)
         })
       }
-    }
 
-    delete activeStreams.value[externalId]
-    console.log(`Cleaned up all resources for external stream '${externalId}'`)
+      // Close WebRTC connection
+      if (externalStreamData.webRtcManager) {
+        try {
+          externalStreamData.webRtcManager.session?.peerConnection.close()
+          externalStreamData.webRtcManager.close(reason)
+          console.log(`Stopped WebRTC manager for external stream '${externalId}'`)
+        } catch (error) {
+          console.warn(`Error stopping WebRTC manager for external stream '${externalId}':`, error)
+        }
+      }
+
+      if (externalStreamData.go2rtcManager) {
+        try {
+          externalStreamData.go2rtcManager.close(reason)
+        } catch (error) {
+          console.warn(`Error stopping go2rtc manager for external stream '${externalId}':`, error)
+        }
+        if (window.electronAPI) {
+          void window.electronAPI.go2rtcRemoveStream(externalId).catch((error) => {
+            console.warn(`Error removing go2rtc stream '${externalId}':`, error)
+          })
+        }
+      }
+    } finally {
+      delete activeStreams.value[externalId]
+      console.log(`Cleaned up all resources for external stream '${externalId}'`)
+    }
   }
 
   /**

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -761,10 +761,7 @@ export const useVideoStore = defineStore('video', () => {
    * @returns {MediaStream | undefined} MediaStream that is running, if available
    */
   const getMediaStream = (streamName: string): MediaStream | undefined => {
-    if (activeStreams.value[streamName] === undefined) {
-      activateStream(streamName)
-    }
-    return activeStreams.value[streamName]!.mediaStream
+    return getStreamData(streamName)?.mediaStream
   }
 
   /**
@@ -773,12 +770,7 @@ export const useVideoStore = defineStore('video', () => {
    * @returns {boolean}
    */
   const isRecording = (streamName: string): boolean => {
-    if (activeStreams.value[streamName] === undefined) activateStream(streamName)
-
-    return (
-      activeStreams.value[streamName]!.mediaRecorder !== undefined &&
-      activeStreams.value[streamName]!.mediaRecorder!.state === 'recording'
-    )
+    return getStreamData(streamName)?.mediaRecorder?.state === 'recording'
   }
 
   /**
@@ -791,22 +783,22 @@ export const useVideoStore = defineStore('video', () => {
     clearInterval(recordingMonitors[streamName])
     delete recordingMonitors[streamName]
 
-    if (activeStreams.value[streamName] === undefined) activateStream(streamName)
+    const streamData = getStreamData(streamName)
 
     // A failed recorder detaches itself, so a chunk arriving after that reaches here with nothing left to stop, and
     // reporting a successful stop would contradict the failure the user was just told about.
-    if (activeStreams.value[streamName]!.mediaRecorder === undefined) {
+    if (streamData?.mediaRecorder === undefined) {
       console.debug(`No recorder attached to stream '${streamName}'. Nothing to stop.`)
       return
     }
 
-    const timeRecordingStart = activeStreams.value[streamName]?.timeRecordingStart
+    const timeRecordingStart = streamData.timeRecordingStart
     const durationInSeconds = timeRecordingStart ? differenceInSeconds(new Date(), timeRecordingStart) : undefined
     eventTracker.capture('Video recording stop', { streamName, durationInSeconds })
 
-    activeStreams.value[streamName]!.timeRecordingStart = undefined
+    streamData.timeRecordingStart = undefined
 
-    activeStreams.value[streamName]!.mediaRecorder?.stop()
+    streamData.mediaRecorder.stop()
 
     alertStore.pushAlert(new Alert(AlertLevel.Success, `Stopped recording stream ${streamName}.`))
   }
@@ -823,26 +815,25 @@ export const useVideoStore = defineStore('video', () => {
    */
   const startRecording = async (streamName: string): Promise<void> => {
     eventTracker.capture('Video recording start', { streamName: streamName })
-    if (activeStreams.value[streamName] === undefined) activateStream(streamName)
+    const streamData = getStreamData(streamName)
 
     if (namesAvailableStreams.value.isEmpty()) {
       showDialog({ message: 'No streams available.', variant: 'error' })
       return
     }
 
-    if (activeStreams.value[streamName]!.mediaStream === undefined) {
+    if (streamData?.mediaStream === undefined) {
       showDialog({ message: 'Media stream not defined.', variant: 'error' })
       return
     }
-    if (!activeStreams.value[streamName]!.mediaStream!.active) {
+    if (!streamData.mediaStream.active) {
       showDialog({ message: 'Media stream not yet active. Wait a second and try again.', variant: 'error' })
       return
     }
 
     await sleep(100)
 
-    activeStreams.value[streamName]!.timeRecordingStart = new Date()
-    const streamData = activeStreams.value[streamName] as StreamData
+    streamData.timeRecordingStart = new Date()
 
     // Generate a unique recording hash
     let recordingHash = ''


### PR DESCRIPTION
**Problem:**

- Vue deep-proxies the stream managers stored in the video store, which unwraps their internal refs.
- Closing a go2rtc manager then writes to a plain boolean and throws: in a dev build that aborts the video widget unmount and the view never switches, in a packaged build the app error handler swallows it and the stream is left stranded in `activeStreams`, unusable until a restart.
- Same cause silently kept WebRTC sessions from ever being ended, and left every stream's status readout stuck on unknown.
- Separately, the store reads a stream's entry right after activating it, which does not exist yet for RTSP streams (activation is async, and a no-op in Lite), so the recorder and player widgets threw on every poll.

**Fix:**

- Store both managers with `markRaw`, so they stay outside the store's reactivity.
- Drop the stream entry in a `finally`, so a failed teardown cannot strand it.
- Read the stream entry through `getStreamData` in every recording and media-stream path, reporting no stream instead of throwing.

Closes #2964