### PR TITLE
Convert fragmented MP4 to traditional MP4 at the end of the video recording

### DIFF
--- a/src/electron/services/video-recording.ts
+++ b/src/electron/services/video-recording.ts
@@ -20,16 +20,19 @@ import { filesystemStorage, getCockpitFolderPath } from './storage'
  *
  * This service provides real-time video processing by streaming WebM chunks directly into FFmpeg
  * during recording. FFmpeg outputs a fragmented MP4 file that is always playable, even if the
- * process crashes mid-recording. This eliminates the need for post-processing finalization.
+ * process crashes mid-recording. This eliminates the need to reassemble the recording from chunks once it ends.
  *
  * Key features:
  * - Chunks are piped to FFmpeg stdin as they arrive
  * - Fragmented MP4 output (frag_keyframe + empty_moov) for crash-safety
  * - No re-encoding (copy codec only)
  * - File is playable at any point during recording
+ * - Converted to a regular non-fragmented MP4 on finalize, so HTTP playback needs 2 range requests
  */
 
 const activeStreamProcesses = new Map<string, LiveStreamProcess>()
+
+const remuxTempSuffix = '.remuxing.tmp'
 
 /**
  * Create a temporary directory for live video processing
@@ -217,6 +220,59 @@ const appendChunkToVideoRecording = async (
 }
 
 /**
+ * Remux a finished recording into a regular MP4, so players can seek it over HTTP without range-requesting
+ * every fragment. The fragmented layout that keeps the recording crash-safe leaves no index a player can
+ * use cheaply, costing one seek per fragment.
+ *
+ * Writes to a sibling temp file and renames over the original only once FFmpeg succeeds, so an interruption
+ * at any point leaves the original recording intact rather than a half-rewritten one.
+ * @param {string} videoPath - Path to the finished fragmented MP4
+ * @returns {Promise<void>} Promise that resolves once the recording has been replaced by the remuxed one
+ */
+const remuxToSeekableMp4 = async (videoPath: string): Promise<void> => {
+  const tempPath = `${videoPath}${remuxTempSuffix}`
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const timeoutMs = 600000 // 10 minutes timeout for the remux
+      const ffmpegProcess = spawn(getFFmpegPath(), ['-i', videoPath, '-c', 'copy', '-f', 'mp4', '-y', tempPath])
+
+      // FFmpeg writes a progress line to stderr about twice a second, so leaving the pipe undrained wedges the
+      // remux once the OS buffer fills. Keeping the tail also makes a non-zero exit diagnosable.
+      let stderrTail = ''
+      ffmpegProcess.stderr?.on('data', (data) => {
+        stderrTail = (stderrTail + data.toString()).slice(-1000)
+      })
+
+      const timeout = setTimeout(() => {
+        ffmpegProcess.kill('SIGKILL')
+        reject(new Error('Remux timed out'))
+      }, timeoutMs)
+
+      ffmpegProcess.on('error', (error) => {
+        clearTimeout(timeout)
+        reject(error)
+      })
+
+      ffmpegProcess.on('close', (code) => {
+        clearTimeout(timeout)
+        if (code === 0) {
+          resolve()
+        } else {
+          reject(new Error(`FFmpeg remux exited with code ${code}: ${stderrTail.trim()}`))
+        }
+      })
+    })
+
+    await fs.rename(tempPath, videoPath)
+  } catch (error) {
+    // A temp the dying child still holds open cannot be removed on Windows, and that must not mask the real error.
+    await fs.rm(tempPath, { force: true }).catch(() => undefined)
+    throw error
+  }
+}
+
+/**
  * Finalize a live video streaming process by closing FFmpeg stdin
  * @param {string} processId - ID of the streaming process to finalize
  */
@@ -263,6 +319,14 @@ const finalizeVideoRecording = async (processId: string): Promise<void> => {
 
         if (code === 0) {
           console.log(`FFmpeg process ${processId} completed successfully`)
+
+          try {
+            await remuxToSeekableMp4(process.outputPath)
+            console.log(`Remuxed ${basename(process.outputPath)} into a seekable MP4`)
+          } catch (remuxError) {
+            // The fragmented recording plays fine locally, so keep it rather than failing the recording.
+            console.warn(`Failed to remux ${processId} into a seekable MP4:`, remuxError)
+          }
 
           // Generate thumbnail from the final MP4 file
           try {
@@ -778,9 +842,31 @@ const createVideoChunksZip = async (hash: string): Promise<string> => {
 }
 
 /**
+ * Delete remux temp files left behind by a quit, crash or power loss mid-remux. They are as large as the
+ * recording and never show up in the video library, so nothing else would ever remove them. Startup is the
+ * right moment to sweep, since no remux of this process can be in flight yet.
+ * @returns {Promise<void>} Promise that resolves once the videos folder has been swept
+ */
+const removeOrphanRemuxTempFiles = async (): Promise<void> => {
+  const videosPath = join(getCockpitFolderPath(), 'videos')
+  try {
+    const fileNames = await filesystemStorage.keys(['videos'])
+    const orphans = fileNames.filter((fileName) => fileName.endsWith(remuxTempSuffix))
+    await Promise.all(orphans.map((fileName) => fs.rm(join(videosPath, fileName), { force: true })))
+    if (orphans.length > 0) {
+      console.log(`Removed ${orphans.length} leftover remux temporary file(s).`)
+    }
+  } catch (error) {
+    console.warn('Failed to remove leftover remux temporary files:', error)
+  }
+}
+
+/**
  * Setup live video IPC handlers for Electron main process
  */
 export const setupVideoRecordingService = (): void => {
+  removeOrphanRemuxTempFiles()
+
   /**
    * Start live video streaming with FFmpeg
    */

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -48,7 +48,7 @@ import {
 import { videoFilename, videoSubtitlesFilename, videoThumbnailFilename } from '@/utils/video'
 
 import { useAlertStore } from './alert'
-const { openSnackbar } = useSnackbar()
+const { openSnackbar, closeSnackbar } = useSnackbar()
 
 export const useVideoStore = defineStore('video', () => {
   const missionStore = useMissionStore()
@@ -1165,6 +1165,13 @@ export const useVideoStore = defineStore('video', () => {
       // Finalize live processing if active (Electron only)
       const processor = liveProcessors.value[recordingHash]
       if (processor) {
+        // Finishing the file takes as long as a full copy of it, so mark the wait instead of leaving the operator
+        // with an idle recorder button and no sign that Cockpit is still working.
+        const processingSnackbarId = openSnackbar({
+          message: 'Finishing the recording. This can take a while for long videos.',
+          variant: 'info',
+          persistent: true,
+        })
         try {
           await processor.stopProcessing()
           openSnackbar({
@@ -1177,6 +1184,7 @@ export const useVideoStore = defineStore('video', () => {
           console.error('Failed to process video:', error)
           alertStore.pushAlert(new Alert(AlertLevel.Error, `Failed to process video for stream ${streamName}.`))
         } finally {
+          closeSnackbar(processingSnackbarId)
           delete liveProcessors.value[recordingHash]
         }
       }


### PR DESCRIPTION
## Summary

Recordings are muxed as fragmented MP4 for crash-safety (`frag_keyframe+empty_moov`), which leaves the file without an index a player can use cheaply: `mvhd` declares no duration, and the only index (`mfra`) sits in the last few hundred bytes. A demuxer therefore walks every fragment to build a seek table — one seek per fragment.

Measured on a real 4.76 GiB / 42-minute recording:

| | before | after |
|---|---|---|
| seeks to determine duration | 1,343 | **2** |
| bytes read to determine duration | 45.5 MB | 1.2 MB |

On local disk those seeks are invisible, which is why recordings play fine when opened locally. Over HTTP each one becomes a range request, so playback never starts. The reported symptom was a video that plays locally but spins forever in Chrome when served from S3 (also reproducible behind nginx/Apache), while *downloading* the same file works — a download is sequential and never seeks.

This remuxes the finished recording into a regular MP4 on finalize.

## Why a separate remux instead of a muxer flag

Recording is left exactly as it was, so the crash-safety property is untouched. The remux writes a sibling temp file and renames over the original only once FFmpeg succeeds, so an interruption at any point leaves the original recording intact.

Doing it in the muxer was tried first, with `+global_sidx` and with `+hybrid_fragmented`. Both reach 2 seeks, but both rewrite the finished file in place, and that is a real regression. Measured by cutting each variant at the point an interruption would leave it:

| interrupted state | current behaviour | `+hybrid_fragmented` |
|---|---|---|
| final index never written | 63.362 s, 1943 packets | **UNPLAYABLE, 0 packets** |
| final index half written | 63.362 s, 1943 packets | **UNPLAYABLE, 0 packets** |

`hybrid_fragmented` absorbs the `moof` boxes into a single `mdat`, so once that header is rewritten there is no fragmented structure left to fall back on — if the `moov` does not land, the whole recording is gone. The current layout degrades gracefully instead: you lose only the `mfra`, which measurement shows is worthless anyway (it does not reduce the seek count at all).

`+faststart` costs +45 s on 4.76 GiB and does not help either, because a conventional MP4's `moov` scales with sample count rather than fragment count, so it still will not fit in an early read.

Spending the disk space to avoid that failure mode is deliberate.

## Behaviour notes

- A volume without room for the second copy makes FFmpeg exit non-zero, which is handled like any other remux failure: the temp is removed and the fragmented recording is kept — it plays fine locally and is merely slow over HTTP.
- A remux failure never fails the recording: the fragmented file is kept and the error logged.
- Remux takes ~12 s for 4.76 GiB and ~0.5 s for 135 MB. It runs after the finalization timeout is cleared, so it is not bounded by that timeout.
- The output is a conventional MP4, which also improves playback in Firefox and Safari.
- Stopping a recording now returns only once the copy has finished, so the "Video processing completed" snackbar arrives later than it used to. A persistent snackbar covers the interval.
- A temp left behind by a crash or power loss mid-remux is swept from the videos folder at startup.

## Not fixed here

Recordings that never finalize get no remux and no index, so they still cost one range request per fragment. That is a separate defect in the finalization path.

Recordings already on disk keep the fragmented layout — the remux only runs when a recording finalizes, and Cockpit offers no way to convert an existing file. Operators who hit this need to re-record or remux those files themselves.

## Verification

- Interrupted remux → original intact (63.362 s / 1943 packets), temp file removed
- Completed remux → all 1943 packets preserved, 2 seeks, temp file removed
- `yarn lint:fix` clean at `--max-warnings=0`; type-check clean on the changed files

## Test plan

- [ ] Record in Standalone and confirm the resulting file plays locally
- [ ] Serve that file over HTTP and confirm it plays *and* seeks in Chrome
- [ ] Confirm the thumbnail is still generated on finalize
- [ ] Kill Cockpit mid-recording and confirm the partial file is still playable
- [ ] Run with a nearly-full disk and confirm the recording survives when the remux fails
- [ ] Kill Cockpit mid-remux, restart, and confirm the leftover `.remuxing.tmp` is gone
