### PR TITLE
Enable H.265 (HEVC) video support

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Below is a table summarizing the current status, but in general, you can expect 
 |-------------|---------------|----------------|
 | **Joystick Support** | Only when tab and window are in focus  | ✅ Window can be unfocused and in the background |
 | **Video** | Needs to be downloaded and merged into a working video using the Desktop app | ✅ Final MP4 file saved directly to your folders |
+| **H.265 (HEVC) cameras** | Only on browsers that can receive H.265 (recent Chromium) | ✅ Plays wherever the system can decode H.265 in hardware, and recordings are re-encoded (to H.265, or to H.264 when the machine cannot encode it) so they can be saved, at some cost in image quality |
 | **Snapshots** | Needs to be downloaded | ✅ Saved directly to your folders |
 | **Vehicle Discovery** | ❌ Not available | ✅ Auto-scan for vehicles in the network|
 | **External Serial GNSS** | ❌ Not available (browsers can't access serial devices outside a secure context) | ✅ Read one or more USB/serial NMEA GNSS receivers into the data-lake |

--- a/src/components/VideoPlayerStatsForNerds.vue
+++ b/src/components/VideoPlayerStatsForNerds.vue
@@ -218,6 +218,13 @@ const fetchRtspInfo = async (): Promise<void> => {
   try {
     const allInfo = await window.electronAPI.go2rtcGetStreamsInfo()
     const info = allInfo[props.streamName]
+    if (info && info.width === undefined) {
+      // This payload is fetched here at 10 Hz for the plots below, while the store polls the same endpoint at its
+      // own pace and fills in the size go2rtc cannot report, so the size is taken from that copy.
+      const filledInfo = videoStore.go2rtcStreamInfo[props.streamName]
+      info.width = filledInfo?.width
+      info.height = filledInfo?.height
+    }
     rtspInfo.value = info
     if (info) {
       if (rtspStartTime === 0) rtspStartTime = Date.now()

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -29,6 +29,13 @@ if (process.platform === 'linux') {
   app.commandLine.appendSwitch('enable-speech-dispatcher')
 }
 
+// Enable Chromium features required to decode/encode H.265 (HEVC) streams.
+// `PlatformHEVCDecoderSupport` enables hardware HEVC decoding for HTMLVideoElement, while
+// `WebRtcAllowH265Receive`/`WebRtcAllowH265Send` allow HEVC to be negotiated over WebRTC
+// (used by go2rtc when bridging RTSP streams into the renderer).
+// These switches must be appended before the `ready` event fires.
+app.commandLine.appendSwitch('enable-features', 'PlatformHEVCDecoderSupport,WebRtcAllowH265Receive,WebRtcAllowH265Send')
+
 export const ROOT_PATH = {
   dist: join(__dirname, '..'),
 }

--- a/src/electron/services/video-recording.ts
+++ b/src/electron/services/video-recording.ts
@@ -31,6 +31,18 @@ import { filesystemStorage, getCockpitFolderPath } from './storage'
 
 const activeStreamProcesses = new Map<string, LiveStreamProcess>()
 
+// Matroska names its codec in the Tracks element, which the first chunk of a recording always carries.
+const hevcMatroskaCodecId = 'V_MPEGH/ISO/HEVC'
+const matroskaHeaderSearchLength = 64 * 1024
+
+/**
+ * Tells whether a recording carries H.265, by looking for its codec id in the first chunk's header.
+ * @param {Uint8Array} firstChunkData - First chunk of the recording, which holds the Matroska header
+ * @returns {boolean} True if the recording is H.265
+ */
+const isHevcRecording = (firstChunkData: Uint8Array): boolean =>
+  Buffer.from(firstChunkData.subarray(0, matroskaHeaderSearchLength)).includes(hevcMatroskaCodecId)
+
 /**
  * Create a temporary directory for live video processing
  * @param {string} prefix - Prefix for the directory name
@@ -87,6 +99,7 @@ const startVideoRecording = async (
     '100M', // 100MB to find decoding info
     '-analyzeduration',
     '15M', // 15 seconds to find decoding info
+    // The WebM demuxer also reads the Matroska that H.265 recordings come in.
     '-f',
     'webm', // Input format is WebM
     '-i',
@@ -95,6 +108,9 @@ const startVideoRecording = async (
     'copy', // Copy video codec (no re-encoding)
     '-c:a',
     'copy', // Copy audio codec (no re-encoding)
+    // Apple's players only open H.265 under the hvc1 tag, while FFmpeg defaults to hev1 on copy. Only H.265
+    // may carry it, so tagging every recording would make the H.264 ones unplayable instead.
+    ...(isHevcRecording(firstChunkData) ? ['-tag:v', 'hvc1'] : []),
     '-movflags',
     'frag_keyframe+empty_moov+default_base_moof', // Fragmented MP4 for crash-safety
     '-fflags',

--- a/src/libs/video-recording-codec.ts
+++ b/src/libs/video-recording-codec.ts
@@ -1,0 +1,112 @@
+import { sleep } from '@/libs/utils'
+
+/**
+ * Formats Chromium accepts for recording an H.265 stream, in order of preference. Keeping HEVC comes first,
+ * as it costs the least and loses the least quality of the two, with H.264 there for machines whose hardware
+ * cannot encode HEVC. The `hvc1.<profile>.<compatibility>.<tier><level>` suffix is not optional: Chromium
+ * reports a bare `hvc1` as unsupported.
+ */
+const hevcRecordingMimeTypes = ['video/x-matroska;codecs=hvc1.1.6.L186.B0', 'video/x-matroska;codecs=avc1']
+
+const hevcCodecNames = ['h265', 'hevc']
+
+const codecNameFromMimeType = (mimeType: string | undefined): string | undefined => mimeType?.split('/')[1]
+
+/**
+ * Tells whether a codec name refers to H.265, which is reported under more than one name.
+ * @param {string | undefined} codec - Codec name, e.g. 'H265'
+ * @returns {boolean} True if the codec is H.265
+ */
+export const isHevcCodec = (codec: string | undefined): boolean => hevcCodecNames.includes(codec?.toLowerCase() ?? '')
+
+/**
+ * Reads the video codec a connection is actually receiving out of its statistics report.
+ *
+ * Codec mime types, such as 'video/H265', come in their own reports, referenced by the stream that uses them.
+ * @param {RTCStatsReport} stats - Report as returned by `RTCPeerConnection.getStats()`
+ * @returns {string | undefined} The codec name, or undefined while no packet has been processed yet
+ */
+export const codecNameFromStats = (stats: RTCStatsReport): string | undefined => {
+  const codecMimeTypes: Record<string, string> = {}
+  let videoCodecId: string | undefined
+  stats.forEach((report) => {
+    if (report.type === 'codec') codecMimeTypes[report.id] = report.mimeType
+    if (report.type === 'inbound-rtp' && report.kind === 'video') videoCodecId = report.codecId
+  })
+
+  return videoCodecId ? codecNameFromMimeType(codecMimeTypes[videoCodecId]) : undefined
+}
+
+/**
+ * Video codecs a connection has negotiated, which are known from the moment the track arrives, unlike the
+ * codec in use, and are thus what we have to go on when recording starts before the first packet.
+ * @param {RTCPeerConnection} peerConnection - Connection receiving the stream
+ * @returns {string[]} Codec names, in the order they were negotiated
+ */
+export const negotiatedVideoCodecNames = (peerConnection: RTCPeerConnection): string[] =>
+  peerConnection
+    .getReceivers()
+    .filter((receiver) => receiver.track?.kind === 'video')
+    .flatMap((receiver) => receiver.getParameters().codecs.map((codec) => codecNameFromMimeType(codec.mimeType)))
+    .filter((name): name is string => name !== undefined)
+
+/**
+ * Decides the mimeType MediaRecorder should record a stream with, based on the codec the stream carries.
+ *
+ * Given no mimeType, Chromium copies the incoming frames straight into the file, which is what we want
+ * whenever we can have it, as it neither costs CPU nor loses quality. That path skips the codec support
+ * check every other path performs, though, and an H.265 stream reaching it takes the whole renderer process
+ * down, so HEVC has to name its format explicitly and pay for a re-encode.
+ * @param {string | undefined} codec - Codec carried by the stream, as reported by the peer connection
+ * @param {(type: string) => boolean} isTypeSupported - Support check, defaulting to MediaRecorder's own
+ * @returns {string | undefined} The mimeType to record with, or undefined to record the frames as they come
+ */
+export const recordingMimeType = (
+  codec: string | undefined,
+  isTypeSupported = (type: string): boolean => MediaRecorder.isTypeSupported(type)
+): string | undefined => {
+  if (!isHevcCodec(codec)) return undefined
+
+  // Naming a type nothing supports is still better than falling back to copying the frames, as an
+  // unsupported type only makes the MediaRecorder constructor throw, which we can catch and report.
+  return hevcRecordingMimeTypes.find((type) => isTypeSupported(type)) ?? hevcRecordingMimeTypes[0]
+}
+
+// ponytail: fixed bits-per-pixel guess, about what a hardware encoder needs to stay visually clean. The
+// source's own bitrate would be exact, but reading it takes two statistics samples spaced in time, which
+// the record button cannot wait for.
+const recordingBitsPerPixel = 0.07
+
+/**
+ * Bitrate to re-encode a recording at, scaled to the picture being recorded.
+ *
+ * Without one, Chromium encodes at a fixed default that ignores the resolution, so a large camera ends up
+ * recorded at a fraction of the quality it was streaming at.
+ * @param {MediaTrackSettings} settings - Settings of the video track being recorded
+ * @returns {number} Bitrate in bits per second
+ */
+export const recordingVideoBitsPerSecond = (settings: MediaTrackSettings): number =>
+  Math.round((settings.width ?? 1920) * (settings.height ?? 1080) * (settings.frameRate ?? 30) * recordingBitsPerPixel)
+
+/**
+ * Settings of a video track, waited on until it knows the size of the frames it carries.
+ *
+ * A received track only learns its size from a decoded frame, and recording can start before the first one
+ * arrives, in which case the bitrate above would be budgeted from the assumed 1080p rather than the real
+ * picture. Gives up on the timeout, as a stream that never delivers a frame must not hold the recording.
+ * @param {MediaStreamTrack} track - Video track about to be recorded
+ * @param {number} timeoutMs - How long to wait before settling for what the track knows
+ * @returns {Promise<MediaTrackSettings>} The track's settings
+ */
+export const videoTrackSettingsWithSize = async (
+  track: MediaStreamTrack,
+  timeoutMs = 1000
+): Promise<MediaTrackSettings> => {
+  const deadline = Date.now() + timeoutMs
+  let settings = track.getSettings()
+  while (settings.width === undefined && Date.now() < deadline) {
+    await sleep(50)
+    settings = track.getSettings()
+  }
+  return settings
+}

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -172,7 +172,17 @@ export const useVideoStore = defineStore('video', () => {
   const fetchGo2rtcStreamInfo = async (): Promise<void> => {
     if (!window.electronAPI) return
     try {
-      go2rtcStreamInfo.value = await window.electronAPI.go2rtcGetStreamsInfo()
+      const streamsInfo = await window.electronAPI.go2rtcGetStreamsInfo()
+      // go2rtc reads the frame size out of the source's stream description, which only carries it for H.264, so
+      // H.265 sources take theirs from the track the renderer decodes. Filled here so every consumer of this
+      // payload sees it, rather than at each place that displays a resolution.
+      Object.entries(streamsInfo).forEach(([externalId, info]) => {
+        if (info.width !== undefined) return
+        const trackSettings = activeStreams.value[externalId]?.mediaStream?.getVideoTracks()[0]?.getSettings()
+        info.width = trackSettings?.width
+        info.height = trackSettings?.height
+      })
+      go2rtcStreamInfo.value = streamsInfo
     } catch (error) {
       console.error('Failed to fetch go2rtc stream info:', error)
     }

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -28,6 +28,14 @@ import {
 import { datalogger } from '@/libs/sensors-logging'
 import { StreamActivationBackoff } from '@/libs/stream-activation-backoff'
 import { isElectron, isEqual, sanitizeFilenameComponent, sleep } from '@/libs/utils'
+import {
+  codecNameFromStats,
+  isHevcCodec,
+  negotiatedVideoCodecNames,
+  recordingMimeType,
+  recordingVideoBitsPerSecond,
+  videoTrackSettingsWithSize,
+} from '@/libs/video-recording-codec'
 import { tempVideoStorage, videoStorage } from '@/libs/videoStorage'
 import type { Stream } from '@/libs/webrtc/signalling_protocol'
 import { readableVideoCodecName } from '@/libs/webrtc/video-codec-support'
@@ -659,8 +667,8 @@ export const useVideoStore = defineStore('video', () => {
   }
 
   /**
-   * Tear down an external stream if it has no remaining consumers and no recorder attached to it (i.e. neither
-   * recording nor finalizing a just-stopped recording)
+   * Tear down an external stream if it has no remaining consumers and no recording in flight (i.e. neither
+   * starting, recording, nor finalizing a just-stopped recording)
    * @param {string} externalId - External stream identifier
    */
   const deactivateStreamIfUnused = (externalId: string): void => {
@@ -669,9 +677,11 @@ export const useVideoStore = defineStore('video', () => {
 
     streamConsumers.delete(externalId)
 
-    // Never tear down a stream while a recorder is attached, even if no widget references it: mediaRecorder stays
-    // set through recording and the async stop() finalizer (telemetry/processing), and onstop clears it when done.
-    if (activeStreams.value[externalId]?.mediaRecorder !== undefined) return
+    // Never tear down a stream while a recording is in flight, even if no widget references it: timeRecordingStart
+    // is stamped from the press onwards, mediaRecorder stays set through recording and the async stop() finalizer
+    // (telemetry/processing), and onstop clears it when done.
+    const streamData = activeStreams.value[externalId]
+    if (streamData?.mediaRecorder !== undefined || streamData?.timeRecordingStart !== undefined) return
 
     teardownStreamResources(externalId, `External stream '${externalId}' is no longer used by any consumer`)
   }
@@ -868,10 +878,44 @@ export const useVideoStore = defineStore('video', () => {
   }
 
   /**
+   * Codec being received for a stream, as reported by the peer connection feeding it
+   * @param {string} streamName - Name of the stream
+   * @returns {Promise<string | undefined>} The codec name, e.g. 'H264', or undefined if it cannot be told
+   */
+  const receivedVideoCodec = async (streamName: string): Promise<string | undefined> => {
+    const peerConnection = getStreamPeerConnection(streamName)?.peerConnection
+    if (!peerConnection) return undefined
+
+    try {
+      const codecInUse = codecNameFromStats(await peerConnection.getStats())
+      if (codecInUse) return codecInUse
+    } catch (error) {
+      const streamLabel = internalStreamNameFromExternal(streamName) ?? streamName
+      console.error(`Could not read the statistics of stream '${streamLabel}': ${error}`)
+    }
+
+    // Recording can start before the first packet is processed, and until then the statistics name no codec at
+    // all. Whatever was negotiated is what may arrive, so the riskiest of those is what we have to record for.
+    const negotiatedCodecs = negotiatedVideoCodecNames(peerConnection)
+    return negotiatedCodecs.find(isHevcCodec) ?? negotiatedCodecs[0]
+  }
+
+  /**
    * Start recording the stream
    * @param {string} streamName - Name of the stream
    */
   const startRecording = async (streamName: string): Promise<void> => {
+    // The internal name, since the external id of an RTSP stream is its URL, credentials included, and these messages
+    // are both shown to the user and written to the logs they share with us.
+    const streamLabel = internalStreamNameFromExternal(streamName) ?? streamName
+
+    // timeRecordingStart is stamped before the awaits that precede the recorder, so it is what marks a start
+    // already in flight, which mediaRecorder (and thus isRecording) only does once those awaits are through.
+    if (activeStreams.value[streamName]?.timeRecordingStart !== undefined) {
+      console.warn(`Recording of stream '${streamLabel}' is already starting or running. Ignoring the request.`)
+      return
+    }
+
     eventTracker.capture('Video recording start', { streamName: streamName })
     const streamData = getStreamData(streamName)
 
@@ -893,20 +937,62 @@ export const useVideoStore = defineStore('video', () => {
 
     streamData.timeRecordingStart = new Date()
 
-    // Generate a unique recording hash
     let recordingHash = ''
-    let refreshHash = true
-    const namesCurrentChunksOnDB = await tempVideoStorage.keys()
-    while (refreshHash) {
-      recordingHash = uuid().slice(0, 8)
-      const hashOnDB = namesCurrentChunksOnDB.some((chunkName) => chunkName.includes(recordingHash))
-      const hashOnRegistry = unprocessedVideos.value[recordingHash] !== undefined
-      refreshHash = hashOnDB || hashOnRegistry
+    let fileName = ''
+    let mimeType: string | undefined
+    let videoTrack: MediaStreamTrack | undefined
+    try {
+      // Generate a unique recording hash
+      let refreshHash = true
+      const namesCurrentChunksOnDB = await tempVideoStorage.keys()
+      while (refreshHash) {
+        recordingHash = uuid().slice(0, 8)
+        const hashOnDB = namesCurrentChunksOnDB.some((chunkName) => chunkName.includes(recordingHash))
+        const hashOnRegistry = unprocessedVideos.value[recordingHash] !== undefined
+        refreshHash = hashOnDB || hashOnRegistry
+      }
+
+      const safeMissionName = sanitizeFilenameComponent(missionStore.missionName) || 'Cockpit'
+      fileName = videoFilename(recordingHash, streamData.timeRecordingStart!, safeMissionName)
+      videoTrack = streamData.mediaStream!.getVideoTracks()[0]
+      mimeType = recordingMimeType(await receivedVideoCodec(streamName))
+      // Only the re-encoding path needs a bitrate; copied frames already carry the camera's own.
+      const recorderOptions: MediaRecorderOptions = mimeType
+        ? { mimeType, videoBitsPerSecond: recordingVideoBitsPerSecond(await videoTrackSettingsWithSize(videoTrack)) }
+        : {}
+      // Only the construction belongs in this try, as its catch blames the codec for whatever comes out of it.
+      let newRecorder: MediaRecorder
+      try {
+        newRecorder = new MediaRecorder(streamData.mediaStream!, recorderOptions)
+      } catch (error) {
+        console.error(`Could not create a recorder for stream '${streamLabel}': ${error}`)
+        const alternative = isElectron()
+          ? 'Set the camera to H.264 and try again.'
+          : 'Set the camera to H.264, or use the Cockpit desktop app, which records formats browsers cannot.'
+        const msg = `This computer cannot record the video format of stream '${streamLabel}'. ${alternative}`
+        showDialog({ message: msg, variant: 'error' })
+        alertStore.pushAlert(new Alert(AlertLevel.Error, msg))
+        return
+      }
+
+      const currentData = activeStreams.value[streamName]
+      if (currentData === undefined) {
+        console.warn(`Stream '${streamLabel}' was torn down while its recorder was being set up. Not recording it.`)
+        return
+      }
+      currentData.mediaRecorder = newRecorder
+    } finally {
+      // Nothing above is guaranteed to reach the recorder, and while timeRecordingStart is set it blocks both a
+      // retry and the stream's teardown, so it is released whenever no recorder came out of this attempt.
+      const currentData = activeStreams.value[streamName]
+      if (currentData !== undefined && currentData.mediaRecorder === undefined) {
+        currentData.timeRecordingStart = undefined
+        // The last consumer may have left while the recorder was being set up, in which case the guard above kept
+        // the stream alive for a recording that never started.
+        deactivateStreamIfUnused(streamName)
+      }
     }
 
-    const safeMissionName = sanitizeFilenameComponent(missionStore.missionName) || 'Cockpit'
-    const fileName = videoFilename(recordingHash, streamData.timeRecordingStart!, safeMissionName)
-    activeStreams.value[streamName]!.mediaRecorder = new MediaRecorder(streamData.mediaStream!)
     const recorder = activeStreams.value[streamName]!.mediaRecorder!
     const recorderIsStillAttached = (): boolean => activeStreams.value[streamName]?.mediaRecorder === recorder
 
@@ -930,9 +1016,8 @@ export const useVideoStore = defineStore('video', () => {
       activeStreams.value[streamName]!.mediaRecorder = undefined
     }
 
-    const videoTrack = streamData.mediaStream!.getVideoTracks()[0]
-    const vWidth = videoTrack.getSettings().width || 1920
-    const vHeight = videoTrack.getSettings().height || 1080
+    const vWidth = videoTrack?.getSettings().width || 1920
+    const vHeight = videoTrack?.getSettings().height || 1080
 
     // Register the video as unprocessed so we can recover latter if needed
     const videoInfo: UnprocessedVideoInfo = {
@@ -954,9 +1039,6 @@ export const useVideoStore = defineStore('video', () => {
     // We also need to clear the interval if it already exists, to avoid multiple intervals running at the same time.
     clearInterval(recordingMonitors[streamName])
     delete recordingMonitors[streamName]
-    // The internal name, since the external id of an RTSP stream is its URL, credentials included, and these warnings
-    // are both shown to the user and written to the logs they share with us.
-    const streamLabel = internalStreamNameFromExternal(streamName) ?? streamName
     if (window.electronAPI) {
       console.info(`Starting electron recording monitor for stream '${streamName}'.`)
       recordingMonitors[streamName] = setInterval(async () => {
@@ -1207,6 +1289,17 @@ export const useVideoStore = defineStore('video', () => {
     broadcastRecordingStart(streamName)
 
     alertStore.pushAlert(new Alert(AlertLevel.Success, `Started recording stream ${streamName}.`))
+
+    if (mimeType) {
+      const savedFormat = mimeType.includes('hvc1') ? 'H.265' : 'H.264'
+      openSnackbar({
+        message:
+          `Recording of stream '${streamLabel}' is being re-encoded to ${savedFormat} as it runs, which costs` +
+          ' extra processing and some image quality. Set the camera to H.264 to record without re-encoding.',
+        variant: 'info',
+        duration: 8000,
+      })
+    }
   }
 
   // Used to discard a file from the video recovery database

--- a/src/tests/libs/video-recording-codec.test.ts
+++ b/src/tests/libs/video-recording-codec.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  codecNameFromStats,
+  negotiatedVideoCodecNames,
+  recordingMimeType,
+  recordingVideoBitsPerSecond,
+  videoTrackSettingsWithSize,
+} from '@/libs/video-recording-codec'
+
+const statsReport = (reports: Record<string, unknown>[]): RTCStatsReport =>
+  new Map(reports.map((report) => [report.id as string, report])) as unknown as RTCStatsReport
+
+const peerConnectionReceiving = (tracks: [string, string[]][]): RTCPeerConnection =>
+  ({
+    getReceivers: () =>
+      tracks.map(([kind, codecs]) => ({
+        track: { kind },
+        getParameters: () => ({ codecs: codecs.map((mimeType) => ({ mimeType })) }),
+      })),
+  } as unknown as RTCPeerConnection)
+
+const supportsEverything = (): boolean => true
+const supportsNothing = (): boolean => false
+const supportsOnlyH264 = (type: string): boolean => type.includes('avc1')
+
+describe('recordingMimeType', () => {
+  it('records non-HEVC streams by copying their frames, without naming a type', () => {
+    expect(recordingMimeType('H264', supportsEverything)).toBeUndefined()
+    expect(recordingMimeType('VP8', supportsEverything)).toBeUndefined()
+    expect(recordingMimeType(undefined, supportsEverything)).toBeUndefined()
+  })
+
+  it('names an explicit type for HEVC streams, whatever case the codec is reported in', () => {
+    expect(recordingMimeType('H265', supportsEverything)).toBe('video/x-matroska;codecs=hvc1.1.6.L186.B0')
+    expect(recordingMimeType('h265', supportsEverything)).toBe('video/x-matroska;codecs=hvc1.1.6.L186.B0')
+    expect(recordingMimeType('hevc', supportsEverything)).toBe('video/x-matroska;codecs=hvc1.1.6.L186.B0')
+  })
+
+  it('falls back to H.264 when HEVC cannot be encoded', () => {
+    expect(recordingMimeType('H265', supportsOnlyH264)).toBe('video/x-matroska;codecs=avc1')
+  })
+
+  it('still names a type when nothing is supported, so the failure surfaces as a catchable error', () => {
+    expect(recordingMimeType('H265', supportsNothing)).toBe('video/x-matroska;codecs=hvc1.1.6.L186.B0')
+  })
+})
+
+describe('codecNameFromStats', () => {
+  it('reads the codec of the video stream, ignoring the audio one', () => {
+    const stats = statsReport([
+      { id: 'C1', type: 'codec', mimeType: 'audio/opus' },
+      { id: 'C2', type: 'codec', mimeType: 'video/H265' },
+      { id: 'R1', type: 'inbound-rtp', kind: 'audio', codecId: 'C1' },
+      { id: 'R2', type: 'inbound-rtp', kind: 'video', codecId: 'C2' },
+    ])
+    expect(codecNameFromStats(stats)).toBe('H265')
+  })
+
+  it('tells nothing while no packet has been processed, so callers can fall back', () => {
+    const noCodecYet = statsReport([{ id: 'R1', type: 'inbound-rtp', kind: 'video' }])
+    expect(codecNameFromStats(noCodecYet)).toBeUndefined()
+    expect(codecNameFromStats(statsReport([]))).toBeUndefined()
+  })
+})
+
+describe('negotiatedVideoCodecNames', () => {
+  it('lists the video codecs of the connection, in the negotiated order', () => {
+    const peerConnection = peerConnectionReceiving([
+      ['audio', ['audio/opus']],
+      ['video', ['video/H265', 'video/H264']],
+    ])
+    expect(negotiatedVideoCodecNames(peerConnection)).toEqual(['H265', 'H264'])
+  })
+
+  it('lists nothing when the connection receives no video', () => {
+    expect(negotiatedVideoCodecNames(peerConnectionReceiving([]))).toEqual([])
+  })
+})
+
+describe('recordingVideoBitsPerSecond', () => {
+  it('scales with the picture, so a 4K camera is not recorded at a 720p rate', () => {
+    const hd = recordingVideoBitsPerSecond({ width: 1280, height: 720, frameRate: 30 })
+    expect(recordingVideoBitsPerSecond({ width: 3840, height: 2160, frameRate: 30 })).toBe(hd * 9)
+  })
+
+  it('assumes 1080p30 when the track reports no settings', () => {
+    const fullHd = recordingVideoBitsPerSecond({ width: 1920, height: 1080, frameRate: 30 })
+    expect(recordingVideoBitsPerSecond({})).toBe(fullHd)
+  })
+})
+
+describe('videoTrackSettingsWithSize', () => {
+  const trackReportingSizeAfter = (calls: number): MediaStreamTrack => {
+    let remaining = calls
+    return {
+      getSettings: () => (remaining-- > 0 ? {} : { width: 3840, height: 2160, frameRate: 30 }),
+    } as unknown as MediaStreamTrack
+  }
+
+  it('waits for the size of a track that has not decoded a frame yet', async () => {
+    expect(await videoTrackSettingsWithSize(trackReportingSizeAfter(3))).toEqual({
+      width: 3840,
+      height: 2160,
+      frameRate: 30,
+    })
+  })
+
+  it('gives up on the timeout, so a stream that never delivers frames cannot hold the recording', async () => {
+    expect(await videoTrackSettingsWithSize(trackReportingSizeAfter(Infinity), 100)).toEqual({})
+  })
+})


### PR DESCRIPTION
Chromium is opted into HEVC through `PlatformHEVCDecoderSupport`, `WebRtcAllowH265Receive` and `WebRtcAllowH265Send`, so H.265 cameras bridged through go2rtc can be decoded by the renderer.

Recording one of those streams used to take the renderer down with it, which is the crash reported at the end of #2672. Chromium's `MediaRecorder` passthrough path crashes on HEVC, so recordings of H.265 streams now ask for an explicit mime type, which re-encodes them (to H.265 where the machine can encode it, to H.264 where it cannot) and says so in a snackbar. Passthrough was re-tested on Chromium 150 with the encoder flags enabled and still crashes, so the re-encode is not avoidable yet.

The desktop remux also tags HEVC recordings as `hvc1` instead of ffmpeg's default `hev1`, without which QuickTime and Photos refuse to open the files.

Evidence:

<img width="699" height="587" alt="image" src="https://github.com/user-attachments/assets/28b85eec-fb16-4492-8cb9-56690a1bd51c" />

<img width="1280" height="660" alt="image" src="https://github.com/user-attachments/assets/4d29fee8-a923-4e48-bb51-9d1ca1a61f7b" />

<img width="1280" height="659" alt="image" src="https://github.com/user-attachments/assets/c40899e1-ea10-4fef-b816-e89d03cf55f9" />

Excerpt of the negotiation with an H.265 camera, decoded by the renderer after the flags are on:

```
[WebRTC] [Session] Remote description set to {
    "type": "offer",
    "sdp": "v=0 ... m=video 9 UDP/TLS/RTP/SAVPF 96 97 ... a=rtpmap:96 H265/90000 ... a=rtpmap:97 rtx/90000 ..."
}
```

