### PR TITLE
Electron: Fix boot failure inside embedded Electron browsers

### DIFF
--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -175,9 +175,9 @@ export const reloadCockpit = (timeout = 3000): void => {
  * @returns {boolean} True if running in Electron, false otherwise
  */
 export const isElectron = (): boolean => {
-  // Check if the userAgent contains 'electron' (for renderer process)
-  if (typeof navigator === 'object' && typeof navigator.userAgent === 'string') {
-    return navigator.userAgent.toLowerCase().includes('electron')
+  // An Electron-hosted webview carries the Electron UA without Cockpit's preload bridge
+  if (typeof window === 'object' && typeof navigator === 'object' && typeof navigator.userAgent === 'string') {
+    return navigator.userAgent.toLowerCase().includes('electron') && window.electronAPI !== undefined
   }
 
   // Check if the process object exists and contains 'electron' (for main process)


### PR DESCRIPTION
**Problem:**

- Cockpit never finished loading inside an Electron-based embedded browser, such as the built-in browser of an Electron-based IDE, leaving the generic "It looks like something went wrong while loading Cockpit." screen. The same server loaded normally in an external Chrome.
- Those browsers announce themselves as Electron without providing the Standalone integration, so Cockpit selected the Standalone filesystem storage, hit the missing integration while setting it up, and stopped before the interface ever mounted.

**Fix:**

- Cockpit now treats a host as Standalone only when the Standalone integration is actually present, instead of trusting the browser's self-description alone (`src/libs/utils.ts:178`).
- Embedded Electron browsers therefore fall back to the same in-browser storage Cockpit Lite already uses, and load normally.
- The shipped Standalone and Lite builds are unaffected: Standalone still provides the integration and keeps its filesystem storage, and Lite never claimed to be Electron.

Closes #2984