### PR TITLE
Raise the reported budget of the Claude PR review

### DIFF
--- a/.github/workflows/claude-pr-review-continue.yml
+++ b/.github/workflows/claude-pr-review-continue.yml
@@ -404,9 +404,11 @@ jobs:
         continue-on-error: true
         env:
           EXECUTION_FILE: ${{ steps.review.outputs.execution_file }}
-          # Derived from the cost line this step prints: 80 turns landed at $3.83-$4.02, so 120 turns
-          # sits near $6. max_turns is what actually caps spend; this only reports.
-          REVIEW_BUDGET_USD: '6.00'
+          # The cost line this step prints put 80 turns at $3.83-$4.02, which extrapolates to about
+          # $6 at the 120-turn cap and so left no headroom at all. $9 is 1.5x that extrapolation,
+          # picked rather than measured; re-derive it from the cost line whenever the cap moves.
+          # max_turns is what actually caps spend; this only reports.
+          REVIEW_BUDGET_USD: '9.00'
         run: .github/scripts/price-agent-run.sh "$EXECUTION_FILE" "$REVIEW_BUDGET_USD" 'PR re-review'
 
       # Always a new comment, never an update — the history of re-reviews is the point. The token

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -136,9 +136,11 @@ jobs:
         continue-on-error: true
         env:
           EXECUTION_FILE: ${{ steps.review.outputs.execution_file }}
-          # Derived from the cost line this step prints: 80 turns landed at $3.83-$4.02, so 120 turns
-          # sits near $6. max_turns is what actually caps spend; this only reports.
-          REVIEW_BUDGET_USD: '6.00'
+          # The cost line this step prints put 80 turns at $3.83-$4.02, which extrapolates to about
+          # $6 at the 120-turn cap and so left no headroom at all. $9 is 1.5x that extrapolation,
+          # picked rather than measured; re-derive it from the cost line whenever the cap moves.
+          # max_turns is what actually caps spend; this only reports.
+          REVIEW_BUDGET_USD: '9.00'
         run: .github/scripts/price-agent-run.sh "$EXECUTION_FILE" "$REVIEW_BUDGET_USD" 'PR review'
 
       # Sticky by the seq=1 marker, so a re-run of this workflow replaces its own comment rather


### PR DESCRIPTION
## Summary

- Raises `REVIEW_BUDGET_USD` from `6.00` to `9.00` in both `claude-pr-review.yml` and `claude-pr-review-continue.yml`.

`REVIEW_BUDGET_USD` does not cap anything. `price-agent-run.sh` only compares the run's actual cost against it and emits a `::warning::`, and the step that calls it runs with `continue-on-error: true`. What holds spend down is `max_turns`, which stays at `120`, as does `timeout_minutes` at `35`.

The old value came from extrapolating a measured 80-turn run ($3.83-$4.02) out to the 120-turn cap, which left it with no headroom: a heavier PR spending exactly the turns it is allowed still warns. $9 is 1.5x that extrapolation — headroom rather than a measurement — so the warning stays meaningful for a genuine overrun while a normal expensive review passes quietly.

## Test plan

- [ ] On the next review run, the "Price the review" step prints its cost line against a $9.00 budget.
- [ ] A run costing between $6 and $9 no longer emits `::warning::Lower max_turns, or raise the budget if the cap is too tight.`