### PR TITLE
1.18.3: Backport the 4K Cam and video fixes onto the 1.18 line

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -15,6 +15,10 @@ module.exports = {
     'es2022': true,
     'vue/setup-compiler-macros': true,
   },
+  globals: {
+    // Global helper defined in src/libs/cosmos.ts and assigned at bootstrap, so it is callable without importing.
+    logUserAction: 'readonly',
+  },
   plugins: ['jsdoc', 'simple-import-sort'],
   ignorePatterns: ['**/src/libs/connection/m2r/**'],
   rules: {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,22 +115,6 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Install snapcraft for arm64
-        if: matrix.os == 'ubuntu-24-arm'
-        run: |
-          sudo apt update
-          sudo apt install -y --fix-missing snapd
-          for i in {1..10}; do
-            if sudo snap install snapcraft --classic; then
-              break
-            elif [ $i -eq 10 ]; then
-              exit 1
-            else
-              echo "Retry $i failed, waiting 30s..."
-              sleep 30
-            fi
-          done
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -195,11 +179,6 @@ jobs:
           # Make keychain name available to electron-builder
           echo "CSC_KEYCHAIN_NAME=${KEYCHAIN_NAME}" >> $GITHUB_ENV
 
-      - name: Deploy (arm)
-        if: matrix.os == 'ubuntu-24-arm'
-        run: |
-          SNAPCRAFT_BUILD_ENVIRONMENT="host" yarn ${{ matrix.deployCommand }}
-
       - name: Deploy (macOS - Release Build)
         if: (matrix.os == 'macos-15-intel' || matrix.os == 'macos-15') && github.event_name != 'pull_request'
         env:
@@ -218,8 +197,8 @@ jobs:
           echo "INFO: Building macOS for Pull Request. Signing and notarization will be skipped."
           yarn ${{ matrix.deployCommand }}:pr
 
-      - name: Deploy (Windows / Linux non-arm)
-        if: matrix.os == 'ubuntu-latest' || matrix.os == 'windows-latest'
+      - name: Deploy (Windows / Linux)
+        if: matrix.os == 'ubuntu-24-arm' || matrix.os == 'ubuntu-latest' || matrix.os == 'windows-latest'
         # No Apple specific env vars needed here as electron-builder ignores them on these platforms
         run: |
           yarn ${{ matrix.deployCommand }}

--- a/package.json
+++ b/package.json
@@ -195,7 +195,8 @@
       "allowToChangeInstallationDirectory": true
     },
     "linux": {
-      "icon": "public/pwa-512x512.png"
+      "icon": "public/pwa-512x512.png",
+      "target": ["AppImage"]
     },
     "flatpak": {
       "base": "org.electronjs.Electron2.BaseApp",

--- a/src/components/CameraReplacementDialog.vue
+++ b/src/components/CameraReplacementDialog.vue
@@ -122,6 +122,14 @@
           </template>
         </div>
 
+        <div v-if="showRtspPreferenceNote" class="flex items-start gap-2">
+          <v-icon size="16" color="grey-lighten-1" class="mt-[2px]">mdi-information-outline</v-icon>
+          <span class="text-xs text-gray-400">
+            Cockpit Standalone can pull RTSP streams directly from the camera, which performs better than WebRTC and
+            uses less of the vehicle's computing resources.
+          </span>
+        </div>
+
         <p class="text-xs text-gray-500 mt-1">
           {{ affectedWidgetCount }} widget{{ affectedWidgetCount === 1 ? '' : 's' }} will be updated.
         </p>
@@ -134,6 +142,7 @@
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 
 import { useBlueOsStorage } from '@/composables/settingsSyncer'
+import { isElectron } from '@/libs/utils'
 import { useVideoStore } from '@/stores/video'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
 import type { VideoStreamCorrespondency } from '@/types/video'
@@ -146,6 +155,7 @@ const videoStore = useVideoStore()
 const widgetStore = useWidgetManagerStore()
 
 const STABILIZATION_DELAY_MS = 15000
+const isStandalone = isElectron()
 
 const showDialog = ref(false)
 const dialogTriggered = ref(false)
@@ -274,11 +284,19 @@ const unusedAvailableStreams = computed(() => {
 const replacementItems = computed(() => {
   return unusedAvailableStreams.value.map((corr) => {
     const info = videoStore.getStreamDisplayInfo(corr.externalId)
+    const preferredSuffix = isStandalone && info.protocolLabel === 'RTSP' ? ' [Preferred]' : ''
     return {
       internalName: corr.name,
-      label: `${corr.name} (${info.protocolLabel} - ${info.resolution})`,
+      label: `${corr.name} (${info.protocolLabel} - ${info.resolution})${preferredSuffix}`,
     }
   })
+})
+
+const showRtspPreferenceNote = computed((): boolean => {
+  if (!isStandalone) return false
+  return unusedAvailableStreams.value.some(
+    (corr) => videoStore.getStreamDisplayInfo(corr.externalId).protocolLabel === 'RTSP'
+  )
 })
 
 const affectedWidgetCount = computed((): number => {

--- a/src/components/VideoPlayerStatsForNerds.vue
+++ b/src/components/VideoPlayerStatsForNerds.vue
@@ -8,6 +8,7 @@
 import { WebRTCStats } from '@peermetrics/webrtc-stats'
 import { onBeforeUnmount, onMounted, onUnmounted, ref, watch } from 'vue'
 
+import { monitorStreamPeerConnection } from '@/libs/webrtc/stats'
 import { useVideoStore } from '@/stores/video'
 import type { Go2RTCStreamInfo } from '@/types/video'
 import { WebRTCStatsEvent } from '@/types/video'
@@ -30,7 +31,8 @@ const props = defineProps({
   },
   height: {
     type: Number,
-    default: 200,
+    // Tall enough to keep the longest stats list (WebRTC, 12 rows) clear of the plot area at the bottom
+    default: 212,
   },
   updateInterval: {
     type: Number,
@@ -68,6 +70,9 @@ let processingDelayDelta = 0
 let freezes = 0
 let frozenTime = 0
 let framedrops = 0
+let jitterBufferDelay = 0
+let jitterBufferEmittedCount = 0
+let jitterBufferDelayPerFrame = 0
 
 let packetLossPercentage = 0
 let framerate = 0
@@ -144,6 +149,8 @@ function draw(): void {
       { label: 'Bitrate', value: bitrateStr, color: 'rgb(255, 165, 0)' },
       { label: 'Packets', value: ppsStr, color: 'rgb(100, 200, 255)' },
       { label: 'Stalls', value: rtspStallCount, color: rtspStallCount > 0 ? 'rgb(255, 0, 0)' : 'white' },
+      { label: 'Buffer', value: `${jitterBufferDelayPerFrame.toFixed(0)}ms`, color: statusColor },
+      { label: 'Frame drops', value: framedrops, color: statusColor },
     ]
 
     stats.forEach((stat, index) => {
@@ -165,6 +172,7 @@ function draw(): void {
       { label: 'Pli', value: pliCount, color: color },
       { label: 'Fir', value: firCount, color: color },
       { label: 'Processing ', value: `${processingDelayDelta.toFixed(0)}ms`, color: color },
+      { label: 'Buffer', value: `${jitterBufferDelayPerFrame.toFixed(0)}ms`, color: color },
       { label: 'Freezes', value: `${freezes}(${frozenTime.toFixed(1)}s)`, color: color },
       { label: 'Bitrate', value: `${bitrate.toFixed(0)}kbps`, color: 'rgb(255, 165, 0)' },
       { label: 'FPS', value: framerate.toFixed(2), color: 'rgb(0, 255, 0)' },
@@ -201,12 +209,7 @@ watch(videoStore.activeStreams, (streams): void => {
     const pcInfo = videoStore.getStreamPeerConnection(streamName)
     if (!pcInfo) return
     if (webrtcStats.peersToMonitor[pcInfo.peerId]) return
-    webrtcStats.addConnection({
-      pc: pcInfo.peerConnection,
-      peerId: pcInfo.peerId,
-      connectionId: pcInfo.sessionId,
-      remote: false,
-    })
+    monitorStreamPeerConnection(webrtcStats, pcInfo)
   })
 })
 
@@ -247,6 +250,8 @@ onMounted(() => {
 
   webrtcStats.on('stats', (ev: WebRTCStatsEvent) => {
     try {
+      if (!webrtcStats.peersToMonitor[ev.peerId]) return
+
       const videoData = ev.data.video.inbound[0]
       if (videoData === undefined) return
       connectionLost = videoData.bitrate === 0
@@ -269,6 +274,14 @@ onMounted(() => {
       freezes = videoData.freezeCount
       frozenTime = videoData.totalFreezesDuration
       framedrops = videoData.framesDropped
+      // Both stats are cumulative, so only their deltas tell how much the last frames actually waited in the buffer
+      const jitterBufferDelayDelta = videoData.jitterBufferDelay - jitterBufferDelay
+      const jitterBufferEmittedDelta = videoData.jitterBufferEmittedCount - jitterBufferEmittedCount
+      if (jitterBufferEmittedDelta > 0) {
+        jitterBufferDelayPerFrame = (1000 * jitterBufferDelayDelta) / jitterBufferEmittedDelta
+      }
+      jitterBufferDelay = videoData.jitterBufferDelay
+      jitterBufferEmittedCount = videoData.jitterBufferEmittedCount
       framerate = videoData.framesPerSecond ?? 0
       videoHeight = videoData.frameHeight
     } catch (e) {

--- a/src/components/mini-widgets/MiniVideoRecorder.vue
+++ b/src/components/mini-widgets/MiniVideoRecorder.vue
@@ -174,6 +174,17 @@ const selectedExternalId = ref<string | undefined>()
 
 const externalStreamId = computed(() => selectedExternalId.value)
 
+// Register/unregister this widget as a consumer of the stream, so the video store can tear down streams that no
+// widget points to anymore instead of leaking their WebRTC session.
+watch(
+  externalStreamId,
+  (newId, oldId) => {
+    if (oldId) videoStore.unregisterStreamConsumer(oldId, miniWidget.value.hash)
+    if (newId) videoStore.registerStreamConsumer(newId, miniWidget.value.hash)
+  },
+  { immediate: true }
+)
+
 const openVideoLibraryModal = (): void => {
   interfaceStore.videoLibraryMode = 'videos'
   interfaceStore.videoLibraryVisibility = true
@@ -425,7 +436,10 @@ if (widgetStore.isRealMiniWidget(miniWidget.value.hash)) {
     }
   }, 1000)
 }
-onBeforeUnmount(() => clearInterval(streamConnectionRoutine))
+onBeforeUnmount(() => {
+  clearInterval(streamConnectionRoutine)
+  if (externalStreamId.value) videoStore.unregisterStreamConsumer(externalStreamId.value, miniWidget.value.hash)
+})
 
 watch(
   () => isVideoLibraryDialogOpen.value,

--- a/src/components/mini-widgets/MiniVideoRecorder.vue
+++ b/src/components/mini-widgets/MiniVideoRecorder.vue
@@ -128,7 +128,8 @@ import { storeToRefs } from 'pinia'
 import { computed, onBeforeMount, onBeforeUnmount, onMounted, ref, toRefs, watch } from 'vue'
 
 import { useInteractionDialog } from '@/composables/interactionDialog'
-import { isEqual, sleep } from '@/libs/utils'
+import { openSnackbar } from '@/composables/snackbar'
+import { isEqual } from '@/libs/utils'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useVideoStore } from '@/stores/video'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
@@ -380,28 +381,30 @@ const timePassedString = computed(() => {
   return `${durationHours}:${durationMinutes}:${durationSeconds}`
 })
 
-const updateCurrentStream = async (internalStreamName: string | undefined): Promise<void> => {
+// Generous ceiling for how long we show the connecting state before warning; well above typical WebRTC
+// negotiation so merely-slow streams aren't cut off, unlike the old 3s hard timeout.
+const streamLoadingTimeoutMs = 20000
+let streamLoadingTimeout: ReturnType<typeof setTimeout> | undefined = undefined
+
+const updateCurrentStream = (internalStreamName: string | undefined): void => {
+  logUserAction(`Selected recording stream '${internalStreamName}'`)
   assertStreamIsSelectedAndAvailable(internalStreamName)
 
   mediaStream.value = undefined
   isLoadingStream.value = true
-
-  let millisPassed = 0
-  const timeStep = 100
-  const waitingTime = 3000
-  while (isLoadingStream.value && millisPassed < waitingTime) {
-    // @ts-ignore: The media stream can (and probably will) get defined as we selected a stream
-    isLoadingStream.value = mediaStream.value === undefined || !mediaStream.value.active
-    await sleep(timeStep)
-    millisPassed += timeStep
-  }
-
-  if (isLoadingStream.value) {
-    showDialog({ message: 'Could not load media stream.', variant: 'error' })
-    return
-  }
-
   miniWidget.value.options.internalStreamName = internalStreamName
+
+  // streamConnectionRoutine clears isLoadingStream once media is flowing; if it never connects, stop spinning
+  // and surface a non-blocking warning so the record button becomes usable again instead of staying disabled.
+  clearTimeout(streamLoadingTimeout)
+  streamLoadingTimeout = setTimeout(() => {
+    if (!isLoadingStream.value) return
+    isLoadingStream.value = false
+    openSnackbar({
+      message: `Could not load media stream '${internalStreamName}'. Check the stream source and try again.`,
+      variant: 'error',
+    })
+  }, streamLoadingTimeoutMs)
 }
 
 let streamConnectionRoutine: ReturnType<typeof setInterval> | undefined = undefined
@@ -425,6 +428,10 @@ if (widgetStore.isRealMiniWidget(miniWidget.value.hash)) {
       if (!isEqual(updatedMediaStream, mediaStream.value)) {
         mediaStream.value = updatedMediaStream
       }
+      if (isLoadingStream.value && mediaStream.value?.active) {
+        isLoadingStream.value = false
+        clearTimeout(streamLoadingTimeout)
+      }
     }
 
     if (!namesAvailableStreams.value.isEmpty() && !namesAvailableStreams.value.includes(nameSelectedStream.value!)) {
@@ -438,6 +445,7 @@ if (widgetStore.isRealMiniWidget(miniWidget.value.hash)) {
 }
 onBeforeUnmount(() => {
   clearInterval(streamConnectionRoutine)
+  clearTimeout(streamLoadingTimeout)
   if (externalStreamId.value) videoStore.unregisterStreamConsumer(externalStreamId.value, miniWidget.value.hash)
 })
 

--- a/src/components/widgets/VideoPlayer.vue
+++ b/src/components/widgets/VideoPlayer.vue
@@ -233,6 +233,17 @@ const externalStreamId = computed(() => {
   return nameSelectedStream.value ? videoStore.externalStreamId(nameSelectedStream.value) : undefined
 })
 
+// Register/unregister this widget as a consumer of the stream, so the video store can tear down streams that no
+// widget points to anymore instead of leaking their WebRTC session.
+watch(
+  externalStreamId,
+  (newId, oldId) => {
+    if (oldId) videoStore.unregisterStreamConsumer(oldId, widget.value.hash)
+    if (newId) videoStore.registerStreamConsumer(newId, widget.value.hash)
+  },
+  { immediate: true }
+)
+
 watch(
   () => videoStore.streamsCorrespondency,
   () => {
@@ -293,6 +304,7 @@ const streamConnectionRoutine = setInterval(() => {
 onBeforeUnmount(() => {
   clearInterval(streamConnectionRoutine)
   if (successTimeoutId) clearTimeout(successTimeoutId)
+  if (externalStreamId.value) videoStore.unregisterStreamConsumer(externalStreamId.value, widget.value.hash)
 })
 
 watch(nameSelectedStream, () => {

--- a/src/components/widgets/VideoPlayer.vue
+++ b/src/components/widgets/VideoPlayer.vue
@@ -10,22 +10,34 @@
     <div v-if="nameSelectedStream === undefined" class="no-video-alert">
       <span>No video stream selected.</span>
     </div>
-    <div
-      v-else-if="!namesAvailableStreams.isEmpty() && !namesAvailableStreams.includes(nameSelectedStream)"
-      class="no-video-alert"
-    >
-      <p>The selected stream "{{ nameSelectedStream }}" is not available.</p>
-      <p>Available ones are: {{ namesAvailableStreams.map((name) => `"${name}"`).join(', ') }}.</p>
-      <br />
-      <p>
-        This can happen if you changed vehicles and the stream name in the new one is different from the former, or if
-        the source is not available at all.
-      </p>
-      <br />
-      <p>
-        Please open this video player configuration and select a new stream from the ones available, or check your
-        source for issues.
-      </p>
+    <div v-else-if="!namesAvailableStreams.includes(nameSelectedStream)" class="no-video-alert">
+      <template v-if="namesAvailableStreams.isEmpty()">
+        <p>No video streams are available.</p>
+        <br />
+        <p>
+          Cockpit may still be looking for this vehicle's streams, or every stream may have been deleted, ignored or
+          turned off.
+        </p>
+        <br />
+        <p>
+          If this message stays, open the video configuration page to restore a stream from the ignored streams list, or
+          check that the vehicle's cameras are on and streaming.
+        </p>
+      </template>
+      <template v-else>
+        <p>The selected stream "{{ nameSelectedStream }}" is not available.</p>
+        <p>Available ones are: {{ namesAvailableStreams.map((name) => `"${name}"`).join(', ') }}.</p>
+        <br />
+        <p>
+          This can happen if you changed vehicles and the stream name in the new one is different from the former, or if
+          the source is not available at all.
+        </p>
+        <br />
+        <p>
+          Please open this video player configuration and select a new stream from the ones available, or check your
+          source for issues.
+        </p>
+      </template>
     </div>
     <Transition name="loading-complete">
       <div v-if="showLoadingOverlay" class="loading-overlay">

--- a/src/composables/go2rtc.ts
+++ b/src/composables/go2rtc.ts
@@ -1,5 +1,7 @@
 import { type Ref, ref } from 'vue'
 
+import { setJitterBufferTarget } from '@/libs/webrtc/jitter-buffer'
+
 const RECONNECT_DELAY_MS = 3000
 // Time we give the peer connection to reach 'connected' before assuming go2rtc is stuck waiting for an
 // unavailable source (e.g. camera not yet on the network) and forcing a reconnect.
@@ -25,8 +27,9 @@ export class Go2RTCManager {
   /**
    * @param {number} go2rtcPort - The port go2rtc is listening on
    * @param {string} streamName - The stream name registered in go2rtc
+   * @param {number} jitterBufferTarget - RTP receiver jitter buffer target in milliseconds
    */
-  constructor(private go2rtcPort: number, private streamName: string) {}
+  constructor(private go2rtcPort: number, private streamName: string, private jitterBufferTarget: number) {}
 
   /**
    * Start the WebRTC connection to go2rtc.
@@ -80,6 +83,8 @@ export class Go2RTCManager {
       const [remoteStream] = event.streams
       if (!remoteStream) return
       this.mediaStream.value = remoteStream
+
+      setJitterBufferTarget(pc, this.jitterBufferTarget)
 
       const videoTracks = remoteStream.getVideoTracks()
       videoTracks.forEach((track) => {

--- a/src/composables/go2rtc.ts
+++ b/src/composables/go2rtc.ts
@@ -1,3 +1,4 @@
+import { v4 as uuid } from 'uuid'
 import { type Ref, ref } from 'vue'
 
 import { setJitterBufferTarget } from '@/libs/webrtc/jitter-buffer'
@@ -17,6 +18,8 @@ export class Go2RTCManager {
   public connected = ref(false)
   public signallerStatus: Ref<string> = ref('Disconnected')
   public streamStatus: Ref<string> = ref('Waiting...')
+  // Changes on every (re)connection, so stats consumers can tell a fresh peer connection from the previous one
+  public connectionId = ''
 
   private pc: RTCPeerConnection | null = null
   private ws: WebSocket | null = null
@@ -30,6 +33,14 @@ export class Go2RTCManager {
    * @param {number} jitterBufferTarget - RTP receiver jitter buffer target in milliseconds
    */
   constructor(private go2rtcPort: number, private streamName: string, private jitterBufferTarget: number) {}
+
+  /**
+   * The current peer connection, exposed for stats monitoring
+   * @returns {RTCPeerConnection | null} The active peer connection, or null if there is none
+   */
+  public get peerConnection(): RTCPeerConnection | null {
+    return this.pc
+  }
 
   /**
    * Start the WebRTC connection to go2rtc.
@@ -76,6 +87,7 @@ export class Go2RTCManager {
 
     const pc = new RTCPeerConnection()
     this.pc = pc
+    this.connectionId = uuid()
 
     pc.addTransceiver('video', { direction: 'recvonly' })
 

--- a/src/composables/go2rtc.ts
+++ b/src/composables/go2rtc.ts
@@ -108,7 +108,12 @@ export class Go2RTCManager {
       console.debug(`[go2rtc] Track added for stream '${this.streamName}'`)
     }
 
-    pc.onconnectionstatechange = () => {
+    // A listener rather than the single-slot pc.onconnectionstatechange, which anything else holding the peer
+    // connection (the stats library, for one) can overwrite, silently taking the reconnection with it
+    pc.addEventListener('connectionstatechange', () => {
+      // A superseded connection must not write the status refs, which by then describe the one that replaced it
+      if (this.pc !== pc) return
+
       const state = pc.connectionState
       console.debug(`[go2rtc] Connection state for '${this.streamName}': ${state}`)
       this.streamStatus.value = state
@@ -127,7 +132,7 @@ export class Go2RTCManager {
           this.connected.value = false
           break
       }
-    }
+    })
 
     this.armConnectWatchdog()
 
@@ -266,7 +271,6 @@ export class Go2RTCManager {
 
     if (this.pc) {
       this.pc.ontrack = null
-      this.pc.onconnectionstatechange = null
       this.pc.onicecandidate = null
       this.pc.close()
       this.pc = null

--- a/src/composables/interactionDialog.ts
+++ b/src/composables/interactionDialog.ts
@@ -9,7 +9,7 @@ import { DialogActions } from '@/types/general'
 /**
  * Options to configure the interaction dialog.
  */
-interface DialogOptions {
+export interface DialogOptions {
   /**
    * Message to display in the dialog. If an array, elements will be displayed as an item list.
    * @type {string}
@@ -51,11 +51,11 @@ interface DialogOptions {
 }
 
 /**
- *
+ * Result returned when the interaction dialog is resolved or dismissed.
  */
-interface DialogResult {
+export interface DialogResult {
   /**
-   *
+   * Whether the user confirmed the dialog (`true`) or dismissed it (`false`).
    */
   isConfirmed: boolean
 }

--- a/src/composables/interactionDialog.ts
+++ b/src/composables/interactionDialog.ts
@@ -97,11 +97,26 @@ export function useInteractionDialog(): {
   })
 
   let dialogApp: App<Element> | null = null
-  let resolveFn: (value: DialogResult | PromiseLike<DialogResult>) => void
-  let rejectFn: (reason?: DialogResult) => void
+  let mountPoint: HTMLElement | null = null
+  let resolveFn: ((value: DialogResult | PromiseLike<DialogResult>) => void) | undefined
+  let rejectFn: ((reason?: DialogResult) => void) | undefined
+
+  const unmountDialog = (): void => {
+    if (dialogApp) {
+      dialogApp.unmount()
+      dialogApp = null
+    }
+    if (mountPoint) {
+      mountPoint.remove()
+      mountPoint = null
+    }
+  }
 
   const mountDialog = (): void => {
-    const mountPoint = document.createElement('div')
+    // Unmount any previously mounted dialog first, otherwise repeated calls stack orphaned dialog
+    // instances that can never be dismissed and end up blocking the whole screen.
+    unmountDialog()
+    mountPoint = document.createElement('div')
     document.body.appendChild(mountPoint)
     dialogApp = createApp(InteractionDialogComponent, {
       ...dialogProps,
@@ -118,6 +133,9 @@ export function useInteractionDialog(): {
   }
 
   const showDialog = (options: DialogOptions): Promise<DialogResult> => {
+    // Settle any still-pending dialog before replacing it so a caller awaiting a superseded dialog doesn't hang
+    // forever. Resolve (rather than reject) to avoid unhandled rejections for the many callers that don't await.
+    resolveFn?.({ isConfirmed: false })
     return new Promise((resolve, reject) => {
       Object.assign(dialogProps, options, { showDialog: true })
       resolveFn = resolve
@@ -128,16 +146,11 @@ export function useInteractionDialog(): {
 
   const closeDialog = (): void => {
     dialogProps.showDialog = false
-    if (dialogApp) {
-      dialogApp.unmount()
-      dialogApp = null
-    }
+    unmountDialog()
   }
 
   onUnmounted(() => {
-    if (dialogApp) {
-      dialogApp.unmount()
-    }
+    unmountDialog()
   })
 
   return { showDialog, closeDialog }

--- a/src/composables/interactionDialog.ts
+++ b/src/composables/interactionDialog.ts
@@ -61,6 +61,16 @@ export interface DialogResult {
 }
 
 /**
+ * Reactive state backing the mounted dialog component.
+ */
+type DialogState = DialogOptions & {
+  /**
+   * Indicates whether the dialog should be shown.
+   */
+  showDialog: boolean
+}
+
+/**
  * Provides methods to control the interaction dialog.
  * @returns {object} - An object containing the showDialog and closeDialog methods.
  */
@@ -77,15 +87,7 @@ export function useInteractionDialog(): {
    */
   closeDialog: () => void
 } {
-  const dialogProps = reactive<
-    DialogOptions & {
-      /**
-       * Indicates whether the dialog should be shown.
-       * @type {boolean}
-       */
-      showDialog: boolean
-    }
-  >({
+  const defaultDialogState = (): DialogState => ({
     message: '',
     variant: '',
     title: '',
@@ -95,6 +97,8 @@ export function useInteractionDialog(): {
     persistent: true,
     timer: 0,
   })
+
+  const dialogProps = reactive<DialogState>(defaultDialogState())
 
   let dialogApp: App<Element> | null = null
   let mountPoint: HTMLElement | null = null
@@ -137,7 +141,9 @@ export function useInteractionDialog(): {
     // forever. Resolve (rather than reject) to avoid unhandled rejections for the many callers that don't await.
     resolveFn?.({ isConfirmed: false })
     return new Promise((resolve, reject) => {
-      Object.assign(dialogProps, options, { showDialog: true })
+      // Merge over a fresh set of defaults so options the caller omits (notably `actions`) never leak from the
+      // previous dialog, which would otherwise leave a stale destructive button on an unrelated dialog.
+      Object.assign(dialogProps, defaultDialogState(), options, { showDialog: true })
       resolveFn = resolve
       rejectFn = reject
       mountDialog()

--- a/src/composables/interactionDialog.ts
+++ b/src/composables/interactionDialog.ts
@@ -76,7 +76,8 @@ type DialogState = DialogOptions & {
  */
 export function useInteractionDialog(): {
   /**
-   * Shows the dialog with the provided options.
+   * Shows the dialog with the provided options. If a dialog with the same options is already open, the pending
+   * promise for it is returned instead of a new dialog being mounted.
    * @param {DialogOptions} options - Options to configure the dialog.
    * @returns {Promise<{ isConfirmed: boolean }>} - A promise that resolves or rejects based on user action.
    */
@@ -104,6 +105,8 @@ export function useInteractionDialog(): {
   let mountPoint: HTMLElement | null = null
   let resolveFn: ((value: DialogResult | PromiseLike<DialogResult>) => void) | undefined
   let rejectFn: ((reason?: DialogResult) => void) | undefined
+  let openDialogKey: string | undefined
+  let openDialogPromise: Promise<DialogResult> | undefined
 
   const unmountDialog = (): void => {
     if (dialogApp) {
@@ -137,21 +140,38 @@ export function useInteractionDialog(): {
   }
 
   const showDialog = (options: DialogOptions): Promise<DialogResult> => {
+    // Callers on a poll or interval ask for the same dialog on every tick. Remounting would tear the open dialog
+    // down and build it back up under the user, so hand back the pending promise while it is still on screen. The
+    // key is the whole resolved state, so the same text with different buttons still gets its own dialog, and
+    // action callbacks drop out of the JSON so freshly built ones don't defeat the comparison.
+    const resolvedOptions = { ...defaultDialogState(), ...options }
+    const key = JSON.stringify(resolvedOptions)
+    if (openDialogPromise && openDialogKey === key) return openDialogPromise
+
     // Settle any still-pending dialog before replacing it so a caller awaiting a superseded dialog doesn't hang
     // forever. Resolve (rather than reject) to avoid unhandled rejections for the many callers that don't await.
     resolveFn?.({ isConfirmed: false })
-    return new Promise((resolve, reject) => {
+    openDialogKey = key
+    openDialogPromise = new Promise<DialogResult>((resolve, reject) => {
       // Merge over a fresh set of defaults so options the caller omits (notably `actions`) never leak from the
       // previous dialog, which would otherwise leave a stale destructive button on an unrelated dialog.
-      Object.assign(dialogProps, defaultDialogState(), options, { showDialog: true })
-      resolveFn = resolve
-      rejectFn = reject
+      Object.assign(dialogProps, resolvedOptions, { showDialog: true })
+      resolveFn = (value) => {
+        openDialogPromise = undefined
+        resolve(value)
+      }
+      rejectFn = (reason) => {
+        openDialogPromise = undefined
+        reject(reason)
+      }
       mountDialog()
     })
+    return openDialogPromise
   }
 
   const closeDialog = (): void => {
     dialogProps.showDialog = false
+    openDialogPromise = undefined
     unmountDialog()
   }
 

--- a/src/composables/snackbar.ts
+++ b/src/composables/snackbar.ts
@@ -3,7 +3,7 @@ import { reactive } from 'vue'
 /**
  * Options to configure the snackbar.
  */
-interface SnackbarOptions {
+export interface SnackbarOptions {
   /**
    * The message to display in the snackbar
    */

--- a/src/composables/webRTC.ts
+++ b/src/composables/webRTC.ts
@@ -43,6 +43,7 @@ export class WebRTCManager {
   private consumerId: string | undefined
   private streamName: string | undefined
   public session: Session | undefined
+  public onUnreceivableVideo?: (codecs: string[]) => void
   private rtcConfiguration: RTCConfiguration
   private selectedICEIPs: string[] = []
   private selectedICEProtocols: string[] = []
@@ -375,6 +376,8 @@ export class WebRTCManager {
       (_sessionId, reason) => this.onSessionClosed(reason),
       (status: string): void => this.updateStreamStatus(status)
     )
+
+    this.session.onUnreceivableVideo = (codecs: string[]): void => this.onUnreceivableVideo?.(codecs)
 
     // Registers Session callback for the Signaller endSession parser
     this.signaller.parseEndSessionQuestion(this.consumerId!, producerId, this.session.id, (sessionId, reason) => {

--- a/src/composables/webRTC.ts
+++ b/src/composables/webRTC.ts
@@ -3,6 +3,7 @@
 import { type Ref, ref, watch } from 'vue'
 
 import * as Connection from '@/libs/connection/connection'
+import { setJitterBufferTarget } from '@/libs/webrtc/jitter-buffer'
 import { Session } from '@/libs/webrtc/session'
 import { Signaller } from '@/libs/webrtc/signaller'
 import type { Stream } from '@/libs/webrtc/signalling_protocol'
@@ -236,7 +237,9 @@ export class WebRTCManager {
     const [remoteStream] = event.streams
     this.mediaStream.value = remoteStream
 
-    this.session?.setJitterBufferTarget(this.JitterBufferTarget)
+    if (this.session?.peerConnection) {
+      setJitterBufferTarget(this.session.peerConnection, this.JitterBufferTarget)
+    }
 
     // Assign 'motion' contentHint to media stream video tracks, so it performs better on low bandwith situations
     // More on that here: https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/contentHint

--- a/src/libs/blueos.ts
+++ b/src/libs/blueos.ts
@@ -345,6 +345,22 @@ export const isWirelessInterfaceName = (interfaceName: string): boolean => inter
 
 const isCabledInterfaceName = (interfaceName: string): boolean => interfaceName.includes('eth')
 
+const minCounterSpanMs = 6000
+
+/**
+ * Turns the progress of one of the vehicle's byte counters into a transfer rate.
+ * The vehicle refreshes those counters slower than Cockpit polls them, so the span has to cover several
+ * refreshes to mean anything: a poll-to-poll delta reads zero most of the time and spikes on the polls that
+ * catch a refresh, on an idle interface just as much as on a busy one.
+ * @param {number} deltaBytes How far the counter moved across the span.
+ * @param {number} spanMs Time the span covers, in milliseconds.
+ * @returns {number} The rate in Mbps, and zero for a span too short to cover a refresh or for a counter reset by a vehicle reboot.
+ */
+export const counterDeltaToMbps = (deltaBytes: number, spanMs: number): number => {
+  if (spanMs < minCounterSpanMs || deltaBytes < 0) return 0
+  return (deltaBytes * 8) / (1024 * 1024) / (spanMs / 1000)
+}
+
 export const getNetworkInfo = async (vehicleAddress: string): Promise<RawNetworkInfo[]> => {
   try {
     const url = `${protocol}//${vehicleAddress}/system-information/system/network`

--- a/src/libs/blueos.ts
+++ b/src/libs/blueos.ts
@@ -183,7 +183,7 @@ export const setKeyDataOnCockpitVehicleStorage = async (
 
 /* eslint-disable jsdoc/require-jsdoc */
 type RawIpInfo = { ip: string; service_type: string; interface_type: string }
-type IpInfo = { ipv4Address: string; interfaceType: string }
+export type IpInfo = { ipv4Address: string; interfaceType: string }
 
 type StreamConfiguration = {
   type: string
@@ -246,6 +246,13 @@ export const getIpsInformationFromVehicle = async (vehicleAddress: string): Prom
     throw new Error(`Could not get information about IPs on BlueOS. ${error}`)
   }
 }
+
+/**
+ * Tells if an interface type reported by the beacon means the vehicle is reached through a cable.
+ * @param {string} interfaceType Interface type as reported by the beacon service.
+ * @returns {boolean} True for wired and USB interfaces.
+ */
+export const isTetheredInterfaceType = (interfaceType: string): boolean => ['WIRED', 'USB'].includes(interfaceType)
 
 /* eslint-disable jsdoc/require-jsdoc */
 type RawM2rServiceInfo = { name: string; version: string; sha: string; build_date: string; authors: string }
@@ -329,12 +336,23 @@ export const getCpusInfo = async (vehicleAddress: string): Promise<RawCpuLoadInf
   }
 }
 
+/**
+ * Tells if a vehicle network interface is a wireless one, judging by the naming convention BlueOS follows.
+ * @param {string} interfaceName Name of the vehicle network interface.
+ * @returns {boolean} True for wireless interfaces.
+ */
+export const isWirelessInterfaceName = (interfaceName: string): boolean => interfaceName.includes('wlan')
+
+const isCabledInterfaceName = (interfaceName: string): boolean => interfaceName.includes('eth')
+
 export const getNetworkInfo = async (vehicleAddress: string): Promise<RawNetworkInfo[]> => {
   try {
     const url = `${protocol}//${vehicleAddress}/system-information/system/network`
     const networkRawInfo: RawNetworkInfo[] = await ky.get(url, { timeout: defaultTimeout }).json()
     return networkRawInfo.filter((network) => {
-      return (network.name.includes('wlan') || network.name.includes('eth')) && !network.name.startsWith('v')
+      return (
+        (isWirelessInterfaceName(network.name) || isCabledInterfaceName(network.name)) && !network.name.startsWith('v')
+      )
     })
   } catch (error) {
     throw new Error(`Could not get network information from BlueOS. ${error}`)

--- a/src/libs/cosmos.ts
+++ b/src/libs/cosmos.ts
@@ -57,6 +57,13 @@ declare global {
   function unused<T>(variable: T): void
 
   /**
+   * Log a user-initiated interaction to the system log with a standard prefix
+   * @param {string} message - Description of the action the user performed
+   * @returns {void}
+   */
+  function logUserAction(message: string): void
+
+  /**
    * Expand Array interface for internal usage
    */
   interface Array<T> {
@@ -582,6 +589,12 @@ global!.unimplemented = function (message?: string) {
 global!.unused = function <T>(variable: T) { } // eslint-disable-line
 
 /* c8 ignore stop */
+
+// Standardized logging for user-initiated interactions. Centralizing the prefix here lets call sites just
+// describe the action (e.g. logUserAction('Opened joystick calibration dialog')) without importing anything.
+global!.logUserAction = function (message: string) {
+  console.info(`[UserAction] ${message}`)
+}
 
 // Extend types
 Array.prototype.first = function <T>(this: T[]): T | undefined {

--- a/src/libs/stream-activation-backoff.ts
+++ b/src/libs/stream-activation-backoff.ts
@@ -1,0 +1,42 @@
+const retryDelayMs = 5000
+
+/**
+ * Backoff bookkeeping for stream activations that failed.
+ *
+ * Stream consumers (video player widget, snapshot tool, recorder) re-request their stream about once a second
+ * and read a missing stream as "not activated yet", so without this a failed activation is retried, and
+ * reported to the user, on every tick. Retries are kept, since the source may still come back, but they are
+ * spaced out and only the failure that starts a streak is worth telling the user about.
+ */
+export class StreamActivationBackoff {
+  private lastFailureTime = new Map<string, number>()
+
+  /**
+   * Whether a stream failed too recently for another activation attempt to be worth making
+   * @param {string} streamName - External stream identifier
+   * @returns {boolean} True while the stream is still inside its retry delay
+   */
+  public isBackingOff(streamName: string): boolean {
+    const lastFailure = this.lastFailureTime.get(streamName)
+    return lastFailure !== undefined && Date.now() - lastFailure < retryDelayMs
+  }
+
+  /**
+   * Record a failed activation attempt, and decide whether this one is worth telling the user about
+   * @param {string} streamName - External stream identifier
+   * @returns {boolean} True when this failure starts a streak, i.e. the user has not been told about it yet
+   */
+  public registerFailure(streamName: string): boolean {
+    const isFirstFailure = !this.lastFailureTime.has(streamName)
+    this.lastFailureTime.set(streamName, Date.now())
+    return isFirstFailure
+  }
+
+  /**
+   * Forget a stream's failure streak, so a later failure is retried right away and reported to the user again
+   * @param {string} streamName - External stream identifier
+   */
+  public forget(streamName: string): void {
+    this.lastFailureTime.delete(streamName)
+  }
+}

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -60,23 +60,51 @@ export const resetCanvas = (context: CanvasRenderingContext2D): void => {
   context.globalCompositeOperation = 'source-over'
 }
 
+// Regex from https://stackoverflow.com/a/106223/3850957
+const ipv4AddressRegex = new RegExp(
+  '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$'
+)
+
 export const isValidNetworkAddress = (maybeAddress: string): boolean => {
   if (maybeAddress && maybeAddress.length >= 255) {
     return false
   }
 
-  // Regexes from https://stackoverflow.com/a/106223/3850957
-  const ipRegex = new RegExp(
-    '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$'
-  )
+  // Regex from https://stackoverflow.com/a/106223/3850957
   const hostnameRegex = new RegExp(
     '^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$'
   )
 
-  if (ipRegex.test(maybeAddress) || hostnameRegex.test(maybeAddress)) {
+  if (ipv4AddressRegex.test(maybeAddress) || hostnameRegex.test(maybeAddress)) {
     return true
   }
   return false
+}
+
+/**
+ * Checks whether a value is a bare IPv4 address, with no scheme, port, or path.
+ * @param {string} value - The value to test.
+ * @returns {boolean} Whether the value is a bare IPv4 address.
+ */
+export const isValidIpv4Address = (value: string): boolean => {
+  return ipv4AddressRegex.test(value)
+}
+
+/**
+ * Extracts a bare IPv4 address from a value that may carry a scheme, port, or path/CIDR suffix
+ * (e.g. `http://192.168.2.2:554/stream`, `192.168.2.0/24`).
+ * @param {string} rawValue - The raw, possibly prefixed or suffixed address.
+ * @returns {string | undefined} The bare IPv4 address, or `undefined` if none could be extracted.
+ */
+export const sanitizeIpv4Address = (rawValue: string): string | undefined => {
+  let candidate = rawValue.trim()
+  if (!candidate) return undefined
+
+  candidate = candidate.replace(/^\w+:\/\//, '')
+  candidate = candidate.split(/[/\\]/)[0]
+  candidate = candidate.split(':')[0]
+
+  return isValidIpv4Address(candidate) ? candidate : undefined
 }
 
 export const isValidURL = (maybeURL: string): boolean => {

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -160,12 +160,16 @@ export const reloadCockpit = (timeout = 3000): void => {
 
 /**
  * Detects if the application is running in Electron
+ *
+ * In the renderer the user agent alone is not enough: Electron-based embedded browsers, like the preview
+ * panes of Electron-based IDEs, carry the same `Electron/<version>` token but never run our preload
+ * script, so the bridge it exposes is what tells our own shell apart from them.
  * @returns {boolean} True if running in Electron, false otherwise
  */
 export const isElectron = (): boolean => {
   // Check if the userAgent contains 'electron' (for renderer process)
   if (typeof navigator === 'object' && typeof navigator.userAgent === 'string') {
-    return navigator.userAgent.toLowerCase().includes('electron')
+    return navigator.userAgent.toLowerCase().includes('electron') && globalThis.window?.electronAPI !== undefined
   }
 
   // Check if the process object exists and contains 'electron' (for main process)

--- a/src/libs/webrtc/jitter-buffer.ts
+++ b/src/libs/webrtc/jitter-buffer.ts
@@ -1,0 +1,43 @@
+/**
+ * Sets the RTP receiver jitter buffer target of every video receiver of a peer connection.
+ * When left unset the browser uses its own adaptive buffer, which grows on CPU or network starvation and does not
+ * shrink back afterwards, so any low-resource event leaves a permanent latency increase behind.
+ * @param {RTCPeerConnection} peerConnection - Connection whose video receivers should be configured
+ * @param {number} jitterBufferTarget - Target buffer time in milliseconds
+ */
+export const setJitterBufferTarget = (peerConnection: RTCPeerConnection, jitterBufferTarget: number): void => {
+  peerConnection.getReceivers().forEach((receiver: RTCRtpReceiver) => {
+    if (receiver.track.kind !== 'video') {
+      return
+    }
+
+    let playoutDelayHint = null
+    if (jitterBufferTarget) {
+      if (jitterBufferTarget > 4000) {
+        jitterBufferTarget = 4000
+      } else if (jitterBufferTarget < 0) {
+        jitterBufferTarget = 0
+      }
+
+      playoutDelayHint = jitterBufferTarget / 1000 // in seconds, legacy Chrome API
+    }
+
+    console.debug(
+      `RTCRtpReceiver jitterBufferTarget attribute set from ${
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (receiver as any).jitterBufferTarget
+      } to ${jitterBufferTarget}`
+    )
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(receiver as any).jitterBufferTarget = jitterBufferTarget // in milliseconds (DOMHighResTimeStamp)
+
+    console.debug(
+      `RTCRtpReceiver playoutDelayHint attribute set from ${
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (receiver as any).playoutDelayHint
+      } to ${playoutDelayHint}`
+    )
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(receiver as any).playoutDelayHint = playoutDelayHint
+  })
+}

--- a/src/libs/webrtc/session.ts
+++ b/src/libs/webrtc/session.ts
@@ -130,47 +130,6 @@ export class Session {
   }
 
   /**
-   * Sets jitterBufferTarget (milliseconds)
-   * @param {number} jitterBufferTarget - Target RTP receiver jitter buffer time in milliseconds
-   */
-  public setJitterBufferTarget(jitterBufferTarget: number): void {
-    this.peerConnection.getReceivers().forEach((receiver: RTCRtpReceiver) => {
-      if (receiver.track.kind !== 'video') {
-        return
-      }
-
-      let playoutDelayHint = null
-      if (jitterBufferTarget) {
-        if (jitterBufferTarget > 4000) {
-          jitterBufferTarget = 4000
-        } else if (jitterBufferTarget < 0) {
-          jitterBufferTarget = 0
-        }
-
-        playoutDelayHint = jitterBufferTarget / 1000 // in seconds, legacy Chrome API
-      }
-
-      console.debug(
-        `RTCRtpReceiver jitterBufferTarget attribute set from ${
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (receiver as any).jitterBufferTarget
-        } to ${jitterBufferTarget}`
-      )
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ;(receiver as any).jitterBufferTarget = jitterBufferTarget // in milliseconds (DOMHighResTimeStamp)
-
-      console.debug(
-        `RTCRtpReceiver playoutDelayHint attribute set from ${
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (receiver as any).playoutDelayHint
-        } to ${playoutDelayHint}`
-      )
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ;(receiver as any).playoutDelayHint = playoutDelayHint
-    })
-  }
-
-  /**
    * Defines the behavior for when a remote SDP is received from the signalling server
    * @param {RTCSessionDescription} description - The SDP received from the signalling server
    */

--- a/src/libs/webrtc/session.ts
+++ b/src/libs/webrtc/session.ts
@@ -1,12 +1,14 @@
 /* eslint-disable jsdoc/no-undefined-types */ // TODO: fix type RTCConfiguration, RTCSessionDescriptionInit, RTCIceCandidateInit and RTCPeerConnectionIceEventInit are undefined
 import type { Signaller } from '@/libs/webrtc/signaller'
 import type { Stream } from '@/libs/webrtc/signalling_protocol'
+import { unreceivableVideoCodecs } from '@/libs/webrtc/video-codec-support'
 
 type OnCloseCallback = (sessionId: string, reason: string) => void
 type OnTrackAddedCallback = (event: RTCTrackEvent) => void
 type onNewIceRemoteAddressCallback = (availableICEIPs: string[]) => void
 type OnStatusChangeCallback = (status: string) => void
 type OnPeerConnectedCallback = () => void
+type OnUnreceivableVideoCallback = (codecs: string[]) => void
 
 /**
  * An abstraction for the Mavlink Camera Manager WebRTC Session
@@ -28,6 +30,7 @@ export class Session {
   public onNewIceRemoteAddress?: onNewIceRemoteAddressCallback
   public onClose?: OnCloseCallback
   public onStatusChange?: OnStatusChangeCallback
+  public onUnreceivableVideo?: OnUnreceivableVideoCallback
 
   /**
    * Creates a new Session instance, connecting with a given Stream
@@ -134,6 +137,16 @@ export class Session {
    * @param {RTCSessionDescription} description - The SDP received from the signalling server
    */
   public onIncomingSDP(description: RTCSessionDescription): void {
+    // Checked on the offer rather than on the failure it causes, as a browser that cannot receive the offered
+    // codec answers without video and simply never plays anything, with no error to report.
+    const unreceivableCodecs = unreceivableVideoCodecs(description.sdp)
+    if (unreceivableCodecs.length > 0) {
+      console.warn(
+        `[WebRTC] [Session] None of the offered video codecs can be received: ${unreceivableCodecs.join(', ')}`
+      )
+      this.onUnreceivableVideo?.(unreceivableCodecs)
+    }
+
     this.peerConnection
       .setRemoteDescription(description)
       .then(() => {

--- a/src/libs/webrtc/stats.ts
+++ b/src/libs/webrtc/stats.ts
@@ -1,0 +1,27 @@
+import { WebRTCStats } from '@peermetrics/webrtc-stats'
+
+import { StreamPeerConnectionInfo } from '@/types/video'
+
+/**
+ * Register a stream's current peer connection for stats monitoring, dropping the monitors of the previous ones
+ * Expects a stats instance dedicated to a single stream, as every other peer registered on it is dropped
+ * @param {ReturnType<typeof WebRTCStats>} stats - Stats instance monitoring the stream
+ * @param {StreamPeerConnectionInfo} pcInfo - The peer connection the stream is currently using, and its ids
+ */
+export const monitorStreamPeerConnection = (
+  stats: ReturnType<typeof WebRTCStats>,
+  pcInfo: StreamPeerConnectionInfo
+): void => {
+  const stalePeerIds = Object.keys(stats.peersToMonitor).filter((peerId) => peerId !== pcInfo.peerId)
+
+  stats.addConnection({
+    pc: pcInfo.peerConnection,
+    peerId: pcInfo.peerId,
+    connectionId: pcInfo.sessionId,
+    remote: false,
+  })
+
+  // Dropped only once the new peer is in, as the library restarts its monitoring intervals whenever the peer
+  // count rises from zero, leaking the interval it was already running
+  stalePeerIds.forEach((peerId) => stats.removePeer(peerId))
+}

--- a/src/libs/webrtc/video-codec-support.ts
+++ b/src/libs/webrtc/video-codec-support.ts
@@ -1,0 +1,46 @@
+// An offer also names the payloads that carry retransmissions and error correction, which every browser
+// accepts and which would otherwise read as a codec it can play.
+const auxiliaryPayloads = ['rtx', 'red', 'ulpfec', 'flexfec-03']
+
+/**
+ * Video codecs an SDP offers, as named in the rtpmap lines of its video sections.
+ * @param {string} sdp - Session description to read
+ * @returns {string[]} Codec names as the SDP spells them, without the auxiliary payloads
+ */
+export const offeredVideoCodecs = (sdp: string): string[] => {
+  const videoSections = sdp.split(/^m=/m).filter((section) => section.startsWith('video'))
+
+  const names = videoSections.flatMap((section) =>
+    [...section.matchAll(/^a=rtpmap:\d+ ([^/\s]+)/gm)].map((match) => match[1])
+  )
+  return [...new Set(names)].filter((name) => !auxiliaryPayloads.includes(name.toLowerCase()))
+}
+
+/**
+ * Offered video codecs that this browser cannot receive, and only when it can receive none of them, since a
+ * single supported codec is enough for the negotiation to settle on it and the video to play.
+ * @param {string} sdp - Session description offered by the camera
+ * @param {RTCRtpCodecCapability[]} receivableCodecs - Codecs the browser receives, queried when not given
+ * @returns {string[]} Offered codec names, or nothing when one of them can be received
+ */
+export const unreceivableVideoCodecs = (
+  sdp: string,
+  receivableCodecs = RTCRtpReceiver.getCapabilities?.('video')?.codecs ?? []
+): string[] => {
+  const offered = offeredVideoCodecs(sdp)
+  if (offered.length === 0) return []
+
+  // An engine that names no codec has told us nothing about what it plays, which is not the same as telling us
+  // that it plays nothing.
+  if (receivableCodecs.length === 0) return []
+
+  const receivable = receivableCodecs.map((codec) => codec.mimeType.replace(/^video\//i, '').toLowerCase())
+  return offered.some((codec) => receivable.includes(codec.toLowerCase())) ? [] : offered
+}
+
+/**
+ * Codec name spelled as camera settings and datasheets do, so users can match it to what they configure.
+ * @param {string} codec - Codec name as an SDP spells it, such as 'H265'
+ * @returns {string} Name for the user, such as 'H.265'
+ */
+export const readableVideoCodecName = (codec: string): string => codec.replace(/^h(26[45])$/i, 'H.$1')

--- a/src/libs/wireless-traffic-warning.ts
+++ b/src/libs/wireless-traffic-warning.ts
@@ -1,0 +1,111 @@
+import { type IpInfo, isTetheredInterfaceType, isWirelessInterfaceName } from '@/libs/blueos'
+
+/**
+ * Watches the upload rate of the vehicle network interfaces and tells when heavy traffic has been
+ * flowing through a wireless link for long enough to be worth warning the user about.
+ */
+export interface WirelessTrafficWatcher {
+  /**
+   * Records a new round of readings and evaluates the traffic condition against them.
+   * @param {Record<string, number>} totalUploadedBytesPerInterface Bytes each vehicle network interface has transmitted since boot, keyed by interface name.
+   * @param {number} timestamp Moment the readings were taken, in milliseconds since the epoch.
+   * @returns {boolean} True when a wireless interface has been busy across every window-long stretch of the recent readings and no warning was shown yet.
+   */
+  shouldWarn: (totalUploadedBytesPerInterface: Record<string, number>, timestamp: number) => boolean
+  /**
+   * Silences the watcher, so a warning that reached the user is not repeated.
+   */
+  registerWarningShown: () => void
+}
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+type CounterSample = { timestamp: number; totalUploadedBytes: number }
+
+const analysisWindowMs = 10000
+const busyWirelessThresholdMbps = 5
+
+// A single large transfer — Cockpit pulls map tile archives and vehicle files over this same link — moves
+// enough bytes to clear the threshold on one window while lasting only seconds, and the once-per-session
+// warning would be spent on it. Asking every window-long stretch of the history to be busy leaves any
+// transfer shorter than a window an idle stretch to fail on, but only once the history spans three windows:
+// below that the transfer sits too close to both ends to leave a whole stretch clear of it. The fourth
+// window is what makes that span reachable at the 1 Hz poll, at the cost of warning around 31 s in.
+const analysisHistoryMs = 4 * analysisWindowMs
+
+// The readings come from a poll that shares the link being measured, so they are lost exactly when the link
+// is congested. Taking the stretches from the samples themselves, instead of from fixed timestamps, keeps a
+// lossy link from silencing the warning, as long as the readings still inside the history span this much of
+// it, which any cadence up to a third of the history guarantees.
+const minHistorySpanMs = analysisHistoryMs - analysisWindowMs
+
+// The vehicle refreshes these counters slower than we poll them, so the per-poll rate reads zero most of
+// the time and spikes on the polls that catch a refresh, on an idle interface just as much as on a busy
+// one. Taking the rate from how far the counter moved across a stretch instead of from what each poll
+// reported is immune to that, and to readings arriving late or out of order.
+const stretchUploadMbps = (from: CounterSample, to: CounterSample): number => {
+  const uploadedBytes = to.totalUploadedBytes - from.totalUploadedBytes
+  if (uploadedBytes < 0) return 0
+  return (uploadedBytes * 8) / (1024 * 1024) / ((to.timestamp - from.timestamp) / 1000)
+}
+
+// Slowest of the stretches spanning at least a window, so an idle one pulls the verdict down with it.
+const slowestSustainedUploadMbps = (samples: CounterSample[]): number => {
+  if (samples.length < 2) return 0
+  if (samples[samples.length - 1].timestamp - samples[0].timestamp < minHistorySpanMs) return 0
+  const rates = samples.flatMap((from, fromIndex) =>
+    samples
+      .slice(fromIndex + 1)
+      .filter((to) => to.timestamp - from.timestamp >= analysisWindowMs)
+      .map((to) => stretchUploadMbps(from, to))
+  )
+  return Math.min(...rates)
+}
+
+/**
+ * Tells if it makes sense to suggest the user to reach the vehicle through the cable, which is only the
+ * case when the vehicle is currently reached over a wireless link and also has a cabled address. An
+ * address that is not one of the reported ones, like an mDNS host name, leaves the current link kind
+ * undetermined, and an unsubstantiated warning is worse than none.
+ * @param {IpInfo[]} ipsInfo Addresses the vehicle is reachable on, as reported by the beacon.
+ * @param {string} currentAddress Address the vehicle is currently being reached on.
+ * @returns {boolean} True when the current link is wireless and a cabled one is available.
+ */
+export const canSuggestCabledLink = (ipsInfo: IpInfo[], currentAddress: string): boolean => {
+  const currentType = ipsInfo.find((ipInfo) => ipInfo.ipv4Address === currentAddress)?.interfaceType
+  if (currentType === undefined || isTetheredInterfaceType(currentType)) return false
+  return ipsInfo.some((ipInfo) => isTetheredInterfaceType(ipInfo.interfaceType))
+}
+
+/**
+ * Creates a watcher holding the rate history the traffic condition is evaluated against.
+ * @returns {WirelessTrafficWatcher} A watcher with no readings recorded yet.
+ */
+export const createWirelessTrafficWatcher = (): WirelessTrafficWatcher => {
+  const samplesPerInterface = new Map<string, CounterSample[]>()
+  let warningShown = false
+
+  return {
+    shouldWarn: (totalUploadedBytesPerInterface, timestamp) => {
+      const historyStart = timestamp - analysisHistoryMs
+      samplesPerInterface.forEach((samples, interfaceName) => {
+        samplesPerInterface.set(
+          interfaceName,
+          samples.filter((sample) => sample.timestamp > historyStart)
+        )
+      })
+      Object.entries(totalUploadedBytesPerInterface).forEach(([interfaceName, totalUploadedBytes]) => {
+        const samples = samplesPerInterface.get(interfaceName) ?? []
+        samples.push({ timestamp, totalUploadedBytes })
+        samplesPerInterface.set(interfaceName, samples)
+      })
+
+      // A vehicle can expose several wireless interfaces, so any of them being busy is enough.
+      const isBusy = ([interfaceName, samples]: [string, CounterSample[]]): boolean =>
+        isWirelessInterfaceName(interfaceName) && slowestSustainedUploadMbps(samples) >= busyWirelessThresholdMbps
+      return !warningShown && [...samplesPerInterface.entries()].some(isBusy)
+    },
+    registerWarningShown: () => {
+      warningShown = true
+    },
+  }
+}

--- a/src/libs/wireless-traffic-warning.ts
+++ b/src/libs/wireless-traffic-warning.ts
@@ -1,4 +1,4 @@
-import { type IpInfo, isTetheredInterfaceType, isWirelessInterfaceName } from '@/libs/blueos'
+import { type IpInfo, counterDeltaToMbps, isTetheredInterfaceType, isWirelessInterfaceName } from '@/libs/blueos'
 
 /**
  * Watches the upload rate of the vehicle network interfaces and tells when heavy traffic has been
@@ -38,17 +38,9 @@ const analysisHistoryMs = 4 * analysisWindowMs
 // it, which any cadence up to a third of the history guarantees.
 const minHistorySpanMs = analysisHistoryMs - analysisWindowMs
 
-// The vehicle refreshes these counters slower than we poll them, so the per-poll rate reads zero most of
-// the time and spikes on the polls that catch a refresh, on an idle interface just as much as on a busy
-// one. Taking the rate from how far the counter moved across a stretch instead of from what each poll
-// reported is immune to that, and to readings arriving late or out of order.
-const stretchUploadMbps = (from: CounterSample, to: CounterSample): number => {
-  const uploadedBytes = to.totalUploadedBytes - from.totalUploadedBytes
-  if (uploadedBytes < 0) return 0
-  return (uploadedBytes * 8) / (1024 * 1024) / ((to.timestamp - from.timestamp) / 1000)
-}
-
-// Slowest of the stretches spanning at least a window, so an idle one pulls the verdict down with it.
+// Taking the rate from how far the counter moved across a stretch, instead of from what each poll reported,
+// is also immune to readings arriving late or out of order. The slowest stretch spanning at least a window
+// decides, so an idle one pulls the verdict down with it.
 const slowestSustainedUploadMbps = (samples: CounterSample[]): number => {
   if (samples.length < 2) return 0
   if (samples[samples.length - 1].timestamp - samples[0].timestamp < minHistorySpanMs) return 0
@@ -56,7 +48,7 @@ const slowestSustainedUploadMbps = (samples: CounterSample[]): number => {
     samples
       .slice(fromIndex + 1)
       .filter((to) => to.timestamp - from.timestamp >= analysisWindowMs)
-      .map((to) => stretchUploadMbps(from, to))
+      .map((to) => counterDeltaToMbps(to.totalUploadedBytes - from.totalUploadedBytes, to.timestamp - from.timestamp))
   )
   return Math.min(...rates)
 }

--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -11,6 +11,7 @@ import { getAllDataLakeVariablesInfo, getDataLakeVariableInfo, setDataLakeVariab
 import { createDataLakeVariable } from '@/libs/actions/data-lake'
 import { altitude_setpoint } from '@/libs/altitude-slider'
 import {
+  counterDeltaToMbps,
   getCpusInfo,
   getCpuTempCelsius,
   getIpsInformationFromVehicle,
@@ -732,10 +733,13 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     const networkDownloadSpeedMbpsVariableId = (interfaceName: string): string =>
       `blueos/network/${interfaceName}/downloadSpeedMbps`
 
-    // Store previous network readings for speed calculation
+    // Store the recent network readings of each interface, which the published speeds are measured across
 
     // eslint-disable-next-line jsdoc/require-jsdoc, prettier/prettier
-    const previousNetworkReadings: Map<string, { bytesReceived: number; bytesTransmitted: number; timestamp: number }> = new Map()
+    const networkReadingsHistory: Map<string, { bytesReceived: number; bytesTransmitted: number; timestamp: number }[]> = new Map()
+
+    // Long enough to span several counter refreshes, which is what makes the published speed the real rate.
+    const speedAveragingWindowMs = 10000
 
     const wirelessTrafficWatcher = createWirelessTrafficWatcher()
     const cabledLinkCheckIntervalMs = 30000
@@ -875,38 +879,31 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
           setDataLakeVariableData(networkTotalTransmittedMBVariableId(networkInterface.name), totalTransmittedMB)
 
           // Calculate and update speeds
-          const previousReading = previousNetworkReadings.get(networkInterface.name)
-          if (previousReading) {
-            const timeDeltaSeconds = (currentTimestamp - previousReading.timestamp) / 1000
-            if (timeDeltaSeconds > 0) {
-              // Calculate speed in bytes per second
-              const downloadSpeedBytesPerSec =
-                (networkInterface.total_received_B - previousReading.bytesReceived) / timeDeltaSeconds
-              const uploadSpeedBytesPerSec =
-                (networkInterface.total_transmitted_B - previousReading.bytesTransmitted) / timeDeltaSeconds
-
-              // Convert to megabits per second (Mbps): bytes/s * 8 bits/byte / (1024 * 1024) = Mbps
-              const downloadSpeedMbps = (downloadSpeedBytesPerSec * 8) / (1024 * 1024)
-              const uploadSpeedMbps = (uploadSpeedBytesPerSec * 8) / (1024 * 1024)
-
-              // Set speeds (ensure they're not negative due to counter resets)
-              setDataLakeVariableData(
-                networkDownloadSpeedMbpsVariableId(networkInterface.name),
-                Math.max(0, downloadSpeedMbps)
-              )
-              setDataLakeVariableData(
-                networkUploadSpeedMbpsVariableId(networkInterface.name),
-                Math.max(0, uploadSpeedMbps)
-              )
-            }
+          const windowStart = currentTimestamp - speedAveragingWindowMs
+          const storedReadings = networkReadingsHistory.get(networkInterface.name) ?? []
+          const readings = storedReadings.filter((reading) => reading.timestamp > windowStart)
+          // A gap longer than the window leaves nothing inside it, and publishing nothing would leave the
+          // previous rate standing as if it were current, so the newest reading is measured against instead.
+          const oldestReading = readings[0] ?? storedReadings[storedReadings.length - 1]
+          if (oldestReading) {
+            const spanMs = currentTimestamp - oldestReading.timestamp
+            setDataLakeVariableData(
+              networkDownloadSpeedMbpsVariableId(networkInterface.name),
+              counterDeltaToMbps(networkInterface.total_received_B - oldestReading.bytesReceived, spanMs)
+            )
+            setDataLakeVariableData(
+              networkUploadSpeedMbpsVariableId(networkInterface.name),
+              counterDeltaToMbps(networkInterface.total_transmitted_B - oldestReading.bytesTransmitted, spanMs)
+            )
           }
 
           // Store current reading for next calculation
-          previousNetworkReadings.set(networkInterface.name, {
+          readings.push({
             bytesReceived: networkInterface.total_received_B,
             bytesTransmitted: networkInterface.total_transmitted_B,
             timestamp: currentTimestamp,
           })
+          networkReadingsHistory.set(networkInterface.name, readings)
         })
 
         // Not awaited, so a slow beacon does not hold this round nor report its failure as a data lake one.

--- a/src/stores/mainVehicle.ts
+++ b/src/stores/mainVehicle.ts
@@ -13,6 +13,7 @@ import { altitude_setpoint } from '@/libs/altitude-slider'
 import {
   getCpusInfo,
   getCpuTempCelsius,
+  getIpsInformationFromVehicle,
   getKeyDataFromCockpitVehicleStorage,
   getNetworkInfo,
   getStatus,
@@ -49,6 +50,7 @@ import type {
 import { Coordinates } from '@/libs/vehicle/types'
 import * as Vehicle from '@/libs/vehicle/vehicle'
 import { VehicleFactory } from '@/libs/vehicle/vehicle-factory'
+import { canSuggestCabledLink, createWirelessTrafficWatcher } from '@/libs/wireless-traffic-warning'
 import type { MissionLoadingCallback, Waypoint } from '@/types/mission'
 
 import { useControllerStore } from './controller'
@@ -735,6 +737,40 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
     // eslint-disable-next-line jsdoc/require-jsdoc, prettier/prettier
     const previousNetworkReadings: Map<string, { bytesReceived: number; bytesTransmitted: number; timestamp: number }> = new Map()
 
+    const wirelessTrafficWatcher = createWirelessTrafficWatcher()
+    const cabledLinkCheckIntervalMs = 30000
+    let checkingCabledLinkSuggestion = false
+    let lastCabledLinkCheckTimestamp = 0
+
+    // Asking the vehicle which links it can be reached on is a request of its own, so it is only made once the
+    // traffic condition holds, and throttled from there. The answer cannot be kept for the session, as a cable
+    // plugged in or pulled changes it. A failure just waits for the next check, since a saturated wireless link
+    // is exactly what makes this request fail, and that is when the warning is most needed.
+    const suggestCabledLinkIfItMakesSense = async (timestamp: number): Promise<void> => {
+      if (checkingCabledLinkSuggestion) return
+      if (timestamp - lastCabledLinkCheckTimestamp < cabledLinkCheckIntervalMs) return
+      checkingCabledLinkSuggestion = true
+      lastCabledLinkCheckTimestamp = timestamp
+
+      try {
+        const ipsInfo = await getIpsInformationFromVehicle(globalAddress.value)
+        if (!canSuggestCabledLink(ipsInfo, globalAddress.value)) return
+      } catch (error) {
+        console.error(`Failed to get the links the vehicle can be reached on: ${error}`)
+        return
+      } finally {
+        checkingCabledLinkSuggestion = false
+      }
+
+      wirelessTrafficWatcher.registerWarningShown()
+      openSnackbar({
+        message:
+          "A lot of data is going through the vehicle's WiFi connection. Connecting through the cabled network should give you better video quality and less delay.",
+        variant: 'warning',
+        persistent: true,
+      })
+    }
+
     const cpusInfos = await getCpusInfo(globalAddress.value)
     cpusInfos.forEach((cpu) => {
       Object.assign(blueOsVariables, {
@@ -825,8 +861,11 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
       try {
         const updatedNetworkInfos = await getNetworkInfo(globalAddress.value)
         const currentTimestamp = Date.now()
+        const totalUploadedBytesPerInterface: Record<string, number> = {}
 
         updatedNetworkInfos.forEach((networkInterface) => {
+          totalUploadedBytesPerInterface[networkInterface.name] = networkInterface.total_transmitted_B
+
           // Convert total bytes to megabytes (MB)
           const totalReceivedMB = networkInterface.total_received_B / (1024 * 1024)
           const totalTransmittedMB = networkInterface.total_transmitted_B / (1024 * 1024)
@@ -869,6 +908,11 @@ export const useMainVehicleStore = defineStore('main-vehicle', () => {
             timestamp: currentTimestamp,
           })
         })
+
+        // Not awaited, so a slow beacon does not hold this round nor report its failure as a data lake one.
+        if (wirelessTrafficWatcher.shouldWarn(totalUploadedBytesPerInterface, currentTimestamp)) {
+          suggestCabledLinkIfItMakesSense(currentTimestamp)
+        }
       } catch (error) {
         console.error(`Failed to update network information in data lake: ${error}`)
       }

--- a/src/stores/omniscientLogger.ts
+++ b/src/stores/omniscientLogger.ts
@@ -11,6 +11,7 @@ import {
 } from '@/libs/actions/data-lake'
 import eventTracker from '@/libs/external-telemetry/event-tracking'
 import { isElectron } from '@/libs/utils'
+import { monitorStreamPeerConnection } from '@/libs/webrtc/stats'
 import { WebRTCStatsEvent, WebRTCVideoStat } from '@/types/video'
 
 import { useMainVehicleStore } from './mainVehicle'
@@ -189,21 +190,16 @@ export const useOmniscientLoggerStore = defineStore('omniscient-logger', () => {
   // Monitor the active streams to add the connections to the WebRTC statistics
   watch(videoStore.activeStreams, (streams) => {
     Object.keys(streams).forEach((streamName) => {
-      const session = streams[streamName]?.webRtcManager?.session
-      if (!session || !session.peerConnection) return
+      const pcInfo = videoStore.getStreamPeerConnection(streamName)
+      if (!pcInfo) return
 
       if (webrtcStreamStats[streamName] === undefined) {
         webrtcStreamStats[streamName] = new WebRTCStats({ getStatsInterval: 100 })
       }
 
-      if (webrtcStreamStats[streamName].peersToMonitor[session.consumerId]) return
+      if (webrtcStreamStats[streamName].peersToMonitor[pcInfo.peerId]) return
 
-      webrtcStreamStats[streamName].addConnection({
-        pc: session.peerConnection, // RTCPeerConnection instance
-        peerId: session.consumerId, // any string that helps you identify this peer,
-        connectionId: session.id, // optional, an id that you can use to keep track of this connection
-        remote: false, // optional, override the global remote flag
-      })
+      monitorStreamPeerConnection(webrtcStreamStats[streamName], pcInfo)
 
       storedKeys.forEach((key) => {
         if (getDataLakeVariableInfo(streamRateVariableId(streamName, key)) === undefined) {
@@ -222,6 +218,9 @@ export const useOmniscientLoggerStore = defineStore('omniscient-logger', () => {
 
       webrtcStreamStats[streamName].on('stats', (ev: WebRTCStatsEvent) => {
         try {
+          // Stats for a peer we no longer monitor describe a connection that has already been replaced
+          if (!webrtcStreamStats[streamName].peersToMonitor[ev.peerId]) return
+
           const videoData = ev.data.video.inbound[0]
           if (videoData === undefined) return
 

--- a/src/stores/snapshot.ts
+++ b/src/stores/snapshot.ts
@@ -4,6 +4,7 @@ import { format } from 'date-fns'
 import saveAs from 'file-saver'
 import piexif from 'piexifjs'
 import { defineStore } from 'pinia'
+import { v4 as uuid } from 'uuid'
 
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { useBlueOsStorage } from '@/composables/settingsSyncer'
@@ -239,6 +240,11 @@ export const useSnapshotStore = defineStore('snapshot', () => {
     }
 
     for (const streamName of streamNames) {
+      // Register as a transient consumer for the whole capture so an ad-hoc snapshot of a stream no widget is
+      // showing doesn't leave it (and its WebRTC session) active afterwards, while keeping it alive for both the
+      // frame grab and the track-settings read below.
+      const consumerId = uuid()
+      videoStore.registerStreamConsumer(streamName, consumerId)
       try {
         let stBlob = await captureStreamFrame(streamName)
         const thumbBlob = await createThumbnail(stBlob, 200, 113)
@@ -255,6 +261,8 @@ export const useSnapshotStore = defineStore('snapshot', () => {
       } catch (err) {
         console.error(`Failed to capture snapshot for stream '${streamName}':`, err)
         failed.push(streamName)
+      } finally {
+        videoStore.unregisterStreamConsumer(streamName, consumerId)
       }
     }
 

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -1015,6 +1015,9 @@ export const useVideoStore = defineStore('video', () => {
 
       if (activeStreams.value[streamName]) {
         activeStreams.value[streamName]!.mediaRecorder = undefined
+        // The recording guard may have kept this stream alive after its last consumer left (e.g. the recorder
+        // widget was unmounted mid-recording); now that recording is done, release it if nothing needs it.
+        deactivateStreamIfUnused(streamName)
       } else {
         console.warn(`Stream '${streamName}' was removed during video processing finalization.`)
       }

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -58,6 +58,9 @@ export const useVideoStore = defineStore('video', () => {
   const allowedIceProtocols = useBlueOsStorage<string[]>('cockpit-allowed-stream-protocols', [])
   const jitterBufferTarget = useBlueOsStorage<number>('cockpit-jitter-buffer-target', 0)
   const activeStreams = ref<{ [key in string]: StreamData | undefined }>({})
+  // Tracks which consumers (widgets, snapshot captures, etc.) currently need each external stream active, so it
+  // can be torn down once nothing references it anymore. Intentionally not reactive/persisted, it's just bookkeeping.
+  const streamConsumers = new Map<string, Set<string>>()
   const mainWebRTCManager = new WebRTCManager(webRTCSignallingURI, rtcConfiguration)
   const availableIceIps = ref<string[]>([])
   const unprocessedVideos = useStorage<{ [key in string]: UnprocessedVideoInfo }>('cockpit-unprocessed-video-info', {})
@@ -465,6 +468,100 @@ export const useVideoStore = defineStore('video', () => {
   }
 
   /**
+   * Tear down all resources tied to an active stream (WebRTC/go2rtc connections, media tracks, recorder), and
+   * remove it from the active streams map.
+   * @param {string} externalId - External stream identifier
+   * @param {string} reason - Human-readable reason, forwarded to the underlying stream managers on close
+   */
+  const teardownStreamResources = (externalId: string, reason: string): void => {
+    const externalStreamData = activeStreams.value[externalId]
+    if (!externalStreamData) return
+
+    // Stop recording if it's active
+    if (externalStreamData.mediaRecorder?.state === 'recording') {
+      externalStreamData.mediaRecorder.stop()
+    }
+
+    // Stop all tracks in the media stream
+    if (externalStreamData.mediaStream) {
+      externalStreamData.mediaStream.getTracks().forEach((track) => {
+        track.stop()
+        console.log(`Stopped track: ${track.kind} for external stream '${externalId}'`)
+      })
+    }
+
+    // Close WebRTC connection
+    if (externalStreamData.webRtcManager) {
+      try {
+        const session = externalStreamData.webRtcManager.session
+        if (session?.peerConnection) {
+          session.peerConnection.close()
+        }
+        externalStreamData.webRtcManager.close(reason)
+        console.log(`Stopped WebRTC manager for external stream '${externalId}'`)
+      } catch (error) {
+        console.warn(`Error stopping WebRTC manager for external stream '${externalId}':`, error)
+      }
+    }
+
+    if (externalStreamData.go2rtcManager) {
+      externalStreamData.go2rtcManager.close(reason)
+      if (window.electronAPI) {
+        void window.electronAPI.go2rtcRemoveStream(externalId).catch((error) => {
+          console.warn(`Error removing go2rtc stream '${externalId}':`, error)
+        })
+      }
+    }
+
+    delete activeStreams.value[externalId]
+    console.log(`Cleaned up all resources for external stream '${externalId}'`)
+  }
+
+  /**
+   * Tear down an external stream if it has no remaining consumers and no recorder attached to it (i.e. neither
+   * recording nor finalizing a just-stopped recording)
+   * @param {string} externalId - External stream identifier
+   */
+  const deactivateStreamIfUnused = (externalId: string): void => {
+    const consumers = streamConsumers.get(externalId)
+    if (consumers && consumers.size > 0) return
+
+    streamConsumers.delete(externalId)
+
+    // Never tear down a stream while a recorder is attached, even if no widget references it: mediaRecorder stays
+    // set through recording and the async stop() finalizer (telemetry/processing), and onstop clears it when done.
+    if (activeStreams.value[externalId]?.mediaRecorder !== undefined) return
+
+    teardownStreamResources(externalId, `External stream '${externalId}' is no longer used by any consumer`)
+  }
+
+  /**
+   * Register a consumer (e.g. a widget) as actively needing an external stream, activating it if needed
+   * @param {string} externalId - External stream identifier
+   * @param {string} consumerId - Unique identifier for the consumer (e.g. widget hash)
+   */
+  const registerStreamConsumer = (externalId: string, consumerId: string): void => {
+    if (!streamConsumers.has(externalId)) {
+      streamConsumers.set(externalId, new Set())
+    }
+    streamConsumers.get(externalId)!.add(consumerId)
+
+    if (activeStreams.value[externalId] === undefined) {
+      activateStream(externalId)
+    }
+  }
+
+  /**
+   * Release a consumer's reference to an external stream, tearing it down if it becomes unused
+   * @param {string} externalId - External stream identifier
+   * @param {string} consumerId - Unique identifier for the consumer (e.g. widget hash)
+   */
+  const unregisterStreamConsumer = (externalId: string, consumerId: string): void => {
+    streamConsumers.get(externalId)?.delete(consumerId)
+    deactivateStreamIfUnused(externalId)
+  }
+
+  /**
    * Get all data related to a given stream, if available
    * @param {string} streamName - Name of the stream
    * @returns {StreamData | undefined} The StreamData object, if available
@@ -754,10 +851,8 @@ export const useVideoStore = defineStore('video', () => {
 
         console.debug(`Live processing started for ${recordingHash}`)
       } catch (error) {
-        // Stop recording and reset the stream data
-        activeStreams.value[streamName]!.mediaRecorder!.stop()
-        activeStreams.value[streamName]!.mediaRecorder = undefined
-        delete activeStreams.value[streamName]
+        // Stop recording and release all resources tied to the stream (WebRTC/go2rtc, tracks, recorder)
+        teardownStreamResources(streamName, `Live processing failed to start for external stream '${streamName}'`)
 
         // Stop live processing if it's running
         if (liveProcessors.value[recordingHash]) {
@@ -1141,48 +1236,10 @@ export const useVideoStore = defineStore('video', () => {
       // Remove from correspondency list
       streamsCorrespondency.value.splice(streamIndex, 1)
 
-      // Clean up all resources for the stream
+      // Clean up all resources for the stream, and any consumer bookkeeping tied to it
+      streamConsumers.delete(externalId)
       if (activeStreams.value[externalId]) {
-        const externalStreamData = activeStreams.value[externalId]
-
-        // Stop recording if it's active
-        if (externalStreamData?.mediaRecorder && externalStreamData.mediaRecorder.state === 'recording') {
-          externalStreamData.mediaRecorder.stop()
-        }
-
-        // Stop all tracks in the media stream
-        if (externalStreamData?.mediaStream) {
-          externalStreamData.mediaStream.getTracks().forEach((track) => {
-            track.stop()
-            console.log(`Stopped track: ${track.kind} for external stream '${externalId}'`)
-          })
-        }
-
-        // Close WebRTC connection
-        if (externalStreamData?.webRtcManager) {
-          try {
-            const session = externalStreamData.webRtcManager.session
-            if (session?.peerConnection) {
-              session.peerConnection.close()
-            }
-            externalStreamData.webRtcManager.close(`External stream '${externalId}' was ignored by user`)
-            console.log(`Stopped WebRTC manager for external stream '${externalId}'`)
-          } catch (error) {
-            console.warn(`Error stopping WebRTC manager for external stream '${externalId}':`, error)
-          }
-        }
-
-        if (externalStreamData?.go2rtcManager) {
-          externalStreamData.go2rtcManager.close(`Stream '${externalId}' deleted by user`)
-          if (window.electronAPI) {
-            void window.electronAPI.go2rtcRemoveStream(externalId).catch((error) => {
-              console.warn(`Error removing go2rtc stream '${externalId}':`, error)
-            })
-          }
-        }
-
-        delete activeStreams.value[externalId]
-        console.log(`Cleaned up all resources for external stream '${externalId}'`)
+        teardownStreamResources(externalId, `External stream '${externalId}' was ignored by user`)
       }
 
       openSnackbar({ variant: 'success', message: `Stream '${stream.name}' deleted and added to ignored list.` })
@@ -1299,6 +1356,8 @@ export const useVideoStore = defineStore('video', () => {
     discardProcessedFilesFromVideoDB,
     getMediaStream,
     getStreamData,
+    registerStreamConsumer,
+    unregisterStreamConsumer,
     getSignallerStatus,
     getStreamStatus,
     getStreamPeerConnection,

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -660,16 +660,30 @@ export const useVideoStore = defineStore('video', () => {
     unprocessedVideos.value = { ...unprocessedVideos.value, ...{ [recordingHash]: videoInfo } }
 
     // Common configuration for the not growing dialogs
+    let notGrowingDialogOpen = false
+    const closeNotGrowingDialog = (): void => {
+      notGrowingDialogOpen = false
+      closeDialog()
+    }
     const suppressNotGrowingDialog = (): void => {
       suppressNotGrowingDialogs.value = true
-      closeDialog()
+      closeNotGrowingDialog()
     }
     const notGrowingDialogConfig = {
       variant: 'error',
+      // Persistent so it can only be closed via the actions below, which reset notGrowingDialogOpen. A
+      // backdrop/Escape dismissal would otherwise leave the flag stuck and stop the dialog from ever reappearing.
+      persistent: true,
       actions: [
         { text: "Don't show again during this session", size: 'small', action: suppressNotGrowingDialog },
-        { text: 'Close', size: 'small', action: closeDialog },
+        { text: 'Close', size: 'small', action: closeNotGrowingDialog },
       ],
+    }
+    // Only show the dialog once at a time, otherwise the timed monitor would re-open it on every tick.
+    const showNotGrowingDialog = (message: string): void => {
+      if (suppressNotGrowingDialogs.value || notGrowingDialogOpen) return
+      notGrowingDialogOpen = true
+      showDialog({ ...notGrowingDialogConfig, message })
     }
 
     // On Electron, we can get the size of the video output file in real time
@@ -698,10 +712,7 @@ export const useVideoStore = defineStore('video', () => {
         }
         const lastKnownFileSize = unprocessedVideos.value[recordingHash].lastKnownFileSize
         if (fileStats.size! <= lastKnownFileSize!) {
-          if (!suppressNotGrowingDialogs.value) {
-            const msg = 'The video output file is not growing. This can indicate a problem with the recording.'
-            showDialog({ ...notGrowingDialogConfig, message: msg })
-          }
+          showNotGrowingDialog('The video output file is not growing. This can indicate a problem with the recording.')
           return
         }
         unprocessedVideos.value[recordingHash].lastKnownFileSize = fileStats.size
@@ -722,10 +733,9 @@ export const useVideoStore = defineStore('video', () => {
         const numberOfChunks = await tempVideoStorage.localForage.length()
         const lastKnownNumberOfChunks = unprocessedVideos.value[recordingHash].lastKnownNumberOfChunks
         if (numberOfChunks <= lastKnownNumberOfChunks!) {
-          if (!suppressNotGrowingDialogs.value) {
-            const msg = 'The number of video chunks is not growing. This can indicate a problem with the recording.'
-            showDialog({ ...notGrowingDialogConfig, message: msg })
-          }
+          showNotGrowingDialog(
+            'The number of video chunks is not growing. This can indicate a problem with the recording.'
+          )
           return
         }
         unprocessedVideos.value[recordingHash].lastKnownNumberOfChunks = numberOfChunks

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -766,13 +766,20 @@ export const useVideoStore = defineStore('video', () => {
 
     if (activeStreams.value[streamName] === undefined) activateStream(streamName)
 
+    // A failed recorder detaches itself, so a chunk arriving after that reaches here with nothing left to stop, and
+    // reporting a successful stop would contradict the failure the user was just told about.
+    if (activeStreams.value[streamName]!.mediaRecorder === undefined) {
+      console.debug(`No recorder attached to stream '${streamName}'. Nothing to stop.`)
+      return
+    }
+
     const timeRecordingStart = activeStreams.value[streamName]?.timeRecordingStart
     const durationInSeconds = timeRecordingStart ? differenceInSeconds(new Date(), timeRecordingStart) : undefined
     eventTracker.capture('Video recording stop', { streamName, durationInSeconds })
 
     activeStreams.value[streamName]!.timeRecordingStart = undefined
 
-    activeStreams.value[streamName]!.mediaRecorder!.stop()
+    activeStreams.value[streamName]!.mediaRecorder?.stop()
 
     alertStore.pushAlert(new Alert(AlertLevel.Success, `Stopped recording stream ${streamName}.`))
   }
@@ -824,6 +831,28 @@ export const useVideoStore = defineStore('video', () => {
     const safeMissionName = sanitizeFilenameComponent(missionStore.missionName) || 'Cockpit'
     const fileName = videoFilename(recordingHash, streamData.timeRecordingStart!, safeMissionName)
     activeStreams.value[streamName]!.mediaRecorder = new MediaRecorder(streamData.mediaStream!)
+    const recorder = activeStreams.value[streamName]!.mediaRecorder!
+    const recorderIsStillAttached = (): boolean => activeStreams.value[streamName]?.mediaRecorder === recorder
+
+    // Registered before starting, as a recorder can fail on the very first frame it is handed
+    activeStreams.value[streamName]!.mediaRecorder!.onerror = (event) => {
+      const error: DOMException | undefined = (event as ErrorEvent).error
+      console.error(`Recorder of stream '${streamName}' failed: ${error?.message ?? 'unknown error'}`)
+      const msg =
+        `Recording of stream '${streamName}' stopped unexpectedly. The video recorded until then was kept and is` +
+        ' available in the Video Library.'
+      showDialog({ message: msg, variant: 'error' })
+      alertStore.pushAlert(new Alert(AlertLevel.Error, msg))
+
+      // The recorder stops itself on error, so the monitor would otherwise nag about a file that stopped growing
+      clearInterval(recordingMonitors[streamName])
+      delete recordingMonitors[streamName]
+
+      // Vue does not proxy a MediaRecorder, so its state flipping to 'inactive' dirties nothing: detaching it here is
+      // what drops the interface out of the recording state, instead of it waiting on the finalization in 'onstop'.
+      activeStreams.value[streamName]!.timeRecordingStart = undefined
+      activeStreams.value[streamName]!.mediaRecorder = undefined
+    }
 
     const videoTrack = streamData.mediaStream!.getVideoTracks()[0]
     const vWidth = videoTrack.getSettings().width || 1920
@@ -1009,7 +1038,7 @@ export const useVideoStore = defineStore('video', () => {
               const msg = `Failed to initialize live processor for stream ${streamName}: ${error.message}`
               showDialog({ message: msg, variant: 'error' })
               alertStore.pushAlert(new Alert(AlertLevel.Error, msg))
-              stopRecording(streamName)
+              if (recorderIsStillAttached()) stopRecording(streamName)
             } else throw error
           }
         }
@@ -1018,7 +1047,7 @@ export const useVideoStore = defineStore('video', () => {
           const msg = 'Failed to initiate recording. First chunk was lost. Try again.'
           showDialog({ message: msg, variant: 'error' })
           alertStore.pushAlert(new Alert(AlertLevel.Error, msg))
-          stopRecording(streamName)
+          if (recorderIsStillAttached()) stopRecording(streamName)
         }
 
         sequentialLostChunks++
@@ -1043,7 +1072,7 @@ export const useVideoStore = defineStore('video', () => {
         const errorMessage = `Failed to generate telemetry overlay: recording metadata for '${recordingHash}' not found.`
         openSnackbar({ message: errorMessage, variant: 'error' })
         delete liveProcessors.value[recordingHash]
-        if (activeStreams.value[streamName]) {
+        if (recorderIsStillAttached()) {
           activeStreams.value[streamName]!.mediaRecorder = undefined
         }
         return
@@ -1080,7 +1109,11 @@ export const useVideoStore = defineStore('video', () => {
       }
 
       if (activeStreams.value[streamName]) {
-        activeStreams.value[streamName]!.mediaRecorder = undefined
+        // The error handler detaches a failed recorder right away, so by now the slot can already hold a newer
+        // recorder that is still running. Only the recorder that stopped may clear it.
+        if (recorderIsStillAttached()) {
+          activeStreams.value[streamName]!.mediaRecorder = undefined
+        }
         // The recording guard may have kept this stream alive after its last consumer left (e.g. the recorder
         // widget was unmounted mid-recording); now that recording is done, release it if nothing needs it.
         deactivateStreamIfUnused(streamName)

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -207,7 +207,11 @@ export const useVideoStore = defineStore('video', () => {
     // ponytail: feeds differing only in the URL query still fall back to '[2]'; keep the query here if one shows up
     const feed = pathSegments.filter(Boolean).pop()?.split('?')[0] ?? ''
 
-    return ['RTSP', host, feed].filter(Boolean).join(' ')
+    // RadCams announce themselves over ONVIF as "UnderwaterCam", which MCM hands us as the source name
+    const sourceName = streamInformation.value.find((info) => info.rtspSourceUrl === rtspUrl)?.sourceName ?? ''
+    const prefix = sourceName.toLowerCase().includes('underwatercam') ? 'RadCam RTSP' : 'RTSP'
+
+    return [prefix, host, feed].filter(Boolean).join(' ')
   }
 
   const initializeStreamsCorrespondency = (): void => {

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -224,13 +224,14 @@ export const useVideoStore = defineStore('video', () => {
     const existingInternalNames = streamsCorrespondency.value.map((corr) => corr.name)
     const newCorrespondencies: VideoStreamCorrespondency[] = []
 
-    let i = 1
     unmappedExternalStreams.forEach((streamName) => {
-      // Find the next available internal name (Stream 1, Stream 2, etc.)
-      let internalName = `Stream ${i}`
+      // Name the stream after the external name, disambiguating collisions with a bracketed counter suffix
+      const baseName = streamName.trim() || 'Stream'
+      let internalName = baseName
+      let suffix = 2
       while (existingInternalNames.includes(internalName)) {
-        i++
-        internalName = `Stream ${i}`
+        internalName = `${baseName} [${suffix}]`
+        suffix++
       }
 
       newCorrespondencies.push({
@@ -238,7 +239,6 @@ export const useVideoStore = defineStore('video', () => {
         externalId: streamName,
       })
       existingInternalNames.push(internalName) // Track this name to avoid duplicates
-      i++
     })
 
     // Add new correspondences to the existing ones instead of replacing them

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -207,24 +207,27 @@ export const useVideoStore = defineStore('video', () => {
     // ponytail: feeds differing only in the URL query still fall back to '[2]'; keep the query here if one shows up
     const feed = pathSegments.filter(Boolean).pop()?.split('?')[0] ?? ''
 
-    // RadCams announce themselves over ONVIF as "UnderwaterCam", which MCM hands us as the source name
+    // Blue Robotics 4K Cams announce themselves over ONVIF as "UnderwaterCam", which MCM hands us as the source name
     const sourceName = streamInformation.value.find((info) => info.rtspSourceUrl === rtspUrl)?.sourceName ?? ''
-    const prefix = sourceName.toLowerCase().includes('underwatercam') ? 'RadCam RTSP' : 'RTSP'
+    const prefix = sourceName.toLowerCase().includes('underwatercam') ? 'BR 4K Cam RTSP' : 'RTSP'
 
     return [prefix, host, feed].filter(Boolean).join(' ')
   }
 
+  // The Blue Robotics 4K Cam's manager extension names its streams '<brand> <host>/<feed>', with 'Blue Robotics 4K Cam' as the brand
+  const isBlueRobotics4kCamStreamName = (name: string): boolean => /^4k cam /.test(name.trim().toLowerCase())
+
   const initializeStreamsCorrespondency = (): void => {
-    // Move already-mapped RadCam WebRTC streams to the ignored list
-    // TODO: This whole logic around auto-ignoring RadCam WebRTC streams should be removed once the MCM stutter problem is fixed
-    const radCamMapped = streamsCorrespondency.value.filter(
+    // Move already-mapped Blue Robotics 4K Cam WebRTC streams to the ignored list
+    // TODO: This whole logic around auto-ignoring Blue Robotics 4K Cam WebRTC streams should be removed once the MCM stutter problem is fixed
+    const fourKCamMapped = streamsCorrespondency.value.filter(
       (corr) =>
         (corr.protocol ?? 'webrtc') === 'webrtc' &&
-        corr.externalId.toLowerCase().includes('radcam') &&
+        isBlueRobotics4kCamStreamName(corr.externalId) &&
         !userRestoredStreamIds.value.includes(corr.externalId)
     )
-    if (radCamMapped.length > 0) {
-      const idsToMove = radCamMapped.map((corr) => corr.externalId)
+    if (fourKCamMapped.length > 0) {
+      const idsToMove = fourKCamMapped.map((corr) => corr.externalId)
       streamsCorrespondency.value = streamsCorrespondency.value.filter((corr) => !idsToMove.includes(corr.externalId))
       const newIgnored = idsToMove.filter((id) => !ignoredStreamExternalIds.value.includes(id))
       if (newIgnored.length > 0) {
@@ -235,19 +238,19 @@ export const useVideoStore = defineStore('video', () => {
     // Get list of external streams that are already mapped
     const alreadyMappedExternalIds = streamsCorrespondency.value.map((corr) => corr.externalId)
 
-    const radCamToIgnore: string[] = []
+    const fourKCamToIgnore: string[] = []
     const unmappedExternalStreams = namesAvailableWebRTCStreams.value.filter((streamName) => {
       if (alreadyMappedExternalIds.includes(streamName)) return false
       if (ignoredStreamExternalIds.value.includes(streamName)) return false
-      if (streamName.toLowerCase().includes('radcam') && !userRestoredStreamIds.value.includes(streamName)) {
-        radCamToIgnore.push(streamName)
+      if (isBlueRobotics4kCamStreamName(streamName) && !userRestoredStreamIds.value.includes(streamName)) {
+        fourKCamToIgnore.push(streamName)
         return false
       }
       return true
     })
 
-    if (radCamToIgnore.length > 0) {
-      ignoredStreamExternalIds.value = [...ignoredStreamExternalIds.value, ...radCamToIgnore]
+    if (fourKCamToIgnore.length > 0) {
+      ignoredStreamExternalIds.value = [...ignoredStreamExternalIds.value, ...fourKCamToIgnore]
     }
 
     if (unmappedExternalStreams.length === 0) return

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -26,6 +26,7 @@ import {
   LiveVideoProcessorInitializationError,
 } from '@/libs/live-video-processor'
 import { datalogger } from '@/libs/sensors-logging'
+import { StreamActivationBackoff } from '@/libs/stream-activation-backoff'
 import { isElectron, isEqual, sanitizeFilenameComponent, sleep } from '@/libs/utils'
 import { tempVideoStorage, videoStorage } from '@/libs/videoStorage'
 import type { Stream } from '@/libs/webrtc/signalling_protocol'
@@ -464,6 +465,7 @@ export const useVideoStore = defineStore('video', () => {
   }, 300)
 
   const rtspActivating = new Set<string>()
+  const rtspActivationBackoff = new StreamActivationBackoff()
   let rtspUnsupportedWarned = false
   const unreceivableVideoWarned = new Set<string>()
   let unreceivableVideoDialogOpened = false
@@ -478,10 +480,19 @@ export const useVideoStore = defineStore('video', () => {
     if (getStreamProtocol(streamName) === 'rtsp') {
       if (rtspActivating.has(streamName)) return
       if (activeStreams.value[streamName]?.go2rtcManager) return
+      if (rtspActivationBackoff.isBackingOff(streamName)) return
+
+      // The external id of an RTSP stream is its URL, credentials included, so never show it to the user
+      const displayName = internalStreamNameFromExternal(streamName) ?? streamName
 
       const rtspUrl = getRtspUrl(streamName)
       if (!rtspUrl) {
-        showDialog({ message: `RTSP URL for stream '${streamName}' is missing.`, variant: 'error' })
+        if (rtspActivationBackoff.registerFailure(streamName)) {
+          const msg =
+            `Video stream '${displayName}' has no address configured.` +
+            ' Delete it and add it again in the video configuration page.'
+          showDialog({ message: msg, variant: 'error' })
+        }
         return
       }
       if (!window.electronAPI) {
@@ -521,10 +532,17 @@ export const useVideoStore = defineStore('video', () => {
             mediaRecorder: undefined,
             timeRecordingStart: undefined,
           }
+          rtspActivationBackoff.forget(streamName)
           console.debug(`Activated RTSP stream '${streamName}' via go2rtc.`)
         } catch (error) {
           console.error(`Failed to activate RTSP stream '${streamName}':`, error)
-          showDialog({ message: `Failed to start RTSP stream '${streamName}'.`, variant: 'error' })
+          if (rtspActivationBackoff.registerFailure(streamName)) {
+            // Nothing in the try above reaches the camera, so a failure here is always local to Cockpit
+            const msg =
+              `Could not start video stream '${displayName}'. Cockpit's video service is not responding.` +
+              ' Restart Cockpit and try again.'
+            showDialog({ message: msg, variant: 'error' })
+          }
         } finally {
           rtspActivating.delete(streamName)
         }
@@ -1353,6 +1371,7 @@ export const useVideoStore = defineStore('video', () => {
 
       // Clean up all resources for the stream, and any consumer bookkeeping tied to it
       streamConsumers.delete(externalId)
+      rtspActivationBackoff.forget(externalId)
       if (activeStreams.value[externalId]) {
         teardownStreamResources(externalId, `External stream '${externalId}' was ignored by user`)
       }

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -4,7 +4,7 @@ import { differenceInSeconds } from 'date-fns'
 import { saveAs } from 'file-saver'
 import { defineStore } from 'pinia'
 import { v4 as uuid } from 'uuid'
-import { computed, ref, watch } from 'vue'
+import { computed, markRaw, ref, watch } from 'vue'
 import adapter from 'webrtc-adapter'
 
 import { Go2RTCManager } from '@/composables/go2rtc'
@@ -424,8 +424,7 @@ export const useVideoStore = defineStore('video', () => {
       if (!activeStreams.value[streamName]?.webRtcManager) return
 
       // Update the list of available remote ICE Ips with those available for each stream
-      // @ts-ignore: availableICEIPs is not reactive here, for some yet to know reason
-      const newIps = activeStreams.value[streamName].webRtcManager.availableICEIPs.filter(
+      const newIps = activeStreams.value[streamName]!.webRtcManager!.availableICEIPs.value.filter(
         (ip: string) => !availableIceIps.value.includes(ip)
       )
       availableIceIps.value = [...availableIceIps.value, ...newIps]
@@ -508,7 +507,8 @@ export const useVideoStore = defineStore('video', () => {
 
           activeStreams.value[streamName] = {
             stream: undefined,
-            go2rtcManager: manager,
+            // A reactive-proxied manager gets its internal refs unwrapped, breaking its own '.value' writes.
+            go2rtcManager: markRaw(manager),
             // @ts-ignore: This is actually not reactive
             mediaStream: mediaStream,
             // @ts-ignore: This is actually not reactive
@@ -557,7 +557,7 @@ export const useVideoStore = defineStore('video', () => {
     activeStreams.value[streamName] = {
       // @ts-ignore: This is actually not reactive
       stream: stream,
-      webRtcManager: webRtcManager,
+      webRtcManager: markRaw(webRtcManager),
       // @ts-ignore: This is actually not reactive
       mediaStream: mediaStream,
       // @ts-ignore: This is actually not reactive
@@ -578,44 +578,49 @@ export const useVideoStore = defineStore('video', () => {
     const externalStreamData = activeStreams.value[externalId]
     if (!externalStreamData) return
 
-    // Stop recording if it's active
-    if (externalStreamData.mediaRecorder?.state === 'recording') {
-      externalStreamData.mediaRecorder.stop()
-    }
-
-    // Stop all tracks in the media stream
-    if (externalStreamData.mediaStream) {
-      externalStreamData.mediaStream.getTracks().forEach((track) => {
-        track.stop()
-        console.log(`Stopped track: ${track.kind} for external stream '${externalId}'`)
-      })
-    }
-
-    // Close WebRTC connection
-    if (externalStreamData.webRtcManager) {
-      try {
-        const session = externalStreamData.webRtcManager.session
-        if (session?.peerConnection) {
-          session.peerConnection.close()
-        }
-        externalStreamData.webRtcManager.close(reason)
-        console.log(`Stopped WebRTC manager for external stream '${externalId}'`)
-      } catch (error) {
-        console.warn(`Error stopping WebRTC manager for external stream '${externalId}':`, error)
+    // A stream left in the map after a failed teardown is unrecoverable: its manager is already
+    // half-closed, and registerStreamConsumer skips activation for a key that exists.
+    try {
+      // Stop recording if it's active
+      if (externalStreamData.mediaRecorder?.state === 'recording') {
+        externalStreamData.mediaRecorder.stop()
       }
-    }
 
-    if (externalStreamData.go2rtcManager) {
-      externalStreamData.go2rtcManager.close(reason)
-      if (window.electronAPI) {
-        void window.electronAPI.go2rtcRemoveStream(externalId).catch((error) => {
-          console.warn(`Error removing go2rtc stream '${externalId}':`, error)
+      // Stop all tracks in the media stream
+      if (externalStreamData.mediaStream) {
+        externalStreamData.mediaStream.getTracks().forEach((track) => {
+          track.stop()
+          console.log(`Stopped track: ${track.kind} for external stream '${externalId}'`)
         })
       }
-    }
 
-    delete activeStreams.value[externalId]
-    console.log(`Cleaned up all resources for external stream '${externalId}'`)
+      // Close WebRTC connection
+      if (externalStreamData.webRtcManager) {
+        try {
+          externalStreamData.webRtcManager.session?.peerConnection.close()
+          externalStreamData.webRtcManager.close(reason)
+          console.log(`Stopped WebRTC manager for external stream '${externalId}'`)
+        } catch (error) {
+          console.warn(`Error stopping WebRTC manager for external stream '${externalId}':`, error)
+        }
+      }
+
+      if (externalStreamData.go2rtcManager) {
+        try {
+          externalStreamData.go2rtcManager.close(reason)
+        } catch (error) {
+          console.warn(`Error stopping go2rtc manager for external stream '${externalId}':`, error)
+        }
+        if (window.electronAPI) {
+          void window.electronAPI.go2rtcRemoveStream(externalId).catch((error) => {
+            console.warn(`Error removing go2rtc stream '${externalId}':`, error)
+          })
+        }
+      }
+    } finally {
+      delete activeStreams.value[externalId]
+      console.log(`Cleaned up all resources for external stream '${externalId}'`)
+    }
   }
 
   /**

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -443,7 +443,7 @@ export const useVideoStore = defineStore('video', () => {
           const port = await window.electronAPI!.go2rtcGetPort()
           await window.electronAPI!.go2rtcAddStream(streamName, rtspUrl)
 
-          const manager = new Go2RTCManager(port, streamName)
+          const manager = new Go2RTCManager(port, streamName, jitterBufferTarget.value)
           const { mediaStream, connected } = manager.start()
 
           activeStreams.value[streamName] = {

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -627,6 +627,14 @@ export const useVideoStore = defineStore('video', () => {
     if (session?.peerConnection) {
       return { peerConnection: session.peerConnection, peerId: session.consumerId, sessionId: session.id }
     }
+
+    const go2rtcManager = data?.go2rtcManager
+    if (go2rtcManager?.peerConnection) {
+      // Fresh id per connection, so a reconnect registers the new peer connection and drops the monitor of the old one.
+      const { peerConnection, connectionId } = go2rtcManager
+      return { peerConnection, peerId: connectionId, sessionId: connectionId }
+    }
+
     return undefined
   }
 

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -59,7 +59,7 @@ export const useVideoStore = defineStore('video', () => {
   console.debug('[WebRTC] Using webrtc-adapter for', adapter.browserDetails)
 
   const streamsCorrespondency = useBlueOsStorage<VideoStreamCorrespondency[]>('cockpit-streams-correspondency', [])
-  const ignoredStreamExternalIds = useBlueOsStorage<string[]>('cockpit-ignored-stream-external-ids', [])
+  const persistedIgnoredStreamExternalIds = useBlueOsStorage<string[]>('cockpit-ignored-stream-external-ids', [])
   const allowedIceIps = useBlueOsStorage<string[]>('cockpit-allowed-stream-ips', [])
   const enableAutoIceIpFetch = useBlueOsStorage('cockpit-enable-auto-ice-ip-fetch', true)
   const allowedIceProtocols = useBlueOsStorage<string[]>('cockpit-allowed-stream-protocols', [])
@@ -77,6 +77,9 @@ export const useVideoStore = defineStore('video', () => {
   const enableLiveProcessing = useBlueOsStorage('cockpit-enable-live-processing', true)
   const keepRawVideoChunksAsBackup = useBlueOsStorage('cockpit-keep-raw-video-chunks-as-backup', true)
   const userRestoredStreamIds = useBlueOsStorage<string[]>('cockpit-user-restored-stream-ids', [])
+  // The ignored list mixes the streams the user chose to hide with the ones an automatic rule hid for them, so this
+  // records which of those ids the user asked for, letting a client the rule does not apply to disregard the rest.
+  const userIgnoredStreamIds = useBlueOsStorage<string[]>('cockpit-user-ignored-stream-ids', [])
   const recordingMonitors: { [key: string]: ReturnType<typeof setInterval> | undefined } = {}
   // Keyed by the warning message, so silencing one recording health warning doesn't silence the others.
   const suppressedRecordingHealthMessages = new Set<string>()
@@ -281,21 +284,40 @@ export const useVideoStore = defineStore('video', () => {
   // The Blue Robotics 4K Cam's manager extension names its streams '<brand> <host>/<feed>', with 'Blue Robotics 4K Cam' as the brand
   const isBlueRobotics4kCamStreamName = (name: string): boolean => /^4k cam /.test(name.trim().toLowerCase())
 
+  // Dropping the WebRTC feed only makes sense where the camera's direct RTSP one can take its place, and RTSP is
+  // Standalone-only, so on Lite the very same rule leaves the user with no stream at all.
+  const shouldAutoIgnore4kCamStream = (externalId: string): boolean =>
+    isElectron() && isBlueRobotics4kCamStreamName(externalId) && !userRestoredStreamIds.value.includes(externalId)
+
+  // The ignored list is vehicle-synced, so the rule's decision reaches Lite anyway, written by an earlier version or
+  // by a Standalone client of the same vehicle. Honouring it there would leave the camera with no stream at all, so
+  // Lite keeps only what the user asked to ignore.
+  const isDisregarded4kCamIgnore = (id: string): boolean =>
+    isBlueRobotics4kCamStreamName(id) && !userIgnoredStreamIds.value.includes(id)
+
+  const ignoredStreamExternalIds = computed(() =>
+    isElectron()
+      ? persistedIgnoredStreamExternalIds.value
+      : persistedIgnoredStreamExternalIds.value.filter((id) => !isDisregarded4kCamIgnore(id))
+  )
+
+  // The one case where the camera comes back on its own: Lite is disregarding an ignore it cannot attribute to the user
+  const hasDisregarded4kCamIgnore = computed(
+    () => !isElectron() && persistedIgnoredStreamExternalIds.value.some(isDisregarded4kCamIgnore)
+  )
+
   const initializeStreamsCorrespondency = (): void => {
     // Move already-mapped Blue Robotics 4K Cam WebRTC streams to the ignored list
     // TODO: This whole logic around auto-ignoring Blue Robotics 4K Cam WebRTC streams should be removed once the MCM stutter problem is fixed
     const fourKCamMapped = streamsCorrespondency.value.filter(
-      (corr) =>
-        (corr.protocol ?? 'webrtc') === 'webrtc' &&
-        isBlueRobotics4kCamStreamName(corr.externalId) &&
-        !userRestoredStreamIds.value.includes(corr.externalId)
+      (corr) => (corr.protocol ?? 'webrtc') === 'webrtc' && shouldAutoIgnore4kCamStream(corr.externalId)
     )
     if (fourKCamMapped.length > 0) {
       const idsToMove = fourKCamMapped.map((corr) => corr.externalId)
       streamsCorrespondency.value = streamsCorrespondency.value.filter((corr) => !idsToMove.includes(corr.externalId))
-      const newIgnored = idsToMove.filter((id) => !ignoredStreamExternalIds.value.includes(id))
+      const newIgnored = idsToMove.filter((id) => !persistedIgnoredStreamExternalIds.value.includes(id))
       if (newIgnored.length > 0) {
-        ignoredStreamExternalIds.value = [...ignoredStreamExternalIds.value, ...newIgnored]
+        persistedIgnoredStreamExternalIds.value = [...persistedIgnoredStreamExternalIds.value, ...newIgnored]
       }
     }
 
@@ -306,7 +328,7 @@ export const useVideoStore = defineStore('video', () => {
     const unmappedExternalStreams = namesAvailableWebRTCStreams.value.filter((streamName) => {
       if (alreadyMappedExternalIds.includes(streamName)) return false
       if (ignoredStreamExternalIds.value.includes(streamName)) return false
-      if (isBlueRobotics4kCamStreamName(streamName) && !userRestoredStreamIds.value.includes(streamName)) {
+      if (shouldAutoIgnore4kCamStream(streamName)) {
         fourKCamToIgnore.push(streamName)
         return false
       }
@@ -314,7 +336,7 @@ export const useVideoStore = defineStore('video', () => {
     })
 
     if (fourKCamToIgnore.length > 0) {
-      ignoredStreamExternalIds.value = [...ignoredStreamExternalIds.value, ...fourKCamToIgnore]
+      persistedIgnoredStreamExternalIds.value = [...persistedIgnoredStreamExternalIds.value, ...fourKCamToIgnore]
     }
 
     if (unmappedExternalStreams.length === 0) return
@@ -1361,8 +1383,11 @@ export const useVideoStore = defineStore('video', () => {
       const stream = streamsCorrespondency.value[streamIndex]
 
       // Add to ignored list and clear user-restored status so auto-ignore can re-apply
-      if (!ignoredStreamExternalIds.value.includes(externalId)) {
-        ignoredStreamExternalIds.value = [...ignoredStreamExternalIds.value, externalId]
+      if (!persistedIgnoredStreamExternalIds.value.includes(externalId)) {
+        persistedIgnoredStreamExternalIds.value = [...persistedIgnoredStreamExternalIds.value, externalId]
+      }
+      if (!userIgnoredStreamIds.value.includes(externalId)) {
+        userIgnoredStreamIds.value = [...userIgnoredStreamIds.value, externalId]
       }
       userRestoredStreamIds.value = userRestoredStreamIds.value.filter((id) => id !== externalId)
 
@@ -1383,11 +1408,12 @@ export const useVideoStore = defineStore('video', () => {
   }
 
   const restoreIgnoredStream = (externalId: string): void => {
-    const ignoredIndex = ignoredStreamExternalIds.value.indexOf(externalId)
+    const ignoredIndex = persistedIgnoredStreamExternalIds.value.indexOf(externalId)
 
     if (ignoredIndex !== -1) {
       // Remove from ignored list
-      ignoredStreamExternalIds.value.splice(ignoredIndex, 1)
+      persistedIgnoredStreamExternalIds.value.splice(ignoredIndex, 1)
+      userIgnoredStreamIds.value = userIgnoredStreamIds.value.filter((id) => id !== externalId)
 
       // Track that the user explicitly restored this stream so auto-ignore won't re-ignore it
       if (!userRestoredStreamIds.value.includes(externalId)) {
@@ -1474,6 +1500,8 @@ export const useVideoStore = defineStore('video', () => {
     tempVideoStorage,
     streamsCorrespondency,
     ignoredStreamExternalIds,
+    hasDisregarded4kCamIgnore,
+    isBlueRobotics4kCamStreamName,
     namessAvailableAbstractedStreams,
     externalStreamId,
     internalStreamNameFromExternal,

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -182,6 +182,34 @@ export const useVideoStore = defineStore('video', () => {
     }
   }
 
+  const uniqueInternalName = (baseName: string, takenNames: string[]): string => {
+    let name = baseName
+    let suffix = 2
+    while (takenNames.includes(name)) {
+      name = `${baseName} [${suffix}]`
+      suffix++
+    }
+    return name
+  }
+
+  // A bare RTSP URL tells the user nothing, so name the stream after the host serving it. Dropping
+  // the credentials keeps them out of the name, and out of the filenames and stored options derived
+  // from it. Not URL(): cameras are not consistent about the '//', and a scheme without it parses
+  // as an opaque path, leaving the hostname empty and the stream named after nothing.
+  const rtspBaseName = (rtspUrl: string): string => {
+    const [authority, ...pathSegments] = rtspUrl
+      .trim()
+      .replace(/^rtsps?:\/{0,2}/i, '')
+      .split('/')
+    const host = (authority.split('@').pop() ?? '').replace(/:\d+$/, '')
+
+    // The path is what tells two feeds of the same camera apart, like an ONVIF main and sub profile
+    // ponytail: feeds differing only in the URL query still fall back to '[2]'; keep the query here if one shows up
+    const feed = pathSegments.filter(Boolean).pop()?.split('?')[0] ?? ''
+
+    return ['RTSP', host, feed].filter(Boolean).join(' ')
+  }
+
   const initializeStreamsCorrespondency = (): void => {
     // Move already-mapped RadCam WebRTC streams to the ignored list
     // TODO: This whole logic around auto-ignoring RadCam WebRTC streams should be removed once the MCM stutter problem is fixed
@@ -225,14 +253,7 @@ export const useVideoStore = defineStore('video', () => {
     const newCorrespondencies: VideoStreamCorrespondency[] = []
 
     unmappedExternalStreams.forEach((streamName) => {
-      // Name the stream after the external name, disambiguating collisions with a bracketed counter suffix
-      const baseName = streamName.trim() || 'Stream'
-      let internalName = baseName
-      let suffix = 2
-      while (existingInternalNames.includes(internalName)) {
-        internalName = `${baseName} [${suffix}]`
-        suffix++
-      }
+      const internalName = uniqueInternalName(streamName.trim() || 'Stream', existingInternalNames)
 
       newCorrespondencies.push({
         name: internalName,
@@ -268,13 +289,8 @@ export const useVideoStore = defineStore('video', () => {
     const existingInternalNames = streamsCorrespondency.value.map((corr) => corr.name)
     const newCorrespondencies: VideoStreamCorrespondency[] = []
 
-    let i = 1
     for (const rtspUrl of unmappedRtspUrls) {
-      let internalName = `RTSP Stream ${i}`
-      while (existingInternalNames.includes(internalName)) {
-        i++
-        internalName = `RTSP Stream ${i}`
-      }
+      const internalName = uniqueInternalName(rtspBaseName(rtspUrl), existingInternalNames)
 
       newCorrespondencies.push({
         name: internalName,
@@ -284,7 +300,6 @@ export const useVideoStore = defineStore('video', () => {
         autoDiscovered: true,
       })
       existingInternalNames.push(internalName)
-      i++
     }
 
     streamsCorrespondency.value = [...streamsCorrespondency.value, ...newCorrespondencies]
@@ -1306,12 +1321,7 @@ export const useVideoStore = defineStore('video', () => {
     }
 
     const existingInternalNames = streamsCorrespondency.value.map((corr) => corr.name)
-    let i = 1
-    let internalName = `RTSP Stream ${i}`
-    while (existingInternalNames.includes(internalName)) {
-      i++
-      internalName = `RTSP Stream ${i}`
-    }
+    const internalName = uniqueInternalName(rtspBaseName(normalizedRtspUrl), existingInternalNames)
 
     const newCorrespondency: VideoStreamCorrespondency = {
       name: internalName,

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -787,29 +787,22 @@ export const useVideoStore = defineStore('video', () => {
     unprocessedVideos.value = { ...unprocessedVideos.value, ...{ [recordingHash]: videoInfo } }
 
     // Common configuration for the not growing dialogs
-    let notGrowingDialogOpen = false
-    const closeNotGrowingDialog = (): void => {
-      notGrowingDialogOpen = false
-      closeDialog()
-    }
     const suppressNotGrowingDialog = (): void => {
       suppressNotGrowingDialogs.value = true
-      closeNotGrowingDialog()
+      closeDialog()
     }
     const notGrowingDialogConfig = {
       variant: 'error',
-      // Persistent so it can only be closed via the actions below, which reset notGrowingDialogOpen. A
-      // backdrop/Escape dismissal would otherwise leave the flag stuck and stop the dialog from ever reappearing.
+      // Persistent so it can only be closed via the actions below. The monitor re-checks every 15 seconds, so the
+      // opt-out action is the only way for the user to stop being told about a problem they already know about.
       persistent: true,
       actions: [
         { text: "Don't show again during this session", size: 'small', action: suppressNotGrowingDialog },
-        { text: 'Close', size: 'small', action: closeNotGrowingDialog },
+        { text: 'Close', size: 'small', action: closeDialog },
       ],
     }
-    // Only show the dialog once at a time, otherwise the timed monitor would re-open it on every tick.
     const showNotGrowingDialog = (message: string): void => {
-      if (suppressNotGrowingDialogs.value || notGrowingDialogOpen) return
-      notGrowingDialogOpen = true
+      if (suppressNotGrowingDialogs.value) return
       showDialog({ ...notGrowingDialogConfig, message })
     }
 

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -1226,17 +1226,7 @@ export const useVideoStore = defineStore('video', () => {
     const streamCorr = streamsCorrespondency.value.find((stream) => stream.externalId === streamID)
 
     if (streamCorr) {
-      const oldInternalName = streamCorr.name
       streamCorr.name = newInternalName
-
-      const streamData = activeStreams.value[oldInternalName]
-      if (streamData) {
-        activeStreams.value = {
-          ...activeStreams.value,
-          [newInternalName]: streamData,
-        }
-        delete activeStreams.value[oldInternalName]
-      }
       lastRenamedStreamName.value = newInternalName
     } else {
       throw new Error(`Stream with ID '${streamID}' not found.`)

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -761,10 +761,7 @@ export const useVideoStore = defineStore('video', () => {
    * @returns {MediaStream | undefined} MediaStream that is running, if available
    */
   const getMediaStream = (streamName: string): MediaStream | undefined => {
-    if (activeStreams.value[streamName] === undefined) {
-      activateStream(streamName)
-    }
-    return activeStreams.value[streamName]!.mediaStream
+    return getStreamData(streamName)?.mediaStream
   }
 
   /**
@@ -773,12 +770,7 @@ export const useVideoStore = defineStore('video', () => {
    * @returns {boolean}
    */
   const isRecording = (streamName: string): boolean => {
-    if (activeStreams.value[streamName] === undefined) activateStream(streamName)
-
-    return (
-      activeStreams.value[streamName]!.mediaRecorder !== undefined &&
-      activeStreams.value[streamName]!.mediaRecorder!.state === 'recording'
-    )
+    return getStreamData(streamName)?.mediaRecorder?.state === 'recording'
   }
 
   /**
@@ -791,22 +783,22 @@ export const useVideoStore = defineStore('video', () => {
     clearInterval(recordingMonitors[streamName])
     delete recordingMonitors[streamName]
 
-    if (activeStreams.value[streamName] === undefined) activateStream(streamName)
+    const streamData = getStreamData(streamName)
 
     // A failed recorder detaches itself, so a chunk arriving after that reaches here with nothing left to stop, and
     // reporting a successful stop would contradict the failure the user was just told about.
-    if (activeStreams.value[streamName]!.mediaRecorder === undefined) {
+    if (streamData?.mediaRecorder === undefined) {
       console.debug(`No recorder attached to stream '${streamName}'. Nothing to stop.`)
       return
     }
 
-    const timeRecordingStart = activeStreams.value[streamName]?.timeRecordingStart
+    const timeRecordingStart = streamData.timeRecordingStart
     const durationInSeconds = timeRecordingStart ? differenceInSeconds(new Date(), timeRecordingStart) : undefined
     eventTracker.capture('Video recording stop', { streamName, durationInSeconds })
 
-    activeStreams.value[streamName]!.timeRecordingStart = undefined
+    streamData.timeRecordingStart = undefined
 
-    activeStreams.value[streamName]!.mediaRecorder?.stop()
+    streamData.mediaRecorder.stop()
 
     alertStore.pushAlert(new Alert(AlertLevel.Success, `Stopped recording stream ${streamName}.`))
   }
@@ -823,26 +815,25 @@ export const useVideoStore = defineStore('video', () => {
    */
   const startRecording = async (streamName: string): Promise<void> => {
     eventTracker.capture('Video recording start', { streamName: streamName })
-    if (activeStreams.value[streamName] === undefined) activateStream(streamName)
+    const streamData = getStreamData(streamName)
 
     if (namesAvailableStreams.value.isEmpty()) {
       showDialog({ message: 'No streams available.', variant: 'error' })
       return
     }
 
-    if (activeStreams.value[streamName]!.mediaStream === undefined) {
+    if (streamData?.mediaStream === undefined) {
       showDialog({ message: 'Media stream not defined.', variant: 'error' })
       return
     }
-    if (!activeStreams.value[streamName]!.mediaStream!.active) {
+    if (!streamData.mediaStream.active) {
       showDialog({ message: 'Media stream not yet active. Wait a second and try again.', variant: 'error' })
       return
     }
 
     await sleep(100)
 
-    activeStreams.value[streamName]!.timeRecordingStart = new Date()
-    const streamData = activeStreams.value[streamName] as StreamData
+    streamData.timeRecordingStart = new Date()
 
     // Generate a unique recording hash
     let recordingHash = ''

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -12,7 +12,12 @@ import { useInteractionDialog } from '@/composables/interactionDialog'
 import { useBlueOsStorage } from '@/composables/settingsSyncer'
 import { useSnackbar } from '@/composables/snackbar'
 import { WebRTCManager } from '@/composables/webRTC'
-import { type ProcessedStreamInfo, getIpsInformationFromVehicle, getStreamInformationFromVehicle } from '@/libs/blueos'
+import {
+  type ProcessedStreamInfo,
+  getIpsInformationFromVehicle,
+  getStreamInformationFromVehicle,
+  isTetheredInterfaceType,
+} from '@/libs/blueos'
 import eventTracker from '@/libs/external-telemetry/event-tracking'
 import { availableCockpitActions, registerActionCallback } from '@/libs/joystick/protocols/cockpit-actions'
 import {
@@ -1235,11 +1240,11 @@ export const useVideoStore = defineStore('video', () => {
           ipsInfo.forEach((ipInfo) => {
             const isIceIp = availableIceIps.value.includes(ipInfo.ipv4Address)
             const alreadyAllowedIp = [...allowedIceIps.value, ...newAllowedIps].includes(ipInfo.ipv4Address)
-            const theteredInterfaceTypes = ['WIRED', 'USB']
-            if (globalAddress === ipInfo.ipv4Address && !theteredInterfaceTypes.includes(ipInfo.interfaceType)) {
+            const isTethered = isTetheredInterfaceType(ipInfo.interfaceType)
+            if (globalAddress === ipInfo.ipv4Address && !isTethered) {
               currentlyOnWirelessConnection = true
             }
-            if (!theteredInterfaceTypes.includes(ipInfo.interfaceType) || alreadyAllowedIp || !isIceIp) return
+            if (!isTethered || alreadyAllowedIp || !isIceIp) return
             console.info(`Adding the wired address '${ipInfo.ipv4Address}' to the list of allowed ICE IPs.`)
             newAllowedIps.push(ipInfo.ipv4Address)
           })

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -71,7 +71,64 @@ export const useVideoStore = defineStore('video', () => {
   const keepRawVideoChunksAsBackup = useBlueOsStorage('cockpit-keep-raw-video-chunks-as-backup', true)
   const userRestoredStreamIds = useBlueOsStorage<string[]>('cockpit-user-restored-stream-ids', [])
   const recordingMonitors: { [key: string]: ReturnType<typeof setInterval> | undefined } = {}
-  const suppressNotGrowingDialogs = ref(false)
+  // Keyed by the warning message, so silencing one recording health warning doesn't silence the others.
+  const suppressedRecordingHealthMessages = new Set<string>()
+  type RecordingHealthWarning = {
+    /**
+     * Text of the warning, shown in the dialog and used as the key of the session opt-out.
+     */
+    message: string
+    /**
+     * Whether the warning means the recording may already be lost, which lets it take the surface from a milder one.
+     */
+    meansDataLoss: boolean
+  }
+  // Shared by the monitors of all recording streams, since they all warn through the same single dialog surface.
+  let openRecordingHealthWarning: RecordingHealthWarning | undefined
+
+  const releaseRecordingHealthDialog = (warning: RecordingHealthWarning): void => {
+    // Compared by identity, not by text: closing the dialog leaves its promise pending, so the release can run a
+    // tick later, once a warning with the very same wording has claimed the surface again.
+    if (openRecordingHealthWarning === warning) openRecordingHealthWarning = undefined
+  }
+  const suppressRecordingHealthDialog = (warning: RecordingHealthWarning): void => {
+    logUserAction(`Silenced the recording health warning "${warning.message}" for this session`)
+    suppressedRecordingHealthMessages.add(warning.message)
+    releaseRecordingHealthDialog(warning)
+    closeDialog()
+  }
+  const closeRecordingHealthDialog = (warning: RecordingHealthWarning): void => {
+    logUserAction(`Closed the recording health warning "${warning.message}"`)
+    releaseRecordingHealthDialog(warning)
+    closeDialog()
+  }
+  const showRecordingHealthDialog = (message: string, meansDataLoss = false): void => {
+    if (suppressedRecordingHealthMessages.has(message)) return
+    // The warning on screen owns the single dialog surface until it is settled, be it by the actions below or by an
+    // unrelated dialog replacing it. Nothing but the user settles it, so a warning about a recording that may
+    // already be lost takes the surface from a milder one instead of waiting behind it forever.
+    // ponytail: warnings that mean the same for the recording queue behind whichever showed first, so a second
+    // unhealthy stream can wait as long as the user leaves the first dialog up. Queue the surface if that bites.
+    if (openRecordingHealthWarning && (openRecordingHealthWarning.meansDataLoss || !meansDataLoss)) return
+    const warning = { message, meansDataLoss }
+    openRecordingHealthWarning = warning
+    const release = (): void => releaseRecordingHealthDialog(warning)
+    showDialog({
+      message,
+      variant: 'error',
+      // Persistent so it can only be closed via the actions below. The monitor re-checks every 15 seconds, so the
+      // opt-out action is the only way for the user to stop being told about a problem they already know about.
+      persistent: true,
+      actions: [
+        {
+          text: "Don't show again during this session",
+          size: 'small',
+          action: () => suppressRecordingHealthDialog(warning),
+        },
+        { text: 'Close', size: 'small', action: () => closeRecordingHealthDialog(warning) },
+      ],
+    }).then(release, release)
+  }
 
   const streamInformation = ref<ProcessedStreamInfo[]>([])
   const go2rtcStreamInfo = ref<Record<string, Go2RTCStreamInfo>>({})
@@ -786,32 +843,15 @@ export const useVideoStore = defineStore('video', () => {
     }
     unprocessedVideos.value = { ...unprocessedVideos.value, ...{ [recordingHash]: videoInfo } }
 
-    // Common configuration for the not growing dialogs
-    const suppressNotGrowingDialog = (): void => {
-      suppressNotGrowingDialogs.value = true
-      closeDialog()
-    }
-    const notGrowingDialogConfig = {
-      variant: 'error',
-      // Persistent so it can only be closed via the actions below. The monitor re-checks every 15 seconds, so the
-      // opt-out action is the only way for the user to stop being told about a problem they already know about.
-      persistent: true,
-      actions: [
-        { text: "Don't show again during this session", size: 'small', action: suppressNotGrowingDialog },
-        { text: 'Close', size: 'small', action: closeDialog },
-      ],
-    }
-    const showNotGrowingDialog = (message: string): void => {
-      if (suppressNotGrowingDialogs.value) return
-      showDialog({ ...notGrowingDialogConfig, message })
-    }
-
     // On Electron, we can get the size of the video output file in real time
     // This is useful to detect if the output file is growing, which is an indication that the recording is still ongoing.
     // On Web, we can only know if the number of chunks is growing, which is an indication that the recording is still ongoing.
     // We also need to clear the interval if it already exists, to avoid multiple intervals running at the same time.
     clearInterval(recordingMonitors[streamName])
     delete recordingMonitors[streamName]
+    // The internal name, since the external id of an RTSP stream is its URL, credentials included, and these warnings
+    // are both shown to the user and written to the logs they share with us.
+    const streamLabel = internalStreamNameFromExternal(streamName) ?? streamName
     if (window.electronAPI) {
       console.info(`Starting electron recording monitor for stream '${streamName}'.`)
       recordingMonitors[streamName] = setInterval(async () => {
@@ -825,14 +865,17 @@ export const useVideoStore = defineStore('video', () => {
         }
         const fileStats = await window.electronAPI?.getFileStats(fileName, ['videos'])
         if (!fileStats || !fileStats.exists) {
-          // eslint-disable-next-line
-          const msg = 'Cannot get size of the video output file. Please check if the file exists. This can indicate a problem with the recording.'
-          showDialog({ message: msg, variant: 'error' })
+          showRecordingHealthDialog(
+            `Cockpit cannot find the file for the recording of stream '${streamLabel}', which means the recording may be lost. We recommend stopping it and starting a new one.`,
+            true
+          )
           return
         }
         const lastKnownFileSize = unprocessedVideos.value[recordingHash].lastKnownFileSize
         if (fileStats.size! <= lastKnownFileSize!) {
-          showNotGrowingDialog('The video output file is not growing. This can indicate a problem with the recording.')
+          showRecordingHealthDialog(
+            `The video output file for stream '${streamLabel}' is not growing. This can indicate a problem with the recording.`
+          )
           return
         }
         unprocessedVideos.value[recordingHash].lastKnownFileSize = fileStats.size
@@ -853,8 +896,8 @@ export const useVideoStore = defineStore('video', () => {
         const numberOfChunks = await tempVideoStorage.localForage.length()
         const lastKnownNumberOfChunks = unprocessedVideos.value[recordingHash].lastKnownNumberOfChunks
         if (numberOfChunks <= lastKnownNumberOfChunks!) {
-          showNotGrowingDialog(
-            'The number of video chunks is not growing. This can indicate a problem with the recording.'
+          showRecordingHealthDialog(
+            `The number of video chunks for stream '${streamLabel}' is not growing. This can indicate a problem with the recording.`
           )
           return
         }

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -24,6 +24,7 @@ import { datalogger } from '@/libs/sensors-logging'
 import { isElectron, isEqual, sanitizeFilenameComponent, sleep } from '@/libs/utils'
 import { tempVideoStorage, videoStorage } from '@/libs/videoStorage'
 import type { Stream } from '@/libs/webrtc/signalling_protocol'
+import { readableVideoCodecName } from '@/libs/webrtc/video-codec-support'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useMissionStore } from '@/stores/mission'
 import { Alert, AlertLevel } from '@/types/alert'
@@ -460,6 +461,8 @@ export const useVideoStore = defineStore('video', () => {
 
   const rtspActivating = new Set<string>()
   let rtspUnsupportedWarned = false
+  const unreceivableVideoWarned = new Set<string>()
+  let unreceivableVideoDialogOpened = false
 
   /**
    * Activates a stream by starting it and storing it's variables inside a common object.
@@ -526,6 +529,25 @@ export const useVideoStore = defineStore('video', () => {
 
     const stream = ref()
     const webRtcManager = new WebRTCManager(webRTCSignallingURI, rtcConfiguration)
+
+    webRtcManager.onUnreceivableVideo = (codecs: string[]): void => {
+      // The camera keeps offering the same codec on every reconnection, so warn once per stream.
+      if (unreceivableVideoWarned.has(streamName)) return
+      unreceivableVideoWarned.add(streamName)
+
+      const codecNames = codecs.map(readableVideoCodecName).join(' or ')
+      const message =
+        `Stream '${streamName}' sends video as ${codecNames}, which Cockpit cannot play.` +
+        ' Set the camera to H.264 to watch it.'
+      alertStore.pushAlert(new Alert(AlertLevel.Error, message))
+
+      // A second camera would replace the dialog of the first, leaving only one of the two ever read, so only
+      // the first one opens it. The alerts above keep an entry per stream either way.
+      if (unreceivableVideoDialogOpened) return
+      unreceivableVideoDialogOpened = true
+      showDialog({ message, variant: 'error' })
+    }
+
     const { mediaStream, connected } = webRtcManager.startStream(
       stream,
       allowedIceIps,

--- a/src/tests/composables/interactionDialog.test.ts
+++ b/src/tests/composables/interactionDialog.test.ts
@@ -1,0 +1,35 @@
+import { expect, test, vi } from 'vitest'
+
+let mounts = 0
+
+vi.mock('@/plugins/vuetify', () => ({ default: () => undefined }))
+vi.mock('@/router', () => ({ default: () => undefined }))
+vi.mock('@/components/InteractionDialog.vue', () => ({
+  default: { template: '<div />', mounted: () => (mounts += 1) },
+}))
+
+import { useInteractionDialog } from '@/composables/interactionDialog'
+
+test('an already open dialog is not remounted by repeated calls with the same options', async () => {
+  const { showDialog, closeDialog } = useInteractionDialog()
+  const problem = { message: 'The recording may be broken.', variant: 'error' }
+
+  const first = showDialog(problem)
+  const second = showDialog(problem)
+  const third = showDialog(problem)
+  expect(mounts).toBe(1)
+  expect(second).toBe(first)
+  expect(third).toBe(first)
+
+  showDialog({ message: 'A different problem.', variant: 'error' })
+  expect(mounts).toBe(2)
+  expect(await first).toEqual({ isConfirmed: false })
+
+  // Same wording, different options, so the caller gets its own dialog instead of the open one's promise.
+  showDialog({ message: 'A different problem.', variant: 'warning' })
+  expect(mounts).toBe(3)
+
+  closeDialog()
+  showDialog({ message: 'A different problem.', variant: 'warning' })
+  expect(mounts).toBe(4)
+})

--- a/src/tests/libs/blueos.test.ts
+++ b/src/tests/libs/blueos.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from 'vitest'
+
+import { counterDeltaToMbps } from '@/libs/blueos'
+
+const megabitsToBytes = (megabits: number): number => (megabits * 1024 * 1024) / 8
+
+test('reads the real rate of a counter that only refreshes every few seconds', () => {
+  // Ten seconds of a 12 Mbps link whose counter last refreshed at second 9, so the newest reading is stale.
+  expect(counterDeltaToMbps(megabitsToBytes(12 * 9), 10000)).toBeCloseTo(10.8)
+
+  // The same link measured between two consecutive polls: one pair falls inside a refresh period and reads
+  // no traffic at all, the next catches the refresh and reads three seconds worth of it as one second.
+  expect(counterDeltaToMbps(0, 1000)).toBe(0)
+  expect(counterDeltaToMbps(megabitsToBytes(12 * 3), 1000)).toBe(0)
+})
+
+test('reports no traffic for a counter reset by a vehicle reboot, and for an empty span', () => {
+  expect(counterDeltaToMbps(-megabitsToBytes(500), 10000)).toBe(0)
+  expect(counterDeltaToMbps(megabitsToBytes(50), 0)).toBe(0)
+})

--- a/src/tests/libs/stream-activation-backoff.test.ts
+++ b/src/tests/libs/stream-activation-backoff.test.ts
@@ -1,0 +1,34 @@
+import { expect, test, vi } from 'vitest'
+
+import { StreamActivationBackoff } from '@/libs/stream-activation-backoff'
+
+test('StreamActivationBackoff', () => {
+  vi.useFakeTimers()
+
+  const backoff = new StreamActivationBackoff()
+  const stream = 'rtsp://192.168.2.10:554/stream_1'
+
+  // The regression this guards: consumers re-request their stream about once a second, so a stream that never
+  // activates used to be retried, and reported to the user, on every one of these ticks.
+  let attempts = 0
+  let dialogs = 0
+  for (let tick = 0; tick < 30; tick++) {
+    if (!backoff.isBackingOff(stream)) {
+      attempts++
+      if (backoff.registerFailure(stream)) dialogs++
+    }
+    vi.advanceTimersByTime(1000)
+  }
+  expect(dialogs).toBe(1)
+  expect(attempts).toBe(6) // 30s of polling, one attempt per 5s of retry delay
+
+  // Other streams are unaffected by this one's failures
+  expect(backoff.isBackingOff('rtsp://192.168.2.11:554/stream_1')).toBe(false)
+
+  // Once it activates, or the user deletes it, a later failure is worth reporting again
+  backoff.forget(stream)
+  expect(backoff.isBackingOff(stream)).toBe(false)
+  expect(backoff.registerFailure(stream)).toBe(true)
+
+  vi.useRealTimers()
+})

--- a/src/tests/libs/utils.test.ts
+++ b/src/tests/libs/utils.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, expect, test } from 'vitest'
+
+import { isElectron } from '@/libs/utils'
+
+const electronUserAgent = 'Mozilla/5.0 Chrome/122.0.6261.156 Electron/29.4.6 Safari/537.36'
+const chromeUserAgent = 'Mozilla/5.0 Chrome/122.0.6261.156 Safari/537.36'
+const originalUserAgent = navigator.userAgent
+
+const setUserAgent = (userAgent: string): void => {
+  Object.defineProperty(navigator, 'userAgent', { value: userAgent, configurable: true })
+}
+
+afterEach(() => {
+  setUserAgent(originalUserAgent)
+  delete window.electronAPI
+})
+
+test('isElectron', () => {
+  // The regression this guards: an Electron-based embedded browser matches the user agent but has no
+  // preload bridge, and taking the Electron path there throws while the app is still booting.
+  setUserAgent(electronUserAgent)
+  expect(isElectron()).toBe(false)
+
+  window.electronAPI = {} as NonNullable<typeof window.electronAPI>
+  expect(isElectron()).toBe(true)
+
+  setUserAgent(chromeUserAgent)
+  expect(isElectron()).toBe(false)
+})

--- a/src/tests/libs/webrtc/jitter-buffer.test.ts
+++ b/src/tests/libs/webrtc/jitter-buffer.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from 'vitest'
+
+import { setJitterBufferTarget } from '@/libs/webrtc/jitter-buffer'
+
+const fakeReceivers = (kinds: string[]): Record<string, unknown>[] =>
+  kinds.map((kind) => ({ track: { kind } } as Record<string, unknown>))
+
+const fakePeerConnection = (receivers: Record<string, unknown>[]): RTCPeerConnection =>
+  ({ getReceivers: () => receivers } as never)
+
+test('Applies the target to video receivers only', () => {
+  const receivers = fakeReceivers(['video', 'audio'])
+
+  setJitterBufferTarget(fakePeerConnection(receivers), 250)
+
+  expect(receivers[0].jitterBufferTarget).toBe(250)
+  expect(receivers[0].playoutDelayHint).toBe(0.25)
+  expect(receivers[1].jitterBufferTarget).toBeUndefined()
+})
+
+test('Clamps the target to the range accepted by browsers', () => {
+  const tooHigh = fakeReceivers(['video'])
+  const negative = fakeReceivers(['video'])
+
+  setJitterBufferTarget(fakePeerConnection(tooHigh), 10000)
+  setJitterBufferTarget(fakePeerConnection(negative), -1)
+
+  expect(tooHigh[0].jitterBufferTarget).toBe(4000)
+  expect(negative[0].jitterBufferTarget).toBe(0)
+})
+
+test('Zero target leaves the legacy hint unset', () => {
+  const receivers = fakeReceivers(['video'])
+
+  setJitterBufferTarget(fakePeerConnection(receivers), 0)
+
+  expect(receivers[0].jitterBufferTarget).toBe(0)
+  expect(receivers[0].playoutDelayHint).toBeNull()
+})

--- a/src/tests/libs/webrtc/stats.test.ts
+++ b/src/tests/libs/webrtc/stats.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from 'vitest'
+
+import { monitorStreamPeerConnection } from '@/libs/webrtc/stats'
+
+test('Registers the new peer connection before dropping the previous one', () => {
+  const calls: string[] = []
+  const peersToMonitor: Record<string, boolean> = { old: true }
+  const stats = {
+    peersToMonitor,
+    addConnection: (options: Record<string, unknown>): void => {
+      calls.push(`add:${options.peerId}`)
+      peersToMonitor[options.peerId as string] = true
+    },
+    removePeer: (peerId: string): void => {
+      calls.push(`remove:${peerId}`)
+      delete peersToMonitor[peerId]
+    },
+  }
+
+  monitorStreamPeerConnection(stats, {
+    peerConnection: {} as RTCPeerConnection,
+    peerId: 'new',
+    sessionId: 'new',
+  })
+
+  expect(calls).toEqual(['add:new', 'remove:old'])
+  expect(Object.keys(peersToMonitor)).toEqual(['new'])
+})
+
+test('Keeps the peer monitored when the same connection is registered again', () => {
+  const peersToMonitor: Record<string, boolean> = { same: true }
+  const stats = {
+    peersToMonitor,
+    addConnection: (options: Record<string, unknown>): void => {
+      peersToMonitor[options.peerId as string] = true
+    },
+    removePeer: (peerId: string): void => {
+      delete peersToMonitor[peerId]
+    },
+  }
+
+  monitorStreamPeerConnection(stats, { peerConnection: {} as RTCPeerConnection, peerId: 'same', sessionId: 'same' })
+
+  expect(Object.keys(peersToMonitor)).toEqual(['same'])
+})

--- a/src/tests/libs/webrtc/video-codec-support.test.ts
+++ b/src/tests/libs/webrtc/video-codec-support.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+
+import { offeredVideoCodecs, readableVideoCodecName, unreceivableVideoCodecs } from '@/libs/webrtc/video-codec-support'
+
+const capabilities = (mimeTypes: string[]): RTCRtpCodecCapability[] =>
+  mimeTypes.map((mimeType) => ({ mimeType, clockRate: 90000 }))
+
+// Trimmed from what mavlink-camera-manager offers for an H.265 camera, which names H.265 as its only video
+// payload, alongside the retransmission payload that pairs with it.
+const hevcOnlyOffer = [
+  'v=0',
+  'o=- 0 0 IN IP4 127.0.0.1',
+  's=-',
+  't=0 0',
+  'm=video 9 UDP/TLS/RTP/SAVPF 96 97',
+  'a=rtpmap:96 H265/90000',
+  'a=rtpmap:97 rtx/90000',
+  'a=fmtp:97 apt=96',
+  'a=sendonly',
+  'm=audio 9 UDP/TLS/RTP/SAVPF 111',
+  'a=rtpmap:111 opus/48000/2',
+].join('\r\n')
+
+const hevcAndH264Offer = hevcOnlyOffer.replace(
+  'a=rtpmap:96 H265/90000',
+  'a=rtpmap:96 H265/90000\r\na=rtpmap:98 H264/90000'
+)
+
+const twoVideoSectionsOffer = [hevcOnlyOffer, 'm=video 9 UDP/TLS/RTP/SAVPF 98', 'a=rtpmap:98 H264/90000'].join('\r\n')
+
+// Verbatim offer of an H.265 camera published by mavlink-camera-manager, which bundles a single video
+// section and pairs the codec with a retransmission payload.
+const cameraHevcOffer =
+  'v=0\r\no=- 8756736665354191860 0 IN IP4 0.0.0.0\r\ns=-\r\nt=0 0\r\na=ice-options:trickle\r\n' +
+  'a=group:BUNDLE video0\r\nm=video 9 UDP/TLS/RTP/SAVPF 96 97\r\nc=IN IP4 0.0.0.0\r\na=setup:actpass\r\n' +
+  'a=rtcp-mux\r\na=rtcp-rsize\r\na=sendonly\r\na=rtpmap:96 H265/90000\r\na=rtcp-fb:96 nack\r\n' +
+  'a=rtcp-fb:96 nack pli\r\na=rtcp-fb:96 ccm fir\r\na=rtcp-fb:96 transport-cc\r\na=rtpmap:97 rtx/90000\r\n' +
+  'a=fmtp:97 apt=96\r\na=mid:video0\r\n'
+
+describe('offeredVideoCodecs', () => {
+  it('reads the video codecs an offer names', () => {
+    expect(offeredVideoCodecs(hevcOnlyOffer)).toEqual(['H265'])
+    expect(offeredVideoCodecs(hevcAndH264Offer)).toEqual(['H265', 'H264'])
+    expect(offeredVideoCodecs(cameraHevcOffer)).toEqual(['H265'])
+  })
+
+  it('reads every video section of an offer, not only the first', () => {
+    expect(offeredVideoCodecs(twoVideoSectionsOffer)).toEqual(['H265', 'H264'])
+  })
+
+  it('leaves out the auxiliary payloads, which are not codecs the video can arrive as', () => {
+    const offer = hevcOnlyOffer.replace('a=sendonly', 'a=rtpmap:98 red/90000\r\na=rtpmap:99 ulpfec/90000')
+    expect(offeredVideoCodecs(offer)).toEqual(['H265'])
+  })
+
+  it('reads nothing from an offer without video', () => {
+    expect(offeredVideoCodecs('v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\na=rtpmap:111 opus/48000/2')).toEqual([])
+    expect(offeredVideoCodecs('')).toEqual([])
+  })
+})
+
+describe('unreceivableVideoCodecs', () => {
+  const withoutHevc = capabilities(['video/VP8', 'video/VP9', 'video/H264', 'video/rtx', 'video/red'])
+  const withHevc = capabilities(['video/VP8', 'video/H264', 'video/H265', 'video/rtx'])
+
+  it('names the codec when the browser can receive none of the offered ones', () => {
+    expect(unreceivableVideoCodecs(hevcOnlyOffer, withoutHevc)).toEqual(['H265'])
+    expect(unreceivableVideoCodecs(cameraHevcOffer, withoutHevc)).toEqual(['H265'])
+    expect(unreceivableVideoCodecs(cameraHevcOffer, withHevc)).toEqual([])
+  })
+
+  it('stays quiet when the browser can receive an offered codec', () => {
+    expect(unreceivableVideoCodecs(hevcOnlyOffer, withHevc)).toEqual([])
+    expect(unreceivableVideoCodecs(hevcAndH264Offer, withoutHevc)).toEqual([])
+    expect(unreceivableVideoCodecs(twoVideoSectionsOffer, withoutHevc)).toEqual([])
+  })
+
+  it('does not take the retransmission payload for a codec it can play', () => {
+    expect(unreceivableVideoCodecs(hevcOnlyOffer, capabilities(['video/rtx']))).toEqual(['H265'])
+  })
+
+  it('stays quiet when there is no video to play, and when the browser reports no codecs at all', () => {
+    expect(unreceivableVideoCodecs('v=0\r\ns=-', withoutHevc)).toEqual([])
+    expect(unreceivableVideoCodecs(hevcOnlyOffer, [])).toEqual([])
+  })
+})
+
+describe('readableVideoCodecName', () => {
+  it('spells the codec as camera settings do', () => {
+    expect(readableVideoCodecName('H265')).toBe('H.265')
+    expect(readableVideoCodecName('h264')).toBe('H.264')
+    expect(readableVideoCodecName('VP8')).toBe('VP8')
+    expect(readableVideoCodecName('AV1')).toBe('AV1')
+  })
+})

--- a/src/tests/libs/wireless-traffic-warning.test.ts
+++ b/src/tests/libs/wireless-traffic-warning.test.ts
@@ -1,0 +1,95 @@
+import { expect, test } from 'vitest'
+
+import {
+  canSuggestCabledLink,
+  createWirelessTrafficWatcher,
+  WirelessTrafficWatcher,
+} from '@/libs/wireless-traffic-warning'
+
+const megabitsToBytes = (megabits: number): number => (megabits * 1024 * 1024) / 8
+
+// Feeds one reading per second, of counters advancing at a steady rate on each interface.
+const feedSteadySeconds = (
+  watcher: WirelessTrafficWatcher,
+  seconds: number,
+  uploadMbpsPerInterface: Record<string, number>,
+  firstSecond = 0
+): boolean[] =>
+  Array.from({ length: seconds }, (_, index) => {
+    const second = firstSecond + index
+    const counters = Object.entries(uploadMbpsPerInterface).map(([name, mbps]) => [
+      name,
+      megabitsToBytes(mbps * second),
+    ])
+    return watcher.shouldWarn(Object.fromEntries(counters), second * 1000)
+  })
+
+test('warns only once the wireless link has been busy across every stretch of the history', () => {
+  const watcher = createWirelessTrafficWatcher()
+  const verdicts = feedSteadySeconds(watcher, 31, { eth0: 1, wlan0: 6 })
+
+  expect(verdicts.slice(0, 30)).not.toContain(true)
+  expect(verdicts[30]).toBe(true)
+
+  // A verdict that never made it to the user does not count, so it keeps being offered until it does.
+  expect(feedSteadySeconds(watcher, 5, { eth0: 1, wlan0: 6 }, 31)).not.toContain(false)
+
+  watcher.registerWarningShown()
+
+  // The advice cannot be acted on without reloading Cockpit, so it is given once and never repeated.
+  expect(feedSteadySeconds(watcher, 400, { eth0: 1, wlan0: 6 }, 36)).not.toContain(true)
+})
+
+test('stays quiet below the busy threshold', () => {
+  expect(feedSteadySeconds(createWirelessTrafficWatcher(), 35, { eth0: 0, wlan0: 4.9 })).not.toContain(true)
+
+  // The same run just above the threshold has to warn, or the silence above is only the history gate.
+  expect(feedSteadySeconds(createWirelessTrafficWatcher(), 35, { eth0: 0, wlan0: 5.1 })).toContain(true)
+})
+
+test('still warns when the readings arrive five seconds apart', () => {
+  const watcher = createWirelessTrafficWatcher()
+  const verdicts = Array.from({ length: 8 }, (_, index) =>
+    watcher.shouldWarn({ wlan0: megabitsToBytes(6 * index * 5) }, index * 5000)
+  )
+
+  expect(verdicts).toContain(true)
+})
+
+test('warns on a busy link whose counter only refreshes every few readings', () => {
+  const watcher = createWirelessTrafficWatcher()
+
+  // The vehicle refreshes the counter every third poll, so two out of three readings report no progress at
+  // all and the third reports three seconds worth of it. The link is carrying 12 Mbps the whole time.
+  const verdicts = Array.from({ length: 35 }, (_, second) =>
+    watcher.shouldWarn({ eth0: 0, wlan0: megabitsToBytes(12 * (second - (second % 3))) }, second * 1000)
+  )
+
+  expect(verdicts).toContain(true)
+})
+
+test('a single transfer on an otherwise idle wireless link does not warn, however big it is', () => {
+  const watcher = createWirelessTrafficWatcher()
+
+  // 200 Mbit at 50 Mbps, spread over four readings so the history can be cut between them, which is the
+  // shape a real transfer has and the one a rule made of fixed windows lets through. It starts off a window
+  // boundary, so the verdict rests on the history being long enough rather than on the alignment.
+  const uploadedMegabits = (second: number): number => Math.min(Math.max(second - 8, 0), 4) * 50
+  const verdicts = Array.from({ length: 60 }, (_, second) =>
+    watcher.shouldWarn({ eth0: 0, wlan0: megabitsToBytes(uploadedMegabits(second)) }, second * 1000)
+  )
+
+  expect(verdicts).not.toContain(true)
+})
+
+test('only suggests the cable when the vehicle is reached wirelessly and a cabled address exists', () => {
+  const wireless = { ipv4Address: '192.168.10.5', interfaceType: 'WIFI' }
+  const wired = { ipv4Address: '192.168.2.2', interfaceType: 'WIRED' }
+
+  expect(canSuggestCabledLink([wireless, wired], wireless.ipv4Address)).toBe(true)
+  expect(canSuggestCabledLink([wireless, wired], wired.ipv4Address)).toBe(false)
+  expect(canSuggestCabledLink([wireless], wireless.ipv4Address)).toBe(false)
+
+  // An mDNS host name matches none of the reported addresses, leaving the current link kind unknown.
+  expect(canSuggestCabledLink([wireless, wired], 'blueos-avahi.local')).toBe(false)
+})

--- a/src/views/ConfigurationVideoView.vue
+++ b/src/views/ConfigurationVideoView.vue
@@ -153,6 +153,13 @@
                   ({{ ignoredStreamExternalIds.length }} ignored)
                 </span>
               </div>
+              <div v-if="show4kCamBrowserNote" class="text-gray-400 text-sm mt-2 mr-2 w-[95%]">
+                The video from your 4K camera may stutter in this browser version of Cockpit. The desktop version plays
+                this camera through its own connection, which is smoother — install it if the stuttering bothers you.
+                <span v-if="videoStore.hasDisregarded4kCamIgnore">
+                  If you had hidden this camera before, it is showing again: hide it once more and it will stay hidden.
+                </span>
+              </div>
               <div v-if="isElectron()" class="mt-4 mr-2 mb-2 w-[95%]">
                 <div class="text-sm text-gray-300 mb-2">Add direct RTSP stream (Standalone)</div>
                 <div class="flex items-end gap-2 w-full">
@@ -500,6 +507,12 @@ const streamsToShow = computed(() => {
       : []),
   ].filter((item) => item.name !== '')
 })
+
+const show4kCamBrowserNote = computed(
+  () =>
+    !isElectron() &&
+    videoStore.streamsCorrespondency.some((corr) => videoStore.isBlueRobotics4kCamStreamName(corr.externalId))
+)
 
 const openEditDialog = (item: VideoStreamCorrespondency): void => {
   editingStream.value = item

--- a/src/views/ConfigurationVideoView.vue
+++ b/src/views/ConfigurationVideoView.vue
@@ -185,7 +185,7 @@
           <template #content>
             <div class="flex justify-center flex-col w-[90%] ml-2">
               <v-combobox
-                v-model="allowedIceIps"
+                :model-value="allowedIceIps"
                 multiple
                 :items="availableIceIps"
                 label="Allowed WebRTC remote IP Addresses"
@@ -196,6 +196,7 @@
                 density="compact"
                 clearable
                 hide-details
+                @update:model-value="handleAllowedIpsUpdate"
               />
               <v-checkbox
                 v-model="videoStore.enableAutoIceIpFetch"
@@ -453,7 +454,8 @@ import { computed, onMounted, ref } from 'vue'
 import ExpansiblePanel from '@/components/ExpansiblePanel.vue'
 import InteractionDialog from '@/components/InteractionDialog.vue'
 import ScrollingText from '@/components/ScrollingText.vue'
-import { isElectron } from '@/libs/utils'
+import { openSnackbar } from '@/composables/snackbar'
+import { isElectron, isValidIpv4Address, sanitizeIpv4Address } from '@/libs/utils'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useSnapshotStore } from '@/stores/snapshot'
 import { useVideoStore } from '@/stores/video'
@@ -608,6 +610,55 @@ onMounted(async () => {
     allowedIceProtocols.value = availableICEProtocols
   }
 })
+
+/**
+ * Sanitizes the list of allowed WebRTC IPs, stripping schemes/ports/paths from prefixed entries and
+ * dropping ones with no extractable IPv4 address, notifying the user of any changes made.
+ * @param {string[] | null} newValue - The raw list of IPs coming from the combobox.
+ */
+function handleAllowedIpsUpdate(newValue: string[] | null): void {
+  if (!newValue) {
+    allowedIceIps.value = []
+    return
+  }
+
+  const cleanedIps: string[] = []
+  const cleanedNotes: string[] = []
+  const rejectedValues: string[] = []
+
+  newValue.forEach((value) => {
+    if (isValidIpv4Address(value)) {
+      cleanedIps.push(value)
+      return
+    }
+
+    const sanitized = sanitizeIpv4Address(value)
+    if (sanitized === undefined) {
+      rejectedValues.push(value)
+      return
+    }
+
+    cleanedIps.push(sanitized)
+    cleanedNotes.push(`'${value}' -> '${sanitized}'`)
+  })
+
+  allowedIceIps.value = [...new Set(cleanedIps)]
+
+  if (cleanedNotes.length > 0) {
+    openSnackbar({
+      message: `Cleaned up allowed WebRTC IP(s): ${cleanedNotes.join(', ')}.`,
+      variant: 'info',
+      persistent: true,
+    })
+  }
+  if (rejectedValues.length > 0) {
+    openSnackbar({
+      message: `Could not extract a valid IP address from: ${rejectedValues.join(', ')}. Entry not added.`,
+      variant: 'warning',
+    })
+  }
+  logUserAction(`Updated allowed WebRTC IPs to [${allowedIceIps.value.join(', ')}]`)
+}
 
 const openVideoLibrary = (): void => {
   interfaceStore.videoLibraryVisibility = true


### PR DESCRIPTION
Backports the video work needed for the 4K Cam launch onto the 1.18 stable line, so 1.18.3 can ship it without carrying the rest of the 1.19 beta.

Base is `v1.18-dev`, branched from the `v1.18.2` tag. Every commit is a `cherry-pick -x` of its master counterpart, so each one links back to the original.

## What is in it

Directly about the camera:

- #2954 rename RadCam mentions to 4K Cam
- #2905 name auto-created streams after the external stream name, and RTSP streams after the camera serving them
- #2906 flag RTSP as the preferred option on the camera replacement dialog
- #2980 keep the 4K Cam WebRTC stream on Lite

The RTSP and video path the camera runs on:

- #2965 crashes caused by RTSP streams
- #2949 apply the configured jitter buffer target to RTSP streams
- #2948 stop reopening the RTSP failure dialog on every poll
- #2968 report video failures that were silent
- #2981 warn when the selected video stream is gone
- #2830 leaked WebRTC sessions from unused streams
- #2822 sanitize allowed WebRTC IP entries
- #2951 stop the recording health monitor from reopening its dialog
- #2955 warn when heavy traffic goes through the vehicle's wireless link

## Dependencies pulled in

Five commits beyond that list, needed to make the above apply and run correctly:

- The four interaction-dialog commits #2951 builds on (`Export types from Snackbar and Interaction Dialog`, `prevent interaction dialogs from stacking into undismissible orphans`, `stop recording monitor from re-opening the not-growing dialog`, `interaction-dialog: reset props between dialogs`). Without them #2951 conflicts badly and the hand-resolved result diverges from master.
- The `logUserAction` global helper (#2814). Three backported commits call it and it does not exist on this line. ESLint catches the call in `ConfigurationVideoView.vue`, but the two in `src/stores/video.ts` would only surface as a `ReferenceError` when the user dismissed the recording health warning.

#2839 (broadcasting recording and snapshot actions over MAVLink) was left out: it conflicts heavily and is unrelated to the camera.

## CI fix carried along

The last commit backports #2781, which removes snapcraft from the workflow. It is unrelated to the camera, but the 1.18 line cannot build without it: the arm64 Linux job installs snapcraft unpinned, and Canonical now serves 9.0.1, which dropped support for the `core20` base the build asks for. That job fails on this line regardless of content, and would fail again on the release tag. Master has not hit it since #2781 landed in June, after v1.18.2 was cut.

## Conflicts resolved

Three, all context drift:

- `MiniVideoRecorder.vue` (#2830) and `ConfigurationVideoView.vue` (#2980) took the master version verbatim.
- `src/tests/libs/utils.test.ts` (#2985) does not exist on this line, so it was created with only the `isElectron` test; `serializeForLogging` is not on 1.18.

## Test plan

- [x] `yarn lint` clean, no warnings
- [x] `yarn build` passes
- [x] Unit tests go from 21 to 46 passing, including every test the backported PRs bring. `cosmos.test.ts` and `connection/connection.test.ts` still fail, identically to a pristine `v1.18.2` checkout
- [ ] 4K Cam on real hardware, on Standalone and on Lite: the stream is auto-ignored on Standalone in favour of RTSP, and stays visible on Lite
- [ ] Record from the camera and confirm the health dialog does not reopen on every poll