### PR TITLE
ci: reject AI-tool authorship in commit-finality

### DIFF
--- a/.github/workflows/commit-finality.yml
+++ b/.github/workflows/commit-finality.yml
@@ -36,8 +36,9 @@ jobs:
         run: |
           set -euo pipefail
           gh pr view "$PR_NUMBER" --repo "$REPO" --json commits \
-            --jq '[.commits[] | {oid: .oid, message: (.messageHeadline + (if (.messageBody // "") == "" then "" else "\n\n" + .messageBody end))}]' \
-            > commits.json
+            --jq '[.commits[] | {oid: .oid, emails: [(.authors // [])[] | .email // ""], names: [(.authors // [])[] | .name // ""], message: (.messageHeadline + (if (.messageBody // "") == "" then "" else "\n\n" + .messageBody end))}]' \
+            > authorship.json
+          jq '[.[] | {oid, message}]' authorship.json > commits.json
           echo "Commits under review:"
           jq -r '.[] | "- \(.oid[0:8]) \(.message | split("\n")[0])"' commits.json
 
@@ -64,6 +65,35 @@ jobs:
             exit 1
           fi
           echo "No GitHub references in commit messages."
+
+      # GitHub copies Co-authored-by trailers into authors, so matching that list
+      # is enough; scanning the message body would fail commits that quote an address.
+      - name: Reject AI authorship
+        run: |
+          set -euo pipefail
+          offenders=$(jq -r '
+            def ai_email: "^(cursoragent@cursor\\.com|noreply@anthropic\\.com|claude-code@anthropic\\.com|noreply@openai\\.com|codex@openai\\.com|copilot@github\\.com|([0-9]+\\+)?(cursoragent|cursor|copilot|claude|claude-code|codex|devin-ai-integration)(\\[bot\\])?@users\\.noreply\\.github\\.com)$";
+            # Claude and Devin are ordinary given names, so the name axis requires
+            # the two-word form; both tools stay covered by their addresses above.
+            def ai_name: "^(cursor( agent)?|github copilot|copilot|claude code|chatgpt( codex)?|codex|devin ai)$";
+            .[]
+            | . as $commit
+            | (
+                ($commit.emails // [] | map(select(test(ai_email; "i"))) | first)
+                // ($commit.names // [] | map(select(test(ai_name; "i"))) | first)
+              ) as $hit
+            | select($hit != null)
+            | "\($commit.oid)\t\($hit)"
+          ' authorship.json)
+          rm -f authorship.json
+          if [ -n "$offenders" ]; then
+            while IFS=$'\t' read -r oid line; do
+              echo "::error::Commit ${oid:0:8} is authored or co-authored by an AI tool: ${line}"
+            done <<< "$offenders"
+            echo "Strip AI Co-authored-by trailers and re-author the commit before merging."
+            exit 1
+          fi
+          echo "No AI-authored or AI-co-authored commits."
 
       - name: Classify commits with Claude
         uses: anthropics/claude-code-base-action@beta

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,6 +197,7 @@ This applies to any pair of components/views with substantial overlap, not just 
 - Branch names follow `issue-<number>-short-words`, using at most 5 words in the descriptive part.
 - Pick the commit-subject prefix that actually fits the change. Every style in this history is fine: a conventional type (`feat`/`fix`/`refactor`/`docs`/etc.), the area touched (`map:`, `widgets:`, `mission-planning:`, `ci:`), or both together (`fix: widgets: …`), the area form being the most common. What matters is that the prefix describes this change — do not prefix every commit with `fix:`.
 - Do not reference GitHub issues or pull requests in commit messages — not `#N`, not `owner/repo#N`, and not closing keywords (`Fixes`/`Closes`/`Resolves` …). Put those in the PR body instead. A reference in a commit re-fires on the issue timeline every time a fork syncs that commit.
+- Do not leave AI-tool authorship on commits (`Co-authored-by: Cursor`, Claude/Copilot/Codex equivalents). Strip the trailer and re-author before pushing; the commit-finality check will fail the PR otherwise.
 
 ## Data-lake first for vehicle data in widgets
 


### PR DESCRIPTION
## Summary
- Fail the commit-finality check when a PR commit is authored or co-authored by Cursor, Claude Code, Copilot, Codex, or Devin, and name the offending commit.
- Matches the author records GitHub derives from the commit — the email the tool commits under, including its `users.noreply.github.com` alias, and the display name — rather than scanning the message, so a commit that merely quotes one of those addresses still passes. The email list started from BlueOS's `block-ai-commits` workflow but has since been extended here, so the two are no longer in parity; this workflow is the source of truth.
- The fetch that feeds the job now writes those author records to a scratch file, deleted before the Claude classifier step runs, so that step gets the same `{oid, message}` input it had before.
- `AGENTS.md` gets the matching rule, aimed at the tool doing the committing rather than at review.

## Test plan
- [ ] After this merges, a PR whose commit has `Co-authored-by: Cursor <cursoragent@cursor.com>` (as in #2968) should fail commit-finality with that commit called out.
- [ ] A PR with no AI author emails or trailers should still pass that step.
