### PR TITLE
Make the Data Logs empty-state text readable

### DIFF
--- a/src/views/ToolsLogsView.vue
+++ b/src/views/ToolsLogsView.vue
@@ -94,7 +94,7 @@
             <div v-if="isLoading" class="flex justify-center items-center py-8">
               <v-progress-circular indeterminate color="white" />
             </div>
-            <div v-else-if="sessions.length === 0" class="text-center py-8 text-gray-400">
+            <div v-else-if="sessions.length === 0" class="text-center py-8 text-white">
               No data sessions found. Select variables to record in the Data Lake table.
             </div>
             <v-data-table


### PR DESCRIPTION
## Summary

<img width="1892" height="1188" alt="image" src="https://github.com/user-attachments/assets/e786fd7f-7420-4fb6-850c-4c39d2859d56" />



- The "No data sessions found..." empty state used `text-gray-400`, which disappears against the glass panel.
- Switch it to `text-white` so it matches the rest of the tools UI.

## Test plan
- [ ] Open Tools → Data Logs with no recorded sessions
- [ ] Confirm the empty-state sentence is white and readable against the panel
- [ ] Confirm the sessions table is unchanged when sessions exist