### PR TITLE
fix: video: keep the 4K Cam WebRTC stream on Lite

### DIFF
--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -67,7 +67,7 @@ export const useVideoStore = defineStore('video', () => {
   console.debug('[WebRTC] Using webrtc-adapter for', adapter.browserDetails)
 
   const streamsCorrespondency = useBlueOsStorage<VideoStreamCorrespondency[]>('cockpit-streams-correspondency', [])
-  const ignoredStreamExternalIds = useBlueOsStorage<string[]>('cockpit-ignored-stream-external-ids', [])
+  const persistedIgnoredStreamExternalIds = useBlueOsStorage<string[]>('cockpit-ignored-stream-external-ids', [])
   const allowedIceIps = useBlueOsStorage<string[]>('cockpit-allowed-stream-ips', [])
   const enableAutoIceIpFetch = useBlueOsStorage('cockpit-enable-auto-ice-ip-fetch', true)
   const allowedIceProtocols = useBlueOsStorage<string[]>('cockpit-allowed-stream-protocols', [])
@@ -85,6 +85,9 @@ export const useVideoStore = defineStore('video', () => {
   const enableLiveProcessing = useBlueOsStorage('cockpit-enable-live-processing', true)
   const keepRawVideoChunksAsBackup = useBlueOsStorage('cockpit-keep-raw-video-chunks-as-backup', true)
   const userRestoredStreamIds = useBlueOsStorage<string[]>('cockpit-user-restored-stream-ids', [])
+  // The ignored list mixes the streams the user chose to hide with the ones an automatic rule hid for them, so this
+  // records which of those ids the user asked for, letting a client the rule does not apply to disregard the rest.
+  const userIgnoredStreamIds = useBlueOsStorage<string[]>('cockpit-user-ignored-stream-ids', [])
   const recordingMonitors: { [key: string]: ReturnType<typeof setInterval> | undefined } = {}
   const broadcastCameraActionsOverMavlink = useBlueOsStorage('cockpit-broadcast-camera-actions-over-mavlink', false)
   // Streams whose recording start we mirrored over MAVLink. The broadcast fires only on the 0->1 and 1->0
@@ -293,21 +296,40 @@ export const useVideoStore = defineStore('video', () => {
   // The Blue Robotics 4K Cam's manager extension names its streams '<brand> <host>/<feed>', with 'Blue Robotics 4K Cam' as the brand
   const isBlueRobotics4kCamStreamName = (name: string): boolean => /^4k cam /.test(name.trim().toLowerCase())
 
+  // Dropping the WebRTC feed only makes sense where the camera's direct RTSP one can take its place, and RTSP is
+  // Standalone-only, so on Lite the very same rule leaves the user with no stream at all.
+  const shouldAutoIgnore4kCamStream = (externalId: string): boolean =>
+    isElectron() && isBlueRobotics4kCamStreamName(externalId) && !userRestoredStreamIds.value.includes(externalId)
+
+  // The ignored list is vehicle-synced, so the rule's decision reaches Lite anyway, written by an earlier version or
+  // by a Standalone client of the same vehicle. Honouring it there would leave the camera with no stream at all, so
+  // Lite keeps only what the user asked to ignore.
+  const isDisregarded4kCamIgnore = (id: string): boolean =>
+    isBlueRobotics4kCamStreamName(id) && !userIgnoredStreamIds.value.includes(id)
+
+  const ignoredStreamExternalIds = computed(() =>
+    isElectron()
+      ? persistedIgnoredStreamExternalIds.value
+      : persistedIgnoredStreamExternalIds.value.filter((id) => !isDisregarded4kCamIgnore(id))
+  )
+
+  // The one case where the camera comes back on its own: Lite is disregarding an ignore it cannot attribute to the user
+  const hasDisregarded4kCamIgnore = computed(
+    () => !isElectron() && persistedIgnoredStreamExternalIds.value.some(isDisregarded4kCamIgnore)
+  )
+
   const initializeStreamsCorrespondency = (): void => {
     // Move already-mapped Blue Robotics 4K Cam WebRTC streams to the ignored list
     // TODO: This whole logic around auto-ignoring Blue Robotics 4K Cam WebRTC streams should be removed once the MCM stutter problem is fixed
     const fourKCamMapped = streamsCorrespondency.value.filter(
-      (corr) =>
-        (corr.protocol ?? 'webrtc') === 'webrtc' &&
-        isBlueRobotics4kCamStreamName(corr.externalId) &&
-        !userRestoredStreamIds.value.includes(corr.externalId)
+      (corr) => (corr.protocol ?? 'webrtc') === 'webrtc' && shouldAutoIgnore4kCamStream(corr.externalId)
     )
     if (fourKCamMapped.length > 0) {
       const idsToMove = fourKCamMapped.map((corr) => corr.externalId)
       streamsCorrespondency.value = streamsCorrespondency.value.filter((corr) => !idsToMove.includes(corr.externalId))
-      const newIgnored = idsToMove.filter((id) => !ignoredStreamExternalIds.value.includes(id))
+      const newIgnored = idsToMove.filter((id) => !persistedIgnoredStreamExternalIds.value.includes(id))
       if (newIgnored.length > 0) {
-        ignoredStreamExternalIds.value = [...ignoredStreamExternalIds.value, ...newIgnored]
+        persistedIgnoredStreamExternalIds.value = [...persistedIgnoredStreamExternalIds.value, ...newIgnored]
       }
     }
 
@@ -318,7 +340,7 @@ export const useVideoStore = defineStore('video', () => {
     const unmappedExternalStreams = namesAvailableWebRTCStreams.value.filter((streamName) => {
       if (alreadyMappedExternalIds.includes(streamName)) return false
       if (ignoredStreamExternalIds.value.includes(streamName)) return false
-      if (isBlueRobotics4kCamStreamName(streamName) && !userRestoredStreamIds.value.includes(streamName)) {
+      if (shouldAutoIgnore4kCamStream(streamName)) {
         fourKCamToIgnore.push(streamName)
         return false
       }
@@ -326,7 +348,7 @@ export const useVideoStore = defineStore('video', () => {
     })
 
     if (fourKCamToIgnore.length > 0) {
-      ignoredStreamExternalIds.value = [...ignoredStreamExternalIds.value, ...fourKCamToIgnore]
+      persistedIgnoredStreamExternalIds.value = [...persistedIgnoredStreamExternalIds.value, ...fourKCamToIgnore]
     }
 
     if (unmappedExternalStreams.length === 0) return
@@ -1404,8 +1426,11 @@ export const useVideoStore = defineStore('video', () => {
       const stream = streamsCorrespondency.value[streamIndex]
 
       // Add to ignored list and clear user-restored status so auto-ignore can re-apply
-      if (!ignoredStreamExternalIds.value.includes(externalId)) {
-        ignoredStreamExternalIds.value = [...ignoredStreamExternalIds.value, externalId]
+      if (!persistedIgnoredStreamExternalIds.value.includes(externalId)) {
+        persistedIgnoredStreamExternalIds.value = [...persistedIgnoredStreamExternalIds.value, externalId]
+      }
+      if (!userIgnoredStreamIds.value.includes(externalId)) {
+        userIgnoredStreamIds.value = [...userIgnoredStreamIds.value, externalId]
       }
       userRestoredStreamIds.value = userRestoredStreamIds.value.filter((id) => id !== externalId)
 
@@ -1426,11 +1451,12 @@ export const useVideoStore = defineStore('video', () => {
   }
 
   const restoreIgnoredStream = (externalId: string): void => {
-    const ignoredIndex = ignoredStreamExternalIds.value.indexOf(externalId)
+    const ignoredIndex = persistedIgnoredStreamExternalIds.value.indexOf(externalId)
 
     if (ignoredIndex !== -1) {
       // Remove from ignored list
-      ignoredStreamExternalIds.value.splice(ignoredIndex, 1)
+      persistedIgnoredStreamExternalIds.value.splice(ignoredIndex, 1)
+      userIgnoredStreamIds.value = userIgnoredStreamIds.value.filter((id) => id !== externalId)
 
       // Track that the user explicitly restored this stream so auto-ignore won't re-ignore it
       if (!userRestoredStreamIds.value.includes(externalId)) {
@@ -1517,6 +1543,8 @@ export const useVideoStore = defineStore('video', () => {
     tempVideoStorage,
     streamsCorrespondency,
     ignoredStreamExternalIds,
+    hasDisregarded4kCamIgnore,
+    isBlueRobotics4kCamStreamName,
     namessAvailableAbstractedStreams,
     externalStreamId,
     internalStreamNameFromExternal,

--- a/src/views/ConfigurationVideoView.vue
+++ b/src/views/ConfigurationVideoView.vue
@@ -171,7 +171,13 @@
                   </v-tooltip>
                 </div>
               </div>
-
+              <div v-if="show4kCamBrowserNote" class="text-gray-400 text-sm mt-2 mr-2 w-[95%]">
+                The video from your 4K camera may stutter in this browser version of Cockpit. The desktop version plays
+                this camera through its own connection, which is smoother — install it if the stuttering bothers you.
+                <span v-if="videoStore.hasDisregarded4kCamIgnore">
+                  If you had hidden this camera before, it is showing again: hide it once more and it will stay hidden.
+                </span>
+              </div>
               <div v-if="isElectron()" class="mt-4 mr-2 mb-2 w-[95%]">
                 <div class="text-sm text-gray-300 mb-2">Add direct RTSP stream (standalone)</div>
                 <div class="flex items-end gap-2 w-full">
@@ -523,6 +529,12 @@ const streamsToShow = computed(() => {
       : []),
   ].filter((item) => item.name !== '')
 })
+
+const show4kCamBrowserNote = computed(
+  () =>
+    !isElectron() &&
+    videoStore.streamsCorrespondency.some((corr) => videoStore.isBlueRobotics4kCamStreamName(corr.externalId))
+)
 
 const openEditDialog = (item: VideoStreamCorrespondency): void => {
   logUserAction(`Opened rename dialog for video stream '${item.name}'`)


### PR DESCRIPTION
## Summary

One commit, in `src/stores/video.ts` and `src/views/ConfigurationVideoView.vue`.

- **4K Cam WebRTC stream no longer auto-ignored on Lite** (#2843). The 4K Cam's WebRTC feed is auto-ignored so its direct RTSP feed is used instead, avoiding the MCM stutter at 4K bitrates. RTSP is only available on Standalone, so on Lite the same rule left the camera's only playable stream ignored and the user with no video at all — and hidden from the video configuration page until "Show ignored streams" was checked. The auto-ignore condition now also requires `isElectron()`, so it only applies where the RTSP replacement actually exists.
- **Ignore records already written are disregarded on Lite.** `cockpit-ignored-stream-external-ids` is vehicle-synced, so the rule's decision reaches Lite anyway: written there by an earlier version of Cockpit, or by a Standalone client of the same vehicle while the Lite session is running. Gating only the writes would leave every user who already hit the bug exactly as broken as before. A deliberate ignore is now recorded in `cockpit-user-ignored-stream-ids` as well, and Lite honours an ignored 4K Cam id only when it finds it there — the stored list is left untouched, so nothing is migrated and Standalone is unaffected. Only ignores made from now on land in the new key, so a Lite user who had deliberately hidden this camera in an earlier version gets it back once and has to hide it again — that provenance was never recorded anywhere, so no code can recover it.
- **The Lite/Standalone difference is stated in the UI.** With the stream back, Lite plays the feed that stutters at 4K bitrates while Standalone silently swaps in the camera's own connection. A note under the streams table on the video configuration page says so, and only shows on Lite when such a camera is present. It also tells the user that a camera they had hidden before is showing again and will stay hidden if they hide it once more.

## Test plan

- [ ] On Lite (browser), connect to a vehicle with a Blue Robotics 4K Cam: the `4K Cam ...` WebRTC stream shows up in the video configuration page as a normal, non-ignored stream and plays in a video widget.
- [ ] On Standalone (Electron), same vehicle: the `4K Cam ...` WebRTC stream is still auto-ignored, and the RTSP feed is the one used.
- [ ] On Standalone, restore the stream manually via "Show ignored streams": it stays restored across reloads (the user-restored override still wins).
- [ ] Open Lite with a profile that already had the stream auto-ignored by a previous version and confirm it becomes visible again, without the stored ignore list being rewritten.
- [ ] With Standalone and Lite open against the same vehicle, confirm the Standalone auto-ignore no longer takes the stream away from the Lite session.
- [ ] On Lite, ignore the 4K Cam stream from the video configuration page and reload: it stays ignored, and the restore button brings it back.
- [ ] On Lite with a profile that had the 4K Cam stream deliberately ignored before this change, confirm it comes back once with the note explaining it, and that re-ignoring it sticks across a reload.

## Checks

- `yarn lint:fix`, `yarn typecheck` and `yarn vitest run` clean, as reported when the work was committed (the two suites failing on `localStorage.getItem` fail identically on `master`).

Closes #2843

