### PR TITLE
Fix bad lint breaking CI on master

### DIFF
--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -1548,8 +1548,7 @@ const renderMeasureOverlay = (cursorLatLng: L.LatLng, evt: L.LeafletMouseEvent |
   // typed instead of leaflet's 0.1% smaller earth.
   const dist = calculateHaversineDistance([anchor.lat, anchor.lng], [cursor.lat, cursor.lng])
 
-  const hidePill =
-    (evt && (isOverSurveyHandle(evt.originalEvent?.target) || isOverLastWaypointMarker(evt))) || dist < 1 // hide if closer than 1 meter to last wp on the array
+  const hidePill = (evt && (isOverSurveyHandle(evt.originalEvent?.target) || isOverLastWaypointMarker(evt))) || dist < 1 // hide if closer than 1 meter to last wp on the array
 
   renderLiveMeasure({
     from: anchor,


### PR DESCRIPTION
## Summary

Master is currently red: the `Install, lint, typecheck, and build` step fails with a single Prettier warning, and `eslint --max-warnings=0` turns that warning into a failed job.

The `hidePill` assignment in `src/views/MissionPlanningView.vue` was wrapped onto a second line, but the code (excluding the trailing comment) fits within the 120-char print width, so Prettier wants it collapsed. This is exactly what `eslint --fix` produces.

Failing run: https://github.com/bluerobotics/cockpit/actions/runs/33512517265/job/99871429308

## Test plan

- [x] `yarn lint` passes with no errors or warnings