### PR TITLE
Persist pending setting changes across restarts

### DIFF
--- a/src/composables/settingsSyncer.ts
+++ b/src/composables/settingsSyncer.ts
@@ -97,13 +97,19 @@ export function useBlueOsStorage<T>(
         clearTimeout(watchUpdaterTimeout)
       }
 
+      const changeEpoch = Date.now()
+
       if (firstPendingChangeEpoch === undefined) {
-        firstPendingChangeEpoch = Date.now()
+        firstPendingChangeEpoch = changeEpoch
       }
+
+      // Journal the change before waiting out the debounce, so closing Cockpit within the debounce
+      // window defers the write to the next boot instead of dropping it with the timer.
+      settingsManager.savePendingKeyValue(key, newValue, changeEpoch)
 
       // Clamp the debounce so a value that keeps changing is still forced out once it has been
       // pending for `maxWaitMs`, instead of the reset-on-every-change debounce never firing.
-      const remainingMaxWait = Math.max(0, maxWaitMs - (Date.now() - firstPendingChangeEpoch))
+      const remainingMaxWait = Math.max(0, maxWaitMs - (changeEpoch - firstPendingChangeEpoch))
       const writeDelay = Math.min(debounceMs, remainingMaxWait)
 
       watchUpdaterTimeout = setTimeout(() => {
@@ -119,7 +125,7 @@ export function useBlueOsStorage<T>(
           diffToPrint = truncatedDiff
         }
         console.log(`[SettingsSyncer] Key ${key} changed on watch:\n${diffToPrint}.`)
-        settingsManager.setKeyValue(key, newValue)
+        settingsManager.setKeyValue(key, newValue, changeEpoch)
         oldRefedValue = deserialize(JSON.stringify(newValue)) as T
         firstPendingChangeEpoch = undefined
       }, writeDelay)

--- a/src/libs/settings-management.ts
+++ b/src/libs/settings-management.ts
@@ -234,39 +234,52 @@ export class SettingsManager {
     userId?: string,
     vehicleId?: string
   ): Promise<void> => {
-    if (this.isNullValue(userId)) {
-      userId = this.currentUsername || fallbackUsername
-    }
-    if (this.isNullValue(vehicleId)) {
-      vehicleId = this.currentVehicleId || fallbackVehicleId
-    }
+    const resolvedUserId = this.resolveUserId(userId)
+    const resolvedVehicleId = this.resolveVehicleId(vehicleId)
+    const newEpoch = epochChange !== undefined ? epochChange : Date.now()
 
     if (this.keyValueUpdateTimeouts[key]) {
       clearTimeout(this.keyValueUpdateTimeouts[key])
     }
 
-    this.keyValueUpdateTimeouts[key] = setTimeout(async () => {
-      const newEpoch = epochChange !== undefined ? epochChange : Date.now()
-      console.log(`[SettingsManager] Updating value of key '${key}' for user '${userId}' and vehicle '${vehicleId}'.`)
-      const newSetting = {
-        epochLastChangedLocally: newEpoch,
-        value: value,
-      }
-      const localSettings = this.getLocalSettings()
-      if (!localSettings[userId!]) {
-        localSettings[userId!] = {}
-      }
-      if (!localSettings[userId!][vehicleId!]) {
-        localSettings[userId!][vehicleId!] = {}
-      }
-      localSettings[userId!][vehicleId!][key] = newSetting
-      this.setLocalSettings(localSettings)
-      this.notifyAllListenersAboutSettingsChange()
-
-      this.pushKeyValueUpdateToVehicleUpdateQueue(vehicleId!, userId!, key, value, newEpoch)
-      await this.sendKeyValueUpdatesToVehicle(userId!, vehicleId!, this.currentVehicleAddress)
-
+    this.keyValueUpdateTimeouts[key] = setTimeout(() => {
+      this.applyKeyValueUpdate(key, value, newEpoch, resolvedUserId, resolvedVehicleId)
     }, keyValueUpdateDebounceTime)
+  }
+
+  /**
+   * Writes a key-value pair to the local settings and sends it to the vehicle
+   * @param {string} key - The key of the setting to update
+   * @param {SettingValue} value - The new value of the setting
+   * @param {number} epochChange - The epoch time at which the setting was changed
+   * @param {string} userId - The ID of the user to which the setting belongs
+   * @param {string} vehicleId - The ID of the vehicle to which the setting belongs
+   */
+  private applyKeyValueUpdate = async (
+    key: string,
+    value: SettingValue,
+    epochChange: number,
+    userId: string,
+    vehicleId: string
+  ): Promise<void> => {
+    console.log(`[SettingsManager] Updating value of key '${key}' for user '${userId}' and vehicle '${vehicleId}'.`)
+    const newSetting = {
+      epochLastChangedLocally: epochChange,
+      value: value,
+    }
+    const localSettings = this.getLocalSettings()
+    if (!localSettings[userId]) {
+      localSettings[userId] = {}
+    }
+    if (!localSettings[userId][vehicleId]) {
+      localSettings[userId][vehicleId] = {}
+    }
+    localSettings[userId][vehicleId][key] = newSetting
+    this.setLocalSettings(localSettings)
+    this.notifyAllListenersAboutSettingsChange()
+
+    this.pushKeyValueUpdateToVehicleUpdateQueue(vehicleId, userId, key, value, epochChange)
+    await this.sendKeyValueUpdatesToVehicle(userId, vehicleId, this.currentVehicleAddress)
   }
 
   /**
@@ -362,6 +375,24 @@ export class SettingsManager {
 
     localSettings[userId][vehicleId] = settings
     this.setLocalSettings(localSettings)
+  }
+
+  /**
+   * Resolves which user a setting belongs to, falling back to the current one
+   * @param {string} [userId] - The ID of the user to which the setting belongs
+   * @returns {string} The resolved user ID
+   */
+  private resolveUserId = (userId?: string): string => {
+    return this.isNullValue(userId) ? this.currentUsername || fallbackUsername : userId!
+  }
+
+  /**
+   * Resolves which vehicle a setting belongs to, falling back to the current one
+   * @param {string} [vehicleId] - The ID of the vehicle to which the setting belongs
+   * @returns {string} The resolved vehicle ID
+   */
+  private resolveVehicleId = (vehicleId?: string): string => {
+    return this.isNullValue(vehicleId) ? this.currentVehicleId || fallbackVehicleId : vehicleId!
   }
 
   /**

--- a/src/libs/settings-management.ts
+++ b/src/libs/settings-management.ts
@@ -10,10 +10,12 @@ import {
   fallbackVehicleId,
   KeyValueVehicleUpdateQueue,
   localOldStyleSettingsKey,
+  localPendingSettingWritesKey,
   LocalSyncedSettings,
   localSyncedSettingsKey,
   NoVehicleIdErrorName,
   OldCockpitSettingsPackage,
+  PendingSettingWrites,
   SettingsListener,
   SettingsListeners,
   SettingsPackage,
@@ -34,7 +36,19 @@ const nullValue = 'null'
 const possibleNullValues = [fallbackUsername, fallbackVehicleId, nullValue, null, undefined, '']
 const keyValueUpdateDebounceTime = 100
 
+// Upper bound on how often the journal of pending writes is serialized and stored, so that a burst of
+// changes costs one storage write instead of one per change.
+const pendingSettingWritesPersistInterval = 1000
+
 export type SettingValue = string | number | boolean | object | null | undefined
+
+const isValidPendingSettingWrite = (candidate: unknown): candidate is PendingSettingWrites[string] => {
+  const pendingWrite = candidate as PendingSettingWrites[string] | null
+  if (typeof pendingWrite !== 'object' || pendingWrite === null) {
+    return false
+  }
+  return pendingWrite.value !== undefined && typeof pendingWrite.epochChange === 'number' && typeof pendingWrite.userId === 'string' && typeof pendingWrite.vehicleId === 'string'
+}
 
 /**
  * Error thrown when the vehicle ID does not match the expected ID
@@ -200,6 +214,10 @@ export class SettingsManager {
   private lastLocalUserVehicleSettings: SettingsPackage = {}
   private currentVehicleAddress: string = nullValue
   private keyValueVehicleUpdateQueue: KeyValueVehicleUpdateQueue = {}
+  private pendingSettingWrites: PendingSettingWrites = {}
+  private pendingSettingWritesPersistTimeout: ReturnType<typeof setTimeout> | undefined = undefined
+  private lastPendingSettingWritesPersistEpoch = 0
+  private lastKeyJournalingEpochs: Record<string, number> = {}
   private initialLoadingComplete = false
   private cachedSettings: LocalSyncedSettings | null = null
   private storage: StorageAdapter
@@ -214,8 +232,19 @@ export class SettingsManager {
     this.storage = storage || new LocalStorageAdapter()
     this.vehicle = vehicle || new BlueOSVehicleAdapter()
     console.log('[SettingsManager]', 'Initializing settings manager.')
+    this.pendingSettingWrites = this.readPendingSettingWrites()
     this.initLocalSettings()
     this.initialLoadingComplete = true
+    // Only after the local settings are resolved, as `initLocalSettings` replaces the whole settings
+    // package for the current user and vehicle and would otherwise discard the replayed writes.
+    this.applyPendingSettingWrites()
+    // Throttling the journal can leave the newest change waiting on a timer, and closing Cockpit is
+    // precisely the moment that change has to be on disk. Flushing here is what covers a clean quit;
+    // the journal itself is what covers the exits that skip these handlers, like a crash or a mobile
+    // task-kill, which is also why `pagehide` is registered, as mobile browsers do not fire
+    // `beforeunload`.
+    window.addEventListener('beforeunload', this.persistPendingSettingWrites)
+    window.addEventListener('pagehide', this.persistPendingSettingWrites)
     console.log('[SettingsManager]', 'Settings manager initialized.')
   }
 
@@ -237,6 +266,8 @@ export class SettingsManager {
     const resolvedUserId = this.resolveUserId(userId)
     const resolvedVehicleId = this.resolveVehicleId(vehicleId)
     const newEpoch = epochChange !== undefined ? epochChange : Date.now()
+
+    this.savePendingKeyValue(key, value, newEpoch, resolvedUserId, resolvedVehicleId)
 
     if (this.keyValueUpdateTimeouts[key]) {
       clearTimeout(this.keyValueUpdateTimeouts[key])
@@ -276,6 +307,7 @@ export class SettingsManager {
     }
     localSettings[userId][vehicleId][key] = newSetting
     this.setLocalSettings(localSettings)
+    this.removePendingKeyValue(key, epochChange)
     this.notifyAllListenersAboutSettingsChange()
 
     this.pushKeyValueUpdateToVehicleUpdateQueue(vehicleId, userId, key, value, epochChange)
@@ -375,6 +407,151 @@ export class SettingsManager {
 
     localSettings[userId][vehicleId] = settings
     this.setLocalSettings(localSettings)
+  }
+
+  /**
+   * Retrieves the journal of setting changes that have not reached the local settings yet
+   * @returns {PendingSettingWrites} The pending setting writes, or an empty journal if none are readable
+   */
+  private readPendingSettingWrites = (): PendingSettingWrites => {
+    const storedPendingWrites = this.storage.getItem(localPendingSettingWritesKey)
+    if (!storedPendingWrites) {
+      return {}
+    }
+    const pendingWrites = deserialize(storedPendingWrites)
+    if (typeof pendingWrites !== 'object' || pendingWrites === null) {
+      console.error('[SettingsManager]', 'Journal of pending setting writes is unreadable. Discarding it.')
+      return {}
+    }
+
+    // The journal is editable by hand through the settings manager UI, and the replay that consumes it
+    // runs from the constructor at module scope, where a malformed record would take the whole app down.
+    const validPendingWrites: PendingSettingWrites = {}
+    Object.entries(pendingWrites).forEach(([key, pendingWrite]) => {
+      if (!isValidPendingSettingWrite(pendingWrite)) {
+        console.error('[SettingsManager]', `Journaled write of key '${key}' is malformed. Discarding it.`)
+        return
+      }
+      validPendingWrites[key] = pendingWrite
+    })
+    return validPendingWrites
+  }
+
+  /**
+   * Requests the journal to be persisted, at most once every `pendingSettingWritesPersistInterval`
+   * @param {boolean} [persistImmediately] - Whether to store the journal right away instead of throttling it
+   */
+  private schedulePendingSettingWritesPersistence = (persistImmediately = false): void => {
+    if (persistImmediately) {
+      this.persistPendingSettingWrites()
+      return
+    }
+    if (this.pendingSettingWritesPersistTimeout !== undefined) {
+      return
+    }
+    const timeSinceLastPersistence = Date.now() - this.lastPendingSettingWritesPersistEpoch
+    if (timeSinceLastPersistence >= pendingSettingWritesPersistInterval) {
+      this.persistPendingSettingWrites()
+      return
+    }
+    this.pendingSettingWritesPersistTimeout = setTimeout(this.persistPendingSettingWrites, pendingSettingWritesPersistInterval - timeSinceLastPersistence)
+  }
+
+  /**
+   * Persists the journal of setting changes that have not reached the local settings yet
+   */
+  private persistPendingSettingWrites = (): void => {
+    clearTimeout(this.pendingSettingWritesPersistTimeout)
+    this.pendingSettingWritesPersistTimeout = undefined
+    this.lastPendingSettingWritesPersistEpoch = Date.now()
+    try {
+      this.storage.setItem(localPendingSettingWritesKey, JSON.stringify(this.pendingSettingWrites))
+    } catch (error) {
+      // The journal only exists to make a change survive a restart, so failing to store it must never
+      // take the change itself down with it.
+      console.error('[SettingsManager]', 'Could not persist the journal of pending setting writes.', error)
+    }
+  }
+
+  /**
+   * Records a setting change in the persisted journal, so that it is applied on the next boot if
+   * Cockpit is closed before the debounced write reaches the local settings
+   * @param {string} key - The key of the setting being changed
+   * @param {T} value - The new value of the setting
+   * @param {number} epochChange - The epoch time at which the setting was changed
+   * @param {string} [userId] - The ID of the user to which the setting belongs
+   * @param {string} [vehicleId] - The ID of the vehicle to which the setting belongs
+   */
+  public savePendingKeyValue = <T extends SettingValue>(
+    key: string,
+    value: T,
+    epochChange: number,
+    userId?: string,
+    vehicleId?: string
+  ): void => {
+    // A zero epoch marks a key being seeded from a default or a migration rather than changed by the
+    // user, and journaling the whole first-boot seeding just to drop it again is not what this is for.
+    if (epochChange === 0) {
+      return
+    }
+
+    // `useBlueOsStorage` journals the change and then hands the very same epoch to `setKeyValue`, which
+    // journals it again, so the repeat is recognized by its epoch instead of being written twice.
+    if (this.pendingSettingWrites[key]?.epochChange === epochChange) {
+      return
+    }
+    this.pendingSettingWrites[key] = {
+      value,
+      epochChange,
+      userId: this.resolveUserId(userId),
+      vehicleId: this.resolveVehicleId(vehicleId),
+    }
+
+    // A change to a key that was quiet is a deliberate one rather than part of a burst, so it is stored
+    // at once instead of waiting out a window opened by whatever else is being journaled meanwhile.
+    const journalingEpoch = Date.now()
+    const lastJournalingEpoch = this.lastKeyJournalingEpochs[key] ?? 0
+    this.lastKeyJournalingEpochs[key] = journalingEpoch
+    this.schedulePendingSettingWritesPersistence(journalingEpoch - lastJournalingEpoch >= pendingSettingWritesPersistInterval)
+  }
+
+  /**
+   * Drops a setting change from the persisted journal once it has reached the local settings
+   * @param {string} key - The key of the setting that was written
+   * @param {number} appliedEpoch - The epoch of the change that was written
+   */
+  private removePendingKeyValue = (key: string, appliedEpoch: number): void => {
+    // A newer change to the same key may have been journaled while this one waited out its debounce,
+    // and dropping it here would lose exactly what the journal exists to protect.
+    if (this.pendingSettingWrites[key]?.epochChange !== appliedEpoch) {
+      return
+    }
+    delete this.pendingSettingWrites[key]
+    this.schedulePendingSettingWritesPersistence()
+  }
+
+  /**
+   * Applies the setting changes the previous session journaled but never got to write
+   */
+  private applyPendingSettingWrites = (): void => {
+    const pendingWrites = Object.entries(this.pendingSettingWrites)
+    if (pendingWrites.length === 0) {
+      return
+    }
+    console.warn('[SettingsManager]', `Applying ${pendingWrites.length} setting write(s) left pending by a previous session.`)
+    pendingWrites.forEach(([key, pendingWrite]) => {
+      const storedSetting = this.getLocalSettings()[pendingWrite.userId]?.[pendingWrite.vehicleId]?.[key]
+
+      // Another tab, or a restored settings backup, can already hold something newer than what was
+      // journaled here, and replaying a change must never walk a newer one back.
+      if (storedSetting !== undefined && storedSetting.epochLastChangedLocally > pendingWrite.epochChange) {
+        console.warn('[SettingsManager]', `Discarding pending write of key '${key}', as a newer value is already stored.`)
+        this.removePendingKeyValue(key, pendingWrite.epochChange)
+        return
+      }
+
+      this.applyKeyValueUpdate(key, pendingWrite.value, pendingWrite.epochChange, pendingWrite.userId, pendingWrite.vehicleId)
+    })
   }
 
   /**
@@ -1004,7 +1181,7 @@ export class SettingsManager {
    */
   private backupCurrentOldStyleSettings = (): void => {
     const oldStyleSettings: OldCockpitSettingsPackage = {}
-    const keysToIgnore = [localSyncedSettingsKey, localOldStyleSettingsKey, cockpitLastConnectedUserKey, cockpitLastConnectedVehicleKey]
+    const keysToIgnore = [localSyncedSettingsKey, localPendingSettingWritesKey, localOldStyleSettingsKey, cockpitLastConnectedUserKey, cockpitLastConnectedVehicleKey]
     const keysToBackup = this.storage.getAllKeys().filter((k) => !keysToIgnore.includes(k))
     for (const key of keysToBackup) {
       const value = this.storage.getItem(key)

--- a/src/tests/libs/settings-management.test.ts
+++ b/src/tests/libs/settings-management.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { StorageAdapter, VehicleAdapter } from '@/libs/settings-management'
+import {
+  type PendingSettingWrites,
+  fallbackUsername,
+  fallbackVehicleId,
+  localPendingSettingWritesKey,
+} from '@/types/settings-management'
+
+// Node's own `localStorage` global shadows jsdom's here and is inert without `--localstorage-file`, so a
+// stand-in has to be in place before the settings manager is loaded, as it builds its singleton against it
+// on load.
+const globalStoredItems = new Map<string, string>()
+Object.defineProperty(globalThis, 'localStorage', {
+  configurable: true,
+  value: {
+    getItem: (key: string) => globalStoredItems.get(key) ?? null,
+    setItem: (key: string, value: string) => globalStoredItems.set(key, value),
+    removeItem: (key: string) => globalStoredItems.delete(key),
+    clear: () => globalStoredItems.clear(),
+  },
+})
+
+const { SettingsManager } = await import('@/libs/settings-management')
+
+const testKey = 'cockpit-test-setting'
+const otherTestKey = 'cockpit-other-test-setting'
+
+/**
+ * A storage adapter for a settings manager under test, alongside what it wrote.
+ */
+interface TestStorage {
+  /**
+   * The backing record, exposed so a test can read what the adapter was given
+   */
+  items: Record<string, string>
+  /**
+   * How many times the journal of pending writes was stored, so a test can tell coalesced writes apart
+   */
+  journalWrites: number
+  /**
+   * The adapter to hand to the settings manager
+   */
+  adapter: StorageAdapter
+}
+
+const buildStorage = (): TestStorage => {
+  const items: Record<string, string> = {}
+  const storage: TestStorage = {
+    items,
+    journalWrites: 0,
+    adapter: {
+      getItem: (key) => items[key] ?? null,
+      setItem: (key, value) => {
+        if (key === localPendingSettingWritesKey) {
+          storage.journalWrites += 1
+        }
+        items[key] = value
+      },
+      removeItem: (key) => {
+        delete items[key]
+      },
+      getAllKeys: () => Object.keys(items),
+    },
+  }
+  return storage
+}
+
+// Every test runs with no vehicle connected, so reaching for the vehicle at all is a failure in itself.
+const unreachableVehicle: VehicleAdapter = {
+  getKeyData: () => Promise.reject(new Error('The vehicle should not be contacted while it is offline.')),
+  setKeyData: () => Promise.reject(new Error('The vehicle should not be contacted while it is offline.')),
+}
+
+const readJournal = (items: Record<string, string>): PendingSettingWrites => {
+  return items[localPendingSettingWritesKey] === undefined ? {} : JSON.parse(items[localPendingSettingWritesKey])
+}
+
+describe('Journal of pending setting writes', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('records a change before the debounced write reaches the local settings', () => {
+    const storage = buildStorage()
+    const manager = new SettingsManager(storage.adapter, unreachableVehicle)
+
+    manager.setKeyValue(testKey, 'changed')
+
+    expect(readJournal(storage.items)[testKey].value).toBe('changed')
+    expect(manager.getKeyValue(testKey)).toBeUndefined()
+  })
+
+  it('drops the record once the change reaches the local settings', () => {
+    const storage = buildStorage()
+    const manager = new SettingsManager(storage.adapter, unreachableVehicle)
+
+    manager.setKeyValue(testKey, 'changed')
+    vi.advanceTimersByTime(1000)
+
+    expect(manager.getKeyValue(testKey)).toBe('changed')
+    expect(readJournal(storage.items)).toEqual({})
+  })
+
+  it('applies a change the previous session recorded but never wrote', () => {
+    const storage = buildStorage()
+    const closedSession = new SettingsManager(storage.adapter, unreachableVehicle)
+    closedSession.setKeyValue(testKey, 'changed')
+
+    // No timers are advanced, standing in for Cockpit being closed inside the debounce window.
+    const newSession = new SettingsManager(storage.adapter, unreachableVehicle)
+
+    expect(newSession.getKeyValue(testKey)).toBe('changed')
+    expect(readJournal(storage.items)).toEqual({})
+  })
+
+  it('discards a recorded change that the stored settings already moved past', () => {
+    const storage = buildStorage()
+    const closedSession = new SettingsManager(storage.adapter, unreachableVehicle)
+    closedSession.setKeyValue(testKey, 'stale', 1000)
+    vi.advanceTimersByTime(1000)
+
+    // Stands in for another tab, or a restored backup, writing something newer than the record below.
+    closedSession.setKeyValue(testKey, 'newest', 3000)
+    vi.advanceTimersByTime(1000)
+    closedSession.savePendingKeyValue(testKey, 'stale', 1000, fallbackUsername, fallbackVehicleId)
+    vi.advanceTimersByTime(1000)
+
+    const newSession = new SettingsManager(storage.adapter, unreachableVehicle)
+
+    expect(newSession.getKeyValue(testKey)).toBe('newest')
+    expect(readJournal(storage.items)).toEqual({})
+  })
+
+  it('keeps a change recorded while an older one was still waiting out its debounce', () => {
+    const storage = buildStorage()
+    const manager = new SettingsManager(storage.adapter, unreachableVehicle)
+
+    manager.setKeyValue(testKey, 'older', 1000)
+    manager.savePendingKeyValue(testKey, 'newer', 2000, fallbackUsername, fallbackVehicleId)
+    vi.advanceTimersByTime(1000)
+
+    expect(manager.getKeyValue(testKey)).toBe('older')
+    expect(readJournal(storage.items)[testKey].value).toBe('newer')
+  })
+
+  it('collapses a burst of changes into a single journal write', () => {
+    const storage = buildStorage()
+    const manager = new SettingsManager(storage.adapter, unreachableVehicle)
+
+    manager.savePendingKeyValue(testKey, 'leading', 1000, fallbackUsername, fallbackVehicleId)
+    const writesAfterLeadingChange = storage.journalWrites
+
+    for (let burstIndex = 0; burstIndex < 50; burstIndex++) {
+      manager.savePendingKeyValue(
+        testKey,
+        `burst-${burstIndex}`,
+        2000 + burstIndex,
+        fallbackUsername,
+        fallbackVehicleId
+      )
+    }
+    expect(storage.journalWrites).toBe(writesAfterLeadingChange)
+
+    vi.advanceTimersByTime(1000)
+
+    expect(storage.journalWrites).toBe(writesAfterLeadingChange + 1)
+    expect(readJournal(storage.items)[testKey].value).toBe('burst-49')
+  })
+
+  it('stores a change to a quiet key without waiting out the window another key opened', () => {
+    const storage = buildStorage()
+    const manager = new SettingsManager(storage.adapter, unreachableVehicle)
+
+    manager.savePendingKeyValue(testKey, 'burst-start', 1000, fallbackUsername, fallbackVehicleId)
+    manager.savePendingKeyValue(testKey, 'burst-next', 2000, fallbackUsername, fallbackVehicleId)
+    manager.savePendingKeyValue(otherTestKey, 'deliberate', 3000, fallbackUsername, fallbackVehicleId)
+
+    expect(readJournal(storage.items)[otherTestKey].value).toBe('deliberate')
+  })
+
+  it('leaves a key seeded from a default out of the journal', () => {
+    const storage = buildStorage()
+    const manager = new SettingsManager(storage.adapter, unreachableVehicle)
+
+    manager.setKeyValue(testKey, 'seeded', 0)
+
+    expect(readJournal(storage.items)).toEqual({})
+  })
+
+  it('discards a malformed record instead of failing to start', () => {
+    const storage = buildStorage()
+    storage.items[localPendingSettingWritesKey] = JSON.stringify({
+      [testKey]: null,
+      [otherTestKey]: { value: 'kept', epochChange: 1000, userId: fallbackUsername, vehicleId: fallbackVehicleId },
+    })
+
+    const manager = new SettingsManager(storage.adapter, unreachableVehicle)
+
+    expect(manager.getKeyValue(testKey)).toBeUndefined()
+    expect(manager.getKeyValue(otherTestKey)).toBe('kept')
+  })
+})

--- a/src/types/settings-management.ts
+++ b/src/types/settings-management.ts
@@ -3,6 +3,7 @@ export const vehicleOldStyleSettingsKey = 'settings'
 export const vehicleOldStyleSettingsBackupKey = 'settings-v1-backup'
 export const vehicleNewStyleSettingsKey = 'settings-v2'
 export const localSyncedSettingsKey = 'cockpit-settings-v2'
+export const localPendingSettingWritesKey = 'cockpit-pending-setting-writes-v1'
 export const cockpitLastConnectedVehicleKey = 'cockpit-last-connected-vehicle-id'
 export const cockpitLastConnectedUserKey = 'cockpit-last-connected-user'
 export const vehicleIdKey = 'cockpit-vehicle-id'
@@ -105,6 +106,33 @@ export interface KeyValueVehicleUpdateQueue {
         epochChange: number
       }
     }
+  }
+}
+
+/**
+ * A journal of setting changes that were requested but have not reached the local settings yet,
+ * because the write is debounced. It is persisted so that a change made moments before Cockpit is
+ * closed is applied on the next boot instead of dying with the debounce timer.
+ * Only the most recent change is kept for each key.
+ */
+export interface PendingSettingWrites {
+  [key: string]: {
+    /**
+     * The new value of the setting
+     */
+    value: any
+    /**
+     * The epoch at which the change was made, so a replay does not present itself as newer than it is
+     */
+    epochChange: number
+    /**
+     * The ID of the user the change was made for
+     */
+    userId: string
+    /**
+     * The ID of the vehicle the change was made for
+     */
+    vehicleId: string
   }
 }
 


### PR DESCRIPTION
## Summary

Setting changes are debounced before being written to the local settings and synced, so a change made moments before Cockpit is closed is lost together with the pending timer. This is easy to hit in practice: the user tweaks a setting and immediately quits, and the change silently never happened.

To avoid that, every change is now journaled to local storage as it is requested, before the debounce runs. The debounced write itself is untouched, but if it never gets to run, the next boot replays the journaled change instead of dropping it. Replays carry the original change epoch, so a value that another tab or a restored backup already moved past is discarded rather than walking the newer value back.

Journaling every change would otherwise put a synchronous serialization and storage write on paths that fire at telemetry and pointer rate, which the debounce used to shield. So the journal's own persistence is throttled per key: the first change to a quiet key is stored immediately, whatever else is being journaled at that moment, and the repeats that follow it cost one write per second instead of one per change. `beforeunload` and `pagehide` handlers flush whatever the throttle is still holding, following what `mission.ts` and `system-logging.ts` already do for their buffered state.

## Changes

- Added the `cockpit-pending-setting-writes-v1` local-storage key and the `PendingSettingWrites` type holding, per key, the value, the change epoch, and the user and vehicle the change belongs to.
- `SettingsManager.setKeyValue` now journals the change up front via the new public `savePendingKeyValue`, and the record is dropped only once the write lands, and only if a newer change to the same key has not been journaled meanwhile.
- The journal is read back through a per-entry validation, so a record malformed by hand through the pirate-mode settings editor is discarded rather than thrown out of the constructor at module scope.
- The journal's persistence is throttled to one storage write per second per key, with the first change to a quiet key written at once and a `beforeunload`/`pagehide` flush for the trailing one. Keys seeded with a zero epoch — the first-run defaults and the legacy telemetry opt-out — are left out of the journal entirely.
- Extracted the body of the debounced write into `applyKeyValueUpdate`, shared by the normal path and by the boot-time replay, plus `resolveUserId`/`resolveVehicleId` helpers for the fallback resolution.
- On construction, journaled writes left by a previous session are replayed after the local settings are loaded, skipping any key whose stored value is already newer.
- `useBlueOsStorage` journals the change at the moment it happens and passes that same epoch through to `setKeyValue`, so the debounce window no longer shifts the recorded change time.
- Excluded the new key from the old-style settings backup.
- Added `src/tests/libs/settings-management.test.ts` covering recording, dropping, replaying, discarding stale replays, keeping a newer journaled change, coalescing a burst into one write, and discarding a malformed record.

The guard that skipped the vehicle push when no vehicle is connected used to live here, and moved to #2987 so it can be reviewed and backported on its own. This branch picks it up again when it rebases onto master.

Closes #2666