### PR TITLE
Report video failures that are currently silent

### DIFF
--- a/src/composables/webRTC.ts
+++ b/src/composables/webRTC.ts
@@ -42,6 +42,7 @@ export class WebRTCManager {
   private consumerId: string | undefined
   private streamName: string | undefined
   public session: Session | undefined
+  public onUnreceivableVideo?: (codecs: string[]) => void
   private rtcConfiguration: RTCConfiguration
   private selectedICEIPs: string[] = []
   private selectedICEProtocols: string[] = []
@@ -372,6 +373,8 @@ export class WebRTCManager {
       (_sessionId, reason) => this.onSessionClosed(reason),
       (status: string): void => this.updateStreamStatus(status)
     )
+
+    this.session.onUnreceivableVideo = (codecs: string[]): void => this.onUnreceivableVideo?.(codecs)
 
     // Registers Session callback for the Signaller endSession parser
     this.signaller.parseEndSessionQuestion(this.consumerId!, producerId, this.session.id, (sessionId, reason) => {

--- a/src/libs/webrtc/session.ts
+++ b/src/libs/webrtc/session.ts
@@ -1,12 +1,14 @@
 /* eslint-disable jsdoc/no-undefined-types */ // TODO: fix type RTCConfiguration, RTCSessionDescriptionInit, RTCIceCandidateInit and RTCPeerConnectionIceEventInit are undefined
 import type { Signaller } from '@/libs/webrtc/signaller'
 import type { Stream } from '@/libs/webrtc/signalling_protocol'
+import { unreceivableVideoCodecs } from '@/libs/webrtc/video-codec-support'
 
 type OnCloseCallback = (sessionId: string, reason: string) => void
 type OnTrackAddedCallback = (event: RTCTrackEvent) => void
 type onNewIceRemoteAddressCallback = (availableICEIPs: string[]) => void
 type OnStatusChangeCallback = (status: string) => void
 type OnPeerConnectedCallback = () => void
+type OnUnreceivableVideoCallback = (codecs: string[]) => void
 
 /**
  * An abstraction for the Mavlink Camera Manager WebRTC Session
@@ -28,6 +30,7 @@ export class Session {
   public onNewIceRemoteAddress?: onNewIceRemoteAddressCallback
   public onClose?: OnCloseCallback
   public onStatusChange?: OnStatusChangeCallback
+  public onUnreceivableVideo?: OnUnreceivableVideoCallback
 
   /**
    * Creates a new Session instance, connecting with a given Stream
@@ -175,6 +178,16 @@ export class Session {
    * @param {RTCSessionDescription} description - The SDP received from the signalling server
    */
   public onIncomingSDP(description: RTCSessionDescription): void {
+    // Checked on the offer rather than on the failure it causes, as a browser that cannot receive the offered
+    // codec answers without video and simply never plays anything, with no error to report.
+    const unreceivableCodecs = unreceivableVideoCodecs(description.sdp)
+    if (unreceivableCodecs.length > 0) {
+      console.warn(
+        `[WebRTC] [Session] None of the offered video codecs can be received: ${unreceivableCodecs.join(', ')}`
+      )
+      this.onUnreceivableVideo?.(unreceivableCodecs)
+    }
+
     this.peerConnection
       .setRemoteDescription(description)
       .then(() => {

--- a/src/libs/webrtc/video-codec-support.ts
+++ b/src/libs/webrtc/video-codec-support.ts
@@ -1,0 +1,46 @@
+// An offer also names the payloads that carry retransmissions and error correction, which every browser
+// accepts and which would otherwise read as a codec it can play.
+const auxiliaryPayloads = ['rtx', 'red', 'ulpfec', 'flexfec-03']
+
+/**
+ * Video codecs an SDP offers, as named in the rtpmap lines of its video sections.
+ * @param {string} sdp - Session description to read
+ * @returns {string[]} Codec names as the SDP spells them, without the auxiliary payloads
+ */
+export const offeredVideoCodecs = (sdp: string): string[] => {
+  const videoSections = sdp.split(/^m=/m).filter((section) => section.startsWith('video'))
+
+  const names = videoSections.flatMap((section) =>
+    [...section.matchAll(/^a=rtpmap:\d+ ([^/\s]+)/gm)].map((match) => match[1])
+  )
+  return [...new Set(names)].filter((name) => !auxiliaryPayloads.includes(name.toLowerCase()))
+}
+
+/**
+ * Offered video codecs that this browser cannot receive, and only when it can receive none of them, since a
+ * single supported codec is enough for the negotiation to settle on it and the video to play.
+ * @param {string} sdp - Session description offered by the camera
+ * @param {RTCRtpCodecCapability[]} receivableCodecs - Codecs the browser receives, queried when not given
+ * @returns {string[]} Offered codec names, or nothing when one of them can be received
+ */
+export const unreceivableVideoCodecs = (
+  sdp: string,
+  receivableCodecs = RTCRtpReceiver.getCapabilities?.('video')?.codecs ?? []
+): string[] => {
+  const offered = offeredVideoCodecs(sdp)
+  if (offered.length === 0) return []
+
+  // An engine that names no codec has told us nothing about what it plays, which is not the same as telling us
+  // that it plays nothing.
+  if (receivableCodecs.length === 0) return []
+
+  const receivable = receivableCodecs.map((codec) => codec.mimeType.replace(/^video\//i, '').toLowerCase())
+  return offered.some((codec) => receivable.includes(codec.toLowerCase())) ? [] : offered
+}
+
+/**
+ * Codec name spelled as camera settings and datasheets do, so users can match it to what they configure.
+ * @param {string} codec - Codec name as an SDP spells it, such as 'H265'
+ * @returns {string} Name for the user, such as 'H.265'
+ */
+export const readableVideoCodecName = (codec: string): string => codec.replace(/^h(26[45])$/i, 'H.$1')

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -24,6 +24,7 @@ import { datalogger } from '@/libs/sensors-logging'
 import { isElectron, isEqual, sanitizeFilenameComponent, sleep } from '@/libs/utils'
 import { tempVideoStorage, videoStorage } from '@/libs/videoStorage'
 import type { Stream } from '@/libs/webrtc/signalling_protocol'
+import { readableVideoCodecName } from '@/libs/webrtc/video-codec-support'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useMissionStore } from '@/stores/mission'
 import { Alert, AlertLevel } from '@/types/alert'
@@ -403,6 +404,8 @@ export const useVideoStore = defineStore('video', () => {
 
   const rtspActivating = new Set<string>()
   let rtspUnsupportedWarned = false
+  const unreceivableVideoWarned = new Set<string>()
+  let unreceivableVideoDialogOpened = false
 
   /**
    * Activates a stream by starting it and storing it's variables inside a common object.
@@ -469,6 +472,25 @@ export const useVideoStore = defineStore('video', () => {
 
     const stream = ref()
     const webRtcManager = new WebRTCManager(webRTCSignallingURI, rtcConfiguration)
+
+    webRtcManager.onUnreceivableVideo = (codecs: string[]): void => {
+      // The camera keeps offering the same codec on every reconnection, so warn once per stream.
+      if (unreceivableVideoWarned.has(streamName)) return
+      unreceivableVideoWarned.add(streamName)
+
+      const codecNames = codecs.map(readableVideoCodecName).join(' or ')
+      const message =
+        `Stream '${streamName}' sends video as ${codecNames}, which Cockpit cannot play.` +
+        ' Set the camera to H.264 to watch it.'
+      alertStore.pushAlert(new Alert(AlertLevel.Error, message))
+
+      // A second camera would replace the dialog of the first, leaving only one of the two ever read, so only
+      // the first one opens it. The alerts above keep an entry per stream either way.
+      if (unreceivableVideoDialogOpened) return
+      unreceivableVideoDialogOpened = true
+      showDialog({ message, variant: 'error' })
+    }
+
     const { mediaStream, connected } = webRtcManager.startStream(
       stream,
       allowedIceIps,

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -701,13 +701,20 @@ export const useVideoStore = defineStore('video', () => {
 
     if (activeStreams.value[streamName] === undefined) activateStream(streamName)
 
+    // A failed recorder detaches itself, so a chunk arriving after that reaches here with nothing left to stop, and
+    // reporting a successful stop would contradict the failure the user was just told about.
+    if (activeStreams.value[streamName]!.mediaRecorder === undefined) {
+      console.debug(`No recorder attached to stream '${streamName}'. Nothing to stop.`)
+      return
+    }
+
     const timeRecordingStart = activeStreams.value[streamName]?.timeRecordingStart
     const durationInSeconds = timeRecordingStart ? differenceInSeconds(new Date(), timeRecordingStart) : undefined
     eventTracker.capture('Video recording stop', { streamName, durationInSeconds })
 
     activeStreams.value[streamName]!.timeRecordingStart = undefined
 
-    activeStreams.value[streamName]!.mediaRecorder!.stop()
+    activeStreams.value[streamName]!.mediaRecorder?.stop()
 
     alertStore.pushAlert(new Alert(AlertLevel.Success, `Stopped recording stream ${streamName}.`))
   }
@@ -759,6 +766,28 @@ export const useVideoStore = defineStore('video', () => {
     const safeMissionName = sanitizeFilenameComponent(missionStore.missionName) || 'Cockpit'
     const fileName = videoFilename(recordingHash, streamData.timeRecordingStart!, safeMissionName)
     activeStreams.value[streamName]!.mediaRecorder = new MediaRecorder(streamData.mediaStream!)
+    const recorder = activeStreams.value[streamName]!.mediaRecorder!
+    const recorderIsStillAttached = (): boolean => activeStreams.value[streamName]?.mediaRecorder === recorder
+
+    // Registered before starting, as a recorder can fail on the very first frame it is handed
+    activeStreams.value[streamName]!.mediaRecorder!.onerror = (event) => {
+      const error: DOMException | undefined = (event as ErrorEvent).error
+      console.error(`Recorder of stream '${streamName}' failed: ${error?.message ?? 'unknown error'}`)
+      const msg =
+        `Recording of stream '${streamName}' stopped unexpectedly. The video recorded until then was kept and is` +
+        ' available in the Video Library.'
+      showDialog({ message: msg, variant: 'error' })
+      alertStore.pushAlert(new Alert(AlertLevel.Error, msg))
+
+      // The recorder stops itself on error, so the monitor would otherwise nag about a file that stopped growing
+      clearInterval(recordingMonitors[streamName])
+      delete recordingMonitors[streamName]
+
+      // Vue does not proxy a MediaRecorder, so its state flipping to 'inactive' dirties nothing: detaching it here is
+      // what drops the interface out of the recording state, instead of it waiting on the finalization in 'onstop'.
+      activeStreams.value[streamName]!.timeRecordingStart = undefined
+      activeStreams.value[streamName]!.mediaRecorder = undefined
+    }
 
     const videoTrack = streamData.mediaStream!.getVideoTracks()[0]
     const vWidth = videoTrack.getSettings().width || 1920
@@ -965,7 +994,7 @@ export const useVideoStore = defineStore('video', () => {
               const msg = `Failed to initialize live processor for stream ${streamName}: ${error.message}`
               showDialog({ message: msg, variant: 'error' })
               alertStore.pushAlert(new Alert(AlertLevel.Error, msg))
-              stopRecording(streamName)
+              if (recorderIsStillAttached()) stopRecording(streamName)
             } else throw error
           }
         }
@@ -974,7 +1003,7 @@ export const useVideoStore = defineStore('video', () => {
           const msg = 'Failed to initiate recording. First chunk was lost. Try again.'
           showDialog({ message: msg, variant: 'error' })
           alertStore.pushAlert(new Alert(AlertLevel.Error, msg))
-          stopRecording(streamName)
+          if (recorderIsStillAttached()) stopRecording(streamName)
         }
 
         sequentialLostChunks++
@@ -999,7 +1028,7 @@ export const useVideoStore = defineStore('video', () => {
         const errorMessage = `Failed to generate telemetry overlay: recording metadata for '${recordingHash}' not found.`
         openSnackbar({ message: errorMessage, variant: 'error' })
         delete liveProcessors.value[recordingHash]
-        if (activeStreams.value[streamName]) {
+        if (recorderIsStillAttached()) {
           activeStreams.value[streamName]!.mediaRecorder = undefined
         }
         return
@@ -1036,7 +1065,11 @@ export const useVideoStore = defineStore('video', () => {
       }
 
       if (activeStreams.value[streamName]) {
-        activeStreams.value[streamName]!.mediaRecorder = undefined
+        // The error handler detaches a failed recorder right away, so by now the slot can already hold a newer
+        // recorder that is still running. Only the recorder that stopped may clear it.
+        if (recorderIsStillAttached()) {
+          activeStreams.value[streamName]!.mediaRecorder = undefined
+        }
         // The recording guard may have kept this stream alive after its last consumer left (e.g. the recorder
         // widget was unmounted mid-recording); now that recording is done, release it if nothing needs it.
         deactivateStreamIfUnused(streamName)

--- a/src/tests/libs/webrtc/video-codec-support.test.ts
+++ b/src/tests/libs/webrtc/video-codec-support.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+
+import { offeredVideoCodecs, readableVideoCodecName, unreceivableVideoCodecs } from '@/libs/webrtc/video-codec-support'
+
+const capabilities = (mimeTypes: string[]): RTCRtpCodecCapability[] =>
+  mimeTypes.map((mimeType) => ({ mimeType, clockRate: 90000 }))
+
+// Trimmed from what mavlink-camera-manager offers for an H.265 camera, which names H.265 as its only video
+// payload, alongside the retransmission payload that pairs with it.
+const hevcOnlyOffer = [
+  'v=0',
+  'o=- 0 0 IN IP4 127.0.0.1',
+  's=-',
+  't=0 0',
+  'm=video 9 UDP/TLS/RTP/SAVPF 96 97',
+  'a=rtpmap:96 H265/90000',
+  'a=rtpmap:97 rtx/90000',
+  'a=fmtp:97 apt=96',
+  'a=sendonly',
+  'm=audio 9 UDP/TLS/RTP/SAVPF 111',
+  'a=rtpmap:111 opus/48000/2',
+].join('\r\n')
+
+const hevcAndH264Offer = hevcOnlyOffer.replace(
+  'a=rtpmap:96 H265/90000',
+  'a=rtpmap:96 H265/90000\r\na=rtpmap:98 H264/90000'
+)
+
+const twoVideoSectionsOffer = [hevcOnlyOffer, 'm=video 9 UDP/TLS/RTP/SAVPF 98', 'a=rtpmap:98 H264/90000'].join('\r\n')
+
+// Verbatim offer of an H.265 camera published by mavlink-camera-manager, which bundles a single video
+// section and pairs the codec with a retransmission payload.
+const cameraHevcOffer =
+  'v=0\r\no=- 8756736665354191860 0 IN IP4 0.0.0.0\r\ns=-\r\nt=0 0\r\na=ice-options:trickle\r\n' +
+  'a=group:BUNDLE video0\r\nm=video 9 UDP/TLS/RTP/SAVPF 96 97\r\nc=IN IP4 0.0.0.0\r\na=setup:actpass\r\n' +
+  'a=rtcp-mux\r\na=rtcp-rsize\r\na=sendonly\r\na=rtpmap:96 H265/90000\r\na=rtcp-fb:96 nack\r\n' +
+  'a=rtcp-fb:96 nack pli\r\na=rtcp-fb:96 ccm fir\r\na=rtcp-fb:96 transport-cc\r\na=rtpmap:97 rtx/90000\r\n' +
+  'a=fmtp:97 apt=96\r\na=mid:video0\r\n'
+
+describe('offeredVideoCodecs', () => {
+  it('reads the video codecs an offer names', () => {
+    expect(offeredVideoCodecs(hevcOnlyOffer)).toEqual(['H265'])
+    expect(offeredVideoCodecs(hevcAndH264Offer)).toEqual(['H265', 'H264'])
+    expect(offeredVideoCodecs(cameraHevcOffer)).toEqual(['H265'])
+  })
+
+  it('reads every video section of an offer, not only the first', () => {
+    expect(offeredVideoCodecs(twoVideoSectionsOffer)).toEqual(['H265', 'H264'])
+  })
+
+  it('leaves out the auxiliary payloads, which are not codecs the video can arrive as', () => {
+    const offer = hevcOnlyOffer.replace('a=sendonly', 'a=rtpmap:98 red/90000\r\na=rtpmap:99 ulpfec/90000')
+    expect(offeredVideoCodecs(offer)).toEqual(['H265'])
+  })
+
+  it('reads nothing from an offer without video', () => {
+    expect(offeredVideoCodecs('v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\na=rtpmap:111 opus/48000/2')).toEqual([])
+    expect(offeredVideoCodecs('')).toEqual([])
+  })
+})
+
+describe('unreceivableVideoCodecs', () => {
+  const withoutHevc = capabilities(['video/VP8', 'video/VP9', 'video/H264', 'video/rtx', 'video/red'])
+  const withHevc = capabilities(['video/VP8', 'video/H264', 'video/H265', 'video/rtx'])
+
+  it('names the codec when the browser can receive none of the offered ones', () => {
+    expect(unreceivableVideoCodecs(hevcOnlyOffer, withoutHevc)).toEqual(['H265'])
+    expect(unreceivableVideoCodecs(cameraHevcOffer, withoutHevc)).toEqual(['H265'])
+    expect(unreceivableVideoCodecs(cameraHevcOffer, withHevc)).toEqual([])
+  })
+
+  it('stays quiet when the browser can receive an offered codec', () => {
+    expect(unreceivableVideoCodecs(hevcOnlyOffer, withHevc)).toEqual([])
+    expect(unreceivableVideoCodecs(hevcAndH264Offer, withoutHevc)).toEqual([])
+    expect(unreceivableVideoCodecs(twoVideoSectionsOffer, withoutHevc)).toEqual([])
+  })
+
+  it('does not take the retransmission payload for a codec it can play', () => {
+    expect(unreceivableVideoCodecs(hevcOnlyOffer, capabilities(['video/rtx']))).toEqual(['H265'])
+  })
+
+  it('stays quiet when there is no video to play, and when the browser reports no codecs at all', () => {
+    expect(unreceivableVideoCodecs('v=0\r\ns=-', withoutHevc)).toEqual([])
+    expect(unreceivableVideoCodecs(hevcOnlyOffer, [])).toEqual([])
+  })
+})
+
+describe('readableVideoCodecName', () => {
+  it('spells the codec as camera settings do', () => {
+    expect(readableVideoCodecName('H265')).toBe('H.265')
+    expect(readableVideoCodecName('h264')).toBe('H.264')
+    expect(readableVideoCodecName('VP8')).toBe('VP8')
+    expect(readableVideoCodecName('AV1')).toBe('AV1')
+  })
+})


### PR DESCRIPTION
Two video failures that Cockpit currently swallows.

A recorder that dies mid-recording left the interface looking like it was still recording, with nothing being written. `MediaRecorder.onerror` is now handled, so the user is told which stream stopped and that the footage recorded until then was kept, the interface drops out of the recording state instead of waiting on the finalization to do it, and the monitor that would otherwise complain about a file that stopped growing is cleared.

A camera whose video format the engine cannot receive gave an empty video pane and no explanation. The codecs offered during the WebRTC negotiation are now compared against what the engine can receive, and when none of them match, the user is told which format the camera sends and what to do about it. H.265 cameras on a browser that cannot receive them are the case that prompted #1725, and the fixtures in the tests are the negotiation of a real H.265 camera.

Independent of both the Electron bump in #2672 and the H.265 support in #2967: these two fixes apply to master as it stands, which is why they are not waiting behind either.

Fix #1725
