### PR TITLE
fix: settings-management: do not sync settings while no vehicle is connected

### DIFF
--- a/src/libs/settings-management.ts
+++ b/src/libs/settings-management.ts
@@ -664,6 +664,12 @@ export class SettingsManager {
     await this.confirmVehicleIdOrThrow(vehicleAddress, vehicleId)
 
     while (Object.keys(this.keyValueVehicleUpdateQueue[vehicleId][userId]).length !== 0) {
+      // A failing key is kept in the queue and retried once per second, so if the vehicle goes away
+      // mid-drain we stop here and leave the rest to the next connection.
+      if (this.currentVehicleAddress !== vehicleAddress) {
+        return
+      }
+
       const updatesForUser = Object.entries(this.keyValueVehicleUpdateQueue[vehicleId][userId])
       for (const [key, update] of updatesForUser) {
         if (vehicleSettings[userId] && vehicleSettings[userId][key]) {
@@ -1115,6 +1121,15 @@ export class SettingsManager {
     }
   }
 
+  /**
+   * Handles a vehicle going offline, so nothing is synced to an address that stopped answering. Changes made
+   * while offline stay in the local settings and in the vehicle queue, and go up when the vehicle is back.
+   */
+  public handleVehicleGettingOffline = (): void => {
+    console.log('[SettingsManager]', 'Handling vehicle getting offline!')
+    this.currentVehicleAddress = nullValue
+  }
+
   private runVehicleGettingOnlinePipeline = async (vehicleAddress: string): Promise<void> => {
     // Before anything else, back up old-style vehicle settings in the vehicle, if needed
     await this.backupOldStyleVehicleSettingsIfNeeded(vehicleAddress)
@@ -1342,6 +1357,14 @@ export const settingsManager = new SettingsManager()
 window.addEventListener('vehicle-online', async (event: VehicleOnlineEvent) => {
   console.log('[SettingsManager]', `Vehicle online event received. Will handle vehicle getting online with address '${event.detail.vehicleAddress}'.`)
   await settingsManager.handleVehicleGettingOnline(event.detail.vehicleAddress)
+})
+
+/**
+ * Event handler for when a vehicle goes offline
+ */
+window.addEventListener('vehicle-offline', () => {
+  console.log('[SettingsManager]', 'Vehicle offline event received. Will stop syncing settings to it.')
+  settingsManager.handleVehicleGettingOffline()
 })
 
 /**

--- a/src/libs/settings-management.ts
+++ b/src/libs/settings-management.ts
@@ -264,7 +264,14 @@ export class SettingsManager {
       this.notifyAllListenersAboutSettingsChange()
 
       this.pushKeyValueUpdateToVehicleUpdateQueue(vehicleId!, userId!, key, value, newEpoch)
-      await this.sendKeyValueUpdatesToVehicle(userId!, vehicleId!, this.currentVehicleAddress)
+
+      // A failed push must not escape this timeout as an unhandled rejection. The updates stay in the
+      // vehicle queue, so whatever drains it next retries them.
+      try {
+        await this.sendKeyValueUpdatesToVehicle(userId!, vehicleId!, this.currentVehicleAddress)
+      } catch (error) {
+        console.error('[SettingsManager]', `Could not send queued settings to vehicle '${vehicleId}'.`, error)
+      }
 
     }, keyValueUpdateDebounceTime)
   }
@@ -547,6 +554,12 @@ export class SettingsManager {
    * @returns {Promise<VehicleSettings>} The settings from the vehicle. If no settings are found, an empty object is returned.
    */
   private getValidSettingsFromVehicle = async (vehicleAddress: string): Promise<VehicleSettings> => {
+    // Before any vehicle has connected there is no address to read from, which for our purposes is the
+    // same as a vehicle with no settings stored on it.
+    if (this.isNullValue(vehicleAddress)) {
+      return {}
+    }
+
     // eslint-disable-next-line vue/max-len, prettier/prettier, max-len
     const getSettingsFn = (): Promise<VehicleSettings | undefined> => this.vehicle.getKeyData(vehicleAddress, vehicleNewStyleSettingsKey)
     try {
@@ -633,6 +646,11 @@ export class SettingsManager {
     vehicleId: string,
     vehicleAddress: string
   ): Promise<void> => {
+    // Without an address there is nowhere to send the updates to, and they stay queued until there is one.
+    if (this.isNullValue(vehicleAddress)) {
+      return
+    }
+
     if (
       !this.keyValueVehicleUpdateQueue[vehicleId] ||
       !this.keyValueVehicleUpdateQueue[vehicleId]?.[userId] ||

--- a/src/types/settings-management.ts
+++ b/src/types/settings-management.ts
@@ -160,6 +160,11 @@ declare global {
     // eslint-disable-next-line jsdoc/require-jsdoc
     'vehicle-online': VehicleOnlineEvent
     /**
+     * Event triggered when a vehicle goes offline
+     */
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    'vehicle-offline': Event
+    /**
      * Event triggered when vehicle sync completes
      */
     // eslint-disable-next-line jsdoc/require-jsdoc


### PR DESCRIPTION
Until a vehicle connects, `currentVehicleAddress` is still the `'null'` placeholder, so every settings request built from it goes to `null/bag/v1.0/get/cockpit/settings-v2` and fails with `ERR_NAME_NOT_RESOLVED`. On a fresh start that happens ~40 times, once per `useBlueOsStorage` key writing its default, and each failure becomes a `VehicleConnectionError` that escapes a `setTimeout` callback as an unhandled rejection.

The first commit puts the guard into the two functions that actually issue the requests, so every producer is covered at once instead of one call site at a time:

- `getValidSettingsFromVehicle` returns empty settings for a placeholder address, which is what it already does for a vehicle with nothing stored. This covers the read inside `getBestSettingsBetweenLocalAndVehicle`, reached from `handleUserChanging` when the Cockpit user is renamed or switched with no vehicle around.
- `sendKeyValueUpdatesToVehicle` returns before its network calls, covering the debounced write in `setKeyValue` plus both `pushSettingsToVehicleUpdateQueue` call sites (`handleUserChanging` and `handleStorageChanging`).

Nothing is lost: the value is written to the local settings and pushed onto the vehicle update queue before either call, and the queue is drained once a vehicle is online. The push in `setKeyValue` is also wrapped in a `try/catch`, so a push that fails against a reachable vehicle is logged instead of escaping the debounce timeout as an unhandled rejection.

The second commit closes the other half: the address used to be replaced and never restored, so the guard only ever described "a vehicle connected at some point". `mainVehicle.ts` already dispatches `vehicle-offline` when the heartbeat times out and nothing was listening, so the settings manager now clears the address there. A setting changed while the vehicle is away stays local and queued instead of burning five 10-second retries against a dead address, and goes up on reconnect through the pipeline that already re-runs on every `vehicle-online`.

Split out of #2979, where the first fix originally landed, so it can be reviewed and backported on its own. That branch has been rebased and no longer carries it.

## Test plan

- [ ] Start Cockpit with no vehicle reachable and change a setting; the console shows no `null/bag/...` requests and no `VehicleConnectionError`.
- [ ] With no vehicle reachable, rename or switch the Cockpit user; same, no failed requests.
- [ ] Connect to a vehicle afterwards and confirm the settings changed while offline are pushed to it.
- [ ] Change a setting with a vehicle connected and confirm it still reaches the vehicle immediately.
- [ ] Disconnect a connected vehicle, change a setting, and confirm no request is attempted; reconnect and confirm the change reaches the vehicle.