### PR TITLE
Mission Planning: Fix mission planning experience on touchscreen, improving gestures, adding edge dragging and typed distances

### DIFF
--- a/src/components/SideConfigPanel.vue
+++ b/src/components/SideConfigPanel.vue
@@ -27,14 +27,19 @@
     </div>
     <v-btn
       v-else-if="!hideButton"
-      icon
+      :icon="!reopenLabel"
       size="x-small"
       variant="text"
       class="reopen_btn bg-[#00000066] text-white elevation-2"
-      :class="reopenPositionClass"
+      :class="[reopenPositionClass, { labeled_tab: reopenLabel }]"
       @click="openPanel"
     >
-      <v-icon class="text-[18px]">{{ `mdi-arrow-${oppositePosition}` }}</v-icon>
+      <div class="flex flex-col items-center gap-1">
+        <span v-if="reopenLabel" class="[writing-mode:vertical-rl] rotate-180 text-[11px] leading-none">
+          {{ reopenLabel }}
+        </span>
+        <v-icon class="text-[18px]">{{ `mdi-arrow-${oppositePosition}` }}</v-icon>
+      </div>
     </v-btn>
   </transition>
 </template>
@@ -57,6 +62,10 @@ const props = defineProps<{
    * hide button
    */
   hideButton?: boolean
+  /**
+   * Text written along the tab that reopens the panel
+   */
+  reopenLabel?: string
 }>()
 
 const closePanel = (): void => {
@@ -181,5 +190,14 @@ const panelPositionStyle = computed<Record<string, string>>((): Record<string, s
   z-index: 500;
   position: fixed;
   border-radius: 4px;
+}
+/* Two classes so the tab keeps its own size and casing even when the consumer's width class falls through to it. */
+.reopen_btn.labeled_tab {
+  width: auto;
+  height: auto;
+  min-width: unset;
+  padding: 8px 2px;
+  text-transform: none;
+  letter-spacing: normal;
 }
 </style>

--- a/src/components/mission-planning/MeasureExtentInput.vue
+++ b/src/components/mission-planning/MeasureExtentInput.vue
@@ -1,0 +1,147 @@
+<template>
+  <input
+    ref="inputEl"
+    :aria-label="`${label} in meters`"
+    class="absolute z-[641] w-[110px] h-[30px] -translate-x-1/2 -translate-y-1/2 bg-transparent text-transparent caret-transparent outline-none pointer-events-none"
+    :style="{ left: `${left}px`, top: `${top}px` }"
+    type="number"
+    inputmode="numeric"
+    step="1"
+    :min="-maxExtentInMeters"
+    :max="maxExtentInMeters"
+    @input="onInput"
+    @change="onChange"
+    @keydown="onKeyDown"
+  />
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref, watch } from 'vue'
+
+import { maxExtentInMeters } from '@/libs/map/typed-extent'
+
+const props = defineProps<{
+  /**
+   * What the field measures, named as it is read out and logged.
+   */
+  label: string
+  /**
+   * Distance from the left of the map, in pixels.
+   */
+  left: number
+  /**
+   * Distance from the top of the map, in pixels.
+   */
+  top: number
+  /**
+   * Extent that has been typed, in meters, or null while the segment is still following the cursor.
+   */
+  value: number | null
+  /**
+   * Extent the tag is reading back while nothing has been typed, in meters.
+   */
+  liveValue: number
+  /**
+   * Whether the number was typed away, which leaves the field empty on purpose rather than untouched.
+   */
+  cleared: boolean
+  /**
+   * Whether the field takes the keyboard as it appears, so a number can be typed without reaching for it.
+   */
+  autofocus: boolean
+  /**
+   * Bumped whenever the keyboard is asked for again, since a field already focused sees no prop change.
+   */
+  focusTicket: number
+}>()
+
+const emit = defineEmits<{
+  (event: 'update:value', value: number | null): void
+  (event: 'apply'): void
+  (event: 'close'): void
+}>()
+
+const inputEl = ref<HTMLInputElement | null>(null)
+
+onMounted(() => {
+  if (props.value !== null) inputEl.value!.value = String(props.value)
+  if (props.autofocus) inputEl.value?.focus()
+})
+
+watch(
+  () => [props.autofocus, props.focusTicket],
+  () => {
+    if (props.autofocus) inputEl.value?.focus()
+  }
+)
+
+// Written only when it disagrees with the field: a number input reads a half-typed "-" as empty, and binding the
+// value back would wipe the minus sign before the digits after it arrive.
+watch(
+  () => props.value,
+  (value) => {
+    const field = inputEl.value
+    if (!field) return
+
+    const shown = field.value === '' ? null : Number(field.value)
+    if (shown !== value) field.value = value === null ? '' : String(value)
+  }
+)
+
+const onInput = (event: Event): void => {
+  const typed = (event.target as HTMLInputElement).value
+  emit('update:value', typed === '' ? null : Number(typed))
+}
+
+const onChange = (): void => {
+  if (props.value !== null) logUserAction(`Typed ${props.value} m for the ${props.label}`)
+}
+
+// Keys a number is typed, corrected and settled with, which are the ones this field answers for itself.
+const editingKeys = ['Backspace', 'Delete', 'Enter', 'Escape', 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown']
+
+// The map's own shortcuts sit on the window, where an Enter would generate the survey waypoints and a Delete
+// would drop a waypoint, so none of them get to see what is being typed in here. Anything the field does not
+// consume still travels, or a focused field would take the map's undo and its modifier tracking with it.
+const onKeyDown = (event: KeyboardEvent): void => {
+  const isEditingKey = editingKeys.includes(event.key) || /^[\d.,-]$/.test(event.key)
+  if (isEditingKey && !event.ctrlKey && !event.metaKey && !event.altKey) event.stopPropagation()
+
+  if (event.key === 'Escape') {
+    logUserAction('Hid the distance box')
+    emit('close')
+    return
+  }
+  if (event.key === 'Enter') {
+    event.preventDefault()
+    emit('apply')
+    return
+  }
+  // An untouched field is a tag still reading the measure back, so a backspace deletes from that number as if it
+  // had been typed in. Once the number is gone the field is empty for good, as any other field would be.
+  if (event.key === 'Backspace' && !props.cleared && inputEl.value?.value === '') {
+    event.preventDefault()
+    const kept = String(Math.round(props.liveValue)).slice(0, -1)
+    inputEl.value.value = kept
+    emit('update:value', kept === '' ? null : Number(kept))
+  }
+}
+</script>
+
+<style scoped>
+/* The measurement tag under the field is what reads the number back, so nothing of the field may paint over it,
+   flowbite's form reset included: it gives every number field a border and a blue ring once focused. */
+input[type='number'],
+input[type='number']:focus {
+  border: none;
+  box-shadow: none;
+}
+input[type='number']::-webkit-inner-spin-button,
+input[type='number']::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+input[type='number']::selection {
+  background: transparent;
+}
+</style>

--- a/src/composables/map/useLiveMeasureOverlay.ts
+++ b/src/composables/map/useLiveMeasureOverlay.ts
@@ -1,0 +1,265 @@
+import L, { type Map as LeafletMap } from 'leaflet'
+import { onBeforeUnmount } from 'vue'
+
+import { formatBearing, formatMetersShort } from '@/libs/mission/general-estimates'
+
+/** The segment the live measure draws, as the view resolved it for the pointer's current position. */
+export interface LiveMeasureSegment {
+  /** Where the segment starts. */
+  from: L.LatLng
+  /** Where the segment ends, which is where the next point would land. */
+  to: L.LatLng
+  /** Length of the segment, in meters. */
+  distanceInMeters: number
+  /** Bearing of the segment, in degrees clockwise from north. */
+  bearingInDegrees: number
+  /** Whether the tag is kept off the map, which is what leaves what it would cover readable. */
+  hidesTag: boolean
+  /** Whether the length was typed away, so the tag reads blank instead of the measure it was showing. */
+  clearsLength: boolean
+  /** Whether the tag takes presses, which it may only do when it is not sitting under the drawing pointer. */
+  tagTakesPresses: boolean
+}
+
+/** Wiring {@link useLiveMeasureOverlay} needs from the view that draws the segment. */
+export interface UseLiveMeasureOverlayOptions {
+  /** Draws the segment again for a coordinate the map moving has put the pointer over. */
+  redraw: (latlng: L.LatLng, containerPoint: L.Point) => void
+  /** Where the cursor is on the page, in client coordinates. */
+  cursorPosition: () => L.Point
+  /** Where a point dragged out with a finger is waiting, so the measure ends there instead of at the cursor. */
+  heldPoint: () => L.LatLng | null
+  /** Reads back a press on the tag, which is how the extent field is asked for without a keyboard. */
+  onTagPressed: () => void
+  /** Reads back the tap that follows it, which is what a mobile browser raises its keyboard for. */
+  onTagTapped: () => void
+}
+
+/** Return type of {@link useLiveMeasureOverlay}. */
+export interface UseLiveMeasureOverlayReturn {
+  /** Binds the overlay to a Leaflet map. */
+  initLiveMeasure: (map: LeafletMap) => void
+  /** Draws the segment, its loose end and the tag reading it back, creating the overlay on first use. */
+  renderLiveMeasure: (segment: LiveMeasureSegment) => void
+  /** Takes the whole overlay off the map. */
+  clearLiveMeasure: () => void
+  /** Moves the segment's start, saying whether there was an overlay on the map to move it on. */
+  setLiveMeasureAnchor: (latlng: L.LatLng) => boolean
+  /** Marks the tag as being typed into, which is what puts a caret in it. */
+  setLiveMeasureTyping: (typing: boolean) => void
+  /** Keeps the measure pinned to the pointer while the map moves under it, at most once a frame. */
+  refreshLiveMeasureOnMapMove: () => void
+  /** Clears the overlay and unbinds the map. */
+  destroyLiveMeasure: () => void
+}
+
+/** The overlay's own nodes, held together so a render never has to check each one for itself. */
+interface LiveMeasureElements {
+  /** Container holding everything the overlay draws. */
+  root: HTMLDivElement
+  /** The dashed line running from the anchor to the segment's loose end. */
+  line: SVGLineElement
+  /** The dot marking that loose end, which is where a finger dragging the line is aiming. */
+  endDot: SVGCircleElement
+  /** The tag reading the measure back, which is also what a tap asks the extent field from. */
+  tag: HTMLDivElement
+  /** The length inside the tag, kept its own node so the caret can stand right after the digits. */
+  length: HTMLSpanElement
+  /** The unit and bearing trailing the length. */
+  rest: HTMLSpanElement
+}
+
+const createSvgElement = <K extends keyof SVGElementTagNameMap>(tag: K): SVGElementTagNameMap[K] =>
+  document.createElementNS('http://www.w3.org/2000/svg', tag)
+
+const tagLabel = 'Type the distance'
+
+/**
+ * Draws the measure of the segment being drawn on a Leaflet map: a dashed line from the last point to where the
+ * next one would land, a dot on that loose end, and a tag reading the length and bearing back. The tag doubles as
+ * the way to ask for the extent field where there is no keyboard to press a shortcut on.
+ * @param {UseLiveMeasureOverlayOptions} options - Where the pointer is, and what a press on the tag means.
+ * @returns {UseLiveMeasureOverlayReturn} Methods to initialize, render, clear and tear down the overlay.
+ */
+export const useLiveMeasureOverlay = (options: UseLiveMeasureOverlayOptions): UseLiveMeasureOverlayReturn => {
+  const { redraw, cursorPosition, heldPoint, onTagPressed, onTagTapped } = options
+
+  let mapRef: LeafletMap | undefined
+  let elements: LiveMeasureElements | null = null
+  let refreshRafId: number | null = null
+  let isTyping = false
+
+  const initLiveMeasure = (map: LeafletMap): void => {
+    mapRef = map
+  }
+
+  const buildOverlay = (map: LeafletMap): LiveMeasureElements => {
+    const root = document.createElement('div')
+    root.className = 'measure-overlay'
+    root.style.pointerEvents = 'none'
+    root.style.position = 'absolute'
+    root.style.top = '0'
+    root.style.left = '0'
+    root.style.width = '100%'
+    root.style.height = '100%'
+    root.style.zIndex = '640'
+
+    const svg = createSvgElement('svg')
+    svg.setAttribute('width', '100%')
+    svg.setAttribute('height', '100%')
+    svg.style.position = 'absolute'
+    svg.style.top = '0'
+    svg.style.left = '0'
+
+    const line = createSvgElement('line')
+    line.setAttribute('stroke-width', '2')
+    line.setAttribute('stroke-dasharray', '10,10')
+    line.setAttribute('opacity', '0.9')
+    line.setAttribute('stroke', '#2563eb')
+
+    // The loose end of the line is where the next point lands, and a finger dragging it needs to see where that is.
+    const endDot = createSvgElement('circle')
+    endDot.setAttribute('r', '5')
+    endDot.setAttribute('fill', '#2563eb')
+    endDot.setAttribute('stroke', '#FFFFFF')
+    endDot.setAttribute('stroke-width', '2')
+
+    svg.append(line, endDot)
+
+    const tag = document.createElement('div')
+    tag.className = 'live-measure-pill'
+    tag.setAttribute('role', 'button')
+    tag.setAttribute('aria-label', tagLabel)
+    tag.title = tagLabel
+    tag.style.position = 'absolute'
+    tag.style.transform = 'translate(-50%, -50%)'
+    tag.style.cursor = 'pointer'
+    // Tapping the tag is how the field is asked for without a keyboard, so the tag owns its presses the way the
+    // map's own controls do: the map is listening inside its container, and the tag is not a place to draw.
+    L.DomEvent.disableClickPropagation(tag)
+    // Taken on the press rather than on the click, which the browser aims wherever the tag has moved to by the
+    // time a finger is lifted.
+    tag.addEventListener('pointerdown', (event) => {
+      event.stopPropagation()
+      onTagPressed()
+    })
+    // Mobile browsers only raise their keyboard for a focus asked from the tap itself, which lands here.
+    tag.addEventListener('click', onTagTapped)
+    tag.addEventListener('keydown', (event) => {
+      if (event.key !== 'Enter' && event.key !== ' ') return
+      event.preventDefault()
+      onTagPressed()
+      onTagTapped()
+    })
+
+    // The caret stands right after the digits being typed, so the length and everything trailing it are their own
+    // spans, written on each move instead of rebuilt.
+    const length = document.createElement('span')
+    length.className = 'measure-length'
+    const rest = document.createElement('span')
+    const caret = document.createElement('span')
+    caret.className = 'measure-caret'
+    tag.append(length, caret, rest)
+
+    root.append(svg, tag)
+    map.getContainer().appendChild(root)
+
+    return { root, line, endDot, tag, length, rest }
+  }
+
+  const ensureOverlay = (map: LeafletMap): LiveMeasureElements => {
+    elements ??= buildOverlay(map)
+    return elements
+  }
+
+  const renderLiveMeasure = (segment: LiveMeasureSegment): void => {
+    const map = mapRef
+    if (!map) return
+
+    const { line, endDot, tag, length, rest } = ensureOverlay(map)
+    const from = map.latLngToContainerPoint(segment.from)
+    const to = map.latLngToContainerPoint(segment.to)
+
+    line.setAttribute('x1', String(from.x))
+    line.setAttribute('y1', String(from.y))
+    line.setAttribute('x2', String(to.x))
+    line.setAttribute('y2', String(to.y))
+    endDot.setAttribute('cx', String(to.x))
+    endDot.setAttribute('cy', String(to.y))
+
+    const [meters, unit] = formatMetersShort(segment.distanceInMeters).split(' ')
+    length.textContent = segment.clearsLength ? '' : meters
+    rest.textContent = `${unit ? ` ${unit}` : ''} · ${formatBearing(segment.bearingInDegrees)}`
+
+    tag.style.left = `${(from.x + to.x) / 2}px`
+    tag.style.top = `${(from.y + to.y) / 2}px`
+    tag.style.display = segment.hidesTag ? 'none' : 'block'
+    // The tag rides the segment's midpoint, so on a short segment it sits under the pointer drawing it, where an
+    // interactive tag would take the presses and moves the map is owed.
+    tag.style.pointerEvents = segment.tagTakesPresses ? 'auto' : 'none'
+    tag.tabIndex = segment.tagTakesPresses ? 0 : -1
+    tag.classList.toggle('typing', isTyping)
+  }
+
+  const clearLiveMeasure = (): void => {
+    elements?.root.remove()
+    elements = null
+  }
+
+  const setLiveMeasureAnchor = (latlng: L.LatLng): boolean => {
+    const map = mapRef
+    if (!map || !elements) return false
+
+    const point = map.latLngToContainerPoint(latlng)
+    elements.line.setAttribute('x1', String(point.x))
+    elements.line.setAttribute('y1', String(point.y))
+    return true
+  }
+
+  // Held here rather than only on the node, which a point placed from a typed distance takes off the map while
+  // the field it was typed into stays open.
+  const setLiveMeasureTyping = (typing: boolean): void => {
+    isTyping = typing
+    elements?.tag.classList.toggle('typing', isTyping)
+  }
+
+  // Guarded on the map rather than on the overlay's nodes, which a point placed from a typed distance takes off
+  // the map and which the redraw is what puts back.
+  const refreshLiveMeasureOnMapMove = (): void => {
+    if (!mapRef || refreshRafId !== null) return
+
+    refreshRafId = requestAnimationFrame(() => {
+      refreshRafId = null
+      const map = mapRef
+      if (!map) return
+
+      const rect = map.getContainer().getBoundingClientRect()
+      const cursor = cursorPosition()
+      // A finger leaves no cursor behind, so a point it dragged out and left waiting is where the measure ends.
+      const held = heldPoint()
+      const containerPoint = held
+        ? map.latLngToContainerPoint(held)
+        : L.point(cursor.x - rect.left, cursor.y - rect.top)
+      redraw(held ?? map.containerPointToLatLng(containerPoint), containerPoint)
+    })
+  }
+
+  const destroyLiveMeasure = (): void => {
+    if (refreshRafId !== null) cancelAnimationFrame(refreshRafId)
+    refreshRafId = null
+    clearLiveMeasure()
+    mapRef = undefined
+  }
+
+  onBeforeUnmount(destroyLiveMeasure)
+
+  return {
+    initLiveMeasure,
+    renderLiveMeasure,
+    clearLiveMeasure,
+    setLiveMeasureAnchor,
+    setLiveMeasureTyping,
+    refreshLiveMeasureOnMapMove,
+    destroyLiveMeasure,
+  }
+}

--- a/src/composables/map/useMeasureExtentInput.ts
+++ b/src/composables/map/useMeasureExtentInput.ts
@@ -1,0 +1,233 @@
+import L, { type Map as LeafletMap } from 'leaflet'
+import { type ComputedRef, type Ref, computed, onBeforeUnmount, ref, shallowRef } from 'vue'
+
+import { clampExtent, minExtentInMeters, pointAtDistanceToward } from '@/libs/map/typed-extent'
+
+/** A segment on the map whose extent can be typed instead of drawn. */
+export interface MeasureExtentTarget {
+  /** What the segment measures, named as it is read out and logged. */
+  label: string
+  /** Where the segment starts. */
+  from: L.LatLng
+  /** Where the segment ends. */
+  to: L.LatLng
+  /** Extent the segment currently has, in meters, which is the number a backspace starts deleting from. */
+  liveValue: number
+  /** Redraws the segment, so what is typed shows on the map without waiting for the cursor to move again. */
+  refresh: () => void
+  /** Takes the typed extent as final, the way a click on the map would, and moves the drawing on. */
+  apply: () => void
+}
+
+/** An extent field laid over the map, ready to be rendered. */
+export interface MeasureExtentBox {
+  /** Identifies which extent the field types. */
+  id: string
+  /** What the field measures, named as it is read out and logged. */
+  label: string
+  /** Distance from the left of the map, in pixels. */
+  left: number
+  /** Distance from the top of the map, in pixels. */
+  top: number
+  /** Extent that has been typed, in meters, or null while the segment still follows the cursor. */
+  value: number | null
+  /** Extent the tag is reading back while nothing has been typed, in meters. */
+  liveValue: number
+  /** Whether the number was typed away, which leaves the field empty on purpose rather than untouched. */
+  cleared: boolean
+  /** Whether the field takes the keyboard as it appears. */
+  autofocus: boolean
+  /** Bumped whenever the keyboard is asked for again, since a field already focused sees no prop change. */
+  focusTicket: number
+}
+
+/** Wiring {@link useMeasureExtentInput} needs from the view that measures on the map. */
+export interface UseMeasureExtentInputOptions {
+  /** Which extent the keyboard shortcut hands the field to, or null when nothing is being measured. */
+  shortcutFocus: () => string | null
+  /** Called once the fields are up, so the segment they were asked for can be redrawn under them. */
+  onOpened: () => void
+}
+
+/** Return type of {@link useMeasureExtentInput}. */
+export interface UseMeasureExtentInputReturn {
+  /** The fields to render over the map. */
+  extentBoxes: ComputedRef<MeasureExtentBox[]>
+  /** Whether typing is currently offered. */
+  extentInputsOpen: Ref<boolean>
+  /** Offers typing, handing the keyboard to the given extent. */
+  openExtentInputs: (focusId: string) => void
+  /** Hands the keyboard back to an extent whose field is already up, after a tap on its tag. */
+  focusExtentInput: (id: string) => void
+  /** Withdraws the offer and forgets what was typed. */
+  closeExtentInputs: () => void
+  /** Forgets what was typed, leaving the fields up for the next segment. */
+  clearExtentValues: () => void
+  /** Points an extent at a segment, or takes it off the map with null. */
+  setExtentTarget: (id: string, target: MeasureExtentTarget | null) => void
+  /** Records what was typed for an extent. */
+  setExtentValue: (id: string, value: number | null) => void
+  /** Takes what was typed for an extent as final. */
+  applyExtent: (id: string) => void
+  /** Whether an extent was typed away, so its tag reads blank instead of the measure it was showing. */
+  isExtentCleared: (id: string) => boolean
+  /** Applies a typed extent to a point still being chosen with the cursor, keeping only its direction. */
+  projectToLockedExtent: (id: string, from: L.LatLng, towards: L.LatLng) => L.LatLng
+  /** Binds the fields to a Leaflet map. */
+  initExtentInputs: (map: LeafletMap) => void
+}
+
+/**
+ * Offers the extents being measured on the map as typed numbers: one field per live measurement tag, sitting on the
+ * tag itself, whose value takes that extent over while the cursor keeps choosing the direction or the side. The
+ * field is rendered invisible, since the tag under it already reads back the number as it is typed.
+ * @param {UseMeasureExtentInputOptions} options - What the shortcut opens and what to redraw once it has.
+ * @returns {UseMeasureExtentInputReturn} The fields to render and the handlers to drive and read them.
+ */
+export const useMeasureExtentInput = (options: UseMeasureExtentInputOptions): UseMeasureExtentInputReturn => {
+  const { shortcutFocus, onOpened } = options
+
+  let mapRef: LeafletMap | undefined
+
+  const extentInputsOpen = ref(false)
+  const focusedId = ref<string | null>(null)
+  const focusTicket = ref(0)
+  // Shallow so the coordinates and the redraw handlers the consumers hand over are kept as they were given.
+  const targets = shallowRef<Record<string, MeasureExtentTarget>>({})
+  const values = ref<Record<string, number | null>>({})
+
+  const initExtentInputs = (map: LeafletMap): void => {
+    mapRef = map
+  }
+
+  const boxPosition = (map: LeafletMap, target: MeasureExtentTarget): Pick<MeasureExtentBox, 'left' | 'top'> => {
+    const from = map.latLngToContainerPoint(target.from)
+    const to = map.latLngToContainerPoint(target.to)
+
+    return { left: (from.x + to.x) / 2, top: (from.y + to.y) / 2 }
+  }
+
+  // A recorded null is a number that was typed away, while an id nobody recorded was never typed into at all.
+  const isExtentCleared = (id: string): boolean => id in values.value && values.value[id] == null
+
+  const extentBoxes = computed<MeasureExtentBox[]>(() => {
+    const map = mapRef
+    if (!extentInputsOpen.value || !map) return []
+
+    return Object.entries(targets.value).map(([id, target]) => ({
+      id,
+      label: target.label,
+      ...boxPosition(map, target),
+      value: values.value[id] ?? null,
+      liveValue: target.liveValue,
+      cleared: isExtentCleared(id),
+      autofocus: id === focusedId.value,
+      focusTicket: focusTicket.value,
+    }))
+  })
+
+  const openExtentInputs = (focusId: string): void => {
+    extentInputsOpen.value = true
+    focusedId.value = focusId
+    values.value = {}
+  }
+
+  const focusExtentInput = (id: string): void => {
+    focusedId.value = id
+    focusTicket.value += 1
+  }
+
+  const closeExtentInputs = (): void => {
+    if (!extentInputsOpen.value) return
+
+    extentInputsOpen.value = false
+    focusedId.value = null
+    values.value = {}
+  }
+
+  const clearExtentValues = (): void => {
+    values.value = {}
+  }
+
+  const setExtentTarget = (id: string, target: MeasureExtentTarget | null): void => {
+    const known = id in targets.value
+    // The consumers follow the cursor whether or not typing was ever asked for, so a closed box records nothing.
+    if (!extentInputsOpen.value && !known) return
+
+    if (target) {
+      targets.value = { ...targets.value, [id]: target }
+      return
+    }
+    if (!known) return
+    // The box being typed into keeps its place, since dropping the target unmounts the field and takes the
+    // keyboard with it, and the segment it measures is cleared for a frame every time a point is placed.
+    if (extentInputsOpen.value && focusedId.value === id) return
+
+    const remaining = { ...targets.value }
+    delete remaining[id]
+    targets.value = remaining
+  }
+
+  const setExtentValue = (id: string, value: number | null): void => {
+    values.value = { ...values.value, [id]: value }
+    targets.value[id]?.refresh()
+  }
+
+  const applyExtent = (id: string): void => {
+    targets.value[id]?.apply()
+  }
+
+  // The extent typed for an id, held to the flyable range, or null when nothing was typed.
+  const lockedExtent = (id: string): number | null => {
+    const value = values.value[id]
+    return value != null && Number.isFinite(value) ? clampExtent(value, minExtentInMeters) : null
+  }
+
+  const projectToLockedExtent = (id: string, from: L.LatLng, towards: L.LatLng): L.LatLng => {
+    const locked = lockedExtent(id)
+    if (locked === null) return towards
+
+    const [lat, lng] = pointAtDistanceToward([from.lat, from.lng], [towards.lat, towards.lng], locked)
+    return L.latLng(lat, lng)
+  }
+
+  // Shapes that do not put the box up on their own are typed by asking for it, and the ones that do can bring it
+  // back after it was dismissed.
+  const onKeyDown = (event: KeyboardEvent): void => {
+    if (event.key.toLowerCase() !== 't' || event.ctrlKey || event.metaKey || event.altKey) return
+
+    const target = event.target as HTMLElement | null
+    if (target && (['INPUT', 'TEXTAREA'].includes(target.tagName) || target.isContentEditable)) return
+
+    if (extentInputsOpen.value) {
+      logUserAction('Hid the distance box')
+      closeExtentInputs()
+      return
+    }
+
+    const focusId = shortcutFocus()
+    if (!focusId) return
+
+    logUserAction('Showed the distance box')
+    openExtentInputs(focusId)
+    onOpened()
+  }
+
+  window.addEventListener('keydown', onKeyDown)
+  onBeforeUnmount(() => window.removeEventListener('keydown', onKeyDown))
+
+  return {
+    extentBoxes,
+    extentInputsOpen,
+    openExtentInputs,
+    focusExtentInput,
+    closeExtentInputs,
+    clearExtentValues,
+    setExtentTarget,
+    setExtentValue,
+    applyExtent,
+    isExtentCleared,
+    projectToLockedExtent,
+    initExtentInputs,
+  }
+}

--- a/src/composables/map/useSurveyEdgeDragging.ts
+++ b/src/composables/map/useSurveyEdgeDragging.ts
@@ -1,0 +1,212 @@
+import L, { type Map as LeafletMap } from 'leaflet'
+import { type Ref, onBeforeUnmount, ref } from 'vue'
+
+import {
+  closestPolygonEdge,
+  draggedEdgeEndpoints,
+  edgeResizeCursor,
+  isOverSurveyHandle,
+} from '@/libs/map/survey-polygon-edges'
+import { isRectangle } from '@/libs/map/survey-rectangle'
+import type { WaypointCoordinates } from '@/types/mission'
+
+/**
+ * Options for {@link useSurveyEdgeDragging}.
+ */
+export interface UseSurveyEdgeDraggingOptions {
+  /** The draft polygon's vertices, in the order they are drawn. */
+  vertices: Ref<L.LatLng[]>
+  /** Reads the draggable markers standing on those vertices, which the moved edge is carried by. */
+  markers: () => L.Marker[]
+  /** Whether the polygon can be edited right now. */
+  isEditable: () => boolean
+  /** Called once per drag, before the first move, so the polygon can be snapshotted for undo. */
+  onDragStart: () => void
+  /** Called on every move, once the edge's markers have been carried to their new positions. */
+  onEdgeMoved: () => void
+  /** Called when the press is released, saying whether the edge ended up moving. */
+  onDragEnd: (moved: boolean) => void
+}
+
+/**
+ * Return type of {@link useSurveyEdgeDragging}.
+ */
+export interface UseSurveyEdgeDraggingReturn {
+  /** Whether a press landed on an edge, so handlers on the polygon itself can stand down. */
+  isEdgePressed: Ref<boolean>
+  /** Whether an edge is being dragged. */
+  isDraggingEdge: Ref<boolean>
+  /** Binds the edge handling to a Leaflet map. */
+  initEdgeDragging: (map: LeafletMap) => void
+  /** Unbinds everything and gives the cursor back. */
+  destroyEdgeDragging: () => void
+}
+
+// The band around an edge that grabs it, wide enough for a fingertip without reaching the vertex handles.
+const grabToleranceInPixels = 10
+// A press has to travel this far before it counts as a drag, so a click near an edge still reaches the map and
+// adds a vertex while the polygon is being drawn.
+const dragThresholdInPixels = 4
+
+/**
+ * Lets the survey polygon be reshaped by its edges: hovering one offers a resize cursor along the axis it moves
+ * on, and pressing and dragging it carries the edge with the pointer. A rectangle's edge is held to its own
+ * normal, since its dimensions are read back from its corners and only survive while they stay square.
+ *
+ * Pointer events drive this rather than Leaflet's mouse events because a touch drag never produces a
+ * `mousemove`, which is what limits the polygon's own drag to a mouse.
+ * @param {UseSurveyEdgeDraggingOptions} options - The polygon to edit and the callbacks to report edits through.
+ * @returns {UseSurveyEdgeDraggingReturn} Drag state plus the methods to bind and unbind the map.
+ */
+export const useSurveyEdgeDragging = (options: UseSurveyEdgeDraggingOptions): UseSurveyEdgeDraggingReturn => {
+  const { vertices, markers, isEditable, onDragStart, onEdgeMoved, onDragEnd } = options
+
+  const isEdgePressed = ref(false)
+  const isDraggingEdge = ref(false)
+
+  let mapRef: LeafletMap | undefined
+  let pressedEdge: number | null = null
+  let pressOrigin: L.Point | null = null
+  let pressedEdgeEndpoints: [WaypointCoordinates, WaypointCoordinates] | null = null
+  let dragOrigin: WaypointCoordinates | null = null
+  let holdEdgeSquare = false
+  let panningWasEnabled = false
+  let cursorBeforeHover: string | null = null
+
+  const asCoordinates = (latLng: L.LatLng): WaypointCoordinates => [latLng.lat, latLng.lng]
+
+  const setCursor = (cursor: string | null): void => {
+    const container = mapRef?.getContainer()
+    if (!container) return
+
+    if (cursor === null) {
+      if (cursorBeforeHover === null) return
+      container.style.cursor = cursorBeforeHover
+      cursorBeforeHover = null
+      return
+    }
+    // Compared against the element rather than a cached value, so the cursor is also reclaimed after the view's
+    // own mousedown handler has swapped in its grabbing cursor.
+    if (container.style.cursor === cursor) return
+    if (cursorBeforeHover === null) cursorBeforeHover = container.style.cursor
+    container.style.cursor = cursor
+  }
+
+  const edgeAt = (event: PointerEvent): number | null => {
+    if (!mapRef || !isEditable()) return null
+    if (isOverSurveyHandle(event.target)) return null
+
+    const points = vertices.value.map((latLng) => mapRef!.latLngToContainerPoint(latLng))
+    return closestPolygonEdge(points, mapRef.mouseEventToContainerPoint(event), grabToleranceInPixels)
+  }
+
+  const cursorForEdge = (edgeIndex: number): string => {
+    const points = vertices.value
+    const start = mapRef!.latLngToContainerPoint(points[edgeIndex])
+    const end = mapRef!.latLngToContainerPoint(points[(edgeIndex + 1) % points.length])
+    return edgeResizeCursor(start, end)
+  }
+
+  const releasePress = (): void => {
+    if (pressedEdge === null) return
+
+    if (panningWasEnabled) mapRef?.dragging.enable()
+    pressedEdge = null
+    pressOrigin = null
+    pressedEdgeEndpoints = null
+    dragOrigin = null
+    isEdgePressed.value = false
+    isDraggingEdge.value = false
+  }
+
+  const onPointerDown = (event: PointerEvent): void => {
+    const isSecondaryPress = !event.isPrimary || pressedEdge !== null
+    if (!mapRef || isSecondaryPress || (event.pointerType === 'mouse' && event.button !== 0)) return
+
+    const edgeIndex = edgeAt(event)
+    if (edgeIndex === null) return
+
+    const points = vertices.value
+    pressedEdge = edgeIndex
+    pressOrigin = mapRef.mouseEventToContainerPoint(event)
+    pressedEdgeEndpoints = [asCoordinates(points[edgeIndex]), asCoordinates(points[(edgeIndex + 1) % points.length])]
+    dragOrigin = asCoordinates(mapRef.containerPointToLatLng(mapRef.mouseEventToContainerPoint(event)))
+    // Decided once per drag, so a free-form polygon dragged through squareness does not suddenly lock up.
+    holdEdgeSquare = isRectangle(points.map(asCoordinates))
+    isEdgePressed.value = true
+
+    // Panning must not follow the same press, and on touch there is nothing else keeping the map still.
+    panningWasEnabled = mapRef.dragging.enabled()
+    if (panningWasEnabled) mapRef.dragging.disable()
+    mapRef.getContainer().setPointerCapture(event.pointerId)
+  }
+
+  const onPointerMove = (event: PointerEvent): void => {
+    if (pressedEdge === null) {
+      const edgeIndex = edgeAt(event)
+      setCursor(edgeIndex === null ? null : cursorForEdge(edgeIndex))
+      return
+    }
+    if (!mapRef || !pressOrigin || !pressedEdgeEndpoints || !dragOrigin) return
+
+    const containerPoint = mapRef.mouseEventToContainerPoint(event)
+    if (!isDraggingEdge.value) {
+      if (containerPoint.distanceTo(pressOrigin) < dragThresholdInPixels) return
+      isDraggingEdge.value = true
+      setCursor(cursorForEdge(pressedEdge))
+      onDragStart()
+      logUserAction('Dragged a survey polygon edge')
+    }
+
+    const edgeMarkers = markers()
+    if (edgeMarkers.length < 3) return
+
+    const pointer = asCoordinates(mapRef.containerPointToLatLng(containerPoint))
+    const [start, end] = draggedEdgeEndpoints(pressedEdgeEndpoints, [dragOrigin, pointer], holdEdgeSquare)
+    edgeMarkers[pressedEdge].setLatLng(start)
+    edgeMarkers[(pressedEdge + 1) % edgeMarkers.length].setLatLng(end)
+    onEdgeMoved()
+  }
+
+  const onPointerUp = (event: PointerEvent): void => {
+    if (pressedEdge === null) return
+
+    const moved = isDraggingEdge.value
+    const container = mapRef?.getContainer()
+    if (container?.hasPointerCapture(event.pointerId)) container.releasePointerCapture(event.pointerId)
+    releasePress()
+    onDragEnd(moved)
+  }
+
+  const onPointerLeave = (): void => {
+    if (pressedEdge === null) setCursor(null)
+  }
+
+  const initEdgeDragging = (map: LeafletMap): void => {
+    mapRef = map
+    const container = map.getContainer()
+    container.addEventListener('pointerdown', onPointerDown)
+    container.addEventListener('pointermove', onPointerMove)
+    container.addEventListener('pointerup', onPointerUp)
+    container.addEventListener('pointercancel', onPointerUp)
+    container.addEventListener('pointerleave', onPointerLeave)
+  }
+
+  const destroyEdgeDragging = (): void => {
+    const container = mapRef?.getContainer()
+    setCursor(null)
+    releasePress()
+    if (container) {
+      container.removeEventListener('pointerdown', onPointerDown)
+      container.removeEventListener('pointermove', onPointerMove)
+      container.removeEventListener('pointerup', onPointerUp)
+      container.removeEventListener('pointercancel', onPointerUp)
+      container.removeEventListener('pointerleave', onPointerLeave)
+    }
+    mapRef = undefined
+  }
+
+  onBeforeUnmount(destroyEdgeDragging)
+
+  return { isEdgePressed, isDraggingEdge, initEdgeDragging, destroyEdgeDragging }
+}

--- a/src/composables/map/useSurveyEdgeDragging.ts
+++ b/src/composables/map/useSurveyEdgeDragging.ts
@@ -5,6 +5,7 @@ import {
   closestPolygonEdge,
   draggedEdgeEndpoints,
   edgeResizeCursor,
+  isOverEdgeAddMarker,
   isOverSurveyHandle,
 } from '@/libs/map/survey-polygon-edges'
 import { isRectangle } from '@/libs/map/survey-rectangle'
@@ -94,7 +95,10 @@ export const useSurveyEdgeDragging = (options: UseSurveyEdgeDraggingOptions): Us
 
   const edgeAt = (event: PointerEvent): number | null => {
     if (!mapRef || !isEditable()) return null
-    if (isOverSurveyHandle(event.target)) return null
+    // A finger has no hover to find an edge with, so the "+" standing on the edge's midpoint doubles as its grab
+    // handle: a tap on it still adds a vertex there, and a drag carries the edge.
+    const grabsByAddMarker = event.pointerType !== 'mouse' && isOverEdgeAddMarker(event.target)
+    if (isOverSurveyHandle(event.target) && !grabsByAddMarker) return null
 
     const points = vertices.value.map((latLng) => mapRef!.latLngToContainerPoint(latLng))
     return closestPolygonEdge(points, mapRef.mouseEventToContainerPoint(event), grabToleranceInPixels)

--- a/src/composables/map/useTouchDrawing.ts
+++ b/src/composables/map/useTouchDrawing.ts
@@ -1,0 +1,260 @@
+import L, { type Map as LeafletMap } from 'leaflet'
+import { type ShallowRef, computed, onBeforeUnmount, shallowRef, watch } from 'vue'
+
+import { isOverSurveyHandle } from '@/libs/map/survey-polygon-edges'
+
+/** Wiring {@link useTouchDrawing} needs from the view that draws on the map. */
+export interface UseTouchDrawingOptions {
+  /** Whether a finger on the map is drawing, which is what leaves panning to a second one. */
+  drawsWithOneFinger: () => boolean
+  /** Whether the segment being drawn already has a point to start from. */
+  hasAnchor: () => boolean
+  /** Whether another handler already took the press, so the map is left to it. */
+  isBlocked: () => boolean
+  /** Lays a point down where the drawing is, which is how the first drag plants the segment's start. */
+  placePoint: (latlng: L.LatLng) => void
+}
+
+/** Return type of {@link useTouchDrawing}. */
+export interface UseTouchDrawingReturn {
+  /** Where a finger left the live line, waiting to be confirmed, or null when nothing is waiting. */
+  pendingPoint: ShallowRef<L.LatLng | null>
+  /** Forgets the point that was waiting, taking its checkmark off the map. */
+  clearPendingPoint: () => void
+  /** Whether the click the browser may raise out of the last drag has to be dropped instead of drawn with. */
+  swallowsClick: () => boolean
+  /** Binds the gestures to a Leaflet map. */
+  initTouchDrawing: (map: LeafletMap) => void
+  /** Unbinds everything and gives panning back. */
+  destroyTouchDrawing: () => void
+}
+
+// A press has to travel this far before it aims instead of tapping, which is what the edge drag asks of one too.
+const dragThresholdInPixels = 4
+// The checkmark stands off the point's diagonal, clear of the line ending there and of the finger that dragged it.
+const confirmOffsetInPixels = 26
+// Controls and handles that own their own presses, which a drawing gesture must not take from them.
+const ownPressSelector = '.leaflet-marker-icon, .leaflet-control, .live-measure-pill, .touch-draw-confirm'
+const confirmLabel = 'Confirm the point'
+
+const confirmMarkup = `
+  <svg width="22" height="22" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" style="display: block;">
+    <circle cx="10" cy="10" r="9" fill="white" stroke="#3B82F6" stroke-width="2"/>
+    <path d="M5.5 10.5L8.5 13.5L14.5 7" stroke="#3B82F6" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round"/>
+  </svg>
+`
+
+/**
+ * Draws with a finger: while a segment is being laid down, one finger on the map aims the line's loose end
+ * instead of panning, panning is left to two fingers, and where the finger lets go waits under a checkmark
+ * until it is confirmed, so it can be dragged again as many times as it takes.
+ * @param {UseTouchDrawingOptions} options - What counts as drawing right now, and how to draw it.
+ * @returns {UseTouchDrawingReturn} The point awaiting confirmation plus the methods to bind and unbind the map.
+ */
+export const useTouchDrawing = (options: UseTouchDrawingOptions): UseTouchDrawingReturn => {
+  const { drawsWithOneFinger, hasAnchor, isBlocked, placePoint } = options
+
+  const pendingPoint = shallowRef<L.LatLng | null>(null)
+  const drawsNow = computed(drawsWithOneFinger)
+
+  let mapRef: LeafletMap | undefined
+  let confirmEl: HTMLDivElement | null = null
+  let pressedPointerId: number | null = null
+  let pressOrigin: L.Point | null = null
+  let isAiming = false
+  let aimedWithoutClick = false
+  let panningWasEnabled = false
+
+  const positionConfirm = (): void => {
+    if (!mapRef || !confirmEl || !pendingPoint.value) return
+
+    const { x, y } = mapRef.latLngToContainerPoint(pendingPoint.value)
+    confirmEl.style.left = `${x + confirmOffsetInPixels}px`
+    confirmEl.style.top = `${y - confirmOffsetInPixels}px`
+  }
+
+  const clearPendingPoint = (): void => {
+    pendingPoint.value = null
+    if (confirmEl) confirmEl.style.display = 'none'
+  }
+
+  const confirmPendingPoint = (): void => {
+    const point = pendingPoint.value
+    if (!point) return
+
+    logUserAction('Confirmed the point dragged out on the map')
+    clearPendingPoint()
+    placePoint(point)
+  }
+
+  const ensureConfirm = (map: LeafletMap): HTMLDivElement => {
+    if (confirmEl) return confirmEl
+
+    const el = document.createElement('div')
+    el.className = 'touch-draw-confirm'
+    el.setAttribute('role', 'button')
+    el.setAttribute('aria-label', confirmLabel)
+    el.title = confirmLabel
+    el.tabIndex = 0
+    el.innerHTML = confirmMarkup
+    el.style.position = 'absolute'
+    el.style.zIndex = '641'
+    el.style.transform = 'translate(-50%, -50%)'
+    el.style.cursor = 'pointer'
+    el.style.display = 'none'
+    // The map is listening for a click on everything inside its container, and this one is not a place to draw.
+    L.DomEvent.disableClickPropagation(el)
+    el.addEventListener('click', confirmPendingPoint)
+    el.addEventListener('keydown', (event) => {
+      if (event.key !== 'Enter' && event.key !== ' ') return
+      event.preventDefault()
+      confirmPendingPoint()
+    })
+    map.getContainer().appendChild(el)
+
+    confirmEl = el
+    return el
+  }
+
+  const holdPointForConfirmation = (latlng: L.LatLng): void => {
+    if (!mapRef) return
+
+    pendingPoint.value = latlng
+    ensureConfirm(mapRef).style.display = 'block'
+    positionConfirm()
+  }
+
+  const restorePanning = (): void => {
+    if (!panningWasEnabled) return
+
+    panningWasEnabled = false
+    mapRef?.dragging.enable()
+  }
+
+  // With its own dragging switched off, leaflet leaves the container free to be panned as a page instead, which
+  // ends the gesture the line is being aimed with. The browser is told to keep its hands off it while it lasts,
+  // the same way leaflet does when it is panning the map itself.
+  const applyTouchAction = (): void => {
+    const container = mapRef?.getContainer()
+    if (container) container.style.touchAction = drawsNow.value ? 'none' : ''
+  }
+
+  const stopPress = (): void => {
+    const container = mapRef?.getContainer()
+    if (pressedPointerId !== null && container?.hasPointerCapture(pressedPointerId)) {
+      container.releasePointerCapture(pressedPointerId)
+    }
+    pressedPointerId = null
+    pressOrigin = null
+    isAiming = false
+    restorePanning()
+  }
+
+  const onPointerDown = (event: PointerEvent): void => {
+    aimedWithoutClick = false
+    // A second finger means the map's own pinch and pan, so the first one stops aiming and leaves the line where
+    // it got to. Panning is given back by that finger's own release, not by this one.
+    if (!event.isPrimary) {
+      pressOrigin = null
+      isAiming = false
+      return
+    }
+    // A first finger arriving while one is still held means the last gesture's release never came, so it is closed
+    // out here rather than leaving panning switched off for good.
+    if (pressedPointerId !== null) stopPress()
+
+    const pressedOn = event.target as HTMLElement | null
+    const ownedElsewhere = isBlocked() || isOverSurveyHandle(pressedOn) || !!pressedOn?.closest?.(ownPressSelector)
+    if (!mapRef || event.pointerType === 'mouse' || !drawsNow.value || ownedElsewhere) return
+
+    clearPendingPoint()
+    pressedPointerId = event.pointerId
+    pressOrigin = mapRef.mouseEventToContainerPoint(event)
+    isAiming = false
+    // The gesture has to be read to its end even when the finger wanders off the map, which is also what keeps
+    // its release from going missing and leaving panning switched off.
+    mapRef.getContainer().setPointerCapture(event.pointerId)
+    panningWasEnabled = mapRef.dragging.enabled()
+    if (panningWasEnabled) mapRef.dragging.disable()
+  }
+
+  const onPointerMove = (event: PointerEvent): void => {
+    if (!mapRef || pressedPointerId !== event.pointerId || !pressOrigin) return
+
+    const containerPoint = mapRef.mouseEventToContainerPoint(event)
+    if (!isAiming) {
+      if (containerPoint.distanceTo(pressOrigin) < dragThresholdInPixels) return
+      isAiming = true
+      // A segment has to start somewhere, so the spot the finger went down on becomes it.
+      if (!hasAnchor()) placePoint(mapRef.containerPointToLatLng(pressOrigin))
+      logUserAction('Dragged the live line out with a finger')
+    }
+
+    // A finger produces no mousemove, so where it drags to is fired as one: the live measure, the rectangle being
+    // swept and everything else already following the cursor then follow the finger too.
+    const latlng = mapRef.containerPointToLatLng(containerPoint)
+    mapRef.fire('mousemove', {
+      latlng,
+      layerPoint: mapRef.latLngToLayerPoint(latlng),
+      containerPoint,
+      originalEvent: event,
+    })
+  }
+
+  const onPointerUp = (event: PointerEvent): void => {
+    if (pressedPointerId !== event.pointerId) return
+
+    const aimedAt = isAiming && mapRef ? mapRef.containerPointToLatLng(mapRef.mouseEventToContainerPoint(event)) : null
+    stopPress()
+    if (!aimedAt) return
+
+    aimedWithoutClick = true
+    holdPointForConfirmation(aimedAt)
+  }
+
+  const initTouchDrawing = (map: LeafletMap): void => {
+    mapRef = map
+    applyTouchAction()
+    const container = map.getContainer()
+    container.addEventListener('pointerdown', onPointerDown)
+    container.addEventListener('pointermove', onPointerMove)
+    container.addEventListener('pointerup', onPointerUp)
+    container.addEventListener('pointercancel', onPointerUp)
+    map.on('move zoom', positionConfirm)
+  }
+
+  const destroyTouchDrawing = (): void => {
+    const container = mapRef?.getContainer()
+    stopPress()
+    clearPendingPoint()
+    if (container) {
+      container.removeEventListener('pointerdown', onPointerDown)
+      container.removeEventListener('pointermove', onPointerMove)
+      container.removeEventListener('pointerup', onPointerUp)
+      container.removeEventListener('pointercancel', onPointerUp)
+      container.style.touchAction = ''
+    }
+    mapRef?.off('move zoom', positionConfirm)
+    confirmEl?.remove()
+    confirmEl = null
+    mapRef = undefined
+  }
+
+  watch(drawsNow, (draws) => {
+    applyTouchAction()
+    // Nothing is being drawn any more, so a point still waiting to be confirmed has nothing left to belong to.
+    if (!draws) clearPendingPoint()
+  })
+  onBeforeUnmount(destroyTouchDrawing)
+
+  return {
+    pendingPoint,
+    clearPendingPoint,
+    // Kept until the next press rather than for a while, since a drag the browser raises no click out of would
+    // otherwise leave the tap after it to be swallowed.
+    swallowsClick: () => aimedWithoutClick,
+    initTouchDrawing,
+    destroyTouchDrawing,
+  }
+}

--- a/src/libs/map/local-frame.ts
+++ b/src/libs/map/local-frame.ts
@@ -1,0 +1,40 @@
+import { earthRadiusMeters } from '@/libs/mission/general-estimates'
+import { degrees, radians } from '@/libs/utils'
+import type { WaypointCoordinates } from '@/types/mission'
+
+/** A point in the local east/north plane, in meters from the frame's anchor. */
+export interface LocalPoint {
+  /** Meters east of the anchor. */
+  x: number
+  /** Meters north of the anchor. */
+  y: number
+}
+
+/** Converters between coordinates and a local east/north plane anchored at one point. */
+export interface LocalFrame {
+  /** Projects a coordinate into the frame. */
+  toLocal: (coordinates: WaypointCoordinates) => LocalPoint
+  /** Lifts a point in the frame back to a coordinate. */
+  toCoordinates: (localPoint: LocalPoint) => WaypointCoordinates
+}
+
+/**
+ * Rectangles are built and measured in this plane, the same equirectangular projection the mission estimates
+ * use, because a spherical quad cannot have four square corners and equal opposite sides at once: walking great
+ * circles instead leaves the far side of a 300 m rectangle a third of a meter long.
+ * @param {WaypointCoordinates} anchor - Coordinate the plane is centered on.
+ * @returns {LocalFrame} Converters in and out of the plane anchored at that coordinate.
+ */
+export const localFrame = (anchor: WaypointCoordinates): LocalFrame => {
+  const cosAnchorLatitude = Math.cos(radians(anchor[0]))
+  return {
+    toLocal: (coordinates) => ({
+      x: earthRadiusMeters * radians(coordinates[1] - anchor[1]) * cosAnchorLatitude,
+      y: earthRadiusMeters * radians(coordinates[0] - anchor[0]),
+    }),
+    toCoordinates: ({ x, y }) => [
+      anchor[0] + degrees(y / earthRadiusMeters),
+      anchor[1] + degrees(x / (earthRadiusMeters * cosAnchorLatitude)),
+    ],
+  }
+}

--- a/src/libs/map/survey-polygon-edges.ts
+++ b/src/libs/map/survey-polygon-edges.ts
@@ -1,0 +1,99 @@
+import { localFrame } from '@/libs/map/local-frame'
+import { degrees, norm360 } from '@/libs/utils'
+import type { WaypointCoordinates } from '@/types/mission'
+
+/** A point on screen, in pixels from the top left of the map container. */
+export interface ScreenPoint {
+  /** Pixels from the container's left edge. */
+  x: number
+  /** Pixels from the container's top edge. */
+  y: number
+}
+
+const handleSelector = '.custom-div-icon, .edge-marker, .delete-popup, .delete-button'
+
+/**
+ * Whether an event landed on one of the survey polygon's own handles rather than on the map under it.
+ * @param {EventTarget | null} target - The element the event was raised on.
+ * @returns {boolean} True when the element is a handle, or sits inside one.
+ */
+export const isOverSurveyHandle = (target: EventTarget | null): boolean =>
+  !!(target as HTMLElement | null)?.closest?.(handleSelector)
+
+const distanceToSegment = (point: ScreenPoint, start: ScreenPoint, end: ScreenPoint): number => {
+  const run = { x: end.x - start.x, y: end.y - start.y }
+  const lengthSquared = run.x * run.x + run.y * run.y
+  const alongRun = lengthSquared === 0 ? 0 : ((point.x - start.x) * run.x + (point.y - start.y) * run.y) / lengthSquared
+  const closest = Math.min(1, Math.max(0, alongRun))
+  return Math.hypot(point.x - (start.x + closest * run.x), point.y - (start.y + closest * run.y))
+}
+
+/**
+ * Index of the polygon edge closest to a point on screen, where edge `i` runs from vertex `i` to the one after it.
+ * @param {ScreenPoint[]} vertices - The polygon's vertices, in container pixels.
+ * @param {ScreenPoint} point - The point to test, in container pixels.
+ * @param {number} toleranceInPixels - How far from an edge still counts as being on it.
+ * @returns {number | null} The edge's index, or null when no edge is within the tolerance.
+ */
+export const closestPolygonEdge = (
+  vertices: ScreenPoint[],
+  point: ScreenPoint,
+  toleranceInPixels: number
+): number | null => {
+  if (vertices.length < 3) return null
+
+  let closestEdge: number | null = null
+  let closestDistance = toleranceInPixels
+  for (let index = 0; index < vertices.length; index++) {
+    const distance = distanceToSegment(point, vertices[index], vertices[(index + 1) % vertices.length])
+    if (distance <= closestDistance) {
+      closestDistance = distance
+      closestEdge = index
+    }
+  }
+  return closestEdge
+}
+
+// Screen y grows downward, so a horizontal edge has a vertical normal and reads as ns-resize.
+const resizeCursors = ['ew-resize', 'nwse-resize', 'ns-resize', 'nesw-resize']
+
+/**
+ * CSS resize cursor whose arrows lie along an edge's normal, which is the axis dragging the edge moves it on.
+ * @param {ScreenPoint} start - The edge's first endpoint, in container pixels.
+ * @param {ScreenPoint} end - The edge's second endpoint, in container pixels.
+ * @returns {string} The cursor keyword to apply to the map container.
+ */
+export const edgeResizeCursor = (start: ScreenPoint, end: ScreenPoint): string => {
+  const normalAngle = norm360(degrees(Math.atan2(end.y - start.y, end.x - start.x)) + 90) % 180
+  return resizeCursors[Math.round(normalAngle / 45) % 4]
+}
+
+/**
+ * Where an edge's endpoints land after a drag: following the pointer for a free-form polygon, and sliding along
+ * the edge's own normal when the shape has to keep its right angles.
+ * @param {[WaypointCoordinates, WaypointCoordinates]} edge - The edge's endpoints as they were before the drag.
+ * @param {[WaypointCoordinates, WaypointCoordinates]} drag - Where the pointer went down, and where it is now.
+ * @param {boolean} alongNormalOnly - Whether the edge may only move perpendicular to itself.
+ * @returns {[WaypointCoordinates, WaypointCoordinates]} The edge's endpoints after the drag.
+ */
+export const draggedEdgeEndpoints = (
+  edge: [WaypointCoordinates, WaypointCoordinates],
+  drag: [WaypointCoordinates, WaypointCoordinates],
+  alongNormalOnly: boolean
+): [WaypointCoordinates, WaypointCoordinates] => {
+  const { toLocal, toCoordinates } = localFrame(edge[0])
+  const run = toLocal(edge[1])
+  const from = toLocal(drag[0])
+  const to = toLocal(drag[1])
+  const offset = { x: to.x - from.x, y: to.y - from.y }
+
+  const length = Math.hypot(run.x, run.y)
+  if (alongNormalOnly && length > 0) {
+    const normal = { x: run.y / length, y: -run.x / length }
+    const alongNormal = offset.x * normal.x + offset.y * normal.y
+    offset.x = normal.x * alongNormal
+    offset.y = normal.y * alongNormal
+  }
+
+  return [toCoordinates(offset), toCoordinates({ x: run.x + offset.x, y: run.y + offset.y })]
+}

--- a/src/libs/map/survey-polygon-edges.ts
+++ b/src/libs/map/survey-polygon-edges.ts
@@ -20,6 +20,14 @@ const handleSelector = '.custom-div-icon, .edge-marker, .delete-popup, .delete-b
 export const isOverSurveyHandle = (target: EventTarget | null): boolean =>
   !!(target as HTMLElement | null)?.closest?.(handleSelector)
 
+/**
+ * Whether an event landed on the "+" an edge carries at its midpoint.
+ * @param {EventTarget | null} target - The element the event was raised on.
+ * @returns {boolean} True when the element is such a marker, or sits inside one.
+ */
+export const isOverEdgeAddMarker = (target: EventTarget | null): boolean =>
+  !!(target as HTMLElement | null)?.closest?.('.edge-marker')
+
 const distanceToSegment = (point: ScreenPoint, start: ScreenPoint, end: ScreenPoint): number => {
   const run = { x: end.x - start.x, y: end.y - start.y }
   const lengthSquared = run.x * run.x + run.y * run.y

--- a/src/libs/map/survey-rectangle.ts
+++ b/src/libs/map/survey-rectangle.ts
@@ -1,0 +1,39 @@
+import { localFrame } from '@/libs/map/local-frame'
+import { degrees } from '@/libs/utils'
+import type { WaypointCoordinates } from '@/types/mission'
+
+// A quad counts as a rectangle while every corner is within this many degrees of square and opposite sides
+// match within this fraction of their length, which absorbs coordinate rounding without accepting a polygon
+// the user has visibly dragged out of shape.
+const squareCornerToleranceDeg = 0.1
+const oppositeSideTolerance = 0.001
+
+/**
+ * Whether a polygon is a rectangle, which is what decides if reshaping it has to keep its corners square.
+ * @param {WaypointCoordinates[]} corners - The polygon's vertices, as an open ring.
+ * @returns {boolean} True when the polygon has four corners, square within tolerance, with matching opposite sides.
+ */
+export const isRectangle = (corners: WaypointCoordinates[]): boolean => {
+  if (corners.length !== 4) return false
+
+  const { toLocal } = localFrame(corners[0])
+  const points = corners.map(toLocal)
+  const edges = points.map((point, index) => ({
+    x: points[(index + 1) % 4].x - point.x,
+    y: points[(index + 1) % 4].y - point.y,
+  }))
+  const lengths = edges.map((edge) => Math.hypot(edge.x, edge.y))
+  if (lengths.some((length) => length === 0)) return false
+
+  const opposedSidesMatch = [
+    [lengths[0], lengths[2]],
+    [lengths[1], lengths[3]],
+  ].every(([first, second]) => Math.abs(first - second) <= oppositeSideTolerance * Math.max(first, second))
+  if (!opposedSidesMatch) return false
+
+  return edges.every((edge, index) => {
+    const next = edges[(index + 1) % 4]
+    const cosine = (edge.x * next.x + edge.y * next.y) / (lengths[index] * lengths[(index + 1) % 4])
+    return Math.abs(degrees(Math.acos(Math.min(1, Math.max(-1, cosine)))) - 90) <= squareCornerToleranceDeg
+  })
+}

--- a/src/libs/map/typed-extent.ts
+++ b/src/libs/map/typed-extent.ts
@@ -1,0 +1,43 @@
+import { localFrame } from '@/libs/map/local-frame'
+import type { WaypointCoordinates } from '@/types/mission'
+
+// A mistyped extra digit would otherwise build an area the path generator sweeps line by line, so every typed
+// extent is held to a range a survey can be flown at.
+export const minExtentInMeters = 1
+export const maxExtentInMeters = 100000
+
+/**
+ * Holds a typed extent to the range a survey can be flown at, keeping its sign, which is how a negative extent
+ * grows the shape to the side opposite the cursor.
+ * @param {number} value - The extent that was typed, in meters.
+ * @param {number} fallback - Extent to keep when nothing usable was typed.
+ * @returns {number} The extent to build with, in meters, negative when it was typed that way.
+ */
+export const clampExtent = (value: number, fallback: number): number => {
+  if (!Number.isFinite(value) || value === 0) return fallback
+
+  const magnitude = Math.min(maxExtentInMeters, Math.max(minExtentInMeters, Math.abs(value)))
+  return value < 0 ? -magnitude : magnitude
+}
+
+/**
+ * Walks a given distance from one coordinate in the direction of another, which is how a typed extent takes over
+ * a segment whose direction is still being chosen with the cursor.
+ * @param {WaypointCoordinates} from - Coordinate the distance is walked from.
+ * @param {WaypointCoordinates} towards - Coordinate giving the direction to walk in.
+ * @param {number} distanceInMeters - How far to walk.
+ * @returns {WaypointCoordinates} The coordinate at that distance, or the origin when there is no direction yet.
+ */
+export const pointAtDistanceToward = (
+  from: WaypointCoordinates,
+  towards: WaypointCoordinates,
+  distanceInMeters: number
+): WaypointCoordinates => {
+  const { toLocal, toCoordinates } = localFrame(from)
+  const { x, y } = toLocal(towards)
+  const magnitude = Math.hypot(x, y)
+  if (magnitude === 0) return from
+
+  const scale = distanceInMeters / magnitude
+  return toCoordinates({ x: x * scale, y: y * scale })
+}

--- a/src/libs/mission/general-estimates.ts
+++ b/src/libs/mission/general-estimates.ts
@@ -5,7 +5,7 @@ import { MissionLeg, WaypointCoordinates } from '@/types/mission'
 import { norm360, radians } from '../utils'
 import { BatteryChemistry } from '../vehicle/types'
 
-const earthRadiusMeters = 6_378_137
+export const earthRadiusMeters = 6_378_137
 
 // Haversine distance between two lat/lng coordinates (in meters) to calculate around-a-sphere distance between two points
 // Equation from https://www.movable-type.co.uk/scripts/latlong.html

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -3243,6 +3243,9 @@ const removeSurveyCrosshatchPathLayer = (): void => {
 const clearSurveyPathByUser = (): void => {
   logUserAction('Cleared survey path')
   clearSurveyPath()
+  // Clearing the draft is how the user starts over, so vertex adding comes back on even when it had been
+  // switched off.
+  if (isCreatingSurvey.value) isDrawingSurveyPolygon.value = true
 }
 
 const clearSurveyPath = (): void => {

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -1246,6 +1246,7 @@ const {
   onDragEnd: (moved) => {
     if (!moved) return
     ignoreNextClick = true
+    createSurveyPath()
   },
 })
 
@@ -1256,6 +1257,14 @@ const cursorCoordinates = ref<[number, number] | null>(null)
 const accessingSurveyContextMenu = ref(false)
 const isDraggingPolygon = ref(false)
 const isDraggingMarker = ref(false)
+const isDraggingSurveyVertex = ref(false)
+
+// The live preview is rebuilt on every pointer move of a reshape, so a polygon that is momentarily too thin for
+// its line spacing must not raise the no-valid-path warning until the gesture is released.
+const isReshapingSurveyPolygon = computed(
+  () => isDraggingSurveyVertex.value || isDraggingPolygon.value || isDraggingSurveyEdge.value
+)
+
 const showHomePositionNotSetDialog = ref(false)
 const fetchingMission = ref(false)
 const missionFetchProgress = ref(0)
@@ -2245,6 +2254,8 @@ const onPolygonMouseDown = (event: L.LeafletMouseEvent): void => {
 }
 
 const onPolygonMouseUp = (event: L.LeafletMouseEvent): void => {
+  const moved = !!dragStartLatLng && !event.latlng.equals(dragStartLatLng)
+
   isDraggingPolygon.value = false
   dragStartLatLng = null
   polygonLatLngsAtDragStart = []
@@ -2254,6 +2265,8 @@ const onPolygonMouseUp = (event: L.LeafletMouseEvent): void => {
   planningMap.value?.off('mouseup', onPolygonMouseUp)
 
   ignoreNextClick = true
+  // Every build during the drag was suppressed, so the polygon at rest is the one allowed to warn.
+  if (moved) createSurveyPath()
 
   L.DomEvent.stopPropagation(event.originalEvent)
   L.DomEvent.preventDefault(event.originalEvent)
@@ -3404,11 +3417,13 @@ const createSurveyPath = (): void => {
 
     if (result.path.length === 0) {
       surveyPreviewPath.value = null
-      showDialog({
-        variant: 'error',
-        message: 'No valid path could be generated. Try adjusting the angle or distance between lines.',
-        timer: 5000,
-      })
+      if (!isReshapingSurveyPolygon.value) {
+        showDialog({
+          variant: 'error',
+          message: 'No valid path could be generated. Try adjusting the angle or distance between lines.',
+          timer: 5000,
+        })
+      }
       return
     }
 
@@ -3927,9 +3942,14 @@ const createSurveyVertexMarker = (
     draggable: true,
   })
     .on('dragstart', () => {
+      isDraggingSurveyVertex.value = true
       pushSurveyPolygonSnapshot()
     })
     .on('drag', () => {
+      onDrag()
+    })
+    .on('dragend', () => {
+      isDraggingSurveyVertex.value = false
       onDrag()
     })
     .on('mouseover', (event: L.LeafletEvent) => {

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -901,6 +901,7 @@ import { useMissionPathSignalOverlay } from '@/composables/baseStation/useMissio
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { useCustomTileProviders } from '@/composables/map/useCustomTileProviders'
 import { useDragMeasureOverlay } from '@/composables/map/useDragMeasureOverlay'
+import { useLiveMeasureOverlay } from '@/composables/map/useLiveMeasureOverlay'
 import { provideMapContext } from '@/composables/map/useMapContext'
 import { useMapOverlays } from '@/composables/map/useMapOverlays'
 import { useMapPoiMarkers } from '@/composables/map/useMapPoiMarkers'
@@ -945,8 +946,6 @@ import {
   bearingBetween,
   calculateHaversineDistance,
   centroidLatLng,
-  formatBearing,
-  formatMetersShort,
   polygonAreaSquareMeters,
 } from '@/libs/mission/general-estimates'
 import { PLANNABLE_VEHICLE_TYPES, vehicleTypeLabel } from '@/libs/mission/library'
@@ -1370,16 +1369,8 @@ let osmSaveBtn: HTMLAnchorElement | undefined
 const nearMissionPathTolerance = 16 // in pixels
 const waypointPickToleranceInPixels = 10
 const measureLayer = shallowRef<L.LayerGroup | null>(null)
-let measureOverlayEl: HTMLDivElement | null = null
-let measureSvgEl: SVGSVGElement | null = null
-let measureLineEl: SVGLineElement | null = null
-let measureEndDotEl: SVGCircleElement | null = null
-let measureTextEl: HTMLDivElement | null = null
-let measureLengthEl: HTMLSpanElement | null = null
-let measureRestEl: HTMLSpanElement | null = null
 // Last cursor event kept so the live measure can be re-rendered while the map pans (no mousemove fires then)
 let lastMeasureCursor: L.LeafletMouseEvent | null = null
-let measureRefreshRafId: number | null = null
 const surveyAreaMarkers = shallowRef<Record<string, L.Marker>>({})
 const liveSurveyAreaMarker = shallowRef<L.Marker | null>(null)
 
@@ -1398,8 +1389,39 @@ const glassMenuCssVars = computed(() => ({
   '--glass-box-shadow': interfaceStore.globalGlassMenuStyles.boxShadow,
 }))
 
+const {
+  initLiveMeasure,
+  renderLiveMeasure,
+  clearLiveMeasure: clearMeasureOverlay,
+  setLiveMeasureAnchor,
+  setLiveMeasureTyping,
+  refreshLiveMeasureOnMapMove,
+  destroyLiveMeasure,
+} = useLiveMeasureOverlay({
+  redraw: (latlng, containerPoint) => {
+    if (lastMeasureCursor) handleMapMouseMove({ ...lastMeasureCursor, latlng, containerPoint })
+  },
+  cursorPosition: () => L.point(cursorLivePositionX.value, cursorLivePositionY.value),
+  heldPoint: () => pendingDrawnPoint.value,
+  onTagPressed: () => {
+    if (extentInputsOpen.value) {
+      focusExtentInput('segment')
+      return
+    }
+    logUserAction('Opened the distance field from the measure tag')
+    openExtentInputs('segment')
+    // A touch never moves a cursor, so the field is placed against the measure the tag is already showing.
+    refreshLiveMeasureOnMapMove()
+  },
+  onTagTapped: () => focusExtentInput('segment'),
+})
+
+watch(extentInputsOpen, (open) => setLiveMeasureTyping(open))
+// A point left waiting is what stands the tag clear of the pointer, so the tag is redrawn as it comes and goes.
+watch(pendingDrawnPoint, () => refreshLiveMeasureOnMapMove())
+
 const clearLiveMeasure = (): void => {
-  destroyMeasureOverlay(planningMap.value || undefined)
+  clearMeasureOverlay()
   angleOverlay.clearVertexAngles()
   clearPendingPoint()
   // An extent typed for the segment just drawn does not carry over to the next one, which starts free again.
@@ -1439,100 +1461,6 @@ const currentMeasurePrevAnchor = (): L.LatLng | null => {
   }
 
   return null
-}
-
-const ensureMeasureOverlay = (map: L.Map): void => {
-  if (measureOverlayEl) return
-  const container = map.getContainer()
-
-  measureOverlayEl = document.createElement('div')
-  measureOverlayEl.className = 'measure-overlay'
-  measureOverlayEl.style.pointerEvents = 'none'
-  measureOverlayEl.style.position = 'absolute'
-  measureOverlayEl.style.top = '0'
-  measureOverlayEl.style.left = '0'
-  measureOverlayEl.style.width = '100%'
-  measureOverlayEl.style.height = '100%'
-  measureOverlayEl.style.zIndex = '640'
-
-  measureSvgEl = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
-  measureSvgEl.setAttribute('width', '100%')
-  measureSvgEl.setAttribute('height', '100%')
-  measureSvgEl.style.position = 'absolute'
-  measureSvgEl.style.top = '0'
-  measureSvgEl.style.left = '0'
-
-  measureLineEl = document.createElementNS('http://www.w3.org/2000/svg', 'line')
-  measureLineEl.setAttribute('stroke-width', '2')
-  measureLineEl.setAttribute('stroke-dasharray', '10,10')
-  measureLineEl.setAttribute('opacity', '0.9')
-  measureLineEl.setAttribute('stroke', '#2563eb')
-
-  // The loose end of the line is where the next point lands, and a finger dragging it needs to see where that is.
-  measureEndDotEl = document.createElementNS('http://www.w3.org/2000/svg', 'circle')
-  measureEndDotEl.setAttribute('r', '5')
-  measureEndDotEl.setAttribute('fill', '#2563eb')
-  measureEndDotEl.setAttribute('stroke', '#FFFFFF')
-  measureEndDotEl.setAttribute('stroke-width', '2')
-
-  measureSvgEl.appendChild(measureLineEl)
-  measureSvgEl.appendChild(measureEndDotEl)
-
-  measureTextEl = document.createElement('div')
-  measureTextEl.className = 'live-measure-pill'
-  measureTextEl.classList.toggle('typing', extentInputsOpen.value)
-  measureTextEl.style.position = 'absolute'
-  measureTextEl.style.transform = 'translate(-50%, -50%)'
-  measureTextEl.style.pointerEvents = 'auto'
-  measureTextEl.style.cursor = 'pointer'
-  // Tapping the tag is how the field is asked for without a keyboard, so the tag owns its presses the way the
-  // map's own controls do: the map is listening inside its container, and the tag is not a place to draw.
-  L.DomEvent.disableClickPropagation(measureTextEl)
-  // Taken on the press rather than on the click, which the browser aims wherever the tag has moved to by the
-  // time a finger is lifted.
-  measureTextEl.addEventListener('pointerdown', (event) => {
-    event.stopPropagation()
-    if (extentInputsOpen.value) {
-      focusExtentInput('segment')
-      return
-    }
-    logUserAction('Opened the distance field from the measure tag')
-    openExtentInputs('segment')
-    // A touch never moves a cursor, so the field is placed against the measure the tag is already showing.
-    refreshLiveMeasureOnMapMove()
-  })
-  // Mobile browsers only raise their keyboard for a focus asked from the tap itself, which lands here.
-  measureTextEl.addEventListener('click', () => focusExtentInput('segment'))
-
-  // The caret stands right after the digits being typed, so the length and everything trailing it are their own
-  // spans, written on each move instead of rebuilt.
-  measureLengthEl = document.createElement('span')
-  measureLengthEl.className = 'measure-length'
-  measureRestEl = document.createElement('span')
-  const caretEl = document.createElement('span')
-  caretEl.className = 'measure-caret'
-  measureTextEl.append(measureLengthEl, caretEl, measureRestEl)
-
-  measureOverlayEl.appendChild(measureSvgEl)
-  measureOverlayEl.appendChild(measureTextEl)
-  container.appendChild(measureOverlayEl)
-}
-
-watch(extentInputsOpen, (open) => measureTextEl?.classList.toggle('typing', open))
-
-const destroyMeasureOverlay = (map?: L.Map): void => {
-  if (!measureOverlayEl) return
-  if (measureOverlayEl) {
-    ;(map?.getContainer() ?? measureOverlayEl.parentElement)?.removeChild(measureOverlayEl)
-  }
-  measureOverlayEl.remove()
-  measureOverlayEl = null
-  measureSvgEl = null
-  measureLineEl = null
-  measureEndDotEl = null
-  measureTextEl = null
-  measureLengthEl = null
-  measureRestEl = null
 }
 
 const placeSurveyPolygonPoint = (latlng: L.LatLng): void => {
@@ -1590,6 +1518,13 @@ const applyTypedSegment = (latlng: L.LatLng): void => {
   refreshLiveMeasureOnMapMove()
 }
 
+const isMeasuringSegment = (): boolean => {
+  const draggingExistingNode = isDraggingMarker.value || isDraggingPolygon.value || isDraggingSurveyEdge.value
+  if (draggingExistingNode) return false
+
+  return isCreatingSimplePath.value || (isCreatingSurvey.value && isDrawingSurveyPolygon.value)
+}
+
 // `evt` is optional so callers triggered without a mousemove (e.g. right after a context-menu
 // action) can still draw the line; hover hit-testing (against survey handles or the last
 // waypoint) is skipped in that case.
@@ -1599,62 +1534,37 @@ const renderMeasureOverlay = (cursorLatLng: L.LatLng, evt: L.LeafletMouseEvent |
   if (evt) lastMeasureCursor = evt
 
   const anchor = currentMeasureAnchor()
-  const draggingExistingNode = isDraggingMarker.value || isDraggingPolygon.value || isDraggingSurveyEdge.value
-  const measuring =
-    !!anchor &&
-    !draggingExistingNode &&
-    (isCreatingSimplePath.value || (isCreatingSurvey.value && isDrawingSurveyPolygon.value))
-  if (!measuring) {
-    destroyMeasureOverlay(planningMap.value)
+  if (!anchor || !isMeasuringSegment()) {
+    clearMeasureOverlay()
     angleOverlay.clearVertexAngles()
     // No segment is being drawn, so there is nothing left for a typed distance to apply to.
     closeExtentInputs()
     return
   }
 
-  const map = planningMap.value
-  ensureMeasureOverlay(map)
-
-  if (measureTextEl) {
-    measureTextEl.style.display = evt && isOverSurveyHandle(evt.originalEvent?.target) ? 'none' : 'block'
-  }
-
   // A typed distance holds the segment's length, so only its direction is still read off the cursor.
-  const cursor = projectToLockedExtent('segment', anchor!, cursorLatLng)
-  const a = map.latLngToContainerPoint(anchor!)
-  const b = map.latLngToContainerPoint(cursor)
-
-  if (measureLineEl) {
-    measureLineEl.setAttribute('x1', String(a.x))
-    measureLineEl.setAttribute('y1', String(a.y))
-    measureLineEl.setAttribute('x2', String(b.x))
-    measureLineEl.setAttribute('y2', String(b.y))
-  }
-  measureEndDotEl?.setAttribute('cx', String(b.x))
-  measureEndDotEl?.setAttribute('cy', String(b.y))
-
-  const midX = (a.x + b.x) / 2
-  const midY = (a.y + b.y) / 2
+  const cursor = projectToLockedExtent('segment', anchor, cursorLatLng)
   // Measured the way the panel and the estimates measure, so a typed extent reads back as the number that was
   // typed instead of leaflet's 0.1% smaller earth.
-  const dist = calculateHaversineDistance([anchor!.lat, anchor!.lng], [cursor.lat, cursor.lng])
+  const dist = calculateHaversineDistance([anchor.lat, anchor.lng], [cursor.lat, cursor.lng])
 
   const hidePill =
     (evt && (isOverSurveyHandle(evt.originalEvent?.target) || isOverLastWaypointMarker(evt))) || dist < 1 // hide if closer than 1 meter to last wp on the array
 
-  const bearing = bearingBetween([anchor!.lat, anchor!.lng], [cursor.lat, cursor.lng])
-  const [length, unit] = formatMetersShort(dist).split(' ')
-  if (measureLengthEl) measureLengthEl.textContent = isExtentCleared('segment') ? '' : length
-  if (measureRestEl) measureRestEl.textContent = `${unit ? ` ${unit}` : ''} · ${formatBearing(bearing)}`
-  if (measureTextEl) {
-    measureTextEl.style.left = `${midX}px`
-    measureTextEl.style.top = `${midY}px`
-    measureTextEl.style.display = hidePill ? 'none' : 'block'
-  }
+  renderLiveMeasure({
+    from: anchor,
+    to: cursor,
+    distanceInMeters: dist,
+    bearingInDegrees: bearingBetween([anchor.lat, anchor.lng], [cursor.lat, cursor.lng]),
+    hidesTag: hidePill,
+    clearsLength: isExtentCleared('segment'),
+    // Only a point already dragged out and left waiting has the tag standing clear of the pointer that drew it.
+    tagTakesPresses: pendingDrawnPoint.value !== null,
+  })
 
   setExtentTarget('segment', {
     label: 'distance',
-    from: anchor!,
+    from: anchor,
     to: cursor,
     liveValue: dist,
     refresh: refreshLiveMeasureOnMapMove,
@@ -1663,33 +1573,10 @@ const renderMeasureOverlay = (cursorLatLng: L.LatLng, evt: L.LeafletMouseEvent |
 
   const prevAnchor = currentMeasurePrevAnchor()
   if (prevAnchor && !hidePill) {
-    angleOverlay.renderVertexAngle(
-      [prevAnchor.lat, prevAnchor.lng],
-      [anchor!.lat, anchor!.lng],
-      [cursor.lat, cursor.lng]
-    )
+    angleOverlay.renderVertexAngle([prevAnchor.lat, prevAnchor.lng], [anchor.lat, anchor.lng], [cursor.lat, cursor.lng])
   } else {
     angleOverlay.clearVertexAngles()
   }
-}
-
-// Keep the live measure pinned to the cursor while the map pans under it.
-const refreshLiveMeasureOnMapMove = (): void => {
-  if (!planningMap.value || !lastMeasureCursor || measureRefreshRafId !== null) return
-  measureRefreshRafId = requestAnimationFrame(() => {
-    measureRefreshRafId = null
-    if (!planningMap.value || !lastMeasureCursor) return
-    const { containerPoint: cursorPoint, latlng: cursorLatlng } = mapPointerPositionFromClient(
-      planningMap.value,
-      cursorLivePositionX.value,
-      cursorLivePositionY.value
-    )
-    // A finger leaves no cursor behind, so a point it dragged out and left waiting is where the measure ends.
-    const held = pendingDrawnPoint.value
-    const containerPoint = held ? planningMap.value.latLngToContainerPoint(held) : cursorPoint
-    const latlng = held ?? cursorLatlng
-    handleMapMouseMove({ ...lastMeasureCursor, latlng, containerPoint })
-  })
 }
 
 const handleMapMouseMove = (e: L.LeafletMouseEvent): void => {
@@ -1704,6 +1591,7 @@ const onMapMouseMove = (e: L.LeafletMouseEvent): void => {
 
   handleMapMouseMove(e)
 }
+
 const saveEsri = (): void => {
   logUserAction('Saved visible Esri map tiles')
   esriSaveBtn?.click()
@@ -2907,13 +2795,7 @@ const performUndo = (): void => {
   interfaceStore.configPanelVisible = false
 
   const anchor = currentMeasureAnchor()
-  if (anchor && measureLineEl && planningMap.value) {
-    const pt = planningMap.value.latLngToContainerPoint(anchor)
-    measureLineEl.setAttribute('x1', String(pt.x))
-    measureLineEl.setAttribute('y1', String(pt.y))
-  } else {
-    clearLiveMeasure()
-  }
+  if (!anchor || !setLiveMeasureAnchor(anchor)) clearLiveMeasure()
 }
 
 const performRedo = (): void => {
@@ -2949,13 +2831,7 @@ const performRedo = (): void => {
   interfaceStore.configPanelVisible = false
 
   const anchor = currentMeasureAnchor()
-  if (anchor && measureLineEl && planningMap.value) {
-    const pt = planningMap.value.latLngToContainerPoint(anchor)
-    measureLineEl.setAttribute('x1', String(pt.x))
-    measureLineEl.setAttribute('y1', String(pt.y))
-  } else {
-    clearLiveMeasure()
-  }
+  if (!anchor || !setLiveMeasureAnchor(anchor)) clearLiveMeasure()
 }
 
 const handleKeyDown = (event: KeyboardEvent): void => {
@@ -4733,6 +4609,7 @@ onMounted(async () => {
   surveyArrowOverlay.initArrowOverlay(planningMap.value!)
   dragMeasureOverlay.initDragMeasureOverlay(planningMap.value!)
   initExtentInputs(planningMap.value!)
+  initLiveMeasure(planningMap.value!)
   initEdgeDragging(planningMap.value!)
   initTouchDrawing(planningMap.value!)
   measureLayer.value = L.layerGroup().addTo(planningMap.value!) as L.LayerGroup
@@ -4877,11 +4754,11 @@ onUnmounted(() => {
   }
   planningMap.value?.off('mousemove', onMapMouseMove)
   planningMap.value?.off('drag', refreshLiveMeasureOnMapMove)
-  if (measureRefreshRafId !== null) cancelAnimationFrame(measureRefreshRafId)
   clearLiveMeasure()
   dragMeasureOverlay.destroyDragMeasureOverlay()
   angleOverlay.destroyAngleOverlay()
   surveyArrowOverlay.destroyArrowOverlay()
+  destroyLiveMeasure()
   destroyEdgeDragging()
   destroyTouchDrawing()
 

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -1,6 +1,21 @@
 <template>
   <div class="mission-planning" :style="glassMenuCssVars">
     <div id="planningMap" ref="planningMap" class="relative" />
+    <MeasureExtentInput
+      v-for="box in extentBoxes"
+      :key="box.id"
+      :label="box.label"
+      :left="box.left"
+      :top="box.top"
+      :value="box.value"
+      :live-value="box.liveValue"
+      :cleared="box.cleared"
+      :autofocus="box.autofocus"
+      :focus-ticket="box.focusTicket"
+      @update:value="(value) => setExtentValue(box.id, value)"
+      @apply="applyExtent(box.id)"
+      @close="closeExtentInputs"
+    />
     <v-tooltip location="top" text="Generate waypoints">
       <template #activator="{ props }">
         <div
@@ -866,6 +881,7 @@ import MapOverlaysDialog from '@/components/map/MapOverlaysDialog.vue'
 import MapCenterControl from '@/components/MapCenterControl.vue'
 import ContextMenu from '@/components/mission-planning/ContextMenu.vue'
 import HomePositionSettingHelp from '@/components/mission-planning/HomePositionSettingHelp.vue'
+import MeasureExtentInput from '@/components/mission-planning/MeasureExtentInput.vue'
 import MissionEstimatesPanel from '@/components/mission-planning/MissionEstimates.vue'
 import MissionPlacementToolbar, {
   PLACEMENT_TOOLBAR_FOOTPRINT,
@@ -889,6 +905,7 @@ import { useMapOverlays } from '@/composables/map/useMapOverlays'
 import { useMapPoiMarkers } from '@/composables/map/useMapPoiMarkers'
 import { useMapTileLayers } from '@/composables/map/useMapTileLayers'
 import { useMapTileLayerSelection } from '@/composables/map/useMapTileLayerSelection'
+import { useMeasureExtentInput } from '@/composables/map/useMeasureExtentInput'
 import { useMissionInsertion } from '@/composables/map/useMissionInsertion'
 import { useMissionPlacement } from '@/composables/map/useMissionPlacement'
 import { type SurveyPreview, useSurveyArrowOverlay } from '@/composables/map/useSurveyArrowOverlay'
@@ -924,6 +941,7 @@ import {
 import { orderedSurveyPath, surveyEndpointEdgeBearing, surveyEntryCornerCount } from '@/libs/map/utils-map'
 import {
   bearingBetween,
+  calculateHaversineDistance,
   centroidLatLng,
   formatBearing,
   formatMetersShort,
@@ -1228,6 +1246,25 @@ const clearSurveyPolygonUndoStack = (): void => {
   surveyPolygonRedoStack.length = 0
 }
 
+const extentInput = useMeasureExtentInput({
+  shortcutFocus: () => (currentMeasureAnchor() ? 'segment' : null),
+  onOpened: () => refreshLiveMeasureOnMapMove(),
+})
+const {
+  extentBoxes,
+  extentInputsOpen,
+  openExtentInputs,
+  focusExtentInput,
+  closeExtentInputs,
+  clearExtentValues,
+  setExtentTarget,
+  setExtentValue,
+  applyExtent,
+  isExtentCleared,
+  projectToLockedExtent,
+  initExtentInputs,
+} = extentInput
+
 const {
   isEdgePressed: isPressingSurveyEdge,
   isDraggingEdge: isDraggingSurveyEdge,
@@ -1318,6 +1355,8 @@ let measureOverlayEl: HTMLDivElement | null = null
 let measureSvgEl: SVGSVGElement | null = null
 let measureLineEl: SVGLineElement | null = null
 let measureTextEl: HTMLDivElement | null = null
+let measureLengthEl: HTMLSpanElement | null = null
+let measureRestEl: HTMLSpanElement | null = null
 // Last cursor event kept so the live measure can be re-rendered while the map pans (no mousemove fires then)
 let lastMeasureCursor: L.LeafletMouseEvent | null = null
 let measureRefreshRafId: number | null = null
@@ -1342,6 +1381,9 @@ const glassMenuCssVars = computed(() => ({
 const clearLiveMeasure = (): void => {
   destroyMeasureOverlay(planningMap.value || undefined)
   angleOverlay.clearVertexAngles()
+  // An extent typed for the segment just drawn does not carry over to the next one, which starts free again.
+  setExtentTarget('segment', null)
+  clearExtentValues()
   lastMeasureCursor = null
 }
 
@@ -1409,13 +1451,45 @@ const ensureMeasureOverlay = (map: L.Map): void => {
 
   measureTextEl = document.createElement('div')
   measureTextEl.className = 'live-measure-pill'
+  measureTextEl.classList.toggle('typing', extentInputsOpen.value)
   measureTextEl.style.position = 'absolute'
   measureTextEl.style.transform = 'translate(-50%, -50%)'
+  measureTextEl.style.pointerEvents = 'auto'
+  measureTextEl.style.cursor = 'pointer'
+  // Tapping the tag is how the field is asked for without a keyboard, so the tag owns its presses the way the
+  // map's own controls do: the map is listening inside its container, and the tag is not a place to draw.
+  L.DomEvent.disableClickPropagation(measureTextEl)
+  // Taken on the press rather than on the click, which the browser aims wherever the tag has moved to by the
+  // time a finger is lifted.
+  measureTextEl.addEventListener('pointerdown', (event) => {
+    event.stopPropagation()
+    if (extentInputsOpen.value) {
+      focusExtentInput('segment')
+      return
+    }
+    logUserAction('Opened the distance field from the measure tag')
+    openExtentInputs('segment')
+    // A touch never moves a cursor, so the field is placed against the measure the tag is already showing.
+    refreshLiveMeasureOnMapMove()
+  })
+  // Mobile browsers only raise their keyboard for a focus asked from the tap itself, which lands here.
+  measureTextEl.addEventListener('click', () => focusExtentInput('segment'))
+
+  // The caret stands right after the digits being typed, so the length and everything trailing it are their own
+  // spans, written on each move instead of rebuilt.
+  measureLengthEl = document.createElement('span')
+  measureLengthEl.className = 'measure-length'
+  measureRestEl = document.createElement('span')
+  const caretEl = document.createElement('span')
+  caretEl.className = 'measure-caret'
+  measureTextEl.append(measureLengthEl, caretEl, measureRestEl)
 
   measureOverlayEl.appendChild(measureSvgEl)
   measureOverlayEl.appendChild(measureTextEl)
   container.appendChild(measureOverlayEl)
 }
+
+watch(extentInputsOpen, (open) => measureTextEl?.classList.toggle('typing', open))
 
 const destroyMeasureOverlay = (map?: L.Map): void => {
   if (!measureOverlayEl) return
@@ -1427,6 +1501,47 @@ const destroyMeasureOverlay = (map?: L.Map): void => {
   measureSvgEl = null
   measureLineEl = null
   measureTextEl = null
+  measureLengthEl = null
+  measureRestEl = null
+}
+
+const placeSurveyPolygonPoint = (latlng: L.LatLng): void => {
+  addSurveyPoint(latlng)
+  clearLiveMeasure()
+}
+
+// Lays a point down wherever the drawing is: a corner of the survey area, or the next waypoint of the path.
+const placeDrawnPoint = (latlng: L.LatLng): boolean => {
+  if (isCreatingSurvey.value && isDrawingSurveyPolygon.value) {
+    placeSurveyPolygonPoint(latlng)
+    return true
+  }
+  if (isCreatingSimplePath.value) {
+    const insertIndex = pendingSimplePathInsertIndex.value
+    addWaypoint(
+      [latlng.lat, latlng.lng],
+      currentWaypointAltitude.value,
+      currentWaypointAltitudeRefType.value,
+      undefined,
+      insertIndex ?? undefined
+    )
+    updateWaypointMarkers()
+    clearLiveMeasure()
+    return true
+  }
+
+  return false
+}
+
+// Enter takes the typed distance as the point itself, so a segment can be laid down without aiming a click at it.
+const applyTypedSegment = (latlng: L.LatLng): void => {
+  const cursorBeforePlacing = lastMeasureCursor
+  if (!placeDrawnPoint(latlng)) return
+
+  // A key press leaves the pointer where it was, so the cursor the measure was following is handed back and the
+  // next segment is drawn from the point just laid rather than waiting for the mouse to move.
+  lastMeasureCursor = cursorBeforePlacing
+  refreshLiveMeasureOnMapMove()
 }
 
 // `evt` is optional so callers triggered without a mousemove (e.g. right after a context-menu
@@ -1446,6 +1561,8 @@ const renderMeasureOverlay = (cursorLatLng: L.LatLng, evt: L.LeafletMouseEvent |
   if (!measuring) {
     destroyMeasureOverlay(planningMap.value)
     angleOverlay.clearVertexAngles()
+    // No segment is being drawn, so there is nothing left for a typed distance to apply to.
+    closeExtentInputs()
     return
   }
 
@@ -1456,8 +1573,10 @@ const renderMeasureOverlay = (cursorLatLng: L.LatLng, evt: L.LeafletMouseEvent |
     measureTextEl.style.display = evt && isOverSurveyHandle(evt.originalEvent?.target) ? 'none' : 'block'
   }
 
+  // A typed distance holds the segment's length, so only its direction is still read off the cursor.
+  const cursor = projectToLockedExtent('segment', anchor!, cursorLatLng)
   const a = map.latLngToContainerPoint(anchor!)
-  const b = map.latLngToContainerPoint(cursorLatLng)
+  const b = map.latLngToContainerPoint(cursor)
 
   if (measureLineEl) {
     measureLineEl.setAttribute('x1', String(a.x))
@@ -1468,26 +1587,38 @@ const renderMeasureOverlay = (cursorLatLng: L.LatLng, evt: L.LeafletMouseEvent |
 
   const midX = (a.x + b.x) / 2
   const midY = (a.y + b.y) / 2
-  const dist = anchor!.distanceTo(cursorLatLng)
+  // Measured the way the panel and the estimates measure, so a typed extent reads back as the number that was
+  // typed instead of leaflet's 0.1% smaller earth.
+  const dist = calculateHaversineDistance([anchor!.lat, anchor!.lng], [cursor.lat, cursor.lng])
 
   const hidePill =
     (evt && (isOverSurveyHandle(evt.originalEvent?.target) || isOverLastWaypointMarker(evt))) || dist < 1 // hide if closer than 1 meter to last wp on the array
 
-  const bearing = bearingBetween([anchor!.lat, anchor!.lng], [cursorLatLng.lat, cursorLatLng.lng])
-  const text = `${formatMetersShort(dist)} · ${formatBearing(bearing)}`
+  const bearing = bearingBetween([anchor!.lat, anchor!.lng], [cursor.lat, cursor.lng])
+  const [length, unit] = formatMetersShort(dist).split(' ')
+  if (measureLengthEl) measureLengthEl.textContent = isExtentCleared('segment') ? '' : length
+  if (measureRestEl) measureRestEl.textContent = `${unit ? ` ${unit}` : ''} · ${formatBearing(bearing)}`
   if (measureTextEl) {
-    measureTextEl.textContent = text
     measureTextEl.style.left = `${midX}px`
     measureTextEl.style.top = `${midY}px`
     measureTextEl.style.display = hidePill ? 'none' : 'block'
   }
+
+  setExtentTarget('segment', {
+    label: 'distance',
+    from: anchor!,
+    to: cursor,
+    liveValue: dist,
+    refresh: refreshLiveMeasureOnMapMove,
+    apply: () => applyTypedSegment(cursor),
+  })
 
   const prevAnchor = currentMeasurePrevAnchor()
   if (prevAnchor && !hidePill) {
     angleOverlay.renderVertexAngle(
       [prevAnchor.lat, prevAnchor.lng],
       [anchor!.lat, anchor!.lng],
-      [cursorLatLng.lat, cursorLatLng.lng]
+      [cursor.lat, cursor.lng]
     )
   } else {
     angleOverlay.clearVertexAngles()
@@ -1511,6 +1642,15 @@ const refreshLiveMeasureOnMapMove = (): void => {
 
 const handleMapMouseMove = (e: L.LeafletMouseEvent): void => {
   renderMeasureOverlay(e.latlng, e)
+}
+
+// A tap on the tag is echoed by a mouse move the browser raises over it, which would aim the line at the tag
+// and take the tag itself out from under the finger before the tap is through.
+const onMapMouseMove = (e: L.LeafletMouseEvent): void => {
+  const movedOver = e.originalEvent?.target as HTMLElement | null
+  if (movedOver?.closest?.('.live-measure-pill')) return
+
+  handleMapMouseMove(e)
 }
 
 const saveEsri = (): void => {
@@ -4468,10 +4608,11 @@ const onMapClick = (e: L.LeafletMouseEvent): void => {
     }
   }
 
-  if (isCreatingSurvey.value && isDrawingSurveyPolygon.value) {
-    addSurveyPoint(e.latlng)
-    clearLiveMeasure()
-  }
+  // A typed distance places the point at that exact distance from the last one, in the direction of the click.
+  const measureAnchor = currentMeasureAnchor()
+  const latlng = measureAnchor ? projectToLockedExtent('segment', measureAnchor, e.latlng) : e.latlng
+
+  if (isCreatingSurvey.value && isDrawingSurveyPolygon.value) placeSurveyPolygonPoint(latlng)
 
   if (planningMap.value) {
     // Check if there is an existing waypoint near the click location
@@ -4500,7 +4641,7 @@ const onMapClick = (e: L.LeafletMouseEvent): void => {
     ) {
       const insertIndex = pendingSimplePathInsertIndex.value
       addWaypoint(
-        [e.latlng.lat, e.latlng.lng],
+        [latlng.lat, latlng.lng],
         currentWaypointAltitude.value,
         currentWaypointAltitudeRefType.value,
         undefined,
@@ -4563,6 +4704,7 @@ onMounted(async () => {
   angleOverlay.initAngleOverlay(planningMap.value!)
   surveyArrowOverlay.initArrowOverlay(planningMap.value!)
   dragMeasureOverlay.initDragMeasureOverlay(planningMap.value!)
+  initExtentInputs(planningMap.value!)
   initEdgeDragging(planningMap.value!)
   measureLayer.value = L.layerGroup().addTo(planningMap.value!) as L.LayerGroup
 
@@ -4630,7 +4772,7 @@ onMounted(async () => {
 
   planningMap.value.on('drag', updateConfirmButtonPosition)
   planningMap.value.on('drag', refreshLiveMeasureOnMapMove)
-  planningMap.value.on('mousemove', handleMapMouseMove)
+  planningMap.value.on('mousemove', onMapMouseMove)
   planningMap.value.on('click', (e: L.LeafletMouseEvent) => {
     onMapClick(e)
   })
@@ -4704,7 +4846,7 @@ onUnmounted(() => {
     window.removeEventListener('blur', onWindowBlur)
     window.removeEventListener('mousemove', onWindowMouseMove)
   }
-  planningMap.value?.off('mousemove', handleMapMouseMove)
+  planningMap.value?.off('mousemove', onMapMouseMove)
   planningMap.value?.off('drag', refreshLiveMeasureOnMapMove)
   if (measureRefreshRafId !== null) cancelAnimationFrame(measureRefreshRafId)
   clearLiveMeasure()
@@ -5194,6 +5336,38 @@ watch(
   backdrop-filter: blur(10px);
   white-space: nowrap;
   transform: translate(0, -50%);
+}
+.live-measure-pill.typing {
+  border-color: #3b82f6;
+}
+/* A tag is small for a finger, so it presses from a halo around it without looking any bigger. */
+.live-measure-pill::before {
+  content: '';
+  position: absolute;
+  inset: -10px;
+}
+/* A number typed away holds the room it had, so the tag does not collapse around the caret left behind. */
+.measure-length:empty {
+  display: inline-block;
+  min-width: 3ch;
+}
+/* The field over the tag is invisible, so the tag carries the caret that says it is being typed into. */
+.measure-caret {
+  display: none;
+  width: 1px;
+  height: 14px;
+  margin: 0 1px;
+  vertical-align: -2px;
+  background: #fff;
+}
+.live-measure-pill.typing .measure-caret {
+  display: inline-block;
+  animation: measure-caret-blink 1.1s step-end infinite;
+}
+@keyframes measure-caret-blink {
+  50% {
+    opacity: 0;
+  }
 }
 .measure-area-icon {
   transform: translate(-50%, -50%);

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -892,6 +892,7 @@ import { useMapTileLayerSelection } from '@/composables/map/useMapTileLayerSelec
 import { useMissionInsertion } from '@/composables/map/useMissionInsertion'
 import { useMissionPlacement } from '@/composables/map/useMissionPlacement'
 import { type SurveyPreview, useSurveyArrowOverlay } from '@/composables/map/useSurveyArrowOverlay'
+import { useSurveyEdgeDragging } from '@/composables/map/useSurveyEdgeDragging'
 import { useVertexAngleOverlay } from '@/composables/map/useVertexAngleOverlay'
 import { useWaypointMarkerSize } from '@/composables/map/useWaypointMarkerSize'
 import { goToMenuPage } from '@/composables/menuRouting'
@@ -910,6 +911,7 @@ import type { NoiseTileOptions } from '@/libs/map/map-tile-fallback'
 import { attachTileNoiseFallback, refreshNoiseFallbackTiles } from '@/libs/map/map-tile-fallback'
 import { positionPanelNearBounds, screenBounds } from '@/libs/map/screen-placement'
 import { applyLiveWaypointCoordinates } from '@/libs/map/survey-arrows'
+import { isOverSurveyHandle } from '@/libs/map/survey-polygon-edges'
 import {
   createGridOverlay,
   fitMapToWaypoints,
@@ -1225,6 +1227,28 @@ const clearSurveyPolygonUndoStack = (): void => {
   surveyPolygonUndoStack.length = 0
   surveyPolygonRedoStack.length = 0
 }
+
+const {
+  isEdgePressed: isPressingSurveyEdge,
+  isDraggingEdge: isDraggingSurveyEdge,
+  initEdgeDragging,
+  destroyEdgeDragging,
+} = useSurveyEdgeDragging({
+  vertices: surveyPolygonVertexesPositions,
+  markers: () => surveyPolygonVertexesMarkers.value,
+  isEditable: () => isCreatingSurvey.value && surveyPolygonVertexesPositions.value.length >= 3,
+  onDragStart: pushSurveyPolygonSnapshot,
+  onEdgeMoved: () => {
+    updatePolygon()
+    createSurveyPath()
+    updateConfirmButtonPosition()
+  },
+  onDragEnd: (moved) => {
+    if (!moved) return
+    ignoreNextClick = true
+  },
+})
+
 let ignoreNextClick = false
 const selectedWaypoint = ref<Waypoint | undefined>(undefined)
 const contextMenuType = ref<ContextMenuTypes>('map')
@@ -1396,12 +1420,6 @@ const destroyMeasureOverlay = (map?: L.Map): void => {
   measureTextEl = null
 }
 
-const isOverSurveyHandle = (evt: L.LeafletMouseEvent): boolean => {
-  const el = evt.originalEvent?.target as HTMLElement | null
-  if (!el) return false
-  return !!el.closest('.custom-div-icon, .edge-marker, .delete-popup, .delete-button')
-}
-
 // `evt` is optional so callers triggered without a mousemove (e.g. right after a context-menu
 // action) can still draw the line; hover hit-testing (against survey handles or the last
 // waypoint) is skipped in that case.
@@ -1411,7 +1429,7 @@ const renderMeasureOverlay = (cursorLatLng: L.LatLng, evt: L.LeafletMouseEvent |
   if (evt) lastMeasureCursor = evt
 
   const anchor = currentMeasureAnchor()
-  const draggingExistingNode = isDraggingMarker.value || isDraggingPolygon.value
+  const draggingExistingNode = isDraggingMarker.value || isDraggingPolygon.value || isDraggingSurveyEdge.value
   const measuring =
     !!anchor &&
     !draggingExistingNode &&
@@ -1426,7 +1444,7 @@ const renderMeasureOverlay = (cursorLatLng: L.LatLng, evt: L.LeafletMouseEvent |
   ensureMeasureOverlay(map)
 
   if (measureTextEl) {
-    measureTextEl.style.display = evt && isOverSurveyHandle(evt) ? 'none' : 'block'
+    measureTextEl.style.display = evt && isOverSurveyHandle(evt.originalEvent?.target) ? 'none' : 'block'
   }
 
   const a = map.latLngToContainerPoint(anchor!)
@@ -1443,7 +1461,8 @@ const renderMeasureOverlay = (cursorLatLng: L.LatLng, evt: L.LeafletMouseEvent |
   const midY = (a.y + b.y) / 2
   const dist = anchor!.distanceTo(cursorLatLng)
 
-  const hidePill = (evt && (isOverSurveyHandle(evt) || isOverLastWaypointMarker(evt))) || dist < 1 // hide if closer than 1 meter to last wp on the array
+  const hidePill =
+    (evt && (isOverSurveyHandle(evt.originalEvent?.target) || isOverLastWaypointMarker(evt))) || dist < 1 // hide if closer than 1 meter to last wp on the array
 
   const bearing = bearingBetween([anchor!.lat, anchor!.lng], [cursorLatLng.lat, cursorLatLng.lng])
   const text = `${formatMetersShort(dist)} · ${formatBearing(bearing)}`
@@ -2209,6 +2228,9 @@ const isOverLastWaypointMarker = (event: L.LeafletMouseEvent): boolean => {
 }
 
 const onPolygonMouseDown = (event: L.LeafletMouseEvent): void => {
+  // A press that landed on an edge is reshaping that edge, so the whole polygon must not follow the pointer too.
+  if (isPressingSurveyEdge.value) return
+
   isDraggingPolygon.value = true
   dragStartLatLng = event.latlng
   pushSurveyPolygonSnapshot()
@@ -4521,6 +4543,7 @@ onMounted(async () => {
   angleOverlay.initAngleOverlay(planningMap.value!)
   surveyArrowOverlay.initArrowOverlay(planningMap.value!)
   dragMeasureOverlay.initDragMeasureOverlay(planningMap.value!)
+  initEdgeDragging(planningMap.value!)
   measureLayer.value = L.layerGroup().addTo(planningMap.value!) as L.LayerGroup
 
   registerLayerSync(planningMap.value)
@@ -4668,6 +4691,7 @@ onUnmounted(() => {
   dragMeasureOverlay.destroyDragMeasureOverlay()
   angleOverlay.destroyAngleOverlay()
   surveyArrowOverlay.destroyArrowOverlay()
+  destroyEdgeDragging()
 
   detachTileFallbacks.forEach((detach) => detach())
   detachTileFallbacks = []

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -788,6 +788,7 @@
   <SideConfigPanel
     v-if="isCreatingSurvey || selectedWaypoint"
     position="right"
+    :reopen-label="isCreatingSurvey ? 'Vertexes' : undefined"
     style="z-index: 600; pointer-events: auto"
     class="w-[320px]"
   >
@@ -910,6 +911,7 @@ import { useMissionInsertion } from '@/composables/map/useMissionInsertion'
 import { useMissionPlacement } from '@/composables/map/useMissionPlacement'
 import { type SurveyPreview, useSurveyArrowOverlay } from '@/composables/map/useSurveyArrowOverlay'
 import { useSurveyEdgeDragging } from '@/composables/map/useSurveyEdgeDragging'
+import { useTouchDrawing } from '@/composables/map/useTouchDrawing'
 import { useVertexAngleOverlay } from '@/composables/map/useVertexAngleOverlay'
 import { useWaypointMarkerSize } from '@/composables/map/useWaypointMarkerSize'
 import { goToMenuPage } from '@/composables/menuRouting'
@@ -1287,6 +1289,22 @@ const {
   },
 })
 
+const {
+  pendingPoint: pendingDrawnPoint,
+  clearPendingPoint,
+  swallowsClick: touchDrawingSwallowsClick,
+  initTouchDrawing,
+  destroyTouchDrawing,
+} = useTouchDrawing({
+  // An area is drawn with the finger from its very first corner, a path only once it has a waypoint to draw from.
+  drawsWithOneFinger: () =>
+    (isCreatingSurvey.value && isDrawingSurveyPolygon.value) ||
+    (isCreatingSimplePath.value && currentMeasureAnchor() !== null),
+  hasAnchor: () => currentMeasureAnchor() !== null,
+  isBlocked: () => isPressingSurveyEdge.value || isDraggingMarker.value || isDraggingSurveyVertex.value,
+  placePoint: (latlng) => placeDrawnPoint(latlng),
+})
+
 let ignoreNextClick = false
 const selectedWaypoint = ref<Waypoint | undefined>(undefined)
 const contextMenuType = ref<ContextMenuTypes>('map')
@@ -1350,10 +1368,12 @@ const gridLayer = shallowRef<L.LayerGroup | undefined>(undefined)
 let esriSaveBtn: HTMLAnchorElement | undefined
 let osmSaveBtn: HTMLAnchorElement | undefined
 const nearMissionPathTolerance = 16 // in pixels
+const waypointPickToleranceInPixels = 10
 const measureLayer = shallowRef<L.LayerGroup | null>(null)
 let measureOverlayEl: HTMLDivElement | null = null
 let measureSvgEl: SVGSVGElement | null = null
 let measureLineEl: SVGLineElement | null = null
+let measureEndDotEl: SVGCircleElement | null = null
 let measureTextEl: HTMLDivElement | null = null
 let measureLengthEl: HTMLSpanElement | null = null
 let measureRestEl: HTMLSpanElement | null = null
@@ -1381,6 +1401,7 @@ const glassMenuCssVars = computed(() => ({
 const clearLiveMeasure = (): void => {
   destroyMeasureOverlay(planningMap.value || undefined)
   angleOverlay.clearVertexAngles()
+  clearPendingPoint()
   // An extent typed for the segment just drawn does not carry over to the next one, which starts free again.
   setExtentTarget('segment', null)
   clearExtentValues()
@@ -1447,7 +1468,15 @@ const ensureMeasureOverlay = (map: L.Map): void => {
   measureLineEl.setAttribute('opacity', '0.9')
   measureLineEl.setAttribute('stroke', '#2563eb')
 
+  // The loose end of the line is where the next point lands, and a finger dragging it needs to see where that is.
+  measureEndDotEl = document.createElementNS('http://www.w3.org/2000/svg', 'circle')
+  measureEndDotEl.setAttribute('r', '5')
+  measureEndDotEl.setAttribute('fill', '#2563eb')
+  measureEndDotEl.setAttribute('stroke', '#FFFFFF')
+  measureEndDotEl.setAttribute('stroke-width', '2')
+
   measureSvgEl.appendChild(measureLineEl)
+  measureSvgEl.appendChild(measureEndDotEl)
 
   measureTextEl = document.createElement('div')
   measureTextEl.className = 'live-measure-pill'
@@ -1500,6 +1529,7 @@ const destroyMeasureOverlay = (map?: L.Map): void => {
   measureOverlayEl = null
   measureSvgEl = null
   measureLineEl = null
+  measureEndDotEl = null
   measureTextEl = null
   measureLengthEl = null
   measureRestEl = null
@@ -1510,13 +1540,29 @@ const placeSurveyPolygonPoint = (latlng: L.LatLng): void => {
   clearLiveMeasure()
 }
 
+// The waypoint a click at this spot picks up instead of adding to, if any.
+const waypointMarkerNear = (latlng: L.LatLng): L.Marker | undefined => {
+  const map = planningMap.value
+  if (!map) return undefined
+
+  const point = map.latLngToContainerPoint(latlng)
+  return Object.values(waypointMarkers.value).find(
+    (marker) => point.distanceTo(map.latLngToContainerPoint(marker.getLatLng())) < waypointPickToleranceInPixels
+  )
+}
+
+// A waypoint only goes down where a click would put one, whichever gesture asked for it: not on top of an
+// existing waypoint, and not while a context menu or the waypoint panel is taking the interaction.
+const canAddWaypointAt = (latlng: L.LatLng): boolean =>
+  !waypointMarkerNear(latlng) && !contextMenuVisible.value && !interfaceStore.configPanelVisible
+
 // Lays a point down wherever the drawing is: a corner of the survey area, or the next waypoint of the path.
 const placeDrawnPoint = (latlng: L.LatLng): boolean => {
   if (isCreatingSurvey.value && isDrawingSurveyPolygon.value) {
     placeSurveyPolygonPoint(latlng)
     return true
   }
-  if (isCreatingSimplePath.value) {
+  if (isCreatingSimplePath.value && canAddWaypointAt(latlng)) {
     const insertIndex = pendingSimplePathInsertIndex.value
     addWaypoint(
       [latlng.lat, latlng.lng],
@@ -1584,6 +1630,8 @@ const renderMeasureOverlay = (cursorLatLng: L.LatLng, evt: L.LeafletMouseEvent |
     measureLineEl.setAttribute('x2', String(b.x))
     measureLineEl.setAttribute('y2', String(b.y))
   }
+  measureEndDotEl?.setAttribute('cx', String(b.x))
+  measureEndDotEl?.setAttribute('cy', String(b.y))
 
   const midX = (a.x + b.x) / 2
   const midY = (a.y + b.y) / 2
@@ -1631,11 +1679,15 @@ const refreshLiveMeasureOnMapMove = (): void => {
   measureRefreshRafId = requestAnimationFrame(() => {
     measureRefreshRafId = null
     if (!planningMap.value || !lastMeasureCursor) return
-    const { containerPoint, latlng } = mapPointerPositionFromClient(
+    const { containerPoint: cursorPoint, latlng: cursorLatlng } = mapPointerPositionFromClient(
       planningMap.value,
       cursorLivePositionX.value,
       cursorLivePositionY.value
     )
+    // A finger leaves no cursor behind, so a point it dragged out and left waiting is where the measure ends.
+    const held = pendingDrawnPoint.value
+    const containerPoint = held ? planningMap.value.latLngToContainerPoint(held) : cursorPoint
+    const latlng = held ?? cursorLatlng
     handleMapMouseMove({ ...lastMeasureCursor, latlng, containerPoint })
   })
 }
@@ -1652,7 +1704,6 @@ const onMapMouseMove = (e: L.LeafletMouseEvent): void => {
 
   handleMapMouseMove(e)
 }
-
 const saveEsri = (): void => {
   logUserAction('Saved visible Esri map tiles')
   esriSaveBtn?.click()
@@ -2591,7 +2642,6 @@ const toggleSurvey = (): void => {
   surveyDraftEntryCorner.value = 0
   isCreatingSurvey.value = true
   isDrawingSurveyPolygon.value = true
-  interfaceStore.configPanelVisible = true
   hideContextMenu()
 }
 
@@ -3772,7 +3822,8 @@ watch(isCreatingSurvey, (isCreatingNow) => {
   if (isCreatingNow) {
     existingWaypoints.value = [...missionStore.currentPlanningWaypoints]
     surveyWaypoints.value = []
-    interfaceStore.configPanelVisible = true
+    // The vertex list stays folded away behind its own arrow, since the map is what the area is drawn on.
+    interfaceStore.configPanelVisible = false
   } else {
     clearSurveyPath()
   }
@@ -4550,6 +4601,10 @@ const onMapClick = (e: L.LeafletMouseEvent): void => {
   // The dedicated home-setting handler owns this click; bail so we don't also drop a survey vertex or waypoint here.
   if (isSettingHomeWaypoint.value) return
 
+  // A drag that aimed the line has already said where the point goes, so a click the browser raises out of that
+  // same gesture is not another point.
+  if (touchDrawingSwallowsClick()) return
+
   const oldWaypoint = selectedWaypoint.value
   if (oldWaypoint) {
     const oldMarker = waypointMarkers.value[oldWaypoint.id]
@@ -4612,45 +4667,18 @@ const onMapClick = (e: L.LeafletMouseEvent): void => {
   const measureAnchor = currentMeasureAnchor()
   const latlng = measureAnchor ? projectToLockedExtent('segment', measureAnchor, e.latlng) : e.latlng
 
-  if (isCreatingSurvey.value && isDrawingSurveyPolygon.value) placeSurveyPolygonPoint(latlng)
-
   if (planningMap.value) {
     // Check if there is an existing waypoint near the click location
-    const clickPoint = planningMap.value.latLngToContainerPoint(e.latlng)
-    let markerUnderMouse = false
-    const thresholdInPixels = 10
-
-    for (const marker of Object.values(waypointMarkers.value)) {
-      const markerPoint = planningMap.value.latLngToContainerPoint(marker.getLatLng())
-      const distance = clickPoint.distanceTo(markerPoint)
-      if (distance < thresholdInPixels) {
-        markerUnderMouse = true
-        selectedWaypoint.value = missionStore.currentPlanningWaypoints.find(
-          (wp) => wp.coordinates[0] === marker.getLatLng().lat && wp.coordinates[1] === marker.getLatLng().lng
-        )
-        interfaceStore.configPanelVisible = true
-        break
-      }
-    }
-
-    if (
-      !markerUnderMouse &&
-      !contextMenuVisible.value &&
-      !interfaceStore.configPanelVisible &&
-      isCreatingSimplePath.value
-    ) {
-      const insertIndex = pendingSimplePathInsertIndex.value
-      addWaypoint(
-        [latlng.lat, latlng.lng],
-        currentWaypointAltitude.value,
-        currentWaypointAltitudeRefType.value,
-        undefined,
-        insertIndex ?? undefined
+    const markerUnderMouse = waypointMarkerNear(e.latlng)
+    if (markerUnderMouse) {
+      const markerPosition = markerUnderMouse.getLatLng()
+      selectedWaypoint.value = missionStore.currentPlanningWaypoints.find(
+        (wp) => wp.coordinates[0] === markerPosition.lat && wp.coordinates[1] === markerPosition.lng
       )
-      // Refresh so the previous start waypoint loses its endpoint visual and the live measure
-      // line anchors to the just-added waypoint (now at index 0).
-      updateWaypointMarkers()
+      interfaceStore.configPanelVisible = true
     }
+
+    placeDrawnPoint(latlng)
     clearLiveMeasure()
   }
 }
@@ -4706,6 +4734,7 @@ onMounted(async () => {
   dragMeasureOverlay.initDragMeasureOverlay(planningMap.value!)
   initExtentInputs(planningMap.value!)
   initEdgeDragging(planningMap.value!)
+  initTouchDrawing(planningMap.value!)
   measureLayer.value = L.layerGroup().addTo(planningMap.value!) as L.LayerGroup
 
   registerLayerSync(planningMap.value)
@@ -4854,6 +4883,7 @@ onUnmounted(() => {
   angleOverlay.destroyAngleOverlay()
   surveyArrowOverlay.destroyArrowOverlay()
   destroyEdgeDragging()
+  destroyTouchDrawing()
 
   detachTileFallbacks.forEach((detach) => detach())
   detachTileFallbacks = []


### PR DESCRIPTION
- Draw surveys and paths with one finger, panning the map with two, with each point left under a checkmark so it can be adjusted before it is confirmed.
- Drag a survey area's edge to resize it, instead of moving its corners one at a time.
- Type an exact distance for the segment being drawn instead of aiming it by eye: press `T` or tap the distance tag, and the typed length holds while the direction still follows the cursor.
- Clear Path puts corner placement back on, instead of leaving the survey tool unable to add corners.
- The survey vertex list starts folded away, leaving the map clear while an area is drawn.
- The "No valid path could be generated" warning waits until a reshape drag ends, instead of firing on every pointer move.

<img width="1310" height="812" alt="image" src="https://github.com/user-attachments/assets/165db642-0562-4dac-b225-cd28c7257af7" />

Closes #2976