### PR TITLE
ci: fold the how-to-vote instructions into a collapsed block

### DIFF
--- a/.github/scripts/review-decisions.sh
+++ b/.github/scripts/review-decisions.sh
@@ -129,6 +129,8 @@ post() {
       printf '### :raising_hand: Decision needed — %s\n\n' "$finding"
       printf '**%s**\n\n' "$title"
       printf "The author's argument: %s\n\n" "$argument"
+      # The summary carries the ask rather than naming the box: folded is the default view.
+      printf '<details>\n<summary>How to vote on this dispute</summary>\n\n'
       printf 'React to this comment and the next `/review` applies the answer:\n\n'
       printf -- '- :+1: accept the argument and leave the code as it is — the finding closes\n'
       printf -- '- :-1: ask for the change anyway — the finding stays open\n\n'
@@ -141,6 +143,7 @@ post() {
       printf 'changes nothing. The same goes once the author makes a different case: the argument '
       printf 'above stops being the one in question, and the newest "Decision needed" comment for '
       printf 'this finding is the live vote.\n'
+      printf '\n</details>\n'
     } > "$body"
 
     comment=$(jq -Rs '{body: .}' < "$body" \


### PR DESCRIPTION
## Summary
- The how-to-vote paragraph in a "Decision needed" comment moves into a collapsed `<details>` block, so what stays visible is the finding, the author's argument, and one plain line: `How to vote on this dispute`.
- Replaces this branch's first approach, which deleted the instructions outright. Round 1 flagged that as leaving two unlabeled thumbs a maintainer can read backwards, with the bot's own seeded pair looking like a 1–1 split — a fair call, so nothing is deleted now, only folded.
- The summary line states that a reaction settles the dispute rather than just naming the box, so a maintainer who never expands it still knows what is being asked. The polarity itself is one click away.

## Test plan
- [ ] Next `/review` that posts a new decision comment renders the fold collapsed, with the argument above it.
- [ ] Expanding the block shows the 👍/👎 mapping and the placeholder-reaction note unchanged.
- [x] `review-decisions.sh --self-check` passes — it covers the jq tally expressions, which this does not touch.