### PR TITLE
fix: utils: only report Electron when the preload bridge is present

### DIFF
--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -172,12 +172,16 @@ export const reloadCockpit = (timeout = 3000): void => {
 
 /**
  * Detects if the application is running in Electron
+ *
+ * In the renderer the user agent alone is not enough: Electron-based embedded browsers, like the preview
+ * panes of Electron-based IDEs, carry the same `Electron/<version>` token but never run our preload
+ * script, so the bridge it exposes is what tells our own shell apart from them.
  * @returns {boolean} True if running in Electron, false otherwise
  */
 export const isElectron = (): boolean => {
   // Check if the userAgent contains 'electron' (for renderer process)
   if (typeof navigator === 'object' && typeof navigator.userAgent === 'string') {
-    return navigator.userAgent.toLowerCase().includes('electron')
+    return navigator.userAgent.toLowerCase().includes('electron') && globalThis.window?.electronAPI !== undefined
   }
 
   // Check if the process object exists and contains 'electron' (for main process)

--- a/src/tests/libs/utils.test.ts
+++ b/src/tests/libs/utils.test.ts
@@ -1,6 +1,6 @@
-import { expect, test } from 'vitest'
+import { afterEach, expect, test } from 'vitest'
 
-import { serializeForLogging } from '@/libs/utils'
+import { isElectron, serializeForLogging } from '@/libs/utils'
 
 test('serializeForLogging', () => {
   // The regression this guards: `JSON.stringify(new Error('boom'))` is `'{}'`, which is what the log used to keep.
@@ -17,4 +17,30 @@ test('serializeForLogging', () => {
   circular.self = circular
   expect(serializeForLogging(circular)).toBe('[object Object]')
   expect(serializeForLogging(Object.create(null))).toBe('{}')
+})
+
+const electronUserAgent = 'Mozilla/5.0 Chrome/122.0.6261.156 Electron/29.4.6 Safari/537.36'
+const chromeUserAgent = 'Mozilla/5.0 Chrome/122.0.6261.156 Safari/537.36'
+const originalUserAgent = navigator.userAgent
+
+const setUserAgent = (userAgent: string): void => {
+  Object.defineProperty(navigator, 'userAgent', { value: userAgent, configurable: true })
+}
+
+afterEach(() => {
+  setUserAgent(originalUserAgent)
+  delete window.electronAPI
+})
+
+test('isElectron', () => {
+  // The regression this guards: an Electron-based embedded browser matches the user agent but has no
+  // preload bridge, and taking the Electron path there throws while the app is still booting.
+  setUserAgent(electronUserAgent)
+  expect(isElectron()).toBe(false)
+
+  window.electronAPI = {} as NonNullable<typeof window.electronAPI>
+  expect(isElectron()).toBe(true)
+
+  setUserAgent(chromeUserAgent)
+  expect(isElectron()).toBe(false)
 })


### PR DESCRIPTION
## Summary

Cockpit never finished booting inside Electron-based embedded browsers — the preview pane of an Electron-based IDE, or any bare Electron `BrowserWindow` — and the user was left on the generic "It looks like something went wrong while loading Cockpit." screen. One commit, guarding the detection itself.

- **`isElectron()` misdetected Electron-hosted webviews** (#2984). Those browsers carry the same `Electron/<version>` user-agent token as our own shell, but they never run `src/electron/preload.ts`, so the detection reported Electron while `window.electronAPI` was undefined. `videoStorage.ts` builds its four `ElectronStorage` instances during module evaluation, and their constructor calls `throwIfNotElectron()`, which threw `Electron filesystem API is not properly initialized`. That killed the boot graph before `main.ts` reached `app.mount('#app')`, so `cockpit-app-loaded` never fired and the 5s fallback in `index.html` stayed up forever. The detection now also requires the bridge the preload exposes, which is what actually tells our shell apart from any other Electron host, so these browsers take the IndexedDB path like any browser. Guarding the shared function covers every caller at once instead of patching each call site, and the preload runs before the page's scripts, so the bridge is already in place in the real app.

| Before | After |
| --- | --- |
| <img src="https://github.com/rafaellehmkuhl/cockpit-public/blob/65826b137330e0d4c7997f26b3bcf53ca72c3c79/pr-assets/pr2985-embedded-browser-before.png?raw=true" width="420"> | <img src="https://github.com/rafaellehmkuhl/cockpit-public/blob/65826b137330e0d4c7997f26b3bcf53ca72c3c79/pr-assets/pr2985-embedded-browser-after.png?raw=true" width="420"> |

Both shots are the same dev server loaded in a bare Electron 29 `BrowserWindow` with no preload script, only `src/libs/utils.ts` differing between them.

## Test plan

- [ ] Open the Standalone (Electron) build and confirm it still uses the filesystem storage: record a video and take a snapshot, then check they land in the Cockpit folder rather than in IndexedDB.
- [ ] In Standalone, confirm the Electron-only settings are still offered (Settings → General shows the Cockpit folder controls, Settings → Video shows the go2rtc/RTSP section).
- [ ] Open Lite in Chrome and confirm video recording and snapshots still work through IndexedDB.
- [ ] Open the dev server in an Electron-based embedded browser (an IDE's built-in browser, for example) and confirm the app now boots instead of showing the fallback error screen.

## Checks

Measured on the same dev server in a bare Electron 29 `BrowserWindow` (no preload), sampling the page every 5s:

| | Before | After |
| --- | --- | --- |
| Console | `Uncaught Error: Electron filesystem API is not properly initialized` | no boot error |
| Log sink chosen | `saved to electron-log` | `saved to the database` |
| `#app` children | 0, still 0 at 60s | 4–5 by the first sample |
| Fallback screen | present | never appears |
| `cockpit-app-loaded` handled | no | yes |

- New `isElectron` case in `src/tests/libs/utils.test.ts` fails (`expected true to be false`) without the change and passes with it.
- `yarn lint:fix` and `yarn typecheck` clean. `yarn test:unit`: 60 tests pass; `cosmos.test.ts` and `connection/connection.test.ts` fail to collect with `localStorage.getItem is not a function`, which reproduces unchanged on `master` and is unrelated to this change.

Closes #2984