### PR TITLE
fix: widgets: warn when the selected video stream is gone

### DIFF
--- a/src/components/widgets/VideoPlayer.vue
+++ b/src/components/widgets/VideoPlayer.vue
@@ -10,22 +10,34 @@
     <div v-if="nameSelectedStream === undefined" class="no-video-alert">
       <span>No video stream selected.</span>
     </div>
-    <div
-      v-else-if="!namesAvailableStreams.isEmpty() && !namesAvailableStreams.includes(nameSelectedStream)"
-      class="no-video-alert"
-    >
-      <p>The selected stream "{{ nameSelectedStream }}" is not available.</p>
-      <p>Available ones are: {{ namesAvailableStreams.map((name) => `"${name}"`).join(', ') }}.</p>
-      <br />
-      <p>
-        This can happen if you changed vehicles and the stream name in the new one is different from the former, or if
-        the source is not available at all.
-      </p>
-      <br />
-      <p>
-        Please open this video player configuration and select a new stream from the ones available, or check your
-        source for issues.
-      </p>
+    <div v-else-if="!namesAvailableStreams.includes(nameSelectedStream)" class="no-video-alert">
+      <template v-if="namesAvailableStreams.isEmpty()">
+        <p>No video streams are available.</p>
+        <br />
+        <p>
+          Cockpit may still be looking for this vehicle's streams, or every stream may have been deleted, ignored or
+          turned off.
+        </p>
+        <br />
+        <p>
+          If this message stays, open the video configuration page to restore a stream from the ignored streams list, or
+          check that the vehicle's cameras are on and streaming.
+        </p>
+      </template>
+      <template v-else>
+        <p>The selected stream "{{ nameSelectedStream }}" is not available.</p>
+        <p>Available ones are: {{ namesAvailableStreams.map((name) => `"${name}"`).join(', ') }}.</p>
+        <br />
+        <p>
+          This can happen if you changed vehicles and the stream name in the new one is different from the former, or if
+          the source is not available at all.
+        </p>
+        <br />
+        <p>
+          Please open this video player configuration and select a new stream from the ones available, or check your
+          source for issues.
+        </p>
+      </template>
     </div>
     <Transition name="loading-complete">
       <div v-if="showLoadingOverlay" class="loading-overlay">


### PR DESCRIPTION
## Summary

One commit, on the video widget's missing-stream alert.

- **Warn when the selected video stream is gone** (#2527). The widget only rendered its "stream is not available" alert when at least one other stream existed, so if the selected stream disappeared and every other stream was ignored, the widget was left fully transparent — the loading overlay is hidden in that same state, so nothing at all was drawn and the user got no hint of what went wrong. The alert now shows whenever the selected stream is missing, and the no-streams case gets its own message: it also covers the moments before Cockpit has found the vehicle's streams, and it points at the video configuration page and the ignored-streams list instead of telling the user to pick from an empty list.

## Test plan

- [ ] Add a Video Player widget and select a stream from the vehicle.
- [ ] Delete that stream on the video configuration page, so no stream is left available to the widget.
- [ ] The widget shows "No video streams are available.", explains that the streams may be still loading, deleted, ignored or off, and points at the video configuration page and the ignored-streams list, instead of rendering transparent.
- [ ] Restore the stream from the ignored list: the widget picks it back up.
- [ ] With another stream still available and the selected one missing, the alert still lists the available ones as before. Note that this branch is transient by design — `streamConnectionRoutine` reassigns the selection to the first available stream within a second, so the widget switching streams here is the expected outcome, not a failure.

## Checks

- `yarn lint`, `yarn typecheck` and `yarn vitest run` clean (two pre-existing `localStorage` collection failures in `cosmos.test.ts` / `connection.test.ts`, present on `master` too).

Closes #2527
