### PR TITLE
Mission Planning: Add a rectangle survey tool with typed dimensions

### DIFF
--- a/src/components/SideConfigPanel.vue
+++ b/src/components/SideConfigPanel.vue
@@ -27,14 +27,19 @@
     </div>
     <v-btn
       v-else-if="!hideButton"
-      icon
+      :icon="!reopenLabel"
       size="x-small"
       variant="text"
       class="reopen_btn bg-[#00000066] text-white elevation-2"
-      :class="reopenPositionClass"
+      :class="[reopenPositionClass, { labeled_tab: reopenLabel }]"
       @click="openPanel"
     >
-      <v-icon class="text-[18px]">{{ `mdi-arrow-${oppositePosition}` }}</v-icon>
+      <div class="flex flex-col items-center gap-1">
+        <span v-if="reopenLabel" class="[writing-mode:vertical-rl] rotate-180 text-[11px] leading-none">
+          {{ reopenLabel }}
+        </span>
+        <v-icon class="text-[18px]">{{ `mdi-arrow-${oppositePosition}` }}</v-icon>
+      </div>
     </v-btn>
   </transition>
 </template>
@@ -57,6 +62,10 @@ const props = defineProps<{
    * hide button
    */
   hideButton?: boolean
+  /**
+   * Text written along the tab that reopens the panel
+   */
+  reopenLabel?: string
 }>()
 
 const closePanel = (): void => {
@@ -181,5 +190,14 @@ const panelPositionStyle = computed<Record<string, string>>((): Record<string, s
   z-index: 500;
   position: fixed;
   border-radius: 4px;
+}
+/* Two classes so the tab keeps its own size and casing even when the consumer's width class falls through to it. */
+.reopen_btn.labeled_tab {
+  width: auto;
+  height: auto;
+  min-width: unset;
+  padding: 8px 2px;
+  text-transform: none;
+  letter-spacing: normal;
 }
 </style>

--- a/src/components/mission-planning/ContextMenu.vue
+++ b/src/components/mission-planning/ContextMenu.vue
@@ -131,6 +131,7 @@
       <div
         class="flex flex-col rounded-md"
         :style="[interfaceStore.globalGlassMenuStyles, { background: '#333333EE', border: '1px solid #FFFFFF44' }]"
+        @pointerdown="onMapMenuPointerDown"
       >
         <v-list-item v-if="!isCreatingSurvey" class="flex items-center gap-x-2 pb-2" @click="handleAddWaypointAtCursor">
           <v-icon
@@ -144,17 +145,82 @@
           <span class="text-white text-sm ml-4">Add waypoint here</span>
         </v-list-item>
         <v-divider />
-        <v-list-item class="flex items-center gap-x-2 pb-2" @click="handleToggleSurvey">
-          <v-icon
-            variant="text"
-            icon="mdi-transit-connection-variant"
-            rounded="full"
-            size="x-small"
-            color="white"
-            class="text-[16px]"
-          ></v-icon>
-          <span class="text-white text-sm ml-4">{{ surveyCreationButtonText }}</span>
-        </v-list-item>
+        <div
+          ref="surveyEntryEl"
+          class="relative"
+          @mouseenter="surveyShapeMenuOpen = true"
+          @mouseleave="surveyShapeMenuOpen = false"
+          @focusin="surveyShapeMenuOpen = true"
+          @focusout="onSurveyEntryFocusOut"
+        >
+          <v-list-item
+            class="items-center pb-2"
+            :aria-haspopup="offersShapeChoice"
+            :aria-expanded="offersShapeChoice && surveyShapeMenuOpen"
+            @click="handleSurveyEntryClick"
+            @pointerdown="startShapeMenuLongPress"
+            @pointerup="cancelShapeMenuLongPress"
+            @pointerleave="cancelShapeMenuLongPress"
+            @pointercancel="cancelShapeMenuLongPress"
+          >
+            <div class="flex items-center w-full">
+              <v-icon
+                variant="text"
+                icon="mdi-transit-connection-variant"
+                rounded="full"
+                size="x-small"
+                color="white"
+                class="text-[16px]"
+              ></v-icon>
+              <span class="text-white text-sm ml-4">{{ surveyCreationButtonText }}</span>
+              <v-icon
+                v-if="offersShapeChoice"
+                variant="text"
+                icon="mdi-menu-right"
+                size="x-small"
+                color="white"
+                class="text-[18px] -mb-[2px] ml-auto -mr-[4px]"
+              ></v-icon>
+            </div>
+          </v-list-item>
+          <div
+            v-if="offersShapeChoice && surveyShapeMenuOpen"
+            class="absolute top-0 flex"
+            :class="shapeMenuOpensLeft ? 'right-full pr-[5px]' : 'left-full pl-[5px]'"
+          >
+            <div
+              class="flex flex-col rounded-md w-max"
+              :style="[
+                interfaceStore.globalGlassMenuStyles,
+                { background: '#333333EE', border: '1px solid #FFFFFF44' },
+              ]"
+            >
+              <v-list-item class="flex items-center gap-x-2 pb-2" @click="handleSetSurveyShape('free-form')">
+                <v-icon
+                  variant="text"
+                  icon="mdi-vector-polygon"
+                  rounded="full"
+                  size="x-small"
+                  color="white"
+                  class="text-[16px]"
+                ></v-icon>
+                <span class="text-white text-sm ml-4">Free form</span>
+              </v-list-item>
+              <v-divider />
+              <v-list-item class="flex items-center gap-x-2 pb-2" @click="handleSetSurveyShape('rectangle')">
+                <v-icon
+                  variant="text"
+                  icon="mdi-rectangle-outline"
+                  rounded="full"
+                  size="x-small"
+                  color="white"
+                  class="text-[16px]"
+                ></v-icon>
+                <span class="text-white text-sm ml-4">Rectangle</span>
+              </v-list-item>
+            </div>
+          </div>
+        </div>
         <v-divider />
         <v-list-item class="flex items-center gap-x-2 pb-2" @click="handleToggleSimplePath">
           <v-icon
@@ -341,10 +407,11 @@
 </template>
 
 <script setup lang="ts">
-import { computed, defineEmits, defineProps, nextTick, ref, watch } from 'vue'
+import { computed, defineEmits, defineProps, nextTick, onBeforeUnmount, ref, watch } from 'vue'
 
 import ScanDirectionDial from '@/components/mission-planning/ScanDirectionDial.vue'
 import { useBaseStation } from '@/composables/baseStation/useBaseStation'
+import type { SurveyDrawShape } from '@/composables/map/useSurveyRectangleDrawing'
 import {
   baseStationMenuIcon,
   baseStationPlaceMenuLabel,
@@ -386,6 +453,7 @@ const emit = defineEmits<{
   (event: 'close'): void
   (event: 'add-waypoint-at-cursor'): void
   (event: 'toggleSurvey'): void
+  (event: 'setSurveyShape', shape: SurveyDrawShape): void
   (event: 'toggleSimplePath'): void
   (event: 'deleteSelectedSurvey'): void
   (event: 'undoGeneratedWaypoints'): void
@@ -414,6 +482,7 @@ const crosshatchEnabled = computed(
 )
 
 const clampedPosition = ref({ x: 0, y: 0 })
+const menuWidth = ref(0)
 
 watch(
   () => [props.visible, props.position, props.menuType] as const,
@@ -426,6 +495,7 @@ watch(
       if (!el) return
       const margin = 8
       const elW = el.offsetWidth
+      menuWidth.value = elW
       const elH = el.offsetHeight
       const vw = window.innerWidth
       const vh = window.innerHeight
@@ -454,6 +524,82 @@ const surveyCreationButtonText = computed(() => {
   }
   return 'Add survey'
 })
+
+// While a survey is being created the entry closes the tool, so there is no shape left to pick.
+const offersShapeChoice = computed(() => !props.isCreatingSurvey)
+const surveyShapeMenuOpen = ref(false)
+const surveyEntryEl = ref<HTMLElement | null>(null)
+
+// Upper bound for the two fixed entries the submenu holds; measuring it would need it painted on a side first.
+const shapeMenuWidth = 160
+
+// The submenu opens to the right, and only folds inward when the window has no room for it there.
+const shapeMenuOpensLeft = computed(
+  () => clampedPosition.value.x + menuWidth.value + shapeMenuWidth > window.innerWidth
+)
+
+// Touch devices have no hover, so holding the entry down is what reveals the submenu there.
+const shapeMenuLongPressDelayMs = 450
+let shapeMenuLongPressTimeout: ReturnType<typeof setTimeout> | null = null
+let shapeMenuOpenedByLongPress = false
+
+const cancelShapeMenuLongPress = (): void => {
+  if (shapeMenuLongPressTimeout === null) return
+  clearTimeout(shapeMenuLongPressTimeout)
+  shapeMenuLongPressTimeout = null
+}
+
+const startShapeMenuLongPress = (event: PointerEvent): void => {
+  // Cleared for a mouse press too, since a finger that opened the submenu and picked from it never reaches the
+  // click that would have consumed the flag, and the next press must not be swallowed by it.
+  shapeMenuOpenedByLongPress = false
+  // A mouse already reveals the submenu by hovering, and treating a slow click as a hold would swallow it.
+  if (!offersShapeChoice.value || event.pointerType === 'mouse') return
+  cancelShapeMenuLongPress()
+  shapeMenuLongPressTimeout = setTimeout(() => {
+    shapeMenuLongPressTimeout = null
+    shapeMenuOpenedByLongPress = true
+    surveyShapeMenuOpen.value = true
+  }, shapeMenuLongPressDelayMs)
+}
+
+// Hovering out is what closes the submenu for a mouse, and neither of the other two ways in has an equivalent:
+// tabbing past the entry fires no mouseleave, and a finger produces none either.
+const onSurveyEntryFocusOut = (event: FocusEvent): void => {
+  if (surveyEntryEl.value?.contains(event.relatedTarget as Node | null)) return
+  surveyShapeMenuOpen.value = false
+}
+
+const onMapMenuPointerDown = (event: PointerEvent): void => {
+  if (surveyEntryEl.value?.contains(event.target as Node)) return
+  surveyShapeMenuOpen.value = false
+}
+
+watch(visible, (isVisible) => {
+  if (isVisible) return
+  cancelShapeMenuLongPress()
+  surveyShapeMenuOpen.value = false
+})
+
+onBeforeUnmount(cancelShapeMenuLongPress)
+
+const handleSurveyEntryClick = (): void => {
+  // The press that opened the submenu must not also pick a format.
+  if (shapeMenuOpenedByLongPress) {
+    shapeMenuOpenedByLongPress = false
+    return
+  }
+  if (!offersShapeChoice.value) {
+    handleToggleSurvey()
+    return
+  }
+  handleSetSurveyShape('free-form')
+}
+
+const handleSetSurveyShape = (shape: SurveyDrawShape): void => {
+  emit('setSurveyShape', shape)
+  emit('close')
+}
 
 const handleAddWaypointAtCursor = (): void => {
   emit('add-waypoint-at-cursor')

--- a/src/components/mission-planning/MeasureExtentInput.vue
+++ b/src/components/mission-planning/MeasureExtentInput.vue
@@ -1,0 +1,140 @@
+<template>
+  <input
+    ref="inputEl"
+    :aria-label="`${label} in meters`"
+    class="absolute z-[641] w-[110px] h-[30px] -translate-x-1/2 -translate-y-1/2 bg-transparent text-transparent caret-transparent outline-none"
+    :style="{ left: `${left}px`, top: `${top}px` }"
+    type="number"
+    inputmode="numeric"
+    step="1"
+    :min="-maxExtentInMeters"
+    :max="maxExtentInMeters"
+    @input="onInput"
+    @change="onChange"
+    @keydown="onKeyDown"
+  />
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref, watch } from 'vue'
+
+import { maxExtentInMeters } from '@/libs/map/typed-extent'
+
+const props = defineProps<{
+  /**
+   * What the field measures, named as it is read out and logged.
+   */
+  label: string
+  /**
+   * Distance from the left of the map, in pixels.
+   */
+  left: number
+  /**
+   * Distance from the top of the map, in pixels.
+   */
+  top: number
+  /**
+   * Extent that has been typed, in meters, or null while the segment is still following the cursor.
+   */
+  value: number | null
+  /**
+   * Extent the tag is reading back while nothing has been typed, in meters.
+   */
+  liveValue: number
+  /**
+   * Whether the number was typed away, which leaves the field empty on purpose rather than untouched.
+   */
+  cleared: boolean
+  /**
+   * Whether the field takes the keyboard as it appears, so a number can be typed without reaching for it.
+   */
+  autofocus: boolean
+  /**
+   * Bumped whenever the keyboard is asked for again, since a field already focused sees no prop change.
+   */
+  focusTicket: number
+}>()
+
+const emit = defineEmits<{
+  (event: 'update:value', value: number | null): void
+  (event: 'apply'): void
+  (event: 'close'): void
+}>()
+
+const inputEl = ref<HTMLInputElement | null>(null)
+
+onMounted(() => {
+  if (props.value !== null) inputEl.value!.value = String(props.value)
+  if (props.autofocus) inputEl.value?.focus()
+})
+
+watch(
+  () => [props.autofocus, props.focusTicket],
+  () => {
+    if (props.autofocus) inputEl.value?.focus()
+  }
+)
+
+// Written only when it disagrees with the field: a number input reads a half-typed "-" as empty, and binding the
+// value back would wipe the minus sign before the digits after it arrive.
+watch(
+  () => props.value,
+  (value) => {
+    const field = inputEl.value
+    if (!field) return
+
+    const shown = field.value === '' ? null : Number(field.value)
+    if (shown !== value) field.value = value === null ? '' : String(value)
+  }
+)
+
+const onInput = (event: Event): void => {
+  const typed = (event.target as HTMLInputElement).value
+  emit('update:value', typed === '' ? null : Number(typed))
+}
+
+const onChange = (): void => {
+  if (props.value !== null) logUserAction(`Typed ${props.value} m for the ${props.label}`)
+}
+
+// The map's own shortcuts sit on the window, where an Enter would generate the survey waypoints and a Delete
+// would drop a waypoint, so none of them get to see what is being typed in here.
+const onKeyDown = (event: KeyboardEvent): void => {
+  event.stopPropagation()
+  if (event.key === 'Escape') {
+    emit('close')
+    return
+  }
+  if (event.key === 'Enter') {
+    event.preventDefault()
+    emit('apply')
+    return
+  }
+  // An untouched field is a tag still reading the measure back, so a backspace deletes from that number as if it
+  // had been typed in. Once the number is gone the field is empty for good, as any other field would be.
+  if (event.key === 'Backspace' && !props.cleared && inputEl.value?.value === '') {
+    event.preventDefault()
+    const kept = String(Math.round(props.liveValue)).slice(0, -1)
+    inputEl.value.value = kept
+    emit('update:value', kept === '' ? null : Number(kept))
+  }
+}
+</script>
+
+<style scoped>
+/* The measurement tag under the field is what reads the number back, so nothing of the field may paint over it,
+   flowbite's form reset included: it gives every number field a border and a blue ring once focused. */
+input[type='number'],
+input[type='number']:focus {
+  border: none;
+  box-shadow: none;
+}
+input[type='number']::-webkit-inner-spin-button,
+input[type='number']::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+input[type='number']::selection {
+  background: transparent;
+}
+</style>

--- a/src/components/mission-planning/SurveyShapeControls.vue
+++ b/src/components/mission-planning/SurveyShapeControls.vue
@@ -3,23 +3,25 @@
     <div class="flex items-center justify-between mx-5 my-2">
       <p class="overflow-visible text-sm text-slate-200">Survey format</p>
       <div class="flex items-center gap-x-4">
-        <v-tooltip v-for="format in formats" :key="format.value" :text="format.label" location="bottom">
+        <v-tooltip v-for="format in formats" :key="format.value" :text="formatHint(format)" location="bottom">
           <template #activator="{ props: tooltipProps }">
-            <v-btn
-              v-bind="tooltipProps"
-              :icon="format.icon"
-              :aria-pressed="shape === format.value"
-              :class="
-                shape === format.value
-                  ? 'bg-[#3B78A8] hover:bg-[#3B78A8]'
-                  : 'bg-[#FFFFFF22] hover:bg-[#FFFFFF33] active:bg-[#FFFFFF44]'
-              "
-              class="rounded-[6px] text-[16px] elevation-1"
-              theme="dark"
-              size="x-small"
-              variant="text"
-              @click="emit('update:shape', format.value)"
-            />
+            <span v-bind="tooltipProps" class="flex">
+              <v-btn
+                :icon="format.icon"
+                :aria-pressed="shape === format.value"
+                :disabled="locked && shape !== format.value"
+                :class="
+                  shape === format.value
+                    ? 'bg-[#3B78A8] hover:bg-[#3B78A8]'
+                    : 'bg-[#FFFFFF22] hover:bg-[#FFFFFF33] active:bg-[#FFFFFF44]'
+                "
+                class="rounded-[6px] text-[16px] elevation-1"
+                theme="dark"
+                size="x-small"
+                variant="text"
+                @click="emit('update:shape', format.value)"
+              />
+            </span>
           </template>
         </v-tooltip>
       </div>
@@ -57,6 +59,10 @@ const props = defineProps<{
    */
   shape: SurveyDrawShape
   /**
+   * Whether a survey is already being drawn, which holds it to the format it was started in.
+   */
+  locked: boolean
+  /**
    * Extents of the draft rectangle, or null when the draft is not a rectangle.
    */
   dimensions: SurveyRectangleDimensions | null
@@ -81,6 +87,10 @@ const formats: SurveyFormatOption[] = [
   { value: 'free-form', label: 'Free form', icon: 'mdi-vector-polygon' },
   { value: 'rectangle', label: 'Rectangle', icon: 'mdi-rectangle-outline' },
 ]
+
+// A format the draft cannot be switched to says so where the user is already looking for the format's name.
+const formatHint = (format: SurveyFormatOption): string =>
+  props.locked && format.value !== props.shape ? `Clear Path to switch to ${format.label.toLowerCase()}` : format.label
 
 const length = ref<number | null>(null)
 const width = ref<number | null>(null)

--- a/src/components/mission-planning/SurveyShapeControls.vue
+++ b/src/components/mission-planning/SurveyShapeControls.vue
@@ -1,0 +1,103 @@
+<template>
+  <div class="flex flex-col">
+    <div class="flex items-center justify-between mx-5 my-2">
+      <p class="overflow-visible text-sm text-slate-200">Survey format</p>
+      <div class="flex items-center gap-x-4">
+        <v-tooltip v-for="format in formats" :key="format.value" :text="format.label" location="bottom">
+          <template #activator="{ props: tooltipProps }">
+            <v-btn
+              v-bind="tooltipProps"
+              :icon="format.icon"
+              :aria-pressed="shape === format.value"
+              :class="
+                shape === format.value
+                  ? 'bg-[#3B78A8] hover:bg-[#3B78A8]'
+                  : 'bg-[#FFFFFF22] hover:bg-[#FFFFFF33] active:bg-[#FFFFFF44]'
+              "
+              class="rounded-[6px] text-[16px] elevation-1"
+              theme="dark"
+              size="x-small"
+              variant="text"
+              @click="emit('update:shape', format.value)"
+            />
+          </template>
+        </v-tooltip>
+      </div>
+    </div>
+
+    <template v-if="dimensions">
+      <p class="m-1 overflow-visible text-sm text-slate-200">Length (m)</p>
+      <input
+        v-model.number="length"
+        class="px-2 py-1 m-1 mx-5 rounded-sm bg-[#FFFFFF22]"
+        type="number"
+        min="1"
+        @change="commitDimensions"
+      />
+      <p class="m-1 overflow-visible text-sm text-slate-200">Width (m)</p>
+      <input
+        v-model.number="width"
+        class="px-2 py-1 m-1 mx-5 rounded-sm bg-[#FFFFFF22]"
+        type="number"
+        min="1"
+        @change="commitDimensions"
+      />
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { nextTick, ref, watch } from 'vue'
+
+import type { SurveyDrawShape, SurveyRectangleDimensions } from '@/composables/map/useSurveyRectangleDrawing'
+
+const props = defineProps<{
+  /**
+   * Shape the next survey polygon is drawn as.
+   */
+  shape: SurveyDrawShape
+  /**
+   * Extents of the draft rectangle, or null when the draft is not a rectangle.
+   */
+  dimensions: SurveyRectangleDimensions | null
+}>()
+
+const emit = defineEmits<{
+  (event: 'update:shape', shape: SurveyDrawShape): void
+  (event: 'update:dimensions', dimensions: SurveyRectangleDimensions): void
+}>()
+
+/** A selectable survey format and how it is presented. */
+interface SurveyFormatOption {
+  /** Shape this option selects. */
+  value: SurveyDrawShape
+  /** Name shown in the tooltip and read out by assistive technology. */
+  label: string
+  /** Material Design Icon identifier. */
+  icon: string
+}
+
+const formats: SurveyFormatOption[] = [
+  { value: 'free-form', label: 'Free form', icon: 'mdi-vector-polygon' },
+  { value: 'rectangle', label: 'Rectangle', icon: 'mdi-rectangle-outline' },
+]
+
+const length = ref<number | null>(null)
+const width = ref<number | null>(null)
+
+const readDimensions = (): void => {
+  length.value = props.dimensions ? Number(props.dimensions.length.toFixed(1)) : null
+  width.value = props.dimensions ? Number(props.dimensions.width.toFixed(1)) : null
+}
+
+watch(() => props.dimensions, readDimensions, { immediate: true })
+
+const commitDimensions = async (): Promise<void> => {
+  if (length.value == null || width.value == null) return
+  emit('update:dimensions', { length: length.value, width: width.value })
+  // The polygon is the only record of its extents, so an entry it clamped or refused must not be left on screen
+  // as if it had been taken.
+  await nextTick()
+  readDimensions()
+}
+</script>

--- a/src/composables/map/useDragMeasureOverlay.ts
+++ b/src/composables/map/useDragMeasureOverlay.ts
@@ -5,6 +5,7 @@ import { bearingBetween, formatBearing, formatMetersShort } from '@/libs/mission
 import { useMissionStore } from '@/stores/mission'
 import type { WaypointCoordinates } from '@/types/mission'
 
+import { useMeasurePillOverlay } from './useMeasurePillOverlay'
 import type { UseVertexAngleOverlayReturn } from './useVertexAngleOverlay'
 
 /**
@@ -27,36 +28,18 @@ export interface UseDragMeasureOverlayReturn {
  */
 export const useDragMeasureOverlay = (angleOverlay: UseVertexAngleOverlayReturn): UseDragMeasureOverlayReturn => {
   const missionStore = useMissionStore()
-
-  let mapRef: LeafletMap | undefined
-  let overlayEl: HTMLDivElement | null = null
-  let pillEls: HTMLDivElement[] = []
+  const { initMeasurePillOverlay, renderMeasurePills, destroyMeasurePillOverlay } = useMeasurePillOverlay()
 
   const initDragMeasureOverlay = (map: LeafletMap): void => {
-    mapRef = map
-  }
-
-  const ensureOverlay = (map: LeafletMap): void => {
-    if (overlayEl) return
-    overlayEl = document.createElement('div')
-    overlayEl.className = 'measure-overlay'
-    overlayEl.style.pointerEvents = 'none'
-    overlayEl.style.position = 'absolute'
-    overlayEl.style.inset = '0'
-    overlayEl.style.zIndex = '640'
-    map.getContainer().appendChild(overlayEl)
+    initMeasurePillOverlay(map)
   }
 
   const destroyDragMeasureOverlay = (): void => {
-    overlayEl?.remove()
-    overlayEl = null
-    pillEls = []
+    destroyMeasurePillOverlay()
     angleOverlay.clearVertexAngles()
   }
 
   const renderDragMeasurePills = (waypointId: string): void => {
-    if (!mapRef) return
-    const map = mapRef
     const wps = missionStore.currentPlanningWaypoints
     const index = wps.findIndex((w) => w.id === waypointId)
     if (index < 0) {
@@ -72,32 +55,19 @@ export const useDragMeasureOverlay = (angleOverlay: UseVertexAngleOverlayReturn)
       return
     }
 
-    ensureOverlay(map)
-    while (pillEls.length < segments.length) {
-      const pill = document.createElement('div')
-      pill.className = 'live-measure-pill'
-      pill.style.position = 'absolute'
-      pill.style.transform = 'translate(-50%, -50%)'
-      overlayEl!.appendChild(pill)
-      pillEls.push(pill)
-    }
-
-    segments.forEach(([from, to], i) => {
-      const fromLatLng = L.latLng(from[0], from[1])
-      const toLatLng = L.latLng(to[0], to[1])
-      const a = map.latLngToContainerPoint(fromLatLng)
-      const b = map.latLngToContainerPoint(toLatLng)
-      const dist = fromLatLng.distanceTo(toLatLng)
-      const bearing = bearingBetween(from, to)
-      const pill = pillEls[i]
-      pill.textContent = `${formatMetersShort(dist)} · ${formatBearing(bearing)}`
-      pill.style.left = `${(a.x + b.x) / 2}px`
-      pill.style.top = `${(a.y + b.y) / 2}px`
-      pill.style.display = dist < 1 ? 'none' : 'block'
-    })
-    for (let i = segments.length; i < pillEls.length; i++) {
-      pillEls[i].style.display = 'none'
-    }
+    renderMeasurePills(
+      segments.map(([from, to]) => {
+        const fromLatLng = L.latLng(from[0], from[1])
+        const toLatLng = L.latLng(to[0], to[1])
+        const distance = fromLatLng.distanceTo(toLatLng)
+        const bearing = bearingBetween(from, to)
+        return {
+          from: fromLatLng,
+          to: toLatLng,
+          text: distance < 1 ? null : `${formatMetersShort(distance)} · ${formatBearing(bearing)}`,
+        }
+      })
+    )
 
     const triples = affectedAngleTriples(wps, index)
     if (triples.length > 0) {

--- a/src/composables/map/useMeasureExtentInput.ts
+++ b/src/composables/map/useMeasureExtentInput.ts
@@ -1,0 +1,230 @@
+import L, { type Map as LeafletMap } from 'leaflet'
+import { type ComputedRef, type Ref, computed, onBeforeUnmount, ref, shallowRef } from 'vue'
+
+import { clampExtent, minExtentInMeters, pointAtDistanceToward } from '@/libs/map/typed-extent'
+
+/** A segment on the map whose extent can be typed instead of drawn. */
+export interface MeasureExtentTarget {
+  /** What the segment measures, named as it is read out and logged. */
+  label: string
+  /** Where the segment starts. */
+  from: L.LatLng
+  /** Where the segment ends. */
+  to: L.LatLng
+  /** Extent the segment currently has, in meters, which is the number a backspace starts deleting from. */
+  liveValue: number
+  /** Redraws the segment, so what is typed shows on the map without waiting for the cursor to move again. */
+  refresh: () => void
+  /** Takes the typed extent as final, the way a click on the map would, and moves the drawing on. */
+  apply: () => void
+}
+
+/** An extent field laid over the map, ready to be rendered. */
+export interface MeasureExtentBox {
+  /** Identifies which extent the field types. */
+  id: string
+  /** What the field measures, named as it is read out and logged. */
+  label: string
+  /** Distance from the left of the map, in pixels. */
+  left: number
+  /** Distance from the top of the map, in pixels. */
+  top: number
+  /** Extent that has been typed, in meters, or null while the segment still follows the cursor. */
+  value: number | null
+  /** Extent the tag is reading back while nothing has been typed, in meters. */
+  liveValue: number
+  /** Whether the number was typed away, which leaves the field empty on purpose rather than untouched. */
+  cleared: boolean
+  /** Whether the field takes the keyboard as it appears. */
+  autofocus: boolean
+  /** Bumped whenever the keyboard is asked for again, since a field already focused sees no prop change. */
+  focusTicket: number
+}
+
+/** Wiring {@link useMeasureExtentInput} needs from the view that measures on the map. */
+export interface UseMeasureExtentInputOptions {
+  /** Which extent the keyboard shortcut hands the field to, or null when nothing is being measured. */
+  shortcutFocus: () => string | null
+  /** Called once the fields are up, so the segment they were asked for can be redrawn under them. */
+  onOpened: () => void
+}
+
+/** Return type of {@link useMeasureExtentInput}. */
+export interface UseMeasureExtentInputReturn {
+  /** The fields to render over the map. */
+  extentBoxes: ComputedRef<MeasureExtentBox[]>
+  /** Whether typing is currently offered. */
+  extentInputsOpen: Ref<boolean>
+  /** Offers typing, handing the keyboard to the given extent. */
+  openExtentInputs: (focusId: string) => void
+  /** Hands the keyboard back to an extent whose field is already up, after a tap on its tag. */
+  focusExtentInput: (id: string) => void
+  /** Withdraws the offer and forgets what was typed. */
+  closeExtentInputs: () => void
+  /** Forgets what was typed, leaving the fields up for the next segment. */
+  clearExtentValues: () => void
+  /** Points an extent at a segment, or takes it off the map with null. */
+  setExtentTarget: (id: string, target: MeasureExtentTarget | null) => void
+  /** Records what was typed for an extent. */
+  setExtentValue: (id: string, value: number | null) => void
+  /** Takes what was typed for an extent as final. */
+  applyExtent: (id: string) => void
+  /** The extent typed for an id, held to the flyable range, or null when nothing was typed. */
+  lockedExtent: (id: string) => number | null
+  /** Whether an extent was typed away, so its tag reads blank instead of the measure it was showing. */
+  isExtentCleared: (id: string) => boolean
+  /** Applies a typed extent to a point still being chosen with the cursor, keeping only its direction. */
+  projectToLockedExtent: (id: string, from: L.LatLng, towards: L.LatLng) => L.LatLng
+  /** Binds the fields to a Leaflet map. */
+  initExtentInputs: (map: LeafletMap) => void
+}
+
+/**
+ * Offers the extents being measured on the map as typed numbers: one field per live measurement tag, sitting on the
+ * tag itself, whose value takes that extent over while the cursor keeps choosing the direction or the side. The
+ * field is rendered invisible, since the tag under it already reads back the number as it is typed.
+ * @param {UseMeasureExtentInputOptions} options - What the shortcut opens and what to redraw once it has.
+ * @returns {UseMeasureExtentInputReturn} The fields to render and the handlers to drive and read them.
+ */
+export const useMeasureExtentInput = (options: UseMeasureExtentInputOptions): UseMeasureExtentInputReturn => {
+  const { shortcutFocus, onOpened } = options
+
+  let mapRef: LeafletMap | undefined
+
+  const extentInputsOpen = ref(false)
+  const focusedId = ref<string | null>(null)
+  const focusTicket = ref(0)
+  // Shallow so the coordinates and the redraw handlers the consumers hand over are kept as they were given.
+  const targets = shallowRef<Record<string, MeasureExtentTarget>>({})
+  const values = ref<Record<string, number | null>>({})
+
+  const initExtentInputs = (map: LeafletMap): void => {
+    mapRef = map
+  }
+
+  const boxPosition = (map: LeafletMap, target: MeasureExtentTarget): Pick<MeasureExtentBox, 'left' | 'top'> => {
+    const from = map.latLngToContainerPoint(target.from)
+    const to = map.latLngToContainerPoint(target.to)
+
+    return { left: (from.x + to.x) / 2, top: (from.y + to.y) / 2 }
+  }
+
+  // A recorded null is a number that was typed away, while an id nobody recorded was never typed into at all.
+  const isExtentCleared = (id: string): boolean => id in values.value && values.value[id] == null
+
+  const extentBoxes = computed<MeasureExtentBox[]>(() => {
+    const map = mapRef
+    if (!extentInputsOpen.value || !map) return []
+
+    return Object.entries(targets.value).map(([id, target]) => ({
+      id,
+      label: target.label,
+      ...boxPosition(map, target),
+      value: values.value[id] ?? null,
+      liveValue: target.liveValue,
+      cleared: isExtentCleared(id),
+      autofocus: id === focusedId.value,
+      focusTicket: focusTicket.value,
+    }))
+  })
+
+  const openExtentInputs = (focusId: string): void => {
+    extentInputsOpen.value = true
+    focusedId.value = focusId
+    values.value = {}
+  }
+
+  const focusExtentInput = (id: string): void => {
+    focusedId.value = id
+    focusTicket.value += 1
+  }
+
+  const closeExtentInputs = (): void => {
+    extentInputsOpen.value = false
+    focusedId.value = null
+    values.value = {}
+  }
+
+  const clearExtentValues = (): void => {
+    values.value = {}
+  }
+
+  const setExtentTarget = (id: string, target: MeasureExtentTarget | null): void => {
+    const known = id in targets.value
+    // The consumers follow the cursor whether or not typing was ever asked for, so a closed box records nothing.
+    if (!extentInputsOpen.value && !known) return
+
+    if (target) {
+      targets.value = { ...targets.value, [id]: target }
+      return
+    }
+    if (!known) return
+
+    const remaining = { ...targets.value }
+    delete remaining[id]
+    targets.value = remaining
+  }
+
+  const setExtentValue = (id: string, value: number | null): void => {
+    values.value = { ...values.value, [id]: value }
+    targets.value[id]?.refresh()
+  }
+
+  const applyExtent = (id: string): void => {
+    targets.value[id]?.apply()
+  }
+
+  const lockedExtent = (id: string): number | null => {
+    const value = values.value[id]
+    return value != null && Number.isFinite(value) ? clampExtent(value, minExtentInMeters) : null
+  }
+
+  const projectToLockedExtent = (id: string, from: L.LatLng, towards: L.LatLng): L.LatLng => {
+    const locked = lockedExtent(id)
+    if (locked === null) return towards
+
+    const [lat, lng] = pointAtDistanceToward([from.lat, from.lng], [towards.lat, towards.lng], locked)
+    return L.latLng(lat, lng)
+  }
+
+  // Shapes that do not put the box up on their own are typed by asking for it, and the ones that do can bring it
+  // back after it was dismissed.
+  const onKeyDown = (event: KeyboardEvent): void => {
+    if (event.key.toLowerCase() !== 't' || event.ctrlKey || event.metaKey || event.altKey) return
+
+    const target = event.target as HTMLElement | null
+    if (target && (['INPUT', 'TEXTAREA'].includes(target.tagName) || target.isContentEditable)) return
+
+    if (extentInputsOpen.value) {
+      logUserAction('Hid the distance box')
+      closeExtentInputs()
+      return
+    }
+
+    const focusId = shortcutFocus()
+    if (!focusId) return
+
+    logUserAction('Showed the distance box')
+    openExtentInputs(focusId)
+    onOpened()
+  }
+
+  window.addEventListener('keydown', onKeyDown)
+  onBeforeUnmount(() => window.removeEventListener('keydown', onKeyDown))
+
+  return {
+    extentBoxes,
+    extentInputsOpen,
+    openExtentInputs,
+    focusExtentInput,
+    closeExtentInputs,
+    clearExtentValues,
+    setExtentTarget,
+    setExtentValue,
+    applyExtent,
+    lockedExtent,
+    isExtentCleared,
+    projectToLockedExtent,
+    initExtentInputs,
+  }
+}

--- a/src/composables/map/useMeasurePillOverlay.ts
+++ b/src/composables/map/useMeasurePillOverlay.ts
@@ -1,0 +1,90 @@
+import L, { type Map as LeafletMap } from 'leaflet'
+import { onBeforeUnmount } from 'vue'
+
+/** A label placed at the midpoint of a segment on the map. */
+export interface MeasurePill {
+  /** Where the segment starts. */
+  from: L.LatLng
+  /** Where the segment ends. */
+  to: L.LatLng
+  /** What the label reads, or null to leave this pill out. */
+  text: string | null
+}
+
+/** Return type of {@link useMeasurePillOverlay}. */
+export interface UseMeasurePillOverlayReturn {
+  /** Binds the overlay to a Leaflet map. */
+  initMeasurePillOverlay: (map: LeafletMap) => void
+  /** Draws one label per pill, centered on its segment in container pixels. */
+  renderMeasurePills: (pills: MeasurePill[]) => void
+  /** Removes the overlay and every label in it. */
+  destroyMeasurePillOverlay: () => void
+}
+
+/**
+ * Owns the pill overlay every live measurement writes into: the container pinned over the map, the pool of label
+ * elements, and their placement at segment midpoints. Callers only decide which segments to label and what the
+ * labels read.
+ * @returns {UseMeasurePillOverlayReturn} Methods to bind the overlay, render labels, and tear it down.
+ */
+export const useMeasurePillOverlay = (): UseMeasurePillOverlayReturn => {
+  let mapRef: LeafletMap | undefined
+  let overlayEl: HTMLDivElement | null = null
+  let pillEls: HTMLDivElement[] = []
+
+  const initMeasurePillOverlay = (map: LeafletMap): void => {
+    mapRef = map
+  }
+
+  const ensureOverlay = (map: LeafletMap): void => {
+    if (overlayEl) return
+
+    overlayEl = document.createElement('div')
+    overlayEl.className = 'measure-overlay'
+    overlayEl.style.pointerEvents = 'none'
+    overlayEl.style.position = 'absolute'
+    overlayEl.style.inset = '0'
+    overlayEl.style.zIndex = '640'
+    map.getContainer().appendChild(overlayEl)
+  }
+
+  const renderMeasurePills = (pills: MeasurePill[]): void => {
+    if (!mapRef) return
+    const map = mapRef
+    ensureOverlay(map)
+
+    while (pillEls.length < pills.length) {
+      const el = document.createElement('div')
+      el.className = 'live-measure-pill'
+      el.style.position = 'absolute'
+      el.style.transform = 'translate(-50%, -50%)'
+      overlayEl!.appendChild(el)
+      pillEls.push(el)
+    }
+
+    pillEls.forEach((el, index) => {
+      const pill = pills[index]
+      if (!pill?.text) {
+        el.style.display = 'none'
+        return
+      }
+
+      const from = map.latLngToContainerPoint(pill.from)
+      const to = map.latLngToContainerPoint(pill.to)
+      el.textContent = pill.text
+      el.style.left = `${(from.x + to.x) / 2}px`
+      el.style.top = `${(from.y + to.y) / 2}px`
+      el.style.display = 'block'
+    })
+  }
+
+  const destroyMeasurePillOverlay = (): void => {
+    overlayEl?.remove()
+    overlayEl = null
+    pillEls = []
+  }
+
+  onBeforeUnmount(destroyMeasurePillOverlay)
+
+  return { initMeasurePillOverlay, renderMeasurePills, destroyMeasurePillOverlay }
+}

--- a/src/composables/map/useRectangleHandles.ts
+++ b/src/composables/map/useRectangleHandles.ts
@@ -1,0 +1,179 @@
+import L, { type Map as LeafletMap } from 'leaflet'
+import { type Ref, onBeforeUnmount, ref, watch } from 'vue'
+
+import { rectangleRotatedAbout, rectangleTranslatedBy } from '@/libs/map/survey-rectangle'
+import type { WaypointCoordinates } from '@/types/mission'
+
+/** The rectangle the handles stand on. */
+export interface RectangleHandlesTarget {
+  /** Its corners, in ring order. */
+  corners: WaypointCoordinates[]
+  /** Which end of the drawn edge the rectangle turns about, the other end being the corner that turns it. */
+  axisIndex: 0 | 1
+}
+
+/** Wiring {@link useRectangleHandles} needs from the view that owns the rectangle. */
+export interface UseRectangleHandlesOptions {
+  /** The rectangle to put handles on, or null while there is none to offer them for. */
+  target: Ref<RectangleHandlesTarget | null>
+  /** Called once per drag, before the first move, so the rectangle can be snapshotted for undo. */
+  onDragStart: () => void
+  /** Called on every move, with the rectangle's corners as the handle has left them. */
+  apply: (corners: WaypointCoordinates[]) => void
+  /** Called when the handle is released, saying whether the rectangle ended up moving. */
+  onDragEnd: (moved: boolean) => void
+}
+
+/** Return type of {@link useRectangleHandles}. */
+export interface UseRectangleHandlesReturn {
+  /** Whether a handle is being dragged, so work the rectangle at rest owns can stand down until it is released. */
+  isDraggingHandle: Ref<boolean>
+  /** Binds the handles to a Leaflet map. */
+  initRectangleHandles: (map: LeafletMap) => void
+  /** Takes the handles off the map. */
+  destroyRectangleHandles: () => void
+}
+
+// Above the vertex markers, since the two corners of the drawn edge carry a handle each and it is the handle,
+// rather than the vertex under it, that a press there is meant for.
+const handleZIndexOffset = 1000
+
+// The handles are grabbed rather than aimed at, and the dot they draw is far smaller than a fingertip, so the
+// area that takes the press is made a good deal wider than the mark it carries.
+const handleSize = 36
+const handleCenter = handleSize / 2
+
+const handleIcon = (color: string, title: string): L.DivIcon =>
+  L.divIcon({
+    html: `
+      <div class="survey-vertex-icon" title="${title}">
+        <svg width="${handleSize}" height="${handleSize}" viewBox="0 0 ${handleSize} ${handleSize}"
+             fill="none" xmlns="http://www.w3.org/2000/svg">
+          <circle cx="${handleCenter}" cy="${handleCenter}" r="5" fill="${color}" stroke="white" stroke-width="2"/>
+        </svg>
+      </div>
+    `,
+    className: 'custom-div-icon',
+    iconSize: [handleSize, handleSize],
+    iconAnchor: [handleCenter, handleCenter],
+  })
+
+/**
+ * Puts the two corners of a rectangle's drawn edge to work: the one the edge was started from carries the whole
+ * rectangle when dragged, and the one across it turns the rectangle about that first corner. Together they place
+ * and aim an area whose extents have already been settled by drawing or typing them.
+ * @param {UseRectangleHandlesOptions} options - The rectangle to handle and the callbacks to report moves through.
+ * @returns {UseRectangleHandlesReturn} The drag state plus the methods to bind and unbind the map.
+ */
+export const useRectangleHandles = (options: UseRectangleHandlesOptions): UseRectangleHandlesReturn => {
+  const { target, onDragStart, apply, onDragEnd } = options
+
+  const isDraggingHandle = ref(false)
+
+  let mapRef: LeafletMap | undefined
+  let axisHandle: L.Marker | null = null
+  let turnHandle: L.Marker | null = null
+  // The rectangle as it was when the handle was taken hold of, so every move of the same drag is measured from
+  // there rather than compounding the last one.
+  let held: RectangleHandlesTarget | null = null
+
+  const asCoordinates = (latLng: L.LatLng): WaypointCoordinates => [latLng.lat, latLng.lng]
+
+  const axisCorner = (rectangle: RectangleHandlesTarget): WaypointCoordinates => rectangle.corners[rectangle.axisIndex]
+
+  const turnCorner = (rectangle: RectangleHandlesTarget): WaypointCoordinates =>
+    rectangle.corners[1 - rectangle.axisIndex]
+
+  const startDrag = (action: string): void => {
+    const rectangle = target.value
+    if (!rectangle) return
+
+    held = { corners: [...rectangle.corners], axisIndex: rectangle.axisIndex }
+    isDraggingHandle.value = true
+    logUserAction(action)
+    onDragStart()
+  }
+
+  const endDrag = (): void => {
+    const moved = held !== null
+    held = null
+    isDraggingHandle.value = false
+    place()
+    onDragEnd(moved)
+  }
+
+  const onAxisDrag = (): void => {
+    if (!held || !axisHandle) return
+    apply(rectangleTranslatedBy(held.corners, axisCorner(held), asCoordinates(axisHandle.getLatLng())))
+  }
+
+  const onTurnDrag = (): void => {
+    if (!held || !turnHandle) return
+
+    const turnedTo = asCoordinates(turnHandle.getLatLng())
+    apply(rectangleRotatedAbout(held.corners, axisCorner(held), turnCorner(held), turnedTo))
+  }
+
+  const ensureHandles = (map: LeafletMap): void => {
+    if (axisHandle && turnHandle) return
+
+    axisHandle = L.marker([0, 0], {
+      icon: handleIcon('#3B82F6', 'Drag to move the survey rectangle'),
+      draggable: true,
+      zIndexOffset: handleZIndexOffset,
+    })
+      .on('dragstart', () => startDrag('Moved the survey rectangle by its corner'))
+      .on('drag', onAxisDrag)
+      .on('dragend', endDrag)
+      .addTo(map)
+
+    turnHandle = L.marker([0, 0], {
+      icon: handleIcon('#F97316', 'Drag to turn the survey rectangle'),
+      draggable: true,
+      zIndexOffset: handleZIndexOffset,
+    })
+      .on('dragstart', () => startDrag('Turned the survey rectangle about its corner'))
+      .on('drag', onTurnDrag)
+      .on('dragend', endDrag)
+      .addTo(map)
+  }
+
+  // A handle taken off the map cannot be holding the rectangle any more, which is what a drag interrupted by the
+  // draft being cleared would otherwise leave it believing.
+  const removeHandles = (): void => {
+    axisHandle?.remove()
+    turnHandle?.remove()
+    axisHandle = null
+    turnHandle = null
+    held = null
+    isDraggingHandle.value = false
+  }
+
+  const place = (): void => {
+    const rectangle = target.value
+    if (!mapRef || !rectangle) {
+      removeHandles()
+      return
+    }
+
+    ensureHandles(mapRef)
+    axisHandle?.setLatLng(axisCorner(rectangle))
+    turnHandle?.setLatLng(turnCorner(rectangle))
+  }
+
+  const initRectangleHandles = (map: LeafletMap): void => {
+    mapRef = map
+    place()
+  }
+
+  const destroyRectangleHandles = (): void => {
+    removeHandles()
+    mapRef = undefined
+  }
+
+  watch(target, place)
+
+  onBeforeUnmount(destroyRectangleHandles)
+
+  return { isDraggingHandle, initRectangleHandles, destroyRectangleHandles }
+}

--- a/src/composables/map/useSurveyEdgeDragging.ts
+++ b/src/composables/map/useSurveyEdgeDragging.ts
@@ -17,14 +17,12 @@ import type { WaypointCoordinates } from '@/types/mission'
 export interface UseSurveyEdgeDraggingOptions {
   /** The draft polygon's vertices, in the order they are drawn. */
   vertices: Ref<L.LatLng[]>
-  /** Reads the draggable markers standing on those vertices, which the moved edge is carried by. */
-  markers: () => L.Marker[]
   /** Whether the polygon can be edited right now. */
   isEditable: () => boolean
   /** Called once per drag, before the first move, so the polygon can be snapshotted for undo. */
   onDragStart: () => void
-  /** Called on every move, once the edge's markers have been carried to their new positions. */
-  onEdgeMoved: () => void
+  /** Called on every move, with the polygon's vertices as the dragged edge has left them. */
+  onEdgeMoved: (vertices: WaypointCoordinates[]) => void
   /** Called when the press is released, saying whether the edge ended up moving. */
   onDragEnd: (moved: boolean) => void
 }
@@ -60,7 +58,7 @@ const dragThresholdInPixels = 4
  * @returns {UseSurveyEdgeDraggingReturn} Drag state plus the methods to bind and unbind the map.
  */
 export const useSurveyEdgeDragging = (options: UseSurveyEdgeDraggingOptions): UseSurveyEdgeDraggingReturn => {
-  const { vertices, markers, isEditable, onDragStart, onEdgeMoved, onDragEnd } = options
+  const { vertices, isEditable, onDragStart, onEdgeMoved, onDragEnd } = options
 
   const isEdgePressed = ref(false)
   const isDraggingEdge = ref(false)
@@ -162,14 +160,14 @@ export const useSurveyEdgeDragging = (options: UseSurveyEdgeDraggingOptions): Us
       logUserAction('Dragged a survey polygon edge')
     }
 
-    const edgeMarkers = markers()
-    if (edgeMarkers.length < 3) return
+    const moved = vertices.value.map(asCoordinates)
+    if (moved.length < 3) return
 
     const pointer = asCoordinates(mapRef.containerPointToLatLng(containerPoint))
     const [start, end] = draggedEdgeEndpoints(pressedEdgeEndpoints, [dragOrigin, pointer], holdEdgeSquare)
-    edgeMarkers[pressedEdge].setLatLng(start)
-    edgeMarkers[(pressedEdge + 1) % edgeMarkers.length].setLatLng(end)
-    onEdgeMoved()
+    moved[pressedEdge] = start
+    moved[(pressedEdge + 1) % moved.length] = end
+    onEdgeMoved(moved)
   }
 
   const onPointerUp = (event: PointerEvent): void => {

--- a/src/composables/map/useSurveyEdgeDragging.ts
+++ b/src/composables/map/useSurveyEdgeDragging.ts
@@ -1,0 +1,212 @@
+import L, { type Map as LeafletMap } from 'leaflet'
+import { type Ref, onBeforeUnmount, ref } from 'vue'
+
+import {
+  closestPolygonEdge,
+  draggedEdgeEndpoints,
+  edgeResizeCursor,
+  isOverSurveyHandle,
+} from '@/libs/map/survey-polygon-edges'
+import { rectangleSpec } from '@/libs/map/survey-rectangle'
+import type { WaypointCoordinates } from '@/types/mission'
+
+/**
+ * Options for {@link useSurveyEdgeDragging}.
+ */
+export interface UseSurveyEdgeDraggingOptions {
+  /** The draft polygon's vertices, in the order they are drawn. */
+  vertices: Ref<L.LatLng[]>
+  /** Reads the draggable markers standing on those vertices, which the moved edge is carried by. */
+  markers: () => L.Marker[]
+  /** Whether the polygon can be edited right now. */
+  isEditable: () => boolean
+  /** Called once per drag, before the first move, so the polygon can be snapshotted for undo. */
+  onDragStart: () => void
+  /** Called on every move, once the edge's markers have been carried to their new positions. */
+  onEdgeMoved: () => void
+  /** Called when the press is released, saying whether the edge ended up moving. */
+  onDragEnd: (moved: boolean) => void
+}
+
+/**
+ * Return type of {@link useSurveyEdgeDragging}.
+ */
+export interface UseSurveyEdgeDraggingReturn {
+  /** Whether a press landed on an edge, so handlers on the polygon itself can stand down. */
+  isEdgePressed: Ref<boolean>
+  /** Whether an edge is being dragged. */
+  isDraggingEdge: Ref<boolean>
+  /** Binds the edge handling to a Leaflet map. */
+  initEdgeDragging: (map: LeafletMap) => void
+  /** Unbinds everything and gives the cursor back. */
+  destroyEdgeDragging: () => void
+}
+
+// The band around an edge that grabs it, wide enough for a fingertip without reaching the vertex handles.
+const grabToleranceInPixels = 10
+// A press has to travel this far before it counts as a drag, so a click near an edge still reaches the map and
+// adds a vertex while the polygon is being drawn.
+const dragThresholdInPixels = 4
+
+/**
+ * Lets the survey polygon be reshaped by its edges: hovering one offers a resize cursor along the axis it moves
+ * on, and pressing and dragging it carries the edge with the pointer. A rectangle's edge is held to its own
+ * normal, since its dimensions are read back from its corners and only survive while they stay square.
+ *
+ * Pointer events drive this rather than Leaflet's mouse events because a touch drag never produces a
+ * `mousemove`, which is what limits the polygon's own drag to a mouse.
+ * @param {UseSurveyEdgeDraggingOptions} options - The polygon to edit and the callbacks to report edits through.
+ * @returns {UseSurveyEdgeDraggingReturn} Drag state plus the methods to bind and unbind the map.
+ */
+export const useSurveyEdgeDragging = (options: UseSurveyEdgeDraggingOptions): UseSurveyEdgeDraggingReturn => {
+  const { vertices, markers, isEditable, onDragStart, onEdgeMoved, onDragEnd } = options
+
+  const isEdgePressed = ref(false)
+  const isDraggingEdge = ref(false)
+
+  let mapRef: LeafletMap | undefined
+  let pressedEdge: number | null = null
+  let pressOrigin: L.Point | null = null
+  let pressedEdgeEndpoints: [WaypointCoordinates, WaypointCoordinates] | null = null
+  let dragOrigin: WaypointCoordinates | null = null
+  let holdEdgeSquare = false
+  let panningWasEnabled = false
+  let cursorBeforeHover: string | null = null
+
+  const asCoordinates = (latLng: L.LatLng): WaypointCoordinates => [latLng.lat, latLng.lng]
+
+  const setCursor = (cursor: string | null): void => {
+    const container = mapRef?.getContainer()
+    if (!container) return
+
+    if (cursor === null) {
+      if (cursorBeforeHover === null) return
+      container.style.cursor = cursorBeforeHover
+      cursorBeforeHover = null
+      return
+    }
+    // Compared against the element rather than a cached value, so the cursor is also reclaimed after the view's
+    // own mousedown handler has swapped in its grabbing cursor.
+    if (container.style.cursor === cursor) return
+    if (cursorBeforeHover === null) cursorBeforeHover = container.style.cursor
+    container.style.cursor = cursor
+  }
+
+  const edgeAt = (event: PointerEvent): number | null => {
+    if (!mapRef || !isEditable()) return null
+    if (isOverSurveyHandle(event.target)) return null
+
+    const points = vertices.value.map((latLng) => mapRef!.latLngToContainerPoint(latLng))
+    return closestPolygonEdge(points, mapRef.mouseEventToContainerPoint(event), grabToleranceInPixels)
+  }
+
+  const cursorForEdge = (edgeIndex: number): string => {
+    const points = vertices.value
+    const start = mapRef!.latLngToContainerPoint(points[edgeIndex])
+    const end = mapRef!.latLngToContainerPoint(points[(edgeIndex + 1) % points.length])
+    return edgeResizeCursor(start, end)
+  }
+
+  const releasePress = (): void => {
+    if (pressedEdge === null) return
+
+    if (panningWasEnabled) mapRef?.dragging.enable()
+    pressedEdge = null
+    pressOrigin = null
+    pressedEdgeEndpoints = null
+    dragOrigin = null
+    isEdgePressed.value = false
+    isDraggingEdge.value = false
+  }
+
+  const onPointerDown = (event: PointerEvent): void => {
+    const isSecondaryPress = !event.isPrimary || pressedEdge !== null
+    if (!mapRef || isSecondaryPress || (event.pointerType === 'mouse' && event.button !== 0)) return
+
+    const edgeIndex = edgeAt(event)
+    if (edgeIndex === null) return
+
+    const points = vertices.value
+    pressedEdge = edgeIndex
+    pressOrigin = mapRef.mouseEventToContainerPoint(event)
+    pressedEdgeEndpoints = [asCoordinates(points[edgeIndex]), asCoordinates(points[(edgeIndex + 1) % points.length])]
+    dragOrigin = asCoordinates(mapRef.containerPointToLatLng(mapRef.mouseEventToContainerPoint(event)))
+    // Decided once per drag, so a free-form polygon dragged through squareness does not suddenly lock up.
+    holdEdgeSquare = rectangleSpec(points.map(asCoordinates)) !== null
+    isEdgePressed.value = true
+
+    // Panning must not follow the same press, and on touch there is nothing else keeping the map still.
+    panningWasEnabled = mapRef.dragging.enabled()
+    if (panningWasEnabled) mapRef.dragging.disable()
+    mapRef.getContainer().setPointerCapture(event.pointerId)
+  }
+
+  const onPointerMove = (event: PointerEvent): void => {
+    if (pressedEdge === null) {
+      const edgeIndex = edgeAt(event)
+      setCursor(edgeIndex === null ? null : cursorForEdge(edgeIndex))
+      return
+    }
+    if (!mapRef || !pressOrigin || !pressedEdgeEndpoints || !dragOrigin) return
+
+    const containerPoint = mapRef.mouseEventToContainerPoint(event)
+    if (!isDraggingEdge.value) {
+      if (containerPoint.distanceTo(pressOrigin) < dragThresholdInPixels) return
+      isDraggingEdge.value = true
+      setCursor(cursorForEdge(pressedEdge))
+      onDragStart()
+      logUserAction('Dragged a survey polygon edge')
+    }
+
+    const edgeMarkers = markers()
+    if (edgeMarkers.length < 3) return
+
+    const pointer = asCoordinates(mapRef.containerPointToLatLng(containerPoint))
+    const [start, end] = draggedEdgeEndpoints(pressedEdgeEndpoints, [dragOrigin, pointer], holdEdgeSquare)
+    edgeMarkers[pressedEdge].setLatLng(start)
+    edgeMarkers[(pressedEdge + 1) % edgeMarkers.length].setLatLng(end)
+    onEdgeMoved()
+  }
+
+  const onPointerUp = (event: PointerEvent): void => {
+    if (pressedEdge === null) return
+
+    const moved = isDraggingEdge.value
+    const container = mapRef?.getContainer()
+    if (container?.hasPointerCapture(event.pointerId)) container.releasePointerCapture(event.pointerId)
+    releasePress()
+    onDragEnd(moved)
+  }
+
+  const onPointerLeave = (): void => {
+    if (pressedEdge === null) setCursor(null)
+  }
+
+  const initEdgeDragging = (map: LeafletMap): void => {
+    mapRef = map
+    const container = map.getContainer()
+    container.addEventListener('pointerdown', onPointerDown)
+    container.addEventListener('pointermove', onPointerMove)
+    container.addEventListener('pointerup', onPointerUp)
+    container.addEventListener('pointercancel', onPointerUp)
+    container.addEventListener('pointerleave', onPointerLeave)
+  }
+
+  const destroyEdgeDragging = (): void => {
+    const container = mapRef?.getContainer()
+    setCursor(null)
+    releasePress()
+    if (container) {
+      container.removeEventListener('pointerdown', onPointerDown)
+      container.removeEventListener('pointermove', onPointerMove)
+      container.removeEventListener('pointerup', onPointerUp)
+      container.removeEventListener('pointercancel', onPointerUp)
+      container.removeEventListener('pointerleave', onPointerLeave)
+    }
+    mapRef = undefined
+  }
+
+  onBeforeUnmount(destroyEdgeDragging)
+
+  return { isEdgePressed, isDraggingEdge, initEdgeDragging, destroyEdgeDragging }
+}

--- a/src/composables/map/useSurveyEdgeDragging.ts
+++ b/src/composables/map/useSurveyEdgeDragging.ts
@@ -5,6 +5,7 @@ import {
   closestPolygonEdge,
   draggedEdgeEndpoints,
   edgeResizeCursor,
+  isOverEdgeAddMarker,
   isOverSurveyHandle,
 } from '@/libs/map/survey-polygon-edges'
 import { rectangleSpec } from '@/libs/map/survey-rectangle'
@@ -94,7 +95,10 @@ export const useSurveyEdgeDragging = (options: UseSurveyEdgeDraggingOptions): Us
 
   const edgeAt = (event: PointerEvent): number | null => {
     if (!mapRef || !isEditable()) return null
-    if (isOverSurveyHandle(event.target)) return null
+    // A finger has no hover to find an edge with, so the "+" standing on the edge's midpoint doubles as its grab
+    // handle: a tap on it still adds a vertex there, and a drag carries the edge.
+    const grabsByAddMarker = event.pointerType !== 'mouse' && isOverEdgeAddMarker(event.target)
+    if (isOverSurveyHandle(event.target) && !grabsByAddMarker) return null
 
     const points = vertices.value.map((latLng) => mapRef!.latLngToContainerPoint(latLng))
     return closestPolygonEdge(points, mapRef.mouseEventToContainerPoint(event), grabToleranceInPixels)

--- a/src/composables/map/useSurveyRectangleDrawing.ts
+++ b/src/composables/map/useSurveyRectangleDrawing.ts
@@ -8,9 +8,12 @@ import {
   rectangleLinesAngle,
   rectangleSpec,
 } from '@/libs/map/survey-rectangle'
+import { clampExtent } from '@/libs/map/typed-extent'
 import { formatMetersShort } from '@/libs/mission/general-estimates'
+import { isTouchDevice } from '@/libs/utils'
 import type { WaypointCoordinates } from '@/types/mission'
 
+import { type UseMeasureExtentInputReturn } from './useMeasureExtentInput'
 import { useMeasurePillOverlay } from './useMeasurePillOverlay'
 
 /** Shape the draft survey polygon is drawn as. */
@@ -28,6 +31,8 @@ export interface SurveyRectangleDimensions {
 export interface UseSurveyRectangleDrawingOptions {
   /** Draft survey polygon vertices, replaced wholesale whenever a rectangle is built. */
   vertices: Ref<L.LatLng[]>
+  /** The on-map extent boxes, shared with the view so only one stage offers typing at a time. */
+  extentInput: UseMeasureExtentInputReturn
   /** Called once a rectangle has been drawn on the map, with the scan angle along its longer axis. */
   onRectangleDrawn: (linesAngle: number) => void
   /** Called once typed extents have been applied, with the new scan angle, or null once the user owns the angle. */
@@ -66,11 +71,6 @@ export interface UseSurveyRectangleDrawingReturn {
   initRectangleDrawing: (map: LeafletMap) => void
 }
 
-// A mistyped extra digit would otherwise rebuild the polygon at a size the path generator sweeps line by line,
-// so both extents are held to a range a survey can be flown at.
-const minExtentInMeters = 1
-const maxExtentInMeters = 100000
-
 const previewStyle: L.PolylineOptions = {
   color: '#3B82F6',
   fillColor: '#60A5FA',
@@ -92,7 +92,7 @@ const previewStyle: L.PolylineOptions = {
 export const useSurveyRectangleDrawing = (
   options: UseSurveyRectangleDrawingOptions
 ): UseSurveyRectangleDrawingReturn => {
-  const { vertices, onRectangleDrawn, onRectangleResized, onShapeChanged } = options
+  const { vertices, extentInput, onRectangleDrawn, onRectangleResized, onShapeChanged } = options
 
   const { initMeasurePillOverlay, renderMeasurePills, destroyMeasurePillOverlay } = useMeasurePillOverlay()
 
@@ -114,18 +114,57 @@ export const useSurveyRectangleDrawing = (
   const areSameCorners = (a: WaypointCoordinates[], b: WaypointCoordinates[]): boolean =>
     a.length === b.length && a.every(([lat, lng], index) => b[index][0] === lat && b[index][1] === lng)
 
-  const clampExtent = (value: number, fallback: number): number =>
-    Number.isFinite(value) ? Math.min(maxExtentInMeters, Math.max(minExtentInMeters, value)) : fallback
+  // A rectangle read back from its own corners, walking the drawn edge from whichever end leaves the area on its
+  // right, so one grown to the left of that edge is described exactly like one grown to the right instead of
+  // being turned inside out the next time its corners are built from the description.
+  const specFromCorners = (corners: WaypointCoordinates[]): SurveyRectangleSpec =>
+    rectangleFromBaselineAndCursor(corners[0], corners[1], corners[2])
 
   const setVertices = (corners: WaypointCoordinates[]): void => {
     vertices.value = corners.map(([lat, lng]) => L.latLng(lat, lng))
   }
 
-  const renderPreview = (cursor: WaypointCoordinates): void => {
-    if (!baseline || !mapRef) return
+  const sweptSpec = (): SurveyRectangleSpec | null =>
+    baseline && lastCursor ? rectangleFromBaselineAndCursor(baseline.start, baseline.end, lastCursor) : null
 
-    lastCursor = cursor
-    const spec = rectangleFromBaselineAndCursor(baseline.start, baseline.end, cursor)
+  // A pill on the drawn edge and one on the edge across it, so both extents are readable on the map itself
+  // rather than only in the panel the user is not looking at while drawing.
+  const renderExtents = (corners: L.LatLng[], extents: SurveyRectangleDimensions): void => {
+    renderMeasurePills([
+      { from: corners[0], to: corners[1], text: extents.length < 1 ? null : formatMetersShort(extents.length) },
+      { from: corners[1], to: corners[2], text: extents.width < 1 ? null : formatMetersShort(extents.width) },
+    ])
+    extentInput.setExtentTarget('length', {
+      label: 'survey length',
+      from: corners[0],
+      to: corners[1],
+      liveValue: extents.length,
+      refresh: onSizingViewChange,
+      // The width is the extent still open, so a settled length hands the keyboard on to it.
+      apply: () => extentInput.focusExtentInput('width'),
+    })
+    extentInput.setExtentTarget('width', {
+      label: 'survey width',
+      from: corners[1],
+      to: corners[2],
+      liveValue: extents.width,
+      refresh: onSizingViewChange,
+      apply: () => commitSizing(),
+    })
+  }
+
+  const renderPreview = (cursor?: WaypointCoordinates): void => {
+    if (cursor) lastCursor = cursor
+    const drawn = sweptSpec()
+    if (!drawn || !mapRef) return
+
+    // Whichever extent has been typed holds the size the cursor would otherwise sweep, leaving the cursor to
+    // choose the side and the extent that has not.
+    const spec = {
+      ...drawn,
+      length: extentInput.lockedExtent('length') ?? drawn.length,
+      width: extentInput.lockedExtent('width') ?? drawn.width,
+    }
     sizingSpec.value = spec
     const corners = rectangleCorners(spec).map(([lat, lng]) => L.latLng(lat, lng))
     if (previewLayer) {
@@ -133,20 +172,15 @@ export const useSurveyRectangleDrawing = (
     } else {
       previewLayer = L.polygon(corners, previewStyle).addTo(mapRef)
     }
-    // A pill on the drawn edge and one on the edge across it, so both extents are readable on the map itself
-    // rather than only in the panel the user is not looking at while drawing.
-    renderMeasurePills([
-      { from: corners[0], to: corners[1], text: spec.length < 1 ? null : formatMetersShort(spec.length) },
-      { from: corners[1], to: corners[2], text: spec.width < 1 ? null : formatMetersShort(spec.width) },
-    ])
+    // Read as distances, since a negative extent says which side of the baseline to grow to rather than measuring
+    // anything backwards.
+    renderExtents(corners, { length: Math.abs(spec.length), width: Math.abs(spec.width) })
   }
 
   const onSizingMouseMove = (event: L.LeafletMouseEvent): void => renderPreview(asCoordinates(event.latlng))
 
   // The pills are placed in container pixels, so a pan or zoom has to redraw them against the new viewport.
-  const onSizingViewChange = (): void => {
-    if (lastCursor) renderPreview(lastCursor)
-  }
+  const onSizingViewChange = (): void => renderPreview()
 
   const stopSizing = (): void => {
     mapRef?.off('mousemove', onSizingMouseMove)
@@ -155,6 +189,9 @@ export const useSurveyRectangleDrawing = (
     previewLayer?.remove()
     previewLayer = null
     destroyMeasurePillOverlay()
+    extentInput.setExtentTarget('length', null)
+    extentInput.setExtentTarget('width', null)
+    extentInput.closeExtentInputs()
     baseline = null
     sizingSpec.value = null
     phase.value = 'idle'
@@ -169,21 +206,28 @@ export const useSurveyRectangleDrawing = (
     return true
   }
 
+  // A rectangle sized back onto its baseline leaves no area to survey, so a commit of one keeps sizing instead of
+  // fixing a degenerate polygon the survey generator would produce no lines for.
+  const commitSizing = (): void => {
+    const spec = sizingSpec.value
+    if (!spec || spec.width === 0 || spec.length === 0) return
+
+    const extents = `${Math.abs(spec.length).toFixed(1)} m by ${Math.abs(spec.width).toFixed(1)} m`
+    logUserAction(`Drew a survey rectangle of ${extents}`)
+    // Stored as the corners of a rectangle read back from itself, so an area grown to the left of the drawn edge
+    // keeps reading its extents back the way it was drawn.
+    const corners = rectangleCorners(specFromCorners(rectangleCorners(spec)))
+    stopSizing()
+    setVertices(corners)
+    derivedCorners = corners
+    onRectangleDrawn(rectangleLinesAngle(corners))
+  }
+
   const consumeSurveyClick = (latlng: L.LatLng): boolean => {
     if (shape.value !== 'rectangle') return false
 
     if (phase.value === 'sizing') {
-      const spec = sizingSpec.value
-      // A click back on the baseline leaves no area to survey, so keep sizing instead of fixing a degenerate
-      // polygon the survey generator would produce no lines for.
-      if (spec && spec.width > 0 && spec.length > 0) {
-        logUserAction(`Drew a survey rectangle of ${spec.length.toFixed(1)} m by ${spec.width.toFixed(1)} m`)
-        const corners = rectangleCorners(spec)
-        stopSizing()
-        setVertices(corners)
-        derivedCorners = corners
-        onRectangleDrawn(rectangleLinesAngle(corners))
-      }
+      commitSizing()
       return true
     }
 
@@ -201,6 +245,9 @@ export const useSurveyRectangleDrawing = (
       phase.value = 'sizing'
       mapRef?.on('mousemove', onSizingMouseMove)
       mapRef?.on('moveend zoomend', onSizingViewChange)
+      // The width is the extent still to be chosen, so it is the one the keyboard lands on. A finger has no
+      // keyboard to land on it, so there the box is left to be asked for by tapping the pill it belongs to.
+      if (!isTouchDevice()) extentInput.openExtentInputs('width')
       renderPreview(asCoordinates(latlng))
       return true
     }
@@ -211,10 +258,13 @@ export const useSurveyRectangleDrawing = (
     return false
   }
 
-  const draftSpec = computed(() => rectangleSpec(vertices.value.map(asCoordinates)))
+  const draftSpec = computed(() => {
+    const corners = vertices.value.map(asCoordinates)
+    return rectangleSpec(corners) === null ? null : specFromCorners(corners)
+  })
 
-  // Only the finished draft's extents, since the ones being swept by the cursor cannot be typed over: they read
-  // out on the map pills instead.
+  // Only the finished draft's extents, since the ones being swept by the cursor are typed on the map boxes next
+  // to their pills rather than in the panel.
   const dimensions = computed<SurveyRectangleDimensions | null>(() => {
     const spec = draftSpec.value
     return spec ? { length: spec.length, width: spec.width } : null

--- a/src/composables/map/useSurveyRectangleDrawing.ts
+++ b/src/composables/map/useSurveyRectangleDrawing.ts
@@ -1,6 +1,7 @@
 import L, { type Map as LeafletMap } from 'leaflet'
-import { type ComputedRef, type Ref, computed, onBeforeUnmount, ref } from 'vue'
+import { type ComputedRef, type Ref, computed, onBeforeUnmount, ref, shallowRef } from 'vue'
 
+import { isOverSurveyHandle } from '@/libs/map/survey-polygon-edges'
 import {
   type SurveyRectangleSpec,
   rectangleCorners,
@@ -15,6 +16,7 @@ import type { WaypointCoordinates } from '@/types/mission'
 
 import { type UseMeasureExtentInputReturn } from './useMeasureExtentInput'
 import { useMeasurePillOverlay } from './useMeasurePillOverlay'
+import { type RectangleHandlesTarget } from './useRectangleHandles'
 
 /** Shape the draft survey polygon is drawn as. */
 export type SurveyDrawShape = 'free-form' | 'rectangle'
@@ -55,6 +57,10 @@ export interface UseSurveyRectangleDrawingReturn {
   shape: Ref<SurveyDrawShape>
   /** Whether the rectangle is currently being sized against the cursor. */
   isSizingRectangle: ComputedRef<boolean>
+  /** Corners of a rectangle being sized that has been taken hold of, whose edges resize it like a polygon's. */
+  heldRectangleVertices: ComputedRef<L.LatLng[]>
+  /** The rectangle to offer move and turn handles on, being the one under the cursor or the square draft. */
+  rectangleHandles: ComputedRef<RectangleHandlesTarget | null>
   /** Extents of the draft polygon while it is a rectangle; null otherwise. */
   dimensions: ComputedRef<SurveyRectangleDimensions | null>
   /** Switches the draw shape. */
@@ -63,6 +69,10 @@ export interface UseSurveyRectangleDrawingReturn {
   consumeSurveyClick: (latlng: L.LatLng) => boolean
   /** Rebuilds the draft rectangle at the given extents, around the same baseline. */
   applyDimensions: (dimensions: SurveyRectangleDimensions) => void
+  /** Takes the rectangle being sized as a handle or an edge has left it, which the cursor stops sweeping. */
+  freezeSizingRectangle: (corners: WaypointCoordinates[]) => void
+  /** Reports the draft rectangle moved bodily, returning the scan angle to follow, or null to leave it alone. */
+  rectangleMovedTo: (corners: WaypointCoordinates[]) => number | null
   /** Hands the scan angle to the user, so it stops being derived from the longer axis. */
   releaseLinesAngle: () => void
   /** Abandons a rectangle being sized, returning whether there was one. */
@@ -99,6 +109,10 @@ export const useSurveyRectangleDrawing = (
   const shape = ref<SurveyDrawShape>('free-form')
   const phase = ref<'idle' | 'baseline' | 'sizing'>('idle')
   const sizingSpec = ref<SurveyRectangleSpec | null>(null)
+  const sizingAxisIndex = ref<0 | 1>(0)
+  // Set once the rectangle has been taken hold of by a handle or an edge, from when on it is the shape itself
+  // that is being placed rather than one still being swept out.
+  const frozenSpec = shallowRef<SurveyRectangleSpec | null>(null)
 
   let mapRef: LeafletMap | undefined
   let baseline: RectangleBaseline | null = null
@@ -110,6 +124,8 @@ export const useSurveyRectangleDrawing = (
   let derivedCorners: WaypointCoordinates[] | null = null
 
   const asCoordinates = (latLng: L.LatLng): WaypointCoordinates => [latLng.lat, latLng.lng]
+
+  const isSameSpot = (a: WaypointCoordinates, b: WaypointCoordinates): boolean => a[0] === b[0] && a[1] === b[1]
 
   const areSameCorners = (a: WaypointCoordinates[], b: WaypointCoordinates[]): boolean =>
     a.length === b.length && a.every(([lat, lng], index) => b[index][0] === lat && b[index][1] === lng)
@@ -155,7 +171,7 @@ export const useSurveyRectangleDrawing = (
 
   const renderPreview = (cursor?: WaypointCoordinates): void => {
     if (cursor) lastCursor = cursor
-    const drawn = sweptSpec()
+    const drawn = frozenSpec.value ?? sweptSpec()
     if (!drawn || !mapRef) return
 
     // Whichever extent has been typed holds the size the cursor would otherwise sweep, leaving the cursor to
@@ -166,6 +182,9 @@ export const useSurveyRectangleDrawing = (
       width: extentInput.lockedExtent('width') ?? drawn.width,
     }
     sizingSpec.value = spec
+    // The rectangle is walked from whichever end of the drawn edge leaves it on the cursor's side, so the corner
+    // it turns about has to be looked up rather than assumed to lead the ring.
+    if (!frozenSpec.value && baseline) sizingAxisIndex.value = isSameSpot(spec.origin, baseline.start) ? 0 : 1
     const corners = rectangleCorners(spec).map(([lat, lng]) => L.latLng(lat, lng))
     if (previewLayer) {
       previewLayer.setLatLngs(corners)
@@ -177,10 +196,32 @@ export const useSurveyRectangleDrawing = (
     renderExtents(corners, { length: Math.abs(spec.length), width: Math.abs(spec.width) })
   }
 
-  const onSizingMouseMove = (event: L.LeafletMouseEvent): void => renderPreview(asCoordinates(event.latlng))
+  const onSizingMouseMove = (event: L.LeafletMouseEvent): void => {
+    // A rectangle taken hold of is the user's to place, so the cursor is left with nothing to sweep and only the
+    // click that fixes it still counts. A move on one of its handles belongs to that handle, and leaflet reports it
+    // before the drag it starts, so sweeping it would collapse the rectangle onto the corner being grabbed.
+    if (frozenSpec.value || isOverSurveyHandle(event.originalEvent.target)) return
+    renderPreview(asCoordinates(event.latlng))
+  }
 
   // The pills are placed in container pixels, so a pan or zoom has to redraw them against the new viewport.
   const onSizingViewChange = (): void => renderPreview()
+
+  const freezeSizingRectangle = (corners: WaypointCoordinates[]): void => {
+    const spec = specFromCorners(corners)
+    if (spec.length === 0) return
+
+    const axis = corners[sizingAxisIndex.value]
+    frozenSpec.value = spec
+    // Reading the corners back can walk the drawn edge the other way round, which puts the corner the rectangle
+    // turns about at the other end of the ring.
+    sizingAxisIndex.value = isSameSpot(spec.origin, axis) ? 0 : 1
+    // These corners already carry whatever was typed, so the boxes go back to reading the extents out instead of
+    // holding them, leaving the drag free to change them.
+    if (extentInput.lockedExtent('length') !== null) extentInput.setExtentValue('length', null)
+    if (extentInput.lockedExtent('width') !== null) extentInput.setExtentValue('width', null)
+    renderPreview()
+  }
 
   const stopSizing = (): void => {
     mapRef?.off('mousemove', onSizingMouseMove)
@@ -193,6 +234,7 @@ export const useSurveyRectangleDrawing = (
     extentInput.setExtentTarget('width', null)
     extentInput.closeExtentInputs()
     baseline = null
+    frozenSpec.value = null
     sizingSpec.value = null
     phase.value = 'idle'
   }
@@ -270,6 +312,21 @@ export const useSurveyRectangleDrawing = (
     return spec ? { length: spec.length, width: spec.width } : null
   })
 
+  // Empty until the rectangle stands still, since one still being swept has the cursor sitting on the very edge a
+  // press would otherwise grab instead of fixing the area.
+  const heldRectangleVertices = computed<L.LatLng[]>(() =>
+    frozenSpec.value && sizingSpec.value
+      ? rectangleCorners(sizingSpec.value).map(([lat, lng]) => L.latLng(lat, lng))
+      : []
+  )
+
+  const rectangleHandles = computed<RectangleHandlesTarget | null>(() => {
+    const sizing = sizingSpec.value
+    if (sizing) return { corners: rectangleCorners(sizing), axisIndex: sizingAxisIndex.value }
+    // A draft is handled by the corners it already has, whether it was drawn as a rectangle or typed into one.
+    return draftSpec.value ? { corners: vertices.value.map(asCoordinates), axisIndex: 0 } : null
+  })
+
   const applyDimensions = (typed: SurveyRectangleDimensions): void => {
     const spec = draftSpec.value
     if (!spec) return
@@ -284,6 +341,15 @@ export const useSurveyRectangleDrawing = (
     setVertices(corners)
     derivedCorners = follows ? corners : null
     onRectangleResized(follows ? rectangleLinesAngle(corners) : null)
+  }
+
+  const rectangleMovedTo = (corners: WaypointCoordinates[]): number | null => {
+    const follows = !!derivedCorners && areSameCorners(derivedCorners, vertices.value.map(asCoordinates))
+    if (!follows) return null
+
+    // The same rectangle in a new place, so an angle that was following its longer axis keeps doing so.
+    derivedCorners = corners
+    return rectangleLinesAngle(corners)
   }
 
   const releaseLinesAngle = (): void => {
@@ -312,10 +378,14 @@ export const useSurveyRectangleDrawing = (
   return {
     shape,
     isSizingRectangle: computed(() => phase.value === 'sizing'),
+    heldRectangleVertices,
+    rectangleHandles,
     dimensions,
     setShape,
     consumeSurveyClick,
     applyDimensions,
+    freezeSizingRectangle,
+    rectangleMovedTo,
     releaseLinesAngle,
     cancelSizing,
     initRectangleDrawing,

--- a/src/composables/map/useSurveyRectangleDrawing.ts
+++ b/src/composables/map/useSurveyRectangleDrawing.ts
@@ -1,0 +1,273 @@
+import L, { type Map as LeafletMap } from 'leaflet'
+import { type ComputedRef, type Ref, computed, onBeforeUnmount, ref } from 'vue'
+
+import {
+  type SurveyRectangleSpec,
+  rectangleCorners,
+  rectangleFromBaselineAndCursor,
+  rectangleLinesAngle,
+  rectangleSpec,
+} from '@/libs/map/survey-rectangle'
+import { formatMetersShort } from '@/libs/mission/general-estimates'
+import type { WaypointCoordinates } from '@/types/mission'
+
+import { useMeasurePillOverlay } from './useMeasurePillOverlay'
+
+/** Shape the draft survey polygon is drawn as. */
+export type SurveyDrawShape = 'free-form' | 'rectangle'
+
+/** Extents of a survey rectangle, in meters. */
+export interface SurveyRectangleDimensions {
+  /** Extent along the edge the user drew. */
+  length: number
+  /** Extent perpendicular to the edge the user drew. */
+  width: number
+}
+
+/** Wiring {@link useSurveyRectangleDrawing} needs from the view that owns the survey draft. */
+export interface UseSurveyRectangleDrawingOptions {
+  /** Draft survey polygon vertices, replaced wholesale whenever a rectangle is built. */
+  vertices: Ref<L.LatLng[]>
+  /** Called once a rectangle has been drawn on the map, with the scan angle along its longer axis. */
+  onRectangleDrawn: (linesAngle: number) => void
+  /** Called once typed extents have been applied, with the new scan angle, or null once the user owns the angle. */
+  onRectangleResized: (linesAngle: number | null) => void
+  /** Called when the draw shape changes, so an unfinished draft can be dropped. */
+  onShapeChanged: (shape: SurveyDrawShape) => void
+}
+
+/** The edge the user drew, which the rectangle is raised from. */
+interface RectangleBaseline {
+  /** Where the edge was started. */
+  start: WaypointCoordinates
+  /** Where the edge was ended. */
+  end: WaypointCoordinates
+}
+
+/** Return type of {@link useSurveyRectangleDrawing}. */
+export interface UseSurveyRectangleDrawingReturn {
+  /** Shape the next survey polygon is drawn as. */
+  shape: Ref<SurveyDrawShape>
+  /** Whether the rectangle is currently being sized against the cursor. */
+  isSizingRectangle: ComputedRef<boolean>
+  /** Extents of the draft polygon while it is a rectangle; null otherwise. */
+  dimensions: ComputedRef<SurveyRectangleDimensions | null>
+  /** Switches the draw shape. */
+  setShape: (shape: SurveyDrawShape) => void
+  /** Handles a map click, returning whether the rectangle tool consumed it. */
+  consumeSurveyClick: (latlng: L.LatLng) => boolean
+  /** Rebuilds the draft rectangle at the given extents, around the same baseline. */
+  applyDimensions: (dimensions: SurveyRectangleDimensions) => void
+  /** Hands the scan angle to the user, so it stops being derived from the longer axis. */
+  releaseLinesAngle: () => void
+  /** Abandons a rectangle being sized, returning whether there was one. */
+  cancelSizing: () => boolean
+  /** Binds the tool to a Leaflet map. */
+  initRectangleDrawing: (map: LeafletMap) => void
+}
+
+// A mistyped extra digit would otherwise rebuild the polygon at a size the path generator sweeps line by line,
+// so both extents are held to a range a survey can be flown at.
+const minExtentInMeters = 1
+const maxExtentInMeters = 100000
+
+const previewStyle: L.PolylineOptions = {
+  color: '#3B82F6',
+  fillColor: '#60A5FA',
+  fillOpacity: 0.15,
+  weight: 2,
+  dashArray: '8,8',
+  interactive: false,
+  className: 'survey-rectangle-preview',
+}
+
+/**
+ * Draws a survey area as a rectangle: the first two clicks lay down one edge, the cursor then sweeps the extent
+ * perpendicular to it, and the third click fixes a polygon with square corners whose scan lines follow its
+ * longer axis. The result is an ordinary four-vertex survey draft, so every existing survey option keeps
+ * applying to it, and its extents stay editable because they are read back from the corners.
+ * @param {UseSurveyRectangleDrawingOptions} options - The draft vertices and the view callbacks to drive.
+ * @returns {UseSurveyRectangleDrawingReturn} The tool's state and the handlers the view routes input to.
+ */
+export const useSurveyRectangleDrawing = (
+  options: UseSurveyRectangleDrawingOptions
+): UseSurveyRectangleDrawingReturn => {
+  const { vertices, onRectangleDrawn, onRectangleResized, onShapeChanged } = options
+
+  const { initMeasurePillOverlay, renderMeasurePills, destroyMeasurePillOverlay } = useMeasurePillOverlay()
+
+  const shape = ref<SurveyDrawShape>('free-form')
+  const phase = ref<'idle' | 'baseline' | 'sizing'>('idle')
+  const sizingSpec = ref<SurveyRectangleSpec | null>(null)
+
+  let mapRef: LeafletMap | undefined
+  let baseline: RectangleBaseline | null = null
+  let previewLayer: L.Polygon | null = null
+  let lastCursor: WaypointCoordinates | null = null
+  // A rectangle implies its own scan direction, so the derived angle keeps following the longer axis until the
+  // user dials in one of their own. Held as the corners it was derived from, so a polygon the user has reshaped
+  // by hand no longer matches and takes the angle over as well.
+  let derivedCorners: WaypointCoordinates[] | null = null
+
+  const asCoordinates = (latLng: L.LatLng): WaypointCoordinates => [latLng.lat, latLng.lng]
+
+  const areSameCorners = (a: WaypointCoordinates[], b: WaypointCoordinates[]): boolean =>
+    a.length === b.length && a.every(([lat, lng], index) => b[index][0] === lat && b[index][1] === lng)
+
+  const clampExtent = (value: number, fallback: number): number =>
+    Number.isFinite(value) ? Math.min(maxExtentInMeters, Math.max(minExtentInMeters, value)) : fallback
+
+  const setVertices = (corners: WaypointCoordinates[]): void => {
+    vertices.value = corners.map(([lat, lng]) => L.latLng(lat, lng))
+  }
+
+  const renderPreview = (cursor: WaypointCoordinates): void => {
+    if (!baseline || !mapRef) return
+
+    lastCursor = cursor
+    const spec = rectangleFromBaselineAndCursor(baseline.start, baseline.end, cursor)
+    sizingSpec.value = spec
+    const corners = rectangleCorners(spec).map(([lat, lng]) => L.latLng(lat, lng))
+    if (previewLayer) {
+      previewLayer.setLatLngs(corners)
+    } else {
+      previewLayer = L.polygon(corners, previewStyle).addTo(mapRef)
+    }
+    // A pill on the drawn edge and one on the edge across it, so both extents are readable on the map itself
+    // rather than only in the panel the user is not looking at while drawing.
+    renderMeasurePills([
+      { from: corners[0], to: corners[1], text: spec.length < 1 ? null : formatMetersShort(spec.length) },
+      { from: corners[1], to: corners[2], text: spec.width < 1 ? null : formatMetersShort(spec.width) },
+    ])
+  }
+
+  const onSizingMouseMove = (event: L.LeafletMouseEvent): void => renderPreview(asCoordinates(event.latlng))
+
+  // The pills are placed in container pixels, so a pan or zoom has to redraw them against the new viewport.
+  const onSizingViewChange = (): void => {
+    if (lastCursor) renderPreview(lastCursor)
+  }
+
+  const stopSizing = (): void => {
+    mapRef?.off('mousemove', onSizingMouseMove)
+    mapRef?.off('moveend zoomend', onSizingViewChange)
+    lastCursor = null
+    previewLayer?.remove()
+    previewLayer = null
+    destroyMeasurePillOverlay()
+    baseline = null
+    sizingSpec.value = null
+    phase.value = 'idle'
+  }
+
+  const cancelSizing = (): boolean => {
+    if (phase.value !== 'sizing') return false
+    stopSizing()
+    // The corner the baseline started from is still on the map, so the next click lays its far end again rather
+    // than falling through as a free-form vertex.
+    if (vertices.value.length > 0) phase.value = 'baseline'
+    return true
+  }
+
+  const consumeSurveyClick = (latlng: L.LatLng): boolean => {
+    if (shape.value !== 'rectangle') return false
+
+    if (phase.value === 'sizing') {
+      const spec = sizingSpec.value
+      // A click back on the baseline leaves no area to survey, so keep sizing instead of fixing a degenerate
+      // polygon the survey generator would produce no lines for.
+      if (spec && spec.width > 0 && spec.length > 0) {
+        logUserAction(`Drew a survey rectangle of ${spec.length.toFixed(1)} m by ${spec.width.toFixed(1)} m`)
+        const corners = rectangleCorners(spec)
+        stopSizing()
+        setVertices(corners)
+        derivedCorners = corners
+        onRectangleDrawn(rectangleLinesAngle(corners))
+      }
+      return true
+    }
+
+    if (phase.value === 'baseline') {
+      const anchor = vertices.value.at(-1)
+      // The draft was emptied while the first corner was awaited (Clear Path, an undo, or the corner itself being
+      // removed), so this click lays that corner down again instead of falling through as a free-form vertex.
+      if (!anchor) return false
+      // A double-click on the first corner would otherwise start sizing against an edge of no length, which
+      // can never be finished into a polygon.
+      if (anchor.equals(latlng)) return true
+
+      logUserAction('Set the survey rectangle baseline')
+      baseline = { start: asCoordinates(anchor), end: asCoordinates(latlng) }
+      phase.value = 'sizing'
+      mapRef?.on('mousemove', onSizingMouseMove)
+      mapRef?.on('moveend zoomend', onSizingViewChange)
+      renderPreview(asCoordinates(latlng))
+      return true
+    }
+
+    // The baseline's first corner is an ordinary vertex, so the view places it and its live measure and undo
+    // step come along with it.
+    if (vertices.value.length === 0) phase.value = 'baseline'
+    return false
+  }
+
+  const draftSpec = computed(() => rectangleSpec(vertices.value.map(asCoordinates)))
+
+  // Only the finished draft's extents, since the ones being swept by the cursor cannot be typed over: they read
+  // out on the map pills instead.
+  const dimensions = computed<SurveyRectangleDimensions | null>(() => {
+    const spec = draftSpec.value
+    return spec ? { length: spec.length, width: spec.width } : null
+  })
+
+  const applyDimensions = (typed: SurveyRectangleDimensions): void => {
+    const spec = draftSpec.value
+    if (!spec) return
+
+    const length = clampExtent(typed.length, spec.length)
+    const width = clampExtent(typed.width, spec.width)
+    if (length === spec.length && width === spec.width) return
+
+    logUserAction(`Set the survey rectangle to ${length.toFixed(1)} m by ${width.toFixed(1)} m`)
+    const follows = !!derivedCorners && areSameCorners(derivedCorners, vertices.value.map(asCoordinates))
+    const corners = rectangleCorners({ ...spec, length, width })
+    setVertices(corners)
+    derivedCorners = follows ? corners : null
+    onRectangleResized(follows ? rectangleLinesAngle(corners) : null)
+  }
+
+  const releaseLinesAngle = (): void => {
+    derivedCorners = null
+  }
+
+  const setShape = (nextShape: SurveyDrawShape): void => {
+    if (nextShape === shape.value) return
+
+    logUserAction(`Switched the survey shape to ${nextShape === 'rectangle' ? 'rectangle' : 'free form'}`)
+    stopSizing()
+    shape.value = nextShape
+    onShapeChanged(nextShape)
+  }
+
+  const initRectangleDrawing = (map: LeafletMap): void => {
+    mapRef = map
+    initMeasurePillOverlay(map)
+  }
+
+  onBeforeUnmount(() => {
+    stopSizing()
+    mapRef = undefined
+  })
+
+  return {
+    shape,
+    isSizingRectangle: computed(() => phase.value === 'sizing'),
+    dimensions,
+    setShape,
+    consumeSurveyClick,
+    applyDimensions,
+    releaseLinesAngle,
+    cancelSizing,
+    initRectangleDrawing,
+  }
+}

--- a/src/composables/map/useTouchDrawing.ts
+++ b/src/composables/map/useTouchDrawing.ts
@@ -1,0 +1,251 @@
+import L, { type Map as LeafletMap } from 'leaflet'
+import { type ShallowRef, computed, onBeforeUnmount, shallowRef, watch } from 'vue'
+
+import { isOverSurveyHandle } from '@/libs/map/survey-polygon-edges'
+
+/** Wiring {@link useTouchDrawing} needs from the view that draws on the map. */
+export interface UseTouchDrawingOptions {
+  /** Whether a finger on the map is drawing, which is what leaves panning to a second one. */
+  drawsWithOneFinger: () => boolean
+  /** Names what a drag is settling right now, as the checkmark reads it out and the log records it. */
+  confirmLabel: () => string
+  /** Whether the segment being drawn already has a point to start from. */
+  hasAnchor: () => boolean
+  /** Whether another handler already took the press, so the map is left to it. */
+  isBlocked: () => boolean
+  /** Lays a point down where the drawing is, which is how the first drag plants the segment's start. */
+  placePoint: (latlng: L.LatLng) => void
+  /** Aims the drawing at a coordinate, the way a moving cursor would. */
+  aimAt: (latlng: L.LatLng, event: PointerEvent) => void
+}
+
+/** Return type of {@link useTouchDrawing}. */
+export interface UseTouchDrawingReturn {
+  /** Where a finger left the live line, waiting to be confirmed, or null when nothing is waiting. */
+  pendingPoint: ShallowRef<L.LatLng | null>
+  /** Forgets the point that was waiting, taking its checkmark off the map. */
+  clearPendingPoint: () => void
+  /** Whether the click the browser may raise out of the last drag has to be dropped instead of drawn with. */
+  swallowsClick: () => boolean
+  /** Binds the gestures to a Leaflet map. */
+  initTouchDrawing: (map: LeafletMap) => void
+  /** Unbinds everything and gives panning back. */
+  destroyTouchDrawing: () => void
+}
+
+// A press has to travel this far before it aims instead of tapping, which is what the edge drag asks of one too.
+const dragThresholdInPixels = 4
+// The checkmark stands off the point's diagonal, clear of the line ending there and of the finger that dragged it.
+const confirmOffsetInPixels = 26
+// Controls and handles that own their own presses, which a drawing gesture must not take from them.
+const ownPressSelector = '.leaflet-marker-icon, .leaflet-control, .live-measure-pill, .touch-draw-confirm'
+
+const confirmMarkup = `
+  <svg width="22" height="22" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" style="display: block;">
+    <circle cx="10" cy="10" r="9" fill="white" stroke="#3B82F6" stroke-width="2"/>
+    <path d="M5.5 10.5L8.5 13.5L14.5 7" stroke="#3B82F6" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round"/>
+  </svg>
+`
+
+/**
+ * Draws with a finger: while a segment is being laid down, one finger on the map aims the line's loose end
+ * instead of panning, panning is left to two fingers, and where the finger lets go waits under a checkmark
+ * until it is confirmed, so it can be dragged again as many times as it takes.
+ * @param {UseTouchDrawingOptions} options - What counts as drawing right now, and how to draw it.
+ * @returns {UseTouchDrawingReturn} The point awaiting confirmation plus the methods to bind and unbind the map.
+ */
+export const useTouchDrawing = (options: UseTouchDrawingOptions): UseTouchDrawingReturn => {
+  const { drawsWithOneFinger, confirmLabel, hasAnchor, isBlocked, placePoint, aimAt } = options
+
+  const pendingPoint = shallowRef<L.LatLng | null>(null)
+  const drawsNow = computed(drawsWithOneFinger)
+
+  let mapRef: LeafletMap | undefined
+  let confirmEl: HTMLDivElement | null = null
+  let pressedPointerId: number | null = null
+  let pressOrigin: L.Point | null = null
+  let isAiming = false
+  let aimedWithoutClick = false
+  let panningWasEnabled = false
+
+  const positionConfirm = (): void => {
+    if (!mapRef || !confirmEl || !pendingPoint.value) return
+
+    const { x, y } = mapRef.latLngToContainerPoint(pendingPoint.value)
+    confirmEl.style.left = `${x + confirmOffsetInPixels}px`
+    confirmEl.style.top = `${y - confirmOffsetInPixels}px`
+  }
+
+  const clearPendingPoint = (): void => {
+    pendingPoint.value = null
+    if (confirmEl) confirmEl.style.display = 'none'
+  }
+
+  const confirmPendingPoint = (): void => {
+    const point = pendingPoint.value
+    if (!point) return
+
+    logUserAction(`Confirmed the ${confirmLabel()} dragged out on the map`)
+    clearPendingPoint()
+    placePoint(point)
+  }
+
+  const ensureConfirm = (map: LeafletMap): HTMLDivElement => {
+    if (confirmEl) return confirmEl
+
+    const el = document.createElement('div')
+    el.className = 'touch-draw-confirm'
+    el.setAttribute('role', 'button')
+    el.innerHTML = confirmMarkup
+    el.style.position = 'absolute'
+    el.style.zIndex = '641'
+    el.style.transform = 'translate(-50%, -50%)'
+    el.style.cursor = 'pointer'
+    el.style.display = 'none'
+    // The map is listening for a click on everything inside its container, and this one is not a place to draw.
+    L.DomEvent.disableClickPropagation(el)
+    el.addEventListener('click', confirmPendingPoint)
+    map.getContainer().appendChild(el)
+
+    confirmEl = el
+    return el
+  }
+
+  const holdPointForConfirmation = (latlng: L.LatLng): void => {
+    if (!mapRef) return
+
+    pendingPoint.value = latlng
+    const el = ensureConfirm(mapRef)
+    const label = `Confirm the ${confirmLabel()}`
+    el.setAttribute('aria-label', label)
+    el.title = label
+    el.style.display = 'block'
+    positionConfirm()
+  }
+
+  const restorePanning = (): void => {
+    if (!panningWasEnabled) return
+
+    panningWasEnabled = false
+    mapRef?.dragging.enable()
+  }
+
+  // With its own dragging switched off, leaflet leaves the container free to be panned as a page instead, which
+  // ends the gesture the line is being aimed with. The browser is told to keep its hands off it while it lasts,
+  // the same way leaflet does when it is panning the map itself.
+  const applyTouchAction = (): void => {
+    const container = mapRef?.getContainer()
+    if (container) container.style.touchAction = drawsNow.value ? 'none' : ''
+  }
+
+  const stopPress = (): void => {
+    const container = mapRef?.getContainer()
+    if (pressedPointerId !== null && container?.hasPointerCapture(pressedPointerId)) {
+      container.releasePointerCapture(pressedPointerId)
+    }
+    pressedPointerId = null
+    pressOrigin = null
+    isAiming = false
+    restorePanning()
+  }
+
+  const onPointerDown = (event: PointerEvent): void => {
+    aimedWithoutClick = false
+    // A second finger means the map's own pinch and pan, so the first one stops aiming and leaves the line where
+    // it got to. Panning is given back by that finger's own release, not by this one.
+    if (!event.isPrimary) {
+      pressOrigin = null
+      isAiming = false
+      return
+    }
+    // A first finger arriving while one is still held means the last gesture's release never came, so it is closed
+    // out here rather than leaving panning switched off for good.
+    if (pressedPointerId !== null) stopPress()
+
+    const pressedOn = event.target as HTMLElement | null
+    const ownedElsewhere = isBlocked() || isOverSurveyHandle(pressedOn) || !!pressedOn?.closest?.(ownPressSelector)
+    if (!mapRef || event.pointerType === 'mouse' || !drawsNow.value || ownedElsewhere) return
+
+    clearPendingPoint()
+    pressedPointerId = event.pointerId
+    pressOrigin = mapRef.mouseEventToContainerPoint(event)
+    isAiming = false
+    // The gesture has to be read to its end even when the finger wanders off the map, which is also what keeps
+    // its release from going missing and leaving panning switched off.
+    mapRef.getContainer().setPointerCapture(event.pointerId)
+    panningWasEnabled = mapRef.dragging.enabled()
+    if (panningWasEnabled) mapRef.dragging.disable()
+  }
+
+  const onPointerMove = (event: PointerEvent): void => {
+    if (!mapRef || pressedPointerId !== event.pointerId || !pressOrigin) return
+
+    const containerPoint = mapRef.mouseEventToContainerPoint(event)
+    if (!isAiming) {
+      if (containerPoint.distanceTo(pressOrigin) < dragThresholdInPixels) return
+      isAiming = true
+      // A segment has to start somewhere, so the spot the finger went down on becomes it.
+      if (!hasAnchor()) placePoint(mapRef.containerPointToLatLng(pressOrigin))
+      logUserAction('Dragged the live line out with a finger')
+    }
+
+    aimAt(mapRef.containerPointToLatLng(containerPoint), event)
+  }
+
+  const onPointerUp = (event: PointerEvent): void => {
+    if (pressedPointerId !== event.pointerId) return
+
+    const aimedAt = isAiming && mapRef ? mapRef.containerPointToLatLng(mapRef.mouseEventToContainerPoint(event)) : null
+    stopPress()
+    if (!aimedAt) return
+
+    aimedWithoutClick = true
+    holdPointForConfirmation(aimedAt)
+  }
+
+  const initTouchDrawing = (map: LeafletMap): void => {
+    mapRef = map
+    applyTouchAction()
+    const container = map.getContainer()
+    container.addEventListener('pointerdown', onPointerDown)
+    container.addEventListener('pointermove', onPointerMove)
+    container.addEventListener('pointerup', onPointerUp)
+    container.addEventListener('pointercancel', onPointerUp)
+    map.on('move zoom', positionConfirm)
+  }
+
+  const destroyTouchDrawing = (): void => {
+    const container = mapRef?.getContainer()
+    stopPress()
+    clearPendingPoint()
+    if (container) {
+      container.removeEventListener('pointerdown', onPointerDown)
+      container.removeEventListener('pointermove', onPointerMove)
+      container.removeEventListener('pointerup', onPointerUp)
+      container.removeEventListener('pointercancel', onPointerUp)
+      container.style.touchAction = ''
+    }
+    mapRef?.off('move zoom', positionConfirm)
+    confirmEl?.remove()
+    confirmEl = null
+    mapRef = undefined
+  }
+
+  watch(drawsNow, (draws) => {
+    applyTouchAction()
+    // Nothing is being drawn any more, so a point still waiting to be confirmed has nothing left to belong to.
+    if (!draws) clearPendingPoint()
+  })
+  onBeforeUnmount(destroyTouchDrawing)
+
+  return {
+    pendingPoint,
+    clearPendingPoint,
+    // Kept until the next press rather than for a while, since a drag the browser raises no click out of would
+    // otherwise leave the tap after it to be swallowed.
+    swallowsClick: () => aimedWithoutClick,
+    initTouchDrawing,
+    destroyTouchDrawing,
+  }
+}

--- a/src/libs/map/local-frame.ts
+++ b/src/libs/map/local-frame.ts
@@ -1,0 +1,40 @@
+import { earthRadiusMeters } from '@/libs/mission/general-estimates'
+import { degrees, radians } from '@/libs/utils'
+import type { WaypointCoordinates } from '@/types/mission'
+
+/** A point in the local east/north plane, in meters from the frame's anchor. */
+export interface LocalPoint {
+  /** Meters east of the anchor. */
+  x: number
+  /** Meters north of the anchor. */
+  y: number
+}
+
+/** Converters between coordinates and a local east/north plane anchored at one point. */
+export interface LocalFrame {
+  /** Projects a coordinate into the frame. */
+  toLocal: (coordinates: WaypointCoordinates) => LocalPoint
+  /** Lifts a point in the frame back to a coordinate. */
+  toCoordinates: (localPoint: LocalPoint) => WaypointCoordinates
+}
+
+/**
+ * Rectangles are built and measured in this plane, the same equirectangular projection the mission estimates
+ * use, because a spherical quad cannot have four square corners and equal opposite sides at once: walking great
+ * circles instead leaves the far side of a 300 m rectangle a third of a meter long.
+ * @param {WaypointCoordinates} anchor - Coordinate the plane is centered on.
+ * @returns {LocalFrame} Converters in and out of the plane anchored at that coordinate.
+ */
+export const localFrame = (anchor: WaypointCoordinates): LocalFrame => {
+  const cosAnchorLatitude = Math.cos(radians(anchor[0]))
+  return {
+    toLocal: (coordinates) => ({
+      x: earthRadiusMeters * radians(coordinates[1] - anchor[1]) * cosAnchorLatitude,
+      y: earthRadiusMeters * radians(coordinates[0] - anchor[0]),
+    }),
+    toCoordinates: ({ x, y }) => [
+      anchor[0] + degrees(y / earthRadiusMeters),
+      anchor[1] + degrees(x / (earthRadiusMeters * cosAnchorLatitude)),
+    ],
+  }
+}

--- a/src/libs/map/survey-polygon-edges.ts
+++ b/src/libs/map/survey-polygon-edges.ts
@@ -1,0 +1,99 @@
+import { localFrame } from '@/libs/map/local-frame'
+import { degrees, norm360 } from '@/libs/utils'
+import type { WaypointCoordinates } from '@/types/mission'
+
+/** A point on screen, in pixels from the top left of the map container. */
+export interface ScreenPoint {
+  /** Pixels from the container's left edge. */
+  x: number
+  /** Pixels from the container's top edge. */
+  y: number
+}
+
+const handleSelector = '.custom-div-icon, .edge-marker, .delete-popup, .delete-button'
+
+/**
+ * Whether an event landed on one of the survey polygon's own handles rather than on the map under it.
+ * @param {EventTarget | null} target - The element the event was raised on.
+ * @returns {boolean} True when the element is a handle, or sits inside one.
+ */
+export const isOverSurveyHandle = (target: EventTarget | null): boolean =>
+  !!(target as HTMLElement | null)?.closest?.(handleSelector)
+
+const distanceToSegment = (point: ScreenPoint, start: ScreenPoint, end: ScreenPoint): number => {
+  const run = { x: end.x - start.x, y: end.y - start.y }
+  const lengthSquared = run.x * run.x + run.y * run.y
+  const alongRun = lengthSquared === 0 ? 0 : ((point.x - start.x) * run.x + (point.y - start.y) * run.y) / lengthSquared
+  const closest = Math.min(1, Math.max(0, alongRun))
+  return Math.hypot(point.x - (start.x + closest * run.x), point.y - (start.y + closest * run.y))
+}
+
+/**
+ * Index of the polygon edge closest to a point on screen, where edge `i` runs from vertex `i` to the one after it.
+ * @param {ScreenPoint[]} vertices - The polygon's vertices, in container pixels.
+ * @param {ScreenPoint} point - The point to test, in container pixels.
+ * @param {number} toleranceInPixels - How far from an edge still counts as being on it.
+ * @returns {number | null} The edge's index, or null when no edge is within the tolerance.
+ */
+export const closestPolygonEdge = (
+  vertices: ScreenPoint[],
+  point: ScreenPoint,
+  toleranceInPixels: number
+): number | null => {
+  if (vertices.length < 3) return null
+
+  let closestEdge: number | null = null
+  let closestDistance = toleranceInPixels
+  for (let index = 0; index < vertices.length; index++) {
+    const distance = distanceToSegment(point, vertices[index], vertices[(index + 1) % vertices.length])
+    if (distance <= closestDistance) {
+      closestDistance = distance
+      closestEdge = index
+    }
+  }
+  return closestEdge
+}
+
+// Screen y grows downward, so a horizontal edge has a vertical normal and reads as ns-resize.
+const resizeCursors = ['ew-resize', 'nwse-resize', 'ns-resize', 'nesw-resize']
+
+/**
+ * CSS resize cursor whose arrows lie along an edge's normal, which is the axis dragging the edge moves it on.
+ * @param {ScreenPoint} start - The edge's first endpoint, in container pixels.
+ * @param {ScreenPoint} end - The edge's second endpoint, in container pixels.
+ * @returns {string} The cursor keyword to apply to the map container.
+ */
+export const edgeResizeCursor = (start: ScreenPoint, end: ScreenPoint): string => {
+  const normalAngle = norm360(degrees(Math.atan2(end.y - start.y, end.x - start.x)) + 90) % 180
+  return resizeCursors[Math.round(normalAngle / 45) % 4]
+}
+
+/**
+ * Where an edge's endpoints land after a drag: following the pointer for a free-form polygon, and sliding along
+ * the edge's own normal when the shape has to keep its right angles.
+ * @param {[WaypointCoordinates, WaypointCoordinates]} edge - The edge's endpoints as they were before the drag.
+ * @param {[WaypointCoordinates, WaypointCoordinates]} drag - Where the pointer went down, and where it is now.
+ * @param {boolean} alongNormalOnly - Whether the edge may only move perpendicular to itself.
+ * @returns {[WaypointCoordinates, WaypointCoordinates]} The edge's endpoints after the drag.
+ */
+export const draggedEdgeEndpoints = (
+  edge: [WaypointCoordinates, WaypointCoordinates],
+  drag: [WaypointCoordinates, WaypointCoordinates],
+  alongNormalOnly: boolean
+): [WaypointCoordinates, WaypointCoordinates] => {
+  const { toLocal, toCoordinates } = localFrame(edge[0])
+  const run = toLocal(edge[1])
+  const from = toLocal(drag[0])
+  const to = toLocal(drag[1])
+  const offset = { x: to.x - from.x, y: to.y - from.y }
+
+  const length = Math.hypot(run.x, run.y)
+  if (alongNormalOnly && length > 0) {
+    const normal = { x: run.y / length, y: -run.x / length }
+    const alongNormal = offset.x * normal.x + offset.y * normal.y
+    offset.x = normal.x * alongNormal
+    offset.y = normal.y * alongNormal
+  }
+
+  return [toCoordinates(offset), toCoordinates({ x: run.x + offset.x, y: run.y + offset.y })]
+}

--- a/src/libs/map/survey-polygon-edges.ts
+++ b/src/libs/map/survey-polygon-edges.ts
@@ -20,6 +20,14 @@ const handleSelector = '.custom-div-icon, .edge-marker, .delete-popup, .delete-b
 export const isOverSurveyHandle = (target: EventTarget | null): boolean =>
   !!(target as HTMLElement | null)?.closest?.(handleSelector)
 
+/**
+ * Whether an event landed on the "+" an edge carries at its midpoint.
+ * @param {EventTarget | null} target - The element the event was raised on.
+ * @returns {boolean} True when the element is such a marker, or sits inside one.
+ */
+export const isOverEdgeAddMarker = (target: EventTarget | null): boolean =>
+  !!(target as HTMLElement | null)?.closest?.('.edge-marker')
+
 const distanceToSegment = (point: ScreenPoint, start: ScreenPoint, end: ScreenPoint): number => {
   const run = { x: end.x - start.x, y: end.y - start.y }
   const lengthSquared = run.x * run.x + run.y * run.y

--- a/src/libs/map/survey-rectangle.ts
+++ b/src/libs/map/survey-rectangle.ts
@@ -111,6 +111,54 @@ export const rectangleSpec = (corners: WaypointCoordinates[]): SurveyRectangleSp
 }
 
 /**
+ * Carries a rectangle's corners by the ground offset between two positions, each corner moved the same distance
+ * east and north so the shape arrives with the extents it left with.
+ * @param {WaypointCoordinates[]} corners - The rectangle's corners.
+ * @param {WaypointCoordinates} from - Where the drag started.
+ * @param {WaypointCoordinates} to - Where the drag has reached.
+ * @returns {WaypointCoordinates[]} The corners at their new place.
+ */
+export const rectangleTranslatedBy = (
+  corners: WaypointCoordinates[],
+  from: WaypointCoordinates,
+  to: WaypointCoordinates
+): WaypointCoordinates[] => {
+  const offset = localFrame(from).toLocal(to)
+  return corners.map((corner) => localFrame(corner).toCoordinates(offset))
+}
+
+/**
+ * Turns a rectangle about one of its own corners, by the angle a second corner has been dragged through around
+ * it, so the shape spins rigidly and keeps both its extents and its square corners.
+ * @param {WaypointCoordinates[]} corners - The rectangle's corners.
+ * @param {WaypointCoordinates} pivot - The corner held still.
+ * @param {WaypointCoordinates} from - Where the turning corner was.
+ * @param {WaypointCoordinates} to - Where it has been dragged to.
+ * @returns {WaypointCoordinates[]} The turned corners.
+ */
+export const rectangleRotatedAbout = (
+  corners: WaypointCoordinates[],
+  pivot: WaypointCoordinates,
+  from: WaypointCoordinates,
+  to: WaypointCoordinates
+): WaypointCoordinates[] => {
+  const { toLocal, toCoordinates } = localFrame(pivot)
+  const before = toLocal(from)
+  const after = toLocal(to)
+  // A corner dragged onto the pivot itself points nowhere, so there is no angle to turn the rectangle through.
+  if (Math.hypot(before.x, before.y) === 0 || Math.hypot(after.x, after.y) === 0) return corners
+
+  const turn = Math.atan2(after.x, after.y) - Math.atan2(before.x, before.y)
+  const cosTurn = Math.cos(turn)
+  const sinTurn = Math.sin(turn)
+
+  return corners.map((corner) => {
+    const { x, y } = toLocal(corner)
+    return toCoordinates({ x: x * cosTurn + y * sinTurn, y: y * cosTurn - x * sinTurn })
+  })
+}
+
+/**
  * Scan angle that runs the survey lines along a rectangle's longer axis, which is the direction that needs the
  * fewest turnarounds to cover it.
  *

--- a/src/libs/map/survey-rectangle.ts
+++ b/src/libs/map/survey-rectangle.ts
@@ -1,0 +1,60 @@
+import { localFrame } from '@/libs/map/local-frame'
+import { degrees, norm360 } from '@/libs/utils'
+import type { WaypointCoordinates } from '@/types/mission'
+
+/** A rectangle described by the edge the user drew plus its extent perpendicular to that edge. */
+export interface SurveyRectangleSpec {
+  /** Corner the drawn baseline starts at. */
+  origin: WaypointCoordinates
+  /** Bearing of the baseline, in degrees clockwise from north. */
+  bearing: number
+  /** Extent along the baseline, in meters. */
+  length: number
+  /** Extent perpendicular to the baseline, in meters. */
+  width: number
+}
+
+// A quad counts as a rectangle while every corner is within this many degrees of square and opposite sides
+// match within this fraction of their length, which absorbs coordinate rounding without accepting a polygon
+// the user has visibly dragged out of shape.
+const squareCornerToleranceDeg = 0.1
+const oppositeSideTolerance = 0.001
+
+/**
+ * Recovers the spec of a rectangular polygon, so a rectangle's dimensions can be read back from its corners
+ * instead of being stored alongside them.
+ * @param {WaypointCoordinates[]} corners - The polygon's vertices, as an open ring.
+ * @returns {SurveyRectangleSpec | null} The spec, or null when the polygon is not a rectangle.
+ */
+export const rectangleSpec = (corners: WaypointCoordinates[]): SurveyRectangleSpec | null => {
+  if (corners.length !== 4) return null
+
+  const { toLocal } = localFrame(corners[0])
+  const points = corners.map(toLocal)
+  const edges = points.map((point, index) => ({
+    x: points[(index + 1) % 4].x - point.x,
+    y: points[(index + 1) % 4].y - point.y,
+  }))
+  const lengths = edges.map((edge) => Math.hypot(edge.x, edge.y))
+  if (lengths.some((length) => length === 0)) return null
+
+  const opposedSidesMatch = [
+    [lengths[0], lengths[2]],
+    [lengths[1], lengths[3]],
+  ].every(([first, second]) => Math.abs(first - second) <= oppositeSideTolerance * Math.max(first, second))
+  if (!opposedSidesMatch) return null
+
+  const cornersAreSquare = edges.every((edge, index) => {
+    const next = edges[(index + 1) % 4]
+    const cosine = (edge.x * next.x + edge.y * next.y) / (lengths[index] * lengths[(index + 1) % 4])
+    return Math.abs(degrees(Math.acos(Math.min(1, Math.max(-1, cosine)))) - 90) <= squareCornerToleranceDeg
+  })
+  if (!cornersAreSquare) return null
+
+  return {
+    origin: corners[0],
+    bearing: norm360(degrees(Math.atan2(edges[0].x, edges[0].y))),
+    length: lengths[0],
+    width: lengths[1],
+  }
+}

--- a/src/libs/map/survey-rectangle.ts
+++ b/src/libs/map/survey-rectangle.ts
@@ -1,5 +1,6 @@
 import { localFrame } from '@/libs/map/local-frame'
-import { degrees, norm360 } from '@/libs/utils'
+import { calculateHaversineDistance } from '@/libs/mission/general-estimates'
+import { degrees, norm360, radians } from '@/libs/utils'
 import type { WaypointCoordinates } from '@/types/mission'
 
 /** A rectangle described by the edge the user drew plus its extent perpendicular to that edge. */
@@ -19,6 +20,56 @@ export interface SurveyRectangleSpec {
 // the user has visibly dragged out of shape.
 const squareCornerToleranceDeg = 0.1
 const oppositeSideTolerance = 0.001
+
+/**
+ * Corners of the rectangle a spec describes, walking the baseline and then the perpendicular extent.
+ * @param {SurveyRectangleSpec} spec - The baseline and the extents to build the rectangle from.
+ * @returns {WaypointCoordinates[]} The four corners, starting at the spec's origin.
+ */
+export const rectangleCorners = (spec: SurveyRectangleSpec): WaypointCoordinates[] => {
+  const { origin, bearing, length, width } = spec
+  const { toCoordinates } = localFrame(origin)
+
+  const along = { x: Math.sin(radians(bearing)), y: Math.cos(radians(bearing)) }
+  const across = { x: along.y, y: -along.x }
+
+  return [
+    origin,
+    toCoordinates({ x: along.x * length, y: along.y * length }),
+    toCoordinates({ x: along.x * length + across.x * width, y: along.y * length + across.y * width }),
+    toCoordinates({ x: across.x * width, y: across.y * width }),
+  ]
+}
+
+/**
+ * Builds the rectangle a drawn baseline and a cursor position describe. The cursor's perpendicular offset from
+ * the baseline sets the width, and the baseline is walked in whichever direction puts the rectangle on the
+ * cursor's side of it.
+ * @param {WaypointCoordinates} start - Where the baseline was started.
+ * @param {WaypointCoordinates} end - Where the baseline was ended.
+ * @param {WaypointCoordinates} cursor - The position choosing the side and the width.
+ * @returns {SurveyRectangleSpec} The rectangle spanning the baseline and reaching the cursor.
+ */
+export const rectangleFromBaselineAndCursor = (
+  start: WaypointCoordinates,
+  end: WaypointCoordinates,
+  cursor: WaypointCoordinates
+): SurveyRectangleSpec => {
+  const { toLocal } = localFrame(start)
+  const baseline = toLocal(end)
+  const toCursor = toLocal(cursor)
+
+  const length = Math.hypot(baseline.x, baseline.y)
+  if (length === 0) return { origin: start, bearing: 0, length: 0, width: 0 }
+
+  // Positive when the cursor sits to the right of the baseline, which is the side rectangleCorners extends to,
+  // so a cursor on the left is served by walking the baseline the other way round.
+  const signedOffset = (toCursor.x * baseline.y - toCursor.y * baseline.x) / length
+
+  return signedOffset >= 0
+    ? { origin: start, bearing: norm360(degrees(Math.atan2(baseline.x, baseline.y))), length, width: signedOffset }
+    : { origin: end, bearing: norm360(degrees(Math.atan2(-baseline.x, -baseline.y))), length, width: -signedOffset }
+}
 
 /**
  * Recovers the spec of a rectangular polygon, so a rectangle's dimensions can be read back from its corners
@@ -57,4 +108,26 @@ export const rectangleSpec = (corners: WaypointCoordinates[]): SurveyRectangleSp
     length: lengths[0],
     width: lengths[1],
   }
+}
+
+/**
+ * Scan angle that runs the survey lines along a rectangle's longer axis, which is the direction that needs the
+ * fewest turnarounds to cover it.
+ *
+ * The angle is measured in the raw lon/lat plane the survey generator sweeps its lines in, not as a geodesic
+ * bearing, because the two only agree on the meridians and the equator: away from them a geodesic bearing fed
+ * to the generator would tilt the lines off the axis by the plane's `cos(latitude)` skew.
+ * @param {WaypointCoordinates[]} corners - The rectangle's corners, as returned by {@link rectangleCorners}.
+ * @returns {number} The scan angle to hand the survey generator, in degrees from 0 to 359.
+ */
+export const rectangleLinesAngle = (corners: WaypointCoordinates[]): number => {
+  if (corners.length < 3) return 0
+
+  const lengthAxis: [WaypointCoordinates, WaypointCoordinates] = [corners[0], corners[1]]
+  const widthAxis: [WaypointCoordinates, WaypointCoordinates] = [corners[1], corners[2]]
+  const longerAxis =
+    calculateHaversineDistance(...widthAxis) > calculateHaversineDistance(...lengthAxis) ? widthAxis : lengthAxis
+
+  const [from, to] = longerAxis
+  return norm360(degrees(Math.atan2(to[1] - from[1], to[0] - from[0])))
 }

--- a/src/libs/map/typed-extent.ts
+++ b/src/libs/map/typed-extent.ts
@@ -1,0 +1,43 @@
+import { localFrame } from '@/libs/map/local-frame'
+import type { WaypointCoordinates } from '@/types/mission'
+
+// A mistyped extra digit would otherwise build an area the path generator sweeps line by line, so every typed
+// extent is held to a range a survey can be flown at.
+export const minExtentInMeters = 1
+export const maxExtentInMeters = 100000
+
+/**
+ * Holds a typed extent to the range a survey can be flown at, keeping its sign, which is how a negative extent
+ * grows the shape to the side opposite the cursor.
+ * @param {number} value - The extent that was typed, in meters.
+ * @param {number} fallback - Extent to keep when nothing usable was typed.
+ * @returns {number} The extent to build with, in meters, negative when it was typed that way.
+ */
+export const clampExtent = (value: number, fallback: number): number => {
+  if (!Number.isFinite(value) || value === 0) return fallback
+
+  const magnitude = Math.min(maxExtentInMeters, Math.max(minExtentInMeters, Math.abs(value)))
+  return value < 0 ? -magnitude : magnitude
+}
+
+/**
+ * Walks a given distance from one coordinate in the direction of another, which is how a typed extent takes over
+ * a segment whose direction is still being chosen with the cursor.
+ * @param {WaypointCoordinates} from - Coordinate the distance is walked from.
+ * @param {WaypointCoordinates} towards - Coordinate giving the direction to walk in.
+ * @param {number} distanceInMeters - How far to walk.
+ * @returns {WaypointCoordinates} The coordinate at that distance, or the origin when there is no direction yet.
+ */
+export const pointAtDistanceToward = (
+  from: WaypointCoordinates,
+  towards: WaypointCoordinates,
+  distanceInMeters: number
+): WaypointCoordinates => {
+  const { toLocal, toCoordinates } = localFrame(from)
+  const { x, y } = toLocal(towards)
+  const magnitude = Math.hypot(x, y)
+  if (magnitude === 0) return from
+
+  const scale = distanceInMeters / magnitude
+  return toCoordinates({ x: x * scale, y: y * scale })
+}

--- a/src/libs/mission/general-estimates.ts
+++ b/src/libs/mission/general-estimates.ts
@@ -5,7 +5,7 @@ import { MissionLeg, WaypointCoordinates } from '@/types/mission'
 import { norm360, radians } from '../utils'
 import { BatteryChemistry } from '../vehicle/types'
 
-const earthRadiusMeters = 6_378_137
+export const earthRadiusMeters = 6_378_137
 
 // Haversine distance between two lat/lng coordinates (in meters) to calculate around-a-sphere distance between two points
 // Equation from https://www.movable-type.co.uk/scripts/latlong.html

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -193,6 +193,13 @@ export const isElectron = (): boolean => {
 }
 
 /**
+ * Detects if the device is driven by touch, which has neither a hover to reveal things with nor a keyboard to
+ * type into them
+ * @returns {boolean} True when the device's main pointer is a finger
+ */
+export const isTouchDevice = (): boolean => window.matchMedia('(pointer: coarse)').matches
+
+/**
  * Detects the host operating system, named as users know it
  * @returns {'Linux' | 'Windows' | 'macOS' | undefined} The host OS name, or undefined when it cannot be told
  */

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -769,6 +769,7 @@
   <SideConfigPanel
     v-if="isCreatingSurvey || selectedWaypoint"
     position="right"
+    :reopen-label="isCreatingSurvey ? 'Vertexes' : undefined"
     style="z-index: 600; pointer-events: auto"
     class="w-[320px]"
   >
@@ -885,6 +886,7 @@ import { useMapTileLayerSelection } from '@/composables/map/useMapTileLayerSelec
 import { useMeasureExtentInput } from '@/composables/map/useMeasureExtentInput'
 import { type SurveyPreview, useSurveyArrowOverlay } from '@/composables/map/useSurveyArrowOverlay'
 import { useSurveyEdgeDragging } from '@/composables/map/useSurveyEdgeDragging'
+import { useTouchDrawing } from '@/composables/map/useTouchDrawing'
 import { useVertexAngleOverlay } from '@/composables/map/useVertexAngleOverlay'
 import { useWaypointMarkerSize } from '@/composables/map/useWaypointMarkerSize'
 import { useSnackbar } from '@/composables/snackbar'
@@ -1258,6 +1260,24 @@ const {
   },
 })
 
+const {
+  pendingPoint: pendingDrawnPoint,
+  clearPendingPoint,
+  swallowsClick: touchDrawingSwallowsClick,
+  initTouchDrawing,
+  destroyTouchDrawing,
+} = useTouchDrawing({
+  // An area is drawn with the finger from its very first corner, a path only once it has a waypoint to draw from.
+  drawsWithOneFinger: () =>
+    (isCreatingSurvey.value && isDrawingSurveyPolygon.value) ||
+    (isCreatingSimplePath.value && currentMeasureAnchor() !== null),
+  confirmLabel: () => 'point',
+  hasAnchor: () => currentMeasureAnchor() !== null,
+  isBlocked: () => isPressingSurveyEdge.value || isDraggingMarker.value || isDraggingSurveyVertex.value,
+  placePoint: (latlng) => placeDrawnPoint(latlng),
+  aimAt: (latlng, event) => fireMapMouseMove(latlng, event),
+})
+
 let ignoreNextClick = false
 const selectedWaypoint = ref<Waypoint | undefined>(undefined)
 const contextMenuType = ref<ContextMenuTypes>('map')
@@ -1325,6 +1345,7 @@ const measureLayer = shallowRef<L.LayerGroup | null>(null)
 let measureOverlayEl: HTMLDivElement | null = null
 let measureSvgEl: SVGSVGElement | null = null
 let measureLineEl: SVGLineElement | null = null
+let measureEndDotEl: SVGCircleElement | null = null
 let measureTextEl: HTMLDivElement | null = null
 let measureLengthEl: HTMLSpanElement | null = null
 let measureRestEl: HTMLSpanElement | null = null
@@ -1352,6 +1373,7 @@ const glassMenuCssVars = computed(() => ({
 const clearLiveMeasure = (): void => {
   destroyMeasureOverlay(planningMap.value || undefined)
   angleOverlay.clearVertexAngles()
+  clearPendingPoint()
   // An extent typed for the segment just drawn does not carry over to the next one, which starts free again.
   setExtentTarget('segment', null)
   clearExtentValues()
@@ -1414,7 +1436,15 @@ const ensureMeasureOverlay = (map: L.Map): void => {
   measureLineEl.setAttribute('opacity', '0.9')
   measureLineEl.setAttribute('stroke', '#2563eb')
 
+  // The loose end of the line is where the next point lands, and a finger dragging it needs to see where that is.
+  measureEndDotEl = document.createElementNS('http://www.w3.org/2000/svg', 'circle')
+  measureEndDotEl.setAttribute('r', '5')
+  measureEndDotEl.setAttribute('fill', '#2563eb')
+  measureEndDotEl.setAttribute('stroke', '#FFFFFF')
+  measureEndDotEl.setAttribute('stroke-width', '2')
+
   measureSvgEl.appendChild(measureLineEl)
+  measureSvgEl.appendChild(measureEndDotEl)
 
   measureTextEl = document.createElement('div')
   measureTextEl.className = 'live-measure-pill'
@@ -1467,6 +1497,7 @@ const destroyMeasureOverlay = (map?: L.Map): void => {
   measureOverlayEl = null
   measureSvgEl = null
   measureLineEl = null
+  measureEndDotEl = null
   measureTextEl = null
   measureLengthEl = null
   measureRestEl = null
@@ -1540,6 +1571,8 @@ const handleMapMouseMove = (e: L.LeafletMouseEvent): void => {
     measureLineEl.setAttribute('x2', String(b.x))
     measureLineEl.setAttribute('y2', String(b.y))
   }
+  measureEndDotEl?.setAttribute('cx', String(b.x))
+  measureEndDotEl?.setAttribute('cy', String(b.y))
 
   const midX = (a.x + b.x) / 2
   const midY = (a.y + b.y) / 2
@@ -1596,9 +1629,26 @@ const refreshLiveMeasureOnMapMove = (): void => {
     if (!planningMap.value || !lastMeasureCursor) return
     const map = planningMap.value
     const rect = map.getContainer().getBoundingClientRect()
-    const containerPoint = L.point(cursorLivePositionX.value - rect.left, cursorLivePositionY.value - rect.top)
-    const latlng = map.containerPointToLatLng(containerPoint)
+    const cursorPoint = L.point(cursorLivePositionX.value - rect.left, cursorLivePositionY.value - rect.top)
+    // A finger leaves no cursor behind, so a point it dragged out and left waiting is where the measure ends.
+    const held = pendingDrawnPoint.value
+    const containerPoint = held ? map.latLngToContainerPoint(held) : cursorPoint
+    const latlng = held ?? map.containerPointToLatLng(containerPoint)
     handleMapMouseMove({ ...lastMeasureCursor, latlng, containerPoint })
+  })
+}
+
+// A finger produces no mousemove, so where it drags to is fired as one: the live measure, the rectangle being
+// swept and everything else already following the cursor then follow the finger too.
+const fireMapMouseMove = (latlng: L.LatLng, originalEvent: PointerEvent): void => {
+  const map = planningMap.value
+  if (!map) return
+
+  map.fire('mousemove', {
+    latlng,
+    layerPoint: map.latLngToLayerPoint(latlng),
+    containerPoint: map.latLngToContainerPoint(latlng),
+    originalEvent,
   })
 }
 
@@ -2540,7 +2590,6 @@ const toggleSurvey = (): void => {
   surveyDraftEntryCorner.value = 0
   isCreatingSurvey.value = true
   isDrawingSurveyPolygon.value = true
-  interfaceStore.configPanelVisible = true
   hideContextMenu()
 }
 
@@ -3644,7 +3693,8 @@ watch(isCreatingSurvey, (isCreatingNow) => {
   if (isCreatingNow) {
     existingWaypoints.value = [...missionStore.currentPlanningWaypoints]
     surveyWaypoints.value = []
-    interfaceStore.configPanelVisible = true
+    // The vertex list stays folded away behind its own arrow, since the map is what the area is drawn on.
+    interfaceStore.configPanelVisible = false
   } else {
     clearSurveyPath()
   }
@@ -4343,6 +4393,10 @@ const onMapClick = (e: L.LeafletMouseEvent): void => {
   // The dedicated home-setting handler owns this click; bail so we don't also drop a survey vertex or waypoint here.
   if (isSettingHomeWaypoint.value) return
 
+  // A drag that aimed the line has already said where the point goes, so a click the browser raises out of that
+  // same gesture is not another point.
+  if (touchDrawingSwallowsClick()) return
+
   const oldWaypoint = selectedWaypoint.value
   if (oldWaypoint) {
     const oldMarker = waypointMarkers.value[oldWaypoint.id]
@@ -4488,6 +4542,7 @@ onMounted(async () => {
   dragMeasureOverlay.initDragMeasureOverlay(planningMap.value!)
   initExtentInputs(planningMap.value!)
   initEdgeDragging(planningMap.value!)
+  initTouchDrawing(planningMap.value!)
   measureLayer.value = L.layerGroup().addTo(planningMap.value!) as L.LayerGroup
 
   registerLayerSync(planningMap.value)
@@ -4641,6 +4696,7 @@ onUnmounted(() => {
   angleOverlay.destroyAngleOverlay()
   surveyArrowOverlay.destroyArrowOverlay()
   destroyEdgeDragging()
+  destroyTouchDrawing()
 
   detachTileFallbacks.forEach((detach) => detach())
   detachTileFallbacks = []

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -932,7 +932,7 @@ import {
   polygonAreaSquareMeters,
 } from '@/libs/mission/general-estimates'
 import { PLANNABLE_VEHICLE_TYPES, vehicleTypeLabel } from '@/libs/mission/library'
-import { degrees, messageFromError, toPlain } from '@/libs/utils'
+import { degrees, isTouchDevice, messageFromError, toPlain } from '@/libs/utils'
 import router from '@/router'
 import { SubMenuComponentName, SubMenuName, useAppInterfaceStore } from '@/stores/appInterface'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
@@ -1230,7 +1230,10 @@ const clearSurveyPolygonUndoStack = (): void => {
 }
 
 const extentInput = useMeasureExtentInput({
-  shortcutFocus: () => (currentMeasureAnchor() ? 'segment' : null),
+  shortcutFocus: () => {
+    if (isSizingRectangle.value) return 'width'
+    return currentMeasureAnchor() ? 'segment' : null
+  },
   onOpened: () => refreshLiveMeasureOnMapMove(),
 })
 const {
@@ -1260,6 +1263,7 @@ const {
   initRectangleDrawing,
 } = useSurveyRectangleDrawing({
   vertices: surveyPolygonVertexesPositions,
+  extentInput,
   onRectangleDrawn: (linesAngle) => {
     isDrawingSurveyPolygon.value = false
     surveyLinesAngle.value = linesAngle
@@ -1544,6 +1548,10 @@ const destroyMeasureOverlay = (map?: L.Map): void => {
 
 const placeSurveyPolygonPoint = (latlng: L.LatLng): void => {
   if (!consumeSurveyClick(latlng)) addSurveyPoint(latlng)
+  // The rectangle's first corner is down, so the edge it raises can be typed rather than drawn. On touch the box
+  // is left to be asked for by tapping the tag, since it has no keyboard waiting behind it.
+  const offersTyping = !isTouchDevice() && surveyDrawShape.value === 'rectangle'
+  if (offersTyping && !extentInputsOpen.value) openExtentInputs('segment')
   clearLiveMeasure()
 }
 

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -867,6 +867,7 @@ import { useMapPoiMarkers } from '@/composables/map/useMapPoiMarkers'
 import { useMapTileLayers } from '@/composables/map/useMapTileLayers'
 import { useMapTileLayerSelection } from '@/composables/map/useMapTileLayerSelection'
 import { type SurveyPreview, useSurveyArrowOverlay } from '@/composables/map/useSurveyArrowOverlay'
+import { useSurveyEdgeDragging } from '@/composables/map/useSurveyEdgeDragging'
 import { useVertexAngleOverlay } from '@/composables/map/useVertexAngleOverlay'
 import { useWaypointMarkerSize } from '@/composables/map/useWaypointMarkerSize'
 import { useSnackbar } from '@/composables/snackbar'
@@ -883,6 +884,7 @@ import { MavCmd } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
 import type { NoiseTileOptions } from '@/libs/map/map-tile-fallback'
 import { attachTileNoiseFallback, refreshNoiseFallbackTiles } from '@/libs/map/map-tile-fallback'
 import { applyLiveWaypointCoordinates } from '@/libs/map/survey-arrows'
+import { isOverSurveyHandle } from '@/libs/map/survey-polygon-edges'
 import {
   createGridOverlay,
   fitMapToWaypoints,
@@ -1196,6 +1198,28 @@ const clearSurveyPolygonUndoStack = (): void => {
   surveyPolygonUndoStack.length = 0
   surveyPolygonRedoStack.length = 0
 }
+
+const {
+  isEdgePressed: isPressingSurveyEdge,
+  isDraggingEdge: isDraggingSurveyEdge,
+  initEdgeDragging,
+  destroyEdgeDragging,
+} = useSurveyEdgeDragging({
+  vertices: surveyPolygonVertexesPositions,
+  markers: () => surveyPolygonVertexesMarkers.value,
+  isEditable: () => isCreatingSurvey.value && surveyPolygonVertexesPositions.value.length >= 3,
+  onDragStart: pushSurveyPolygonSnapshot,
+  onEdgeMoved: () => {
+    updatePolygon()
+    createSurveyPath()
+    updateConfirmButtonPosition()
+  },
+  onDragEnd: (moved) => {
+    if (!moved) return
+    ignoreNextClick = true
+  },
+})
+
 let ignoreNextClick = false
 const selectedWaypoint = ref<Waypoint | undefined>(undefined)
 const contextMenuType = ref<ContextMenuTypes>('map')
@@ -1363,19 +1387,13 @@ const destroyMeasureOverlay = (map?: L.Map): void => {
   measureTextEl = null
 }
 
-const isOverSurveyHandle = (evt: L.LeafletMouseEvent): boolean => {
-  const el = evt.originalEvent?.target as HTMLElement | null
-  if (!el) return false
-  return !!el.closest('.custom-div-icon, .edge-marker, .delete-popup, .delete-button')
-}
-
 const handleMapMouseMove = (e: L.LeafletMouseEvent): void => {
   if (!planningMap.value) return
 
   lastMeasureCursor = e
 
   const anchor = currentMeasureAnchor()
-  const draggingExistingNode = isDraggingMarker.value || isDraggingPolygon.value
+  const draggingExistingNode = isDraggingMarker.value || isDraggingPolygon.value || isDraggingSurveyEdge.value
   const measuring =
     !!anchor &&
     !draggingExistingNode &&
@@ -1391,7 +1409,7 @@ const handleMapMouseMove = (e: L.LeafletMouseEvent): void => {
 
   // NEW: hide/show the live pill when hovering survey nodes/add/delete UI
   if (measureTextEl) {
-    measureTextEl.style.display = isOverSurveyHandle(e) ? 'none' : 'block'
+    measureTextEl.style.display = isOverSurveyHandle(e.originalEvent?.target) ? 'none' : 'block'
   }
 
   const a = map.latLngToContainerPoint(anchor!)
@@ -1408,7 +1426,7 @@ const handleMapMouseMove = (e: L.LeafletMouseEvent): void => {
   const midY = (a.y + b.y) / 2
   const dist = anchor!.distanceTo(e.latlng)
 
-  const hidePill = isOverSurveyHandle(e) || isOverLastWaypointMarker(e) || dist < 1 // hide if closer than 1 meter to last wp on the array
+  const hidePill = isOverSurveyHandle(e.originalEvent?.target) || isOverLastWaypointMarker(e) || dist < 1 // hide if closer than 1 meter to last wp on the array
 
   const bearing = bearingBetween([anchor!.lat, anchor!.lng], [e.latlng.lat, e.latlng.lng])
   const text = `${formatMetersShort(dist)} · ${formatBearing(bearing)}`
@@ -2181,6 +2199,9 @@ const isOverLastWaypointMarker = (event: L.LeafletMouseEvent): boolean => {
 }
 
 const onPolygonMouseDown = (event: L.LeafletMouseEvent): void => {
+  // A press that landed on an edge is reshaping that edge, so the whole polygon must not follow the pointer too.
+  if (isPressingSurveyEdge.value) return
+
   isDraggingPolygon.value = true
   dragStartLatLng = event.latlng
   pushSurveyPolygonSnapshot()
@@ -4314,6 +4335,7 @@ onMounted(async () => {
   angleOverlay.initAngleOverlay(planningMap.value!)
   surveyArrowOverlay.initArrowOverlay(planningMap.value!)
   dragMeasureOverlay.initDragMeasureOverlay(planningMap.value!)
+  initEdgeDragging(planningMap.value!)
   measureLayer.value = L.layerGroup().addTo(planningMap.value!) as L.LayerGroup
 
   registerLayerSync(planningMap.value)
@@ -4460,6 +4482,7 @@ onUnmounted(() => {
   dragMeasureOverlay.destroyDragMeasureOverlay()
   angleOverlay.destroyAngleOverlay()
   surveyArrowOverlay.destroyArrowOverlay()
+  destroyEdgeDragging()
 
   detachTileFallbacks.forEach((detach) => detach())
   detachTileFallbacks = []

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -3126,6 +3126,9 @@ const removeSurveyCrosshatchPathLayer = (): void => {
 const clearSurveyPathByUser = (): void => {
   logUserAction('Cleared survey path')
   clearSurveyPath()
+  // Clearing the draft is how the user starts over, so vertex adding comes back on even when it had been
+  // switched off.
+  if (isCreatingSurvey.value) isDrawingSurveyPolygon.value = true
 }
 
 const clearSurveyPath = (): void => {

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -332,6 +332,7 @@
         <div v-if="isCreatingSurvey" class="flex flex-col">
           <SurveyShapeControls
             :shape="surveyDrawShape"
+            :locked="surveyPolygonVertexesPositions.length > 0"
             :dimensions="surveyRectangleDimensions"
             @update:shape="setSurveyDrawShape"
             @update:dimensions="applySurveyRectangleDimensions"

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -330,6 +330,13 @@
         </div>
         <v-divider v-if="!isCreatingSimplePath && !isCreatingSurvey" class="my-2" />
         <div v-if="isCreatingSurvey" class="flex flex-col">
+          <SurveyShapeControls
+            :shape="surveyDrawShape"
+            :dimensions="surveyRectangleDimensions"
+            @update:shape="setSurveyDrawShape"
+            @update:dimensions="applySurveyRectangleDimensions"
+          />
+          <v-divider class="my-1" />
           <p class="m-1 overflow-visible text-sm text-slate-200">Distance between lines (m)</p>
           <input
             v-model.number="distanceBetweenSurveyLines"
@@ -865,6 +872,7 @@ import HomePositionSettingHelp from '@/components/mission-planning/HomePositionS
 import MeasureExtentInput from '@/components/mission-planning/MeasureExtentInput.vue'
 import MissionEstimatesPanel from '@/components/mission-planning/MissionEstimates.vue'
 import ScanDirectionDial from '@/components/mission-planning/ScanDirectionDial.vue'
+import SurveyShapeControls from '@/components/mission-planning/SurveyShapeControls.vue'
 import SurveyVertexList from '@/components/mission-planning/SurveyVertexList.vue'
 import WaypointConfigPanel from '@/components/mission-planning/WaypointConfigPanel.vue'
 import MissionLibraryModal from '@/components/MissionLibraryModal.vue'
@@ -886,6 +894,7 @@ import { useMapTileLayerSelection } from '@/composables/map/useMapTileLayerSelec
 import { useMeasureExtentInput } from '@/composables/map/useMeasureExtentInput'
 import { type SurveyPreview, useSurveyArrowOverlay } from '@/composables/map/useSurveyArrowOverlay'
 import { useSurveyEdgeDragging } from '@/composables/map/useSurveyEdgeDragging'
+import { useSurveyRectangleDrawing } from '@/composables/map/useSurveyRectangleDrawing'
 import { useTouchDrawing } from '@/composables/map/useTouchDrawing'
 import { useVertexAngleOverlay } from '@/composables/map/useVertexAngleOverlay'
 import { useWaypointMarkerSize } from '@/composables/map/useWaypointMarkerSize'
@@ -1239,6 +1248,34 @@ const {
 } = extentInput
 
 const {
+  shape: surveyDrawShape,
+  isSizingRectangle,
+  dimensions: surveyRectangleDimensions,
+  setShape: setSurveyDrawShape,
+  consumeSurveyClick,
+  applyDimensions: applySurveyRectangleDimensions,
+  releaseLinesAngle: releaseSurveyLinesAngle,
+  cancelSizing: cancelSurveyRectangleSizing,
+  initRectangleDrawing,
+} = useSurveyRectangleDrawing({
+  vertices: surveyPolygonVertexesPositions,
+  onRectangleDrawn: (linesAngle) => {
+    isDrawingSurveyPolygon.value = false
+    surveyLinesAngle.value = linesAngle
+    rebuildSurveyPolygonFromPositions()
+  },
+  onRectangleResized: (linesAngle) => {
+    if (linesAngle !== null) surveyLinesAngle.value = linesAngle
+    rebuildSurveyPolygonFromPositions()
+  },
+  onShapeChanged: () => {
+    if (!isDrawingSurveyPolygon.value || surveyPolygonVertexesPositions.value.length === 0) return
+    pushSurveyPolygonSnapshot()
+    clearSurveyPath()
+  },
+})
+
+const {
   isEdgePressed: isPressingSurveyEdge,
   isDraggingEdge: isDraggingSurveyEdge,
   initEdgeDragging,
@@ -1246,7 +1283,8 @@ const {
 } = useSurveyEdgeDragging({
   vertices: surveyPolygonVertexesPositions,
   markers: () => surveyPolygonVertexesMarkers.value,
-  isEditable: () => isCreatingSurvey.value && surveyPolygonVertexesPositions.value.length >= 3,
+  isEditable: () =>
+    isCreatingSurvey.value && !isSizingRectangle.value && surveyPolygonVertexesPositions.value.length >= 3,
   onDragStart: pushSurveyPolygonSnapshot,
   onEdgeMoved: () => {
     updatePolygon()
@@ -1504,7 +1542,7 @@ const destroyMeasureOverlay = (map?: L.Map): void => {
 }
 
 const placeSurveyPolygonPoint = (latlng: L.LatLng): void => {
-  addSurveyPoint(latlng)
+  if (!consumeSurveyClick(latlng)) addSurveyPoint(latlng)
   clearLiveMeasure()
 }
 
@@ -1544,6 +1582,7 @@ const handleMapMouseMove = (e: L.LeafletMouseEvent): void => {
   const measuring =
     !!anchor &&
     !draggingExistingNode &&
+    !isSizingRectangle.value &&
     (isCreatingSimplePath.value || (isCreatingSurvey.value && isDrawingSurveyPolygon.value))
   if (!measuring) {
     destroyMeasureOverlay(planningMap.value)
@@ -2817,6 +2856,7 @@ const performUndo = (): void => {
     surveyPolygonVertexesPositions.value = removedSurvey.polygonCoordinates.map(([lat, lng]) => L.latLng(lat, lng))
     distanceBetweenSurveyLines.value = removedSurvey.distanceBetweenLines
     surveyLinesAngle.value = removedSurvey.surveyLinesAngle
+    releaseSurveyLinesAngle()
     surveyCrosshatch.value = removedSurvey.crosshatch ?? false
     crosshatchDistanceBetweenLines.value =
       removedSurvey.crosshatchDistanceBetweenLines ?? removedSurvey.distanceBetweenLines
@@ -2908,7 +2948,7 @@ const performRedo = (): void => {
 
 const handleKeyDown = (event: KeyboardEvent): void => {
   if (event.key === 'Escape') {
-    if (isCreatingSurvey.value) {
+    if (isCreatingSurvey.value && !cancelSurveyRectangleSizing()) {
       if (isDrawingSurveyPolygon.value) {
         isDrawingSurveyPolygon.value = false
       }
@@ -3285,11 +3325,13 @@ const surveyLinesAngleDisplay = computed({
     return Number(surveyLinesAngle.value.toFixed(1))
   },
   set(value) {
+    releaseSurveyLinesAngle()
     surveyLinesAngle.value = value
   },
 })
 
 const onSurveyLinesAngleChange = (angle: number): void => {
+  releaseSurveyLinesAngle()
   surveyLinesAngle.value = angle
 }
 
@@ -3345,6 +3387,7 @@ const clearSurveyPathByUser = (): void => {
 }
 
 const clearSurveyPath = (): void => {
+  cancelSurveyRectangleSizing()
   surveyPreviewPath.value = null
   if (surveyPathLayer.value) {
     planningMap.value?.removeLayer(surveyPathLayer.value as unknown as L.Layer)
@@ -4067,6 +4110,7 @@ const undoGenerateWaypoints = (): void => {
   surveyPolygonVertexesPositions.value = survey.polygonCoordinates.map(([lat, lng]) => L.latLng(lat, lng))
   distanceBetweenSurveyLines.value = survey.distanceBetweenLines
   surveyLinesAngle.value = survey.surveyLinesAngle
+  releaseSurveyLinesAngle()
   surveyCrosshatch.value = survey.crosshatch ?? false
   crosshatchDistanceBetweenLines.value = survey.crosshatchDistanceBetweenLines ?? survey.distanceBetweenLines
   surveyDraftEntryCorner.value = survey.entryCorner ?? 0
@@ -4541,6 +4585,7 @@ onMounted(async () => {
   surveyArrowOverlay.initArrowOverlay(planningMap.value!)
   dragMeasureOverlay.initDragMeasureOverlay(planningMap.value!)
   initExtentInputs(planningMap.value!)
+  initRectangleDrawing(planningMap.value!)
   initEdgeDragging(planningMap.value!)
   initTouchDrawing(planningMap.value!)
   measureLayer.value = L.layerGroup().addTo(planningMap.value!) as L.LayerGroup

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -1217,6 +1217,7 @@ const {
   onDragEnd: (moved) => {
     if (!moved) return
     ignoreNextClick = true
+    createSurveyPath()
   },
 })
 
@@ -1227,6 +1228,14 @@ const cursorCoordinates = ref<[number, number] | null>(null)
 const accessingSurveyContextMenu = ref(false)
 const isDraggingPolygon = ref(false)
 const isDraggingMarker = ref(false)
+const isDraggingSurveyVertex = ref(false)
+
+// The live preview is rebuilt on every pointer move of a reshape, so a polygon that is momentarily too thin for
+// its line spacing must not raise the no-valid-path warning until the gesture is released.
+const isReshapingSurveyPolygon = computed(
+  () => isDraggingSurveyVertex.value || isDraggingPolygon.value || isDraggingSurveyEdge.value
+)
+
 const showHomePositionNotSetDialog = ref(false)
 const fetchingMission = ref(false)
 const missionFetchProgress = ref(0)
@@ -2216,6 +2225,8 @@ const onPolygonMouseDown = (event: L.LeafletMouseEvent): void => {
 }
 
 const onPolygonMouseUp = (event: L.LeafletMouseEvent): void => {
+  const moved = !!dragStartLatLng && !event.latlng.equals(dragStartLatLng)
+
   isDraggingPolygon.value = false
   dragStartLatLng = null
   polygonLatLngsAtDragStart = []
@@ -2225,6 +2236,8 @@ const onPolygonMouseUp = (event: L.LeafletMouseEvent): void => {
   planningMap.value?.off('mouseup', onPolygonMouseUp)
 
   ignoreNextClick = true
+  // Every build during the drag was suppressed, so the polygon at rest is the one allowed to warn.
+  if (moved) createSurveyPath()
 
   L.DomEvent.stopPropagation(event.originalEvent)
   L.DomEvent.preventDefault(event.originalEvent)
@@ -3286,11 +3299,13 @@ const createSurveyPath = (): void => {
 
     if (result.path.length === 0) {
       surveyPreviewPath.value = null
-      showDialog({
-        variant: 'error',
-        message: 'No valid path could be generated. Try adjusting the angle or distance between lines.',
-        timer: 5000,
-      })
+      if (!isReshapingSurveyPolygon.value) {
+        showDialog({
+          variant: 'error',
+          message: 'No valid path could be generated. Try adjusting the angle or distance between lines.',
+          timer: 5000,
+        })
+      }
       return
     }
 
@@ -3790,9 +3805,14 @@ const createSurveyVertexMarker = (
     draggable: true,
   })
     .on('dragstart', () => {
+      isDraggingSurveyVertex.value = true
       pushSurveyPolygonSnapshot()
     })
     .on('drag', () => {
+      onDrag()
+    })
+    .on('dragend', () => {
+      isDraggingSurveyVertex.value = false
       onDrag()
     })
     .on('mouseover', (event: L.LeafletEvent) => {

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -747,6 +747,7 @@
     @delete-selected-survey="deleteSelectedSurvey"
     @rotate-survey-entry-point="rotateSurveyEntryPoint"
     @toggle-survey="toggleSurvey"
+    @set-survey-shape="startSurveyWithShape"
     @toggle-simple-path="toggleSimplePath"
     @undo-generated-waypoints="undoGenerateWaypoints"
     @regenerate-survey-waypoints="regenerateSurveyWaypoints"
@@ -894,7 +895,7 @@ import { useMapTileLayerSelection } from '@/composables/map/useMapTileLayerSelec
 import { useMeasureExtentInput } from '@/composables/map/useMeasureExtentInput'
 import { type SurveyPreview, useSurveyArrowOverlay } from '@/composables/map/useSurveyArrowOverlay'
 import { useSurveyEdgeDragging } from '@/composables/map/useSurveyEdgeDragging'
-import { useSurveyRectangleDrawing } from '@/composables/map/useSurveyRectangleDrawing'
+import { type SurveyDrawShape, useSurveyRectangleDrawing } from '@/composables/map/useSurveyRectangleDrawing'
 import { useTouchDrawing } from '@/composables/map/useTouchDrawing'
 import { useVertexAngleOverlay } from '@/composables/map/useVertexAngleOverlay'
 import { useWaypointMarkerSize } from '@/composables/map/useWaypointMarkerSize'
@@ -2630,6 +2631,11 @@ const toggleSurvey = (): void => {
   isCreatingSurvey.value = true
   isDrawingSurveyPolygon.value = true
   hideContextMenu()
+}
+
+const startSurveyWithShape = (shape: SurveyDrawShape): void => {
+  setSurveyDrawShape(shape)
+  if (!isCreatingSurvey.value) toggleSurvey()
 }
 
 const targetFollower = new TargetFollower(

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -893,6 +893,7 @@ import { useMapPoiMarkers } from '@/composables/map/useMapPoiMarkers'
 import { useMapTileLayers } from '@/composables/map/useMapTileLayers'
 import { useMapTileLayerSelection } from '@/composables/map/useMapTileLayerSelection'
 import { useMeasureExtentInput } from '@/composables/map/useMeasureExtentInput'
+import { useRectangleHandles } from '@/composables/map/useRectangleHandles'
 import { type SurveyPreview, useSurveyArrowOverlay } from '@/composables/map/useSurveyArrowOverlay'
 import { useSurveyEdgeDragging } from '@/composables/map/useSurveyEdgeDragging'
 import { type SurveyDrawShape, useSurveyRectangleDrawing } from '@/composables/map/useSurveyRectangleDrawing'
@@ -1254,10 +1255,14 @@ const {
 const {
   shape: surveyDrawShape,
   isSizingRectangle,
+  heldRectangleVertices,
+  rectangleHandles,
   dimensions: surveyRectangleDimensions,
   setShape: setSurveyDrawShape,
   consumeSurveyClick,
   applyDimensions: applySurveyRectangleDimensions,
+  freezeSizingRectangle,
+  rectangleMovedTo,
   releaseLinesAngle: releaseSurveyLinesAngle,
   cancelSizing: cancelSurveyRectangleSizing,
   initRectangleDrawing,
@@ -1280,21 +1285,44 @@ const {
   },
 })
 
+// A rectangle taken hold of is resized by its edges before it is even fixed, so the shape those edges belong to
+// is the one being placed while there is one, and the draft polygon otherwise.
+const surveyEdgeVertices = computed(() =>
+  isSizingRectangle.value ? heldRectangleVertices.value : surveyPolygonVertexesPositions.value
+)
+
 const {
   isEdgePressed: isPressingSurveyEdge,
   isDraggingEdge: isDraggingSurveyEdge,
   initEdgeDragging,
   destroyEdgeDragging,
 } = useSurveyEdgeDragging({
-  vertices: surveyPolygonVertexesPositions,
-  markers: () => surveyPolygonVertexesMarkers.value,
-  isEditable: () =>
-    isCreatingSurvey.value && !isSizingRectangle.value && surveyPolygonVertexesPositions.value.length >= 3,
-  onDragStart: pushSurveyPolygonSnapshot,
-  onEdgeMoved: () => {
-    updatePolygon()
+  vertices: surveyEdgeVertices,
+  isEditable: () => isCreatingSurvey.value && surveyEdgeVertices.value.length >= 3,
+  onDragStart: () => {
+    if (!isSizingRectangle.value) pushSurveyPolygonSnapshot()
+  },
+  onEdgeMoved: (corners) => applyDraftCorners(corners),
+  onDragEnd: (moved) => {
+    if (!moved) return
+    ignoreNextClick = true
     createSurveyPath()
-    updateConfirmButtonPosition()
+  },
+})
+
+const {
+  isDraggingHandle: isDraggingRectangleHandle,
+  initRectangleHandles,
+  destroyRectangleHandles,
+} = useRectangleHandles({
+  target: rectangleHandles,
+  onDragStart: () => {
+    if (!isSizingRectangle.value) pushSurveyPolygonSnapshot()
+  },
+  apply: (corners) => {
+    const linesAngle = rectangleMovedTo(corners)
+    if (linesAngle !== null) surveyLinesAngle.value = linesAngle
+    applyDraftCorners(corners)
   },
   onDragEnd: (moved) => {
     if (!moved) return
@@ -1314,9 +1342,13 @@ const {
   drawsWithOneFinger: () =>
     (isCreatingSurvey.value && isDrawingSurveyPolygon.value) ||
     (isCreatingSimplePath.value && currentMeasureAnchor() !== null),
-  confirmLabel: () => 'point',
+  confirmLabel: () => (isSizingRectangle.value ? 'survey size' : 'point'),
   hasAnchor: () => currentMeasureAnchor() !== null,
-  isBlocked: () => isPressingSurveyEdge.value || isDraggingMarker.value || isDraggingSurveyVertex.value,
+  isBlocked: () =>
+    isPressingSurveyEdge.value ||
+    isDraggingMarker.value ||
+    isDraggingSurveyVertex.value ||
+    isDraggingRectangleHandle.value,
   placePoint: (latlng) => placeDrawnPoint(latlng),
   aimAt: (latlng, event) => fireMapMouseMove(latlng, event),
 })
@@ -1333,7 +1365,11 @@ const isDraggingSurveyVertex = ref(false)
 // The live preview is rebuilt on every pointer move of a reshape, so a polygon that is momentarily too thin for
 // its line spacing must not raise the no-valid-path warning until the gesture is released.
 const isReshapingSurveyPolygon = computed(
-  () => isDraggingSurveyVertex.value || isDraggingPolygon.value || isDraggingSurveyEdge.value
+  () =>
+    isDraggingSurveyVertex.value ||
+    isDraggingPolygon.value ||
+    isDraggingSurveyEdge.value ||
+    isDraggingRectangleHandle.value
 )
 
 const showHomePositionNotSetDialog = ref(false)
@@ -3501,6 +3537,32 @@ const updatePolygon = (): void => {
   updateSurveyMarkersPositions()
 }
 
+// The rectangle's handles and the polygon's edges both hand over the whole ring they have moved, which lands on
+// the preview while the area is still being swept and on the draft's own markers once it has been fixed.
+const applyDraftCorners = (corners: WaypointCoordinates[]): void => {
+  if (isSizingRectangle.value) {
+    freezeSizingRectangle(corners)
+    return
+  }
+
+  surveyPolygonVertexesMarkers.value.forEach((marker, index) => marker.setLatLng(corners[index]))
+  updatePolygon()
+  createSurveyPath()
+  updateConfirmButtonPosition()
+}
+
+// A rectangle being sized carries a handle on each corner of the edge it was drawn from, so the vertex that edge
+// was started from must come off the map while it lasts: it stands under the handle that has taken it over, and
+// would be left behind the moment the rectangle is carried away from it.
+watch(isSizingRectangle, (sizing) => {
+  const map = planningMap.value
+  if (!map) return
+  surveyPolygonVertexesMarkers.value.forEach((marker) => {
+    if (sizing) marker.remove()
+    else marker.addTo(map)
+  })
+})
+
 const checkAndRemoveSurveyPath = (): void => {
   if (surveyPolygonVertexesPositions.value.length >= 4 || !surveyPathLayer.value) return
   surveyPreviewPath.value = null
@@ -4600,6 +4662,7 @@ onMounted(async () => {
   dragMeasureOverlay.initDragMeasureOverlay(planningMap.value!)
   initExtentInputs(planningMap.value!)
   initRectangleDrawing(planningMap.value!)
+  initRectangleHandles(planningMap.value!)
   initEdgeDragging(planningMap.value!)
   initTouchDrawing(planningMap.value!)
   measureLayer.value = L.layerGroup().addTo(planningMap.value!) as L.LayerGroup
@@ -4754,6 +4817,7 @@ onUnmounted(() => {
   dragMeasureOverlay.destroyDragMeasureOverlay()
   angleOverlay.destroyAngleOverlay()
   surveyArrowOverlay.destroyArrowOverlay()
+  destroyRectangleHandles()
   destroyEdgeDragging()
   destroyTouchDrawing()
 

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -1,6 +1,21 @@
 <template>
   <div class="mission-planning" :style="glassMenuCssVars">
     <div id="planningMap" ref="planningMap" class="relative" />
+    <MeasureExtentInput
+      v-for="box in extentBoxes"
+      :key="box.id"
+      :label="box.label"
+      :left="box.left"
+      :top="box.top"
+      :value="box.value"
+      :live-value="box.liveValue"
+      :cleared="box.cleared"
+      :autofocus="box.autofocus"
+      :focus-ticket="box.focusTicket"
+      @update:value="(value) => setExtentValue(box.id, value)"
+      @apply="applyExtent(box.id)"
+      @close="closeExtentInputs"
+    />
     <v-tooltip location="top" text="Generate waypoints">
       <template #activator="{ props }">
         <div
@@ -846,6 +861,7 @@ import MapOverlaysDialog from '@/components/map/MapOverlaysDialog.vue'
 import MapCenterControl from '@/components/MapCenterControl.vue'
 import ContextMenu from '@/components/mission-planning/ContextMenu.vue'
 import HomePositionSettingHelp from '@/components/mission-planning/HomePositionSettingHelp.vue'
+import MeasureExtentInput from '@/components/mission-planning/MeasureExtentInput.vue'
 import MissionEstimatesPanel from '@/components/mission-planning/MissionEstimates.vue'
 import ScanDirectionDial from '@/components/mission-planning/ScanDirectionDial.vue'
 import SurveyVertexList from '@/components/mission-planning/SurveyVertexList.vue'
@@ -866,6 +882,7 @@ import { useMapOverlays } from '@/composables/map/useMapOverlays'
 import { useMapPoiMarkers } from '@/composables/map/useMapPoiMarkers'
 import { useMapTileLayers } from '@/composables/map/useMapTileLayers'
 import { useMapTileLayerSelection } from '@/composables/map/useMapTileLayerSelection'
+import { useMeasureExtentInput } from '@/composables/map/useMeasureExtentInput'
 import { type SurveyPreview, useSurveyArrowOverlay } from '@/composables/map/useSurveyArrowOverlay'
 import { useSurveyEdgeDragging } from '@/composables/map/useSurveyEdgeDragging'
 import { useVertexAngleOverlay } from '@/composables/map/useVertexAngleOverlay'
@@ -896,6 +913,7 @@ import {
 import { orderedSurveyPath, surveyEndpointEdgeBearing, surveyEntryCornerCount } from '@/libs/map/utils-map'
 import {
   bearingBetween,
+  calculateHaversineDistance,
   centroidLatLng,
   formatBearing,
   formatMetersShort,
@@ -1199,6 +1217,25 @@ const clearSurveyPolygonUndoStack = (): void => {
   surveyPolygonRedoStack.length = 0
 }
 
+const extentInput = useMeasureExtentInput({
+  shortcutFocus: () => (currentMeasureAnchor() ? 'segment' : null),
+  onOpened: () => refreshLiveMeasureOnMapMove(),
+})
+const {
+  extentBoxes,
+  extentInputsOpen,
+  openExtentInputs,
+  focusExtentInput,
+  closeExtentInputs,
+  clearExtentValues,
+  setExtentTarget,
+  setExtentValue,
+  applyExtent,
+  isExtentCleared,
+  projectToLockedExtent,
+  initExtentInputs,
+} = extentInput
+
 const {
   isEdgePressed: isPressingSurveyEdge,
   isDraggingEdge: isDraggingSurveyEdge,
@@ -1289,6 +1326,8 @@ let measureOverlayEl: HTMLDivElement | null = null
 let measureSvgEl: SVGSVGElement | null = null
 let measureLineEl: SVGLineElement | null = null
 let measureTextEl: HTMLDivElement | null = null
+let measureLengthEl: HTMLSpanElement | null = null
+let measureRestEl: HTMLSpanElement | null = null
 // Last cursor event kept so the live measure can be re-rendered while the map pans (no mousemove fires then)
 let lastMeasureCursor: L.LeafletMouseEvent | null = null
 let measureRefreshRafId: number | null = null
@@ -1313,6 +1352,9 @@ const glassMenuCssVars = computed(() => ({
 const clearLiveMeasure = (): void => {
   destroyMeasureOverlay(planningMap.value || undefined)
   angleOverlay.clearVertexAngles()
+  // An extent typed for the segment just drawn does not carry over to the next one, which starts free again.
+  setExtentTarget('segment', null)
+  clearExtentValues()
   lastMeasureCursor = null
 }
 
@@ -1376,13 +1418,45 @@ const ensureMeasureOverlay = (map: L.Map): void => {
 
   measureTextEl = document.createElement('div')
   measureTextEl.className = 'live-measure-pill'
+  measureTextEl.classList.toggle('typing', extentInputsOpen.value)
   measureTextEl.style.position = 'absolute'
   measureTextEl.style.transform = 'translate(-50%, -50%)'
+  measureTextEl.style.pointerEvents = 'auto'
+  measureTextEl.style.cursor = 'pointer'
+  // Tapping the tag is how the field is asked for without a keyboard, so the tag owns its presses the way the
+  // map's own controls do: the map is listening inside its container, and the tag is not a place to draw.
+  L.DomEvent.disableClickPropagation(measureTextEl)
+  // Taken on the press rather than on the click, which the browser aims wherever the tag has moved to by the
+  // time a finger is lifted.
+  measureTextEl.addEventListener('pointerdown', (event) => {
+    event.stopPropagation()
+    if (extentInputsOpen.value) {
+      focusExtentInput('segment')
+      return
+    }
+    logUserAction('Opened the distance field from the measure tag')
+    openExtentInputs('segment')
+    // A touch never moves a cursor, so the field is placed against the measure the tag is already showing.
+    refreshLiveMeasureOnMapMove()
+  })
+  // Mobile browsers only raise their keyboard for a focus asked from the tap itself, which lands here.
+  measureTextEl.addEventListener('click', () => focusExtentInput('segment'))
+
+  // The caret stands right after the digits being typed, so the length and everything trailing it are their own
+  // spans, written on each move instead of rebuilt.
+  measureLengthEl = document.createElement('span')
+  measureLengthEl.className = 'measure-length'
+  measureRestEl = document.createElement('span')
+  const caretEl = document.createElement('span')
+  caretEl.className = 'measure-caret'
+  measureTextEl.append(measureLengthEl, caretEl, measureRestEl)
 
   measureOverlayEl.appendChild(measureSvgEl)
   measureOverlayEl.appendChild(measureTextEl)
   container.appendChild(measureOverlayEl)
 }
+
+watch(extentInputsOpen, (open) => measureTextEl?.classList.toggle('typing', open))
 
 const destroyMeasureOverlay = (map?: L.Map): void => {
   if (!measureOverlayEl) return
@@ -1394,6 +1468,39 @@ const destroyMeasureOverlay = (map?: L.Map): void => {
   measureSvgEl = null
   measureLineEl = null
   measureTextEl = null
+  measureLengthEl = null
+  measureRestEl = null
+}
+
+const placeSurveyPolygonPoint = (latlng: L.LatLng): void => {
+  addSurveyPoint(latlng)
+  clearLiveMeasure()
+}
+
+// Lays a point down wherever the drawing is: a corner of the survey area, or the next waypoint of the path.
+const placeDrawnPoint = (latlng: L.LatLng): boolean => {
+  if (isCreatingSurvey.value && isDrawingSurveyPolygon.value) {
+    placeSurveyPolygonPoint(latlng)
+    return true
+  }
+  if (isCreatingSimplePath.value) {
+    addWaypoint([latlng.lat, latlng.lng], currentWaypointAltitude.value, currentWaypointAltitudeRefType.value)
+    clearLiveMeasure()
+    return true
+  }
+
+  return false
+}
+
+// Enter takes the typed distance as the point itself, so a segment can be laid down without aiming a click at it.
+const applyTypedSegment = (latlng: L.LatLng): void => {
+  const cursorBeforePlacing = lastMeasureCursor
+  if (!placeDrawnPoint(latlng)) return
+
+  // A key press leaves the pointer where it was, so the cursor the measure was following is handed back and the
+  // next segment is drawn from the point just laid rather than waiting for the mouse to move.
+  lastMeasureCursor = cursorBeforePlacing
+  refreshLiveMeasureOnMapMove()
 }
 
 const handleMapMouseMove = (e: L.LeafletMouseEvent): void => {
@@ -1410,6 +1517,7 @@ const handleMapMouseMove = (e: L.LeafletMouseEvent): void => {
   if (!measuring) {
     destroyMeasureOverlay(planningMap.value)
     angleOverlay.clearVertexAngles()
+    setExtentTarget('segment', null)
     return
   }
 
@@ -1421,8 +1529,10 @@ const handleMapMouseMove = (e: L.LeafletMouseEvent): void => {
     measureTextEl.style.display = isOverSurveyHandle(e.originalEvent?.target) ? 'none' : 'block'
   }
 
+  // A typed distance holds the segment's length, so only its direction is still read off the cursor.
+  const cursor = projectToLockedExtent('segment', anchor!, e.latlng)
   const a = map.latLngToContainerPoint(anchor!)
-  const b = map.latLngToContainerPoint(e.latlng)
+  const b = map.latLngToContainerPoint(cursor)
 
   if (measureLineEl) {
     measureLineEl.setAttribute('x1', String(a.x))
@@ -1433,25 +1543,45 @@ const handleMapMouseMove = (e: L.LeafletMouseEvent): void => {
 
   const midX = (a.x + b.x) / 2
   const midY = (a.y + b.y) / 2
-  const dist = anchor!.distanceTo(e.latlng)
+  // Measured the way the panel and the estimates measure, so a typed extent reads back as the number that was
+  // typed instead of leaflet's 0.1% smaller earth.
+  const dist = calculateHaversineDistance([anchor!.lat, anchor!.lng], [cursor.lat, cursor.lng])
 
-  const hidePill = isOverSurveyHandle(e.originalEvent?.target) || isOverLastWaypointMarker(e) || dist < 1 // hide if closer than 1 meter to last wp on the array
+  const overSurveyUi = isOverSurveyHandle(e.originalEvent?.target) || isOverLastWaypointMarker(e)
+  const hidePill = overSurveyUi || dist < 1 // hide if closer than 1 meter to last wp on the array
 
-  const bearing = bearingBetween([anchor!.lat, anchor!.lng], [e.latlng.lat, e.latlng.lng])
-  const text = `${formatMetersShort(dist)} · ${formatBearing(bearing)}`
+  const bearing = bearingBetween([anchor!.lat, anchor!.lng], [cursor.lat, cursor.lng])
+  const [length, unit] = formatMetersShort(dist).split(' ')
+  if (measureLengthEl) measureLengthEl.textContent = isExtentCleared('segment') ? '' : length
+  if (measureRestEl) measureRestEl.textContent = `${unit ? ` ${unit}` : ''} · ${formatBearing(bearing)}`
   if (measureTextEl) {
-    measureTextEl.textContent = text
     measureTextEl.style.left = `${midX}px`
     measureTextEl.style.top = `${midY}px`
     measureTextEl.style.display = hidePill ? 'none' : 'block'
   }
+
+  // Only what is drawn over the box takes it off the map: a segment short enough to hide the pill is usually one
+  // shortened by the box itself, which cannot be the reason to remove what is being typed into.
+  setExtentTarget(
+    'segment',
+    overSurveyUi
+      ? null
+      : {
+          label: 'distance',
+          from: anchor!,
+          to: cursor,
+          liveValue: dist,
+          refresh: refreshLiveMeasureOnMapMove,
+          apply: () => applyTypedSegment(cursor),
+        }
+  )
 
   const prevAnchor = currentMeasurePrevAnchor()
   if (prevAnchor && !hidePill) {
     angleOverlay.renderVertexAngle(
       [prevAnchor.lat, prevAnchor.lng],
       [anchor!.lat, anchor!.lng],
-      [e.latlng.lat, e.latlng.lng]
+      [cursor.lat, cursor.lng]
     )
   } else {
     angleOverlay.clearVertexAngles()
@@ -4270,10 +4400,11 @@ const onMapClick = (e: L.LeafletMouseEvent): void => {
     }
   }
 
-  if (isCreatingSurvey.value && isDrawingSurveyPolygon.value) {
-    addSurveyPoint(e.latlng)
-    clearLiveMeasure()
-  }
+  // A typed distance places the point at that exact distance from the last one, in the direction of the click.
+  const measureAnchor = currentMeasureAnchor()
+  const latlng = measureAnchor ? projectToLockedExtent('segment', measureAnchor, e.latlng) : e.latlng
+
+  if (isCreatingSurvey.value && isDrawingSurveyPolygon.value) placeSurveyPolygonPoint(latlng)
 
   if (planningMap.value) {
     // Check if there is an existing waypoint near the click location
@@ -4300,7 +4431,7 @@ const onMapClick = (e: L.LeafletMouseEvent): void => {
       !interfaceStore.configPanelVisible &&
       isCreatingSimplePath.value
     ) {
-      addWaypoint([e.latlng.lat, e.latlng.lng], currentWaypointAltitude.value, currentWaypointAltitudeRefType.value)
+      addWaypoint([latlng.lat, latlng.lng], currentWaypointAltitude.value, currentWaypointAltitudeRefType.value)
     }
     clearLiveMeasure()
   }
@@ -4355,6 +4486,7 @@ onMounted(async () => {
   angleOverlay.initAngleOverlay(planningMap.value!)
   surveyArrowOverlay.initArrowOverlay(planningMap.value!)
   dragMeasureOverlay.initDragMeasureOverlay(planningMap.value!)
+  initExtentInputs(planningMap.value!)
   initEdgeDragging(planningMap.value!)
   measureLayer.value = L.layerGroup().addTo(planningMap.value!) as L.LayerGroup
 
@@ -4421,7 +4553,13 @@ onMounted(async () => {
 
   planningMap.value.on('drag', updateConfirmButtonPosition)
   planningMap.value.on('drag', refreshLiveMeasureOnMapMove)
-  planningMap.value.on('mousemove', handleMapMouseMove)
+  planningMap.value.on('mousemove', (e: L.LeafletMouseEvent) => {
+    // A tap on the tag is echoed by a mouse move the browser raises over it, which would aim the line at the tag
+    // and take the tag itself out from under the finger before the tap is through.
+    const movedOver = e.originalEvent?.target as HTMLElement | null
+    if (movedOver?.closest?.('.live-measure-pill')) return
+    handleMapMouseMove(e)
+  })
   planningMap.value.on('click', (e: L.LeafletMouseEvent) => {
     onMapClick(e)
   })
@@ -4976,6 +5114,38 @@ watch(
   backdrop-filter: blur(10px);
   white-space: nowrap;
   transform: translate(0, -50%);
+}
+.live-measure-pill.typing {
+  border-color: #3b82f6;
+}
+/* A tag is small for a finger, so it presses from a halo around it without looking any bigger. */
+.live-measure-pill::before {
+  content: '';
+  position: absolute;
+  inset: -10px;
+}
+/* A number typed away holds the room it had, so the tag does not collapse around the caret left behind. */
+.measure-length:empty {
+  display: inline-block;
+  min-width: 3ch;
+}
+/* The field over the tag is invisible, so the tag carries the caret that says it is being typed into. */
+.measure-caret {
+  display: none;
+  width: 1px;
+  height: 14px;
+  margin: 0 1px;
+  vertical-align: -2px;
+  background: #fff;
+}
+.live-measure-pill.typing .measure-caret {
+  display: inline-block;
+  animation: measure-caret-blink 1.1s step-end infinite;
+}
+@keyframes measure-caret-blink {
+  50% {
+    opacity: 0;
+  }
 }
 .measure-area-icon {
   transform: translate(-50%, -50%);


### PR DESCRIPTION
- To be merged after #2977. Merging it will collapse the [drop] commits at the bottom of this branch.

- Survey areas can be drawn as a rectangle: two clicks lay one edge, the preview then follows the pointer for the width and the side it extends to, and a third click locks a shape with square corners.
- Length and width read out on the map while it is being drawn, and stay typeable in the survey panel afterwards, so retyping either rebuilds the rectangle around the same edge.
- A rectangle still being drawn can be moved by the handle on its first corner and turned by the one on its second, and dragging one of its edges slides that edge along its own normal, so the shape stays rectangular.
- Survey lines start out parallel to the rectangle's longer axis, and stay put once the scan-direction dial, or a reshape by hand, takes the angle over.
- The result is an ordinary survey area, so line spacing, turnaround distance, crosshatch and entry-point rotation all apply to it unchanged.
- The format is picked from a row at the top of the survey panel, or from the map's right-click menu: clicking "Create survey" draws free form, and hovering it (holding it, on a touchscreen) offers the choice.
- Once an area is started, the other format is locked out, so the two shapes cannot be mixed in a single survey.

![Survey format row at the top of the survey panel](https://raw.githubusercontent.com/ArturoManzoli/cockpit/pr-assets/survey-format-panel-row.png)

![Survey format choice in the map context menu](https://raw.githubusercontent.com/ArturoManzoli/cockpit/pr-assets/survey-format-context-menu.png)

Closes #2894
