### PR TITLE
fix: widgets: fill in missing mini-widget bar containers

### DIFF
--- a/src/components/WidgetBar.vue
+++ b/src/components/WidgetBar.vue
@@ -11,23 +11,53 @@
     <slot name="prepend" />
     <template v-if="position === 'top'">
       <div class="flex-1">
-        <MiniWidgetContainer :container="containers[0]" :allow-editing="widgetStore.editingMode" align="start" />
+        <MiniWidgetContainer
+          v-if="containers[0]"
+          :container="containers[0]"
+          :allow-editing="widgetStore.editingMode"
+          align="start"
+        />
       </div>
       <div class="grow" />
       <div class="flex-1">
-        <MiniWidgetContainer :container="containers[1]" :allow-editing="widgetStore.editingMode" align="center" />
+        <MiniWidgetContainer
+          v-if="containers[1]"
+          :container="containers[1]"
+          :allow-editing="widgetStore.editingMode"
+          align="center"
+        />
       </div>
       <div class="grow" />
       <div class="flex-1">
-        <MiniWidgetContainer :container="containers[2]" :allow-editing="widgetStore.editingMode" align="end" />
+        <MiniWidgetContainer
+          v-if="containers[2]"
+          :container="containers[2]"
+          :allow-editing="widgetStore.editingMode"
+          align="end"
+        />
       </div>
     </template>
     <template v-else>
-      <MiniWidgetContainer :container="containers[0]" :allow-editing="widgetStore.editingMode" align="start" />
+      <MiniWidgetContainer
+        v-if="containers[0]"
+        :container="containers[0]"
+        :allow-editing="widgetStore.editingMode"
+        align="start"
+      />
       <div />
-      <MiniWidgetContainer :container="containers[1]" :allow-editing="widgetStore.editingMode" align="center" />
+      <MiniWidgetContainer
+        v-if="containers[1]"
+        :container="containers[1]"
+        :allow-editing="widgetStore.editingMode"
+        align="center"
+      />
       <div />
-      <MiniWidgetContainer :container="containers[2]" :allow-editing="widgetStore.editingMode" align="end" />
+      <MiniWidgetContainer
+        v-if="containers[2]"
+        :container="containers[2]"
+        :allow-editing="widgetStore.editingMode"
+        align="end"
+      />
     </template>
     <div
       v-if="isOverflowing && widgetStore.editingMode"
@@ -89,7 +119,7 @@ const { width: windowWidth } = useWindowSize()
 // eslint-disable-next-line jsdoc/require-jsdoc
 interface Props {
   /**
-   * The three mini-widget containers to render (left, center, right)
+   * The up-to-three mini-widget containers to render (left, center, right)
    */
   containers: MiniWidgetContainerType[]
   /**

--- a/src/stores/widgetManager.ts
+++ b/src/stores/widgetManager.ts
@@ -39,6 +39,7 @@ import {
   CustomWidgetElement,
   CustomWidgetElementContainer,
   DragState,
+  fillMissingBarContainers,
   InternalWidgetSetupInfo,
   MiniWidgetManagerVars,
   validateProfile,
@@ -76,6 +77,17 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
     const migrated = migrateLegacyViewsGroup(vehicleType)
     if (migrated) viewsGroup.value = migrated
   })
+
+  // Both bars are rendered with three containers, but a profile migrated or imported from an older version can
+  // carry fewer, and the stored value can still be replaced after boot by a vehicle sync or by the migration above.
+  const fillBarContainers = (): void => {
+    const topContainers = currentMiniWidgetsProfile.value.containers ?? []
+    currentMiniWidgetsProfile.value.containers = fillMissingBarContainers(topContainers, 'Top')
+    viewsGroup.value.views?.forEach((view) => {
+      view.miniWidgetContainers = fillMissingBarContainers(view.miniWidgetContainers ?? [], 'Bottom')
+    })
+  }
+  watch([currentMiniWidgetsProfile, viewsGroup], fillBarContainers, { immediate: true })
 
   const desiredTopBarHeightPixels = ref(48)
   const desiredBottomBarHeightPixels = ref(48)
@@ -489,6 +501,7 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
         return
       }
       maybeView.hash = uuid4()
+      maybeView.miniWidgetContainers = fillMissingBarContainers(maybeView.miniWidgetContainers ?? [], 'Bottom')
       currentProfile.value.views.unshift(maybeView)
     }
     // @ts-ignore: We know the event type and need refactor of the event typing
@@ -737,10 +750,6 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
   // Profile migrations
   // TODO: remove on first stable release
   onBeforeMount(() => {
-    if (currentMiniWidgetsProfile.value.containers.length < 3) {
-      currentMiniWidgetsProfile.value = miniWidgetsProfile
-    }
-
     const alreadyUsedViewHashes: string[] = []
     const alreadyUsedWidgetHashes: string[] = []
     const alreadyUsedMiniWidgetHashes: string[] = []

--- a/src/tests/types/widgets.test.ts
+++ b/src/tests/types/widgets.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from 'vitest'
+
+import { type MiniWidgetContainer, fillMissingBarContainers } from '@/types/widgets'
+
+const container = (name: string): MiniWidgetContainer => ({ name, widgets: [] })
+
+test('a bar with fewer containers than slots gets the missing ones, keeping the stored ones', () => {
+  const stored = [container('Bottom-left container')]
+
+  const filled = fillMissingBarContainers(stored, 'Bottom')
+
+  expect(filled).toHaveLength(3)
+  expect(filled[0]).toBe(stored[0])
+  expect(filled.map((c) => c.name)).toEqual([
+    'Bottom-left container',
+    'Bottom-center container',
+    'Bottom-right container',
+  ])
+})
+
+test('a hole in a value applied by the vehicle sync is filled, and containers past the slots are kept', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const stored = [container('Top-left container'), null as any, container('Top-right container'), container('Extra')]
+
+  const filled = fillMissingBarContainers(stored, 'Top')
+
+  expect(filled.map((c) => c.name)).toEqual([
+    'Top-left container',
+    'Top-center container',
+    'Top-right container',
+    'Extra',
+  ])
+})
+
+test('a complete bar is returned untouched, so nothing is written back to the settings', () => {
+  const stored = [container('Top-left container'), container('Top-center container'), container('Top-right container')]
+
+  expect(fillMissingBarContainers(stored, 'Top')).toBe(stored)
+  expect(fillMissingBarContainers(fillMissingBarContainers([], 'Bottom'), 'Bottom')).toHaveLength(3)
+})

--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -981,6 +981,31 @@ export const validateMiniWidget = (maybeMiniWidget: MiniWidget): maybeMiniWidget
   return true
 }
 
+/** The slots, left to right, that every mini-widget bar is rendered with */
+const barSlots = ['left', 'center', 'right']
+
+/**
+ * Fills a bar's stored containers up to the slots the bar is rendered with, keeping the ones already there and
+ * any extras. Profiles migrated or imported from older versions can carry fewer, which leaves the bar rendering
+ * an undefined container. Containers beyond the slots are kept so no mini-widget is ever dropped.
+ * @param {MiniWidgetContainer[]} containers - The containers stored for the bar
+ * @param {'Top' | 'Bottom'} position - The bar the containers belong to, used to name the ones added
+ * @returns {MiniWidgetContainer[]} The containers, or the same array when nothing was missing
+ */
+export const fillMissingBarContainers = (
+  containers: MiniWidgetContainer[],
+  position: 'Top' | 'Bottom'
+): MiniWidgetContainer[] => {
+  if (barSlots.every((_slot, index) => containers[index])) return containers
+
+  const filled = [...containers]
+  barSlots.forEach((slot, index) => {
+    if (!filled[index]) filled[index] = { name: `${position}-${slot} container`, widgets: [] }
+  })
+
+  return filled
+}
+
 export const validateContainer = (maybeContainer: MiniWidgetContainer): maybeContainer is MiniWidgetContainer => {
   if (maybeContainer.name === undefined) throw new Error('View validation failed: property "name" is missing.')
   const checkFails: string[] = []


### PR DESCRIPTION
## Summary

A view whose `miniWidgetContainers` carries fewer than three entries does not just break the bottom bar — it takes the whole app down to the "something went wrong while loading Cockpit" recovery screen. `WidgetBar` renders `containers[0..2]` unconditionally and `MiniWidgetContainer` reads `container.widgets` in `onBeforeMount`, so the missing third container throws during render.

Nothing guaranteed the count. The defaults and `addView` create three, but the legacy profile migration copies old profiles through untouched, `importViewsGroup` and `importView` accept any file that passes `validateView` (which only checks the property is an array), and a vehicle sync can replace the stored value after boot. The top bar had a guard for exactly this case, `containers.length < 3`, but it threw the user's whole profile away and restored the defaults.

- **Fill the missing slots** rather than replacing the profile, in `fillMissingBarContainers`, called for both bars when the stored value is loaded or replaced, and again in `importView`, whose nested insert the watcher does not see. Containers already there are kept, including any beyond the three slots, so no mini-widget is ever dropped. The function returns the same array when nothing is missing, so a healthy profile is not written back to the settings on every boot.
- **Drop the top bar's old length check**, now superseded. Its recovery was destructive: a profile with two containers lost its widgets to the defaults, where it now keeps them and gains an empty third.
- **Guard `WidgetBar`** so a container that is somehow still missing renders nothing instead of crashing the view.

| Before | After |
| --- | --- |
| <img src="https://github.com/rafaellehmkuhl/cockpit-public/blob/391a286c3e1507e85f8adb12bf3eb4407005d60d/pr-assets/pr2992-short-bar-before.png?raw=true" width="420"> | <img src="https://github.com/rafaellehmkuhl/cockpit-public/blob/391a286c3e1507e85f8adb12bf3eb4407005d60d/pr-assets/pr2992-short-bar-after.png?raw=true" width="420"> |

## Test plan

- [ ] With an existing profile, confirm both bars still show every mini-widget where they were.
- [ ] Import a views group exported by an older Cockpit and confirm it loads, with any missing bar slot appearing empty rather than breaking the view.
- [ ] Add a mini-widget to each of the three bottom slots, reload, and confirm they persist.
- [ ] Seed the two-container view from the issue and confirm Cockpit loads.

## Checks

- Repro from the issue, before → after: recovery screen with `Uncaught TypeError: Cannot read properties of undefined (reading 'widgets')` and `.bottom-bar` count 0 → no errors, `.bottom-bar` count 1, and the stored view healed to `Bottom-left / Bottom-center / Bottom-right container`.
- `yarn lint:fix` clean, and `yarn vitest run src/tests/types` passes with the three new cases for `fillMissingBarContainers`.

Closes #2991

