### PR TITLE
Settings: Stop persisting and syncing settings with no value

### DIFF
--- a/src/components/configuration/CockpitSettingsManager.vue
+++ b/src/components/configuration/CockpitSettingsManager.vue
@@ -591,6 +591,9 @@ const commitChanges = async (item: SettingsRow): Promise<void> => {
   if (saving[item.originalKey]) return
   const editedValue = editedValues[item.originalKey]
   const previousValue = userSettings.value[item.originalKey]
+  // The settings manager persists a value-less setting as `null`, so the wait below and the row have to
+  // expect what it stored rather than what it was handed.
+  const committedValue = item.source === 'v2' ? editedValue ?? null : editedValue
   saving[item.originalKey] = true
   try {
     if (item.source === 'v2' && item.v2SettingKey) {
@@ -602,14 +605,14 @@ const commitChanges = async (item: SettingsRow): Promise<void> => {
         selectedUserId.value,
         selectedVehicleId.value
       )
-      await waitForV2ValueToPersist(item.v2SettingKey, editedValue, selectedUserId.value, selectedVehicleId.value)
+      await waitForV2ValueToPersist(item.v2SettingKey, committedValue, selectedUserId.value, selectedVehicleId.value)
       loadUserSettings()
     } else {
       localStorage.setItem(item.storageKey, localStorageValueToString(editedValue))
       localStorageSnapshot.value[item.storageKey] = editedValue
     }
     editing[item.originalKey] = false
-    userSettings.value[item.originalKey] = editedValue
+    userSettings.value[item.originalKey] = committedValue
     if (!isApplyingImportedConfig) logUserAction(`Changed setting '${displaySettingName(item)}'`)
   } catch (error: any) {
     editedValues[item.originalKey] = previousValue

--- a/src/libs/settings-management.ts
+++ b/src/libs/settings-management.ts
@@ -34,7 +34,8 @@ const nullValue = 'null'
 const possibleNullValues = [fallbackUsername, fallbackVehicleId, nullValue, null, undefined, '']
 const keyValueUpdateDebounceTime = 100
 
-export type SettingValue = string | number | boolean | object | null | undefined
+// No `undefined`: a cleared setting is spelled `null`, so writing one with no value at all is a type error.
+export type SettingValue = string | number | boolean | object | null
 
 /**
  * Error thrown when the vehicle ID does not match the expected ID
@@ -248,9 +249,15 @@ export class SettingsManager {
     this.keyValueUpdateTimeouts[key] = setTimeout(async () => {
       const newEpoch = epochChange !== undefined ? epochChange : Date.now()
       console.log(`[SettingsManager] Updating value of key '${key}' for user '${userId}' and vehicle '${vehicleId}'.`)
+      // `undefined` is dropped by JSON.stringify, so it would reach storage and the vehicle as a setting with no value
+      // at all. `null` is how a deliberately cleared setting is spelled, and it survives the round-trip.
+      if (value === undefined) {
+        console.warn(`[SettingsManager] Key '${key}' was written with no value. Storing 'null' instead.`)
+      }
+      const storedValue = value ?? null
       const newSetting = {
         epochLastChangedLocally: newEpoch,
-        value: value,
+        value: storedValue,
       }
       const localSettings = this.getLocalSettings()
       if (!localSettings[userId!]) {
@@ -263,7 +270,7 @@ export class SettingsManager {
       this.setLocalSettings(localSettings)
       this.notifyAllListenersAboutSettingsChange()
 
-      this.pushKeyValueUpdateToVehicleUpdateQueue(vehicleId!, userId!, key, value, newEpoch)
+      this.pushKeyValueUpdateToVehicleUpdateQueue(vehicleId!, userId!, key, storedValue, newEpoch)
 
       // A failed push must not escape this timeout as an unhandled rejection. The updates stay in the
       // vehicle queue, so whatever drains it next retries them.

--- a/src/libs/settings-management.ts
+++ b/src/libs/settings-management.ts
@@ -507,31 +507,6 @@ export class SettingsManager {
   }
 
   /**
-   * Merges two settings packages
-   * @param {SettingsPackage} settings1 - The first settings package
-   * @param {SettingsPackage} settings2 - The second settings package
-   * @returns {SettingsPackage} The merged settings package
-   */
-  private getMergedSettings = (settings1: SettingsPackage, settings2: SettingsPackage): SettingsPackage => {
-    const mergedSettings: SettingsPackage = {}
-
-    Object.keys({ ...settings1, ...settings2 }).forEach((key) => {
-      const setting1 = settings1[key]
-      const setting2 = settings2[key]
-
-      if (setting1 && setting2) {
-        mergedSettings[key] = setting1.epochLastChangedLocally > setting2.epochLastChangedLocally ? setting1 : setting2
-      } else if (setting1) {
-        mergedSettings[key] = setting1
-      } else if (setting2) {
-        mergedSettings[key] = setting2
-      }
-    })
-
-    return mergedSettings
-  }
-
-  /**
    * Adds a new key-value update to the vehicle update queue
    * @param {string} vehicleId - The ID of the vehicle to which the update belongs
    * @param {string} userId - The ID of the user to which the update belongs
@@ -679,11 +654,18 @@ export class SettingsManager {
 
       const updatesForUser = Object.entries(this.keyValueVehicleUpdateQueue[vehicleId][userId])
       for (const [key, update] of updatesForUser) {
-        if (vehicleSettings[userId] && vehicleSettings[userId][key]) {
-          const noValue = update.value === undefined
+        // A setting with no value would land on the vehicle as an entry every topside then reads back as a valid
+        // setting, so it is dropped whether or not the key already exists there.
+        if (update.value === undefined) {
+          delete this.keyValueVehicleUpdateQueue[vehicleId][userId][key]
+          continue
+        }
+        // A value-less entry already on the vehicle counts as no setting at all, so its epoch must not win the
+        // comparison below and shield itself from the real value being sent.
+        if (vehicleSettings[userId]?.[key]?.value !== undefined) {
           const sameValue = isEqual(vehicleSettings[userId][key].value, update.value)
           const vehicleSettingIsNewer = vehicleSettings[userId][key].epochLastChangedLocally > update.epochChange
-          if (noValue || sameValue || vehicleSettingIsNewer) {
+          if (sameValue || vehicleSettingIsNewer) {
             delete this.keyValueVehicleUpdateQueue[vehicleId][userId][key]
             continue
           }
@@ -895,7 +877,9 @@ export class SettingsManager {
         const vehicleSetting = vehicleUserSettings[key]
         const localSetting = localUserVehicleSettings[key]
 
-        const hasLocalSetting = localSetting !== undefined
+        // A stored setting can carry no value at all, and preferring one by epoch would serve it back to every
+        // topside, so it counts as absent and gets dropped from the merged package instead.
+        const hasLocalSetting = localSetting?.value !== undefined
         if (hasLocalSetting) {
           console.debug(`[SettingsManager] Has local setting with epoch ${localSetting.epochLastChangedLocally}.`)
           console.debug('[SettingsManager] Local setting value:')
@@ -904,7 +888,7 @@ export class SettingsManager {
           console.debug(`[SettingsManager] No local setting.`)
         }
 
-        const hasVehicleSetting = vehicleSetting !== undefined
+        const hasVehicleSetting = vehicleSetting?.value !== undefined
         if (hasVehicleSetting) {
           console.debug(`[SettingsManager] Has vehicle setting with epoch ${vehicleSetting.epochLastChangedLocally}.`)
           console.debug('[SettingsManager] Vehicle setting value:')

--- a/src/stores/mission.ts
+++ b/src/stores/mission.ts
@@ -125,7 +125,7 @@ export const useMissionStore = defineStore('mission', () => {
   } | null>(null)
 
   // Fallback vehicle type used by vehicle-specific planning features when no vehicle is connected.
-  const plannedVehicleType = useBlueOsStorage<MavType | undefined>('cockpit-planned-vehicle-type', undefined)
+  const plannedVehicleType = useBlueOsStorage<MavType | null>('cockpit-planned-vehicle-type', null)
   const savedMissions = useBlueOsStorage<SavedMission[]>('cockpit-mission-library', [])
   // Thumbnail bytes live local-first in IndexedDB and sync to the vehicle as real files, so adding many
   // entries never bloats the settings payload the way inlined base64 SVGs would.
@@ -789,7 +789,7 @@ export const useMissionStore = defineStore('mission', () => {
   const effectiveVehicleType = computed<MavType | undefined>(() => {
     return mainVehicleStore.isVehicleOnline
       ? (mainVehicleStore.vehicleType as MavType | undefined)
-      : plannedVehicleType.value
+      : plannedVehicleType.value ?? undefined
   })
 
   // When `payload.id` matches an existing entry that entry is updated in-place; otherwise a new


### PR DESCRIPTION
**Problem:**

- `setKeyValue` stored the value it was handed verbatim, so an `undefined` became `{ epochLastChangedLocally, value: undefined }` and `JSON.stringify` dropped the field, leaving `{ epochLastChangedLocally: N }` in `cockpit-settings-v2` (`src/libs/settings-management.ts:253`).
- The upload's `noValue` check sat inside the "key already exists on the vehicle" branch, so a fresh install uploaded the value-less entry anyway (`src/libs/settings-management.ts:652`).
- The merge counted such an entry as present (`vehicleSetting !== undefined`), so it could win the epoch comparison, be written back into local storage and be served to every other topside (`src/libs/settings-management.ts:876`).
- A deliberate clear was therefore indistinguishable from a value that was never set, so clearing a key on one topside never propagated to another.

**Fix:**

- `setKeyValue` stores `null` when handed `undefined`, so the field survives `JSON.stringify` and a cleared key round-trips (`src/libs/settings-management.ts:256`). It warns naming the key, so a caller still passing `undefined` is visible in the syslog.
- The upload drops a value-less update whether or not the key already exists on the vehicle (`src/libs/settings-management.ts:634`).
- The merge reads a value-less entry as no setting, so it falls into the existing skip case and leaves the merged package instead of being preferred by epoch (`src/libs/settings-management.ts:855` and `:864`). Nothing is deleted from the vehicle.
- `commitChanges` normalizes once and waits on the value the manager actually stores, since the settings editor otherwise polls for the pre-coercion value and times out (`src/components/configuration/CockpitSettingsManager.vue:596`).
- Dropped `getMergedSettings`, an unreachable third copy of the local-versus-vehicle comparison that decided presence by truthiness and carried the same defect.
- `cockpit-planned-vehicle-type` was the last vehicle-synced key defaulting to `undefined` and now defaults to `null` (`src/stores/mission.ts:128`). `effectiveVehicleType` keeps its `MavType | undefined` shape, so the planner surfaces reading it are unchanged, and a type the user already chose is left alone.

Closes #2914
