### PR TITLE
video: generate a recording's telemetry subtitles when it has none

### DIFF
--- a/src/composables/videoChunkManager.ts
+++ b/src/composables/videoChunkManager.ts
@@ -3,6 +3,7 @@ import { ref } from 'vue'
 import { LiveVideoProcessor } from '@/libs/live-video-processor'
 import { datalogger } from '@/libs/sensors-logging'
 import { formatBytes, isElectron } from '@/libs/utils'
+import { telemetryOverlayWindowCandidates } from '@/libs/video-telemetry'
 import { useVideoStore } from '@/stores/video'
 import { type FileDescriptor } from '@/types/video'
 import { videoFilename, videoSubtitlesFilename } from '@/utils/video'
@@ -21,6 +22,17 @@ export interface ChunkGroup {
   chunks: Array<{ key: string; size: number; timestamp: Date }>
 }
 /* eslint-enable jsdoc/require-jsdoc */
+
+/**
+ * A recording's telemetry overlay, as resolved from storage or generated from the logged telemetry.
+ */
+interface ResolvedTelemetryOverlay extends FileDescriptor {
+  /**
+   * Whether the overlay is in the video storage under `filename`, which a caller that works from the
+   * name rather than from `blob` needs to know before it hands that name to anything else
+   */
+  stored: boolean
+}
 
 /* eslint-disable jsdoc/require-jsdoc */
 /**
@@ -295,6 +307,54 @@ export const useVideoChunkManager = (): {
   }
 
   /**
+   * Resolve the telemetry overlay of a chunk group, generating it from the logged telemetry and storing
+   * it alongside the recording when the recording never got one.
+   * @param {ChunkGroup} group - The chunk group to resolve the overlay for
+   * @returns {Promise<ResolvedTelemetryOverlay>} The telemetry overlay file
+   */
+  const resolveTelemetryOverlayFile = async (group: ChunkGroup): Promise<ResolvedTelemetryOverlay> => {
+    try {
+      const existingAssFile = await findAssTelemetryFile(group.hash)
+      if (existingAssFile) return { ...existingAssFile, stored: true }
+    } catch (error) {
+      console.warn(`Could not read the stored telemetry overlay of ${group.hash}, generating a new one:`, error)
+    }
+
+    const subtitlesFileName = videoSubtitlesFilename(group.fileName || videoFilename(group.hash, group.firstChunkDate))
+    const candidateWindows = telemetryOverlayWindowCandidates(
+      videoStore.unprocessedVideos[group.hash],
+      group.chunks.map((chunk) => chunk.timestamp)
+    )
+
+    for (const candidate of candidateWindows) {
+      let overlay: Blob
+      try {
+        const telemetryLog = await datalogger.generateLog(candidate.start, candidate.end)
+        const startEpoch = candidate.start.getTime()
+        const assContent = datalogger.toAssOverlay(telemetryLog, candidate.width, candidate.height, startEpoch)
+        overlay = new Blob([assContent], { type: 'text/plain' })
+      } catch (error) {
+        console.warn(`Could not generate the telemetry overlay of ${group.hash} from the ${candidate.source}:`, error)
+        continue
+      }
+
+      // Storing it is what makes the next download instant, so a storage failure must not cost the
+      // caller an overlay that is already built.
+      let stored = true
+      try {
+        await videoStore.videoStorage.setItem(subtitlesFileName, overlay)
+      } catch (error) {
+        stored = false
+        console.warn(`Could not store the generated telemetry overlay of ${group.hash}:`, error)
+      }
+
+      return { blob: overlay, filename: subtitlesFileName, stored }
+    }
+
+    throw new Error(`No telemetry was logged for the time window of recording ${group.hash}`)
+  }
+
+  /**
    * Download chunk group as ZIP
    * @param {ChunkGroup} group
    * @returns {Promise<void>} Promise that resolves when download is complete
@@ -304,6 +364,17 @@ export const useVideoChunkManager = (): {
       isProcessingChunks.value = true
 
       if (isElectron()) {
+        // The main process picks the overlay up from the videos folder, so it has to be there already.
+        try {
+          const { filename, stored } = await resolveTelemetryOverlayFile(group)
+          if (!stored) {
+            throw new Error(`Could not store the telemetry overlay as '${filename}'.`)
+          }
+        } catch (error) {
+          const message = `Creating the ZIP without a telemetry subtitle file. ${error}`
+          openSnackbar({ message, variant: 'warning' })
+        }
+
         // Electron version: Create ZIP using filesystem (no memory limits)
         const zipFilePath = await window.electronAPI?.createVideoChunksZip(group.hash)
 
@@ -361,14 +432,15 @@ export const useVideoChunkManager = (): {
 
           // Add .ass telemetry file (only in first batch)
           if (i === 0) {
-            const assFile = await findAssTelemetryFile(group.hash)
-            if (assFile) {
+            try {
+              const assFile = await resolveTelemetryOverlayFile(group)
               files.push({
                 file: { blob: assFile.blob, filename: assFile.filename },
                 lastModDate: files[0].lastModDate,
               })
-            } else {
-              openSnackbar({ message: 'Failed to find .ass telemetry file for the recording.', variant: 'error' })
+            } catch (error) {
+              const message = `Downloading the chunks without a telemetry subtitle file. ${error}`
+              openSnackbar({ message, variant: 'warning' })
             }
           }
 
@@ -487,94 +559,6 @@ export const useVideoChunkManager = (): {
   }
 
   /**
-   * Generate an .ass telemetry blob from a datalogger log, save it to video storage, and copy it
-   * to the output path on the filesystem.
-   * @param {Awaited<ReturnType<typeof datalogger.generateLog>>} telemetryLog - The generated log
-   * @param {number} videoWidth - Video width in pixels
-   * @param {number} videoHeight - Video height in pixels
-   * @param {number} startEpoch - Video start epoch in milliseconds
-   * @param {string} subtitlesFileName - The filename (key) under which to store the .ass file
-   * @param {string} outputPath - Full filesystem path of the processed video
-   * @returns {Promise<void>}
-   */
-  const saveAndCopyTelemetry = async (
-    telemetryLog: Awaited<ReturnType<typeof datalogger.generateLog>>,
-    videoWidth: number,
-    videoHeight: number,
-    startEpoch: number,
-    subtitlesFileName: string,
-    outputPath: string
-  ): Promise<void> => {
-    const assContent = datalogger.toAssOverlay(telemetryLog, videoWidth, videoHeight, startEpoch)
-    const logBlob = new Blob([assContent], { type: 'text/plain' })
-    await videoStore.videoStorage.setItem(subtitlesFileName, logBlob)
-    await window.electronAPI!.copyTelemetryFile(subtitlesFileName, videoSubtitlesFilename(outputPath))
-  }
-
-  /**
-   * Attempts to resolve telemetry for a processed chunk group using a 3-tier fallback:
-   *   1. Copy an existing .ass file from video storage
-   *   2. Generate from unprocessedVideos metadata (dateStart/dateFinish/resolution)
-   *   3. Reconstruct the time range from chunk timestamps
-   * Throws if all tiers fail.
-   * @param {ChunkGroup} group - The chunk group being processed
-   * @param {string} outputPath - Full filesystem path of the processed video
-   * @returns {Promise<void>}
-   */
-  const copyOrGenerateTelemetryOverlayFile = async (group: ChunkGroup, outputPath: string): Promise<void> => {
-    const subtitlesFileName = videoSubtitlesFilename(group.fileName || videoFilename(group.hash, group.firstChunkDate))
-
-    // Tier 1: Try to find and copy an existing .ass file
-    try {
-      const videoKeys = await videoStore.videoStorage.keys()
-      const existingAssFile = videoKeys.find((key) => key.includes(group.hash) && key.endsWith('.ass'))
-      if (existingAssFile) {
-        await window.electronAPI!.copyTelemetryFile(existingAssFile, videoSubtitlesFilename(outputPath))
-        console.info(`Tier 1: Copied existing telemetry file for ${group.hash}.`)
-        return
-      }
-      console.info(`Tier 1: No existing .ass file found for ${group.hash}. Trying metadata generation...`)
-    } catch (error) {
-      console.warn(`Tier 1: Failed to copy existing telemetry for ${group.hash}:`, error)
-    }
-
-    // Tier 2: Try to generate from unprocessedVideos metadata
-    try {
-      const recordingData = videoStore.unprocessedVideos[group.hash]
-      if (recordingData?.dateStart && recordingData?.dateFinish) {
-        const dateStart = new Date(recordingData.dateStart)
-        const dateFinish = new Date(recordingData.dateFinish)
-        console.info(`Tier 2: Generating telemetry from recording metadata for ${group.hash}...`)
-
-        const telemetryLog = await datalogger.generateLog(dateStart, dateFinish)
-        const vWidth = recordingData.vWidth ?? 1920
-        const vHeight = recordingData.vHeight ?? 1080
-        await saveAndCopyTelemetry(telemetryLog, vWidth, vHeight, dateStart.getTime(), subtitlesFileName, outputPath)
-        console.info(`Tier 2: Telemetry generated from metadata for ${group.hash}.`)
-        return
-      }
-      console.info(`Tier 2: No recording metadata found for ${group.hash}. Trying timestamp reconstruction...`)
-    } catch (error) {
-      console.warn(`Tier 2: Failed to generate telemetry from metadata for ${group.hash}:`, error)
-    }
-
-    // Tier 3: Reconstruct time range from chunk timestamps
-    const validChunks = group.chunks.filter((c) => c.timestamp.getTime() > 0)
-    if (validChunks.length === 0) {
-      throw new Error(`No valid chunk timestamps available for ${group.hash}`)
-    }
-
-    const sortedByTime = [...validChunks].sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime())
-    const estimatedStart = sortedByTime[0].timestamp
-    const estimatedEnd = new Date(sortedByTime[sortedByTime.length - 1].timestamp.getTime() + 1000)
-    console.info(`Tier 3: Reconstructing telemetry from chunk timestamps for ${group.hash}...`)
-
-    const telemetryLog = await datalogger.generateLog(estimatedStart, estimatedEnd)
-    await saveAndCopyTelemetry(telemetryLog, 1920, 1080, estimatedStart.getTime(), subtitlesFileName, outputPath)
-    console.info(`Tier 3: Telemetry reconstructed from chunk timestamps for ${group.hash}.`)
-  }
-
-  /**
    * Process a chunk group using the live video processor
    * @param {ChunkGroup} group
    * @returns {Promise<void>} Promise that resolves when processing is complete
@@ -632,7 +616,13 @@ export const useVideoChunkManager = (): {
 
       // Find and copy (if it exists) or generate (if it doesn't) telemetry overlay file
       try {
-        await copyOrGenerateTelemetryOverlayFile(group, outputPath)
+        const { filename, stored } = await resolveTelemetryOverlayFile(group)
+        // The copy reads the file back from the videos folder, so an unstored overlay copies nothing
+        // and would leave the processed video without subtitles under a success message.
+        if (!stored) {
+          throw new Error(`Could not store the telemetry overlay as '${filename}'.`)
+        }
+        await window.electronAPI.copyTelemetryFile(filename, videoSubtitlesFilename(outputPath))
       } catch (telemetryError) {
         const errorMessage = `Could not generate telemetry overlay for the processed video: ${telemetryError}`
         openSnackbar({ message: errorMessage, variant: 'error' })

--- a/src/libs/video-telemetry.ts
+++ b/src/libs/video-telemetry.ts
@@ -1,0 +1,70 @@
+import type { UnprocessedVideoInfo } from '@/types/video'
+
+/**
+ * A recording's time window and resolution, to render a telemetry overlay for.
+ */
+export interface TelemetryOverlayWindow {
+  /**
+   * When the recording started. Overlay timestamps are relative to it.
+   */
+  start: Date
+  /**
+   * When the recording finished
+   */
+  end: Date
+  /**
+   * Width of the video, in pixels
+   */
+  width: number
+  /**
+   * Height of the video, in pixels
+   */
+  height: number
+  /**
+   * Where the window was taken from, to tell the candidates apart while logging
+   */
+  source: string
+}
+
+// Recordings made before the resolution was stored, and windows rebuilt from chunks, have none to go by.
+const fallbackResolution = { width: 1920, height: 1080 }
+
+/**
+ * The windows a recording's telemetry overlay can be generated for, best first.
+ *
+ * The recording metadata comes first because it holds the real start and finish. Chunk timestamps are
+ * a reconstruction, only as good as the clock that wrote them, and a chunk whose timestamp is unknown
+ * reads as the epoch, so it is left out.
+ * @param {UnprocessedVideoInfo | undefined} recording - Metadata of the recording, while still known
+ * @param {Date[]} chunkTimestamps - Timestamps of the recording's chunks, in any order
+ * @returns {TelemetryOverlayWindow[]} Candidate windows, in the order they should be tried
+ */
+export const telemetryOverlayWindowCandidates = (
+  recording: UnprocessedVideoInfo | undefined,
+  chunkTimestamps: Date[]
+): TelemetryOverlayWindow[] => {
+  const candidates: TelemetryOverlayWindow[] = []
+
+  if (recording?.dateStart && recording?.dateFinish) {
+    candidates.push({
+      start: new Date(recording.dateStart),
+      end: new Date(recording.dateFinish),
+      width: recording.vWidth ?? fallbackResolution.width,
+      height: recording.vHeight ?? fallbackResolution.height,
+      source: 'recording metadata',
+    })
+  }
+
+  const knownEpochs = chunkTimestamps.map((timestamp) => timestamp.getTime()).filter((epoch) => epoch > 0)
+  if (knownEpochs.length > 0) {
+    candidates.push({
+      start: new Date(Math.min(...knownEpochs)),
+      // Every chunk covers the second that follows it, so the recording ends a second after the last one.
+      end: new Date(Math.max(...knownEpochs) + 1000),
+      ...fallbackResolution,
+      source: 'chunk timestamps',
+    })
+  }
+
+  return candidates
+}

--- a/src/libs/video-telemetry.ts
+++ b/src/libs/video-telemetry.ts
@@ -36,12 +36,12 @@ const fallbackResolution = { width: 1920, height: 1080 }
  * a reconstruction, only as good as the clock that wrote them, and a chunk whose timestamp is unknown
  * reads as the epoch, so it is left out.
  * @param {UnprocessedVideoInfo | undefined} recording - Metadata of the recording, while still known
- * @param {Date[]} chunkTimestamps - Timestamps of the recording's chunks, in any order
+ * @param {Date[]} [chunkTimestamps] - Timestamps of the recording's chunks, in any order
  * @returns {TelemetryOverlayWindow[]} Candidate windows, in the order they should be tried
  */
 export const telemetryOverlayWindowCandidates = (
   recording: UnprocessedVideoInfo | undefined,
-  chunkTimestamps: Date[]
+  chunkTimestamps: Date[] = []
 ): TelemetryOverlayWindow[] => {
   const candidates: TelemetryOverlayWindow[] = []
 

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -29,6 +29,7 @@ import {
 import { datalogger } from '@/libs/sensors-logging'
 import { StreamActivationBackoff } from '@/libs/stream-activation-backoff'
 import { isElectron, isEqual, sanitizeFilenameComponent, sleep } from '@/libs/utils'
+import { telemetryOverlayWindowCandidates } from '@/libs/video-telemetry'
 import { tempVideoStorage, videoStorage } from '@/libs/videoStorage'
 import type { Stream } from '@/libs/webrtc/signalling_protocol'
 import { readableVideoCodecName } from '@/libs/webrtc/video-codec-support'
@@ -794,14 +795,19 @@ export const useVideoStore = defineStore('video', () => {
 
       console.info(`Generating telemetry overlay for recording '${recordingHash}'...`)
 
-      const telemetryLog = await datalogger.generateLog(recordingData.dateStart!, recordingData.dateFinish!)
+      const [overlayWindow] = telemetryOverlayWindowCandidates(recordingData)
+      if (!overlayWindow) {
+        throw new Error(`Recording '${recordingHash}' has no known start and finish times.`)
+      }
+
+      const telemetryLog = await datalogger.generateLog(overlayWindow.start, overlayWindow.end)
 
       if (telemetryLog !== undefined) {
         const assLog = datalogger.toAssOverlay(
           telemetryLog,
-          recordingData.vWidth!,
-          recordingData.vHeight!,
-          recordingData.dateStart!.getTime()
+          overlayWindow.width,
+          overlayWindow.height,
+          overlayWindow.start.getTime()
         )
         const logBlob = new Blob([assLog], { type: 'text/plain' })
 

--- a/src/tests/libs/video-telemetry.test.ts
+++ b/src/tests/libs/video-telemetry.test.ts
@@ -59,5 +59,6 @@ describe('telemetryOverlayWindowCandidates', () => {
   it('has no window to offer for a recording with neither metadata nor timed chunks', () => {
     expect(telemetryOverlayWindowCandidates(undefined, [new Date(0)])).toEqual([])
     expect(telemetryOverlayWindowCandidates(buildRecording({ dateFinish: undefined }), [])).toEqual([])
+    expect(telemetryOverlayWindowCandidates(undefined)).toEqual([])
   })
 })

--- a/src/tests/libs/video-telemetry.test.ts
+++ b/src/tests/libs/video-telemetry.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+
+import { telemetryOverlayWindowCandidates } from '@/libs/video-telemetry'
+import type { UnprocessedVideoInfo } from '@/types/video'
+
+const buildRecording = (info: Partial<UnprocessedVideoInfo>): UnprocessedVideoInfo => ({
+  fileName: 'Cockpit (Sep 02, 2026 - 10꞉00꞉00 GMT-3) #abc12345.mp4',
+  dateStart: new Date('2026-09-02T13:00:00Z'),
+  dateFinish: new Date('2026-09-02T13:00:30Z'),
+  dateLastRecordingUpdate: new Date('2026-09-02T13:00:30Z'),
+  dateLastProcessingUpdate: undefined,
+  lastKnownFileSize: undefined,
+  lastKnownNumberOfChunks: undefined,
+  vWidth: 1280,
+  vHeight: 720,
+  ...info,
+})
+
+const chunkTimestamps = [
+  new Date('2026-09-02T13:00:02Z'),
+  new Date('2026-09-02T13:00:00Z'),
+  new Date('2026-09-02T13:00:01Z'),
+]
+
+describe('telemetryOverlayWindowCandidates', () => {
+  it('prefers the recording metadata, with the resolution the recording was made at', () => {
+    const candidates = telemetryOverlayWindowCandidates(buildRecording({}), chunkTimestamps)
+
+    expect(candidates.map((candidate) => candidate.source)).toEqual(['recording metadata', 'chunk timestamps'])
+    expect(candidates[0].start.toISOString()).toBe('2026-09-02T13:00:00.000Z')
+    expect(candidates[0].end.toISOString()).toBe('2026-09-02T13:00:30.000Z')
+    expect(candidates[0]).toMatchObject({ width: 1280, height: 720 })
+  })
+
+  it('rebuilds the window from the chunk timestamps when there is no metadata left', () => {
+    const candidates = telemetryOverlayWindowCandidates(undefined, chunkTimestamps)
+
+    expect(candidates).toHaveLength(1)
+    expect(candidates[0].source).toBe('chunk timestamps')
+    expect(candidates[0].start.toISOString()).toBe('2026-09-02T13:00:00.000Z')
+    // The last chunk starts at 13:00:02 and covers the second that follows it.
+    expect(candidates[0].end.toISOString()).toBe('2026-09-02T13:00:03.000Z')
+    expect(candidates[0]).toMatchObject({ width: 1920, height: 1080 })
+  })
+
+  it('falls back to a standard resolution when the recording did not store one', () => {
+    const candidates = telemetryOverlayWindowCandidates(buildRecording({ vWidth: undefined, vHeight: undefined }), [])
+
+    expect(candidates).toHaveLength(1)
+    expect(candidates[0]).toMatchObject({ width: 1920, height: 1080 })
+  })
+
+  it('discards chunks with an unknown timestamp', () => {
+    const candidates = telemetryOverlayWindowCandidates(undefined, [new Date(0), ...chunkTimestamps, new Date(0)])
+
+    expect(candidates[0].start.toISOString()).toBe('2026-09-02T13:00:00.000Z')
+  })
+
+  it('has no window to offer for a recording with neither metadata nor timed chunks', () => {
+    expect(telemetryOverlayWindowCandidates(undefined, [new Date(0)])).toEqual([])
+    expect(telemetryOverlayWindowCandidates(buildRecording({ dateFinish: undefined }), [])).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

A recording whose `.ass` subtitle file was never written could not get it back from the application, even with the telemetry it is built from still sitting in the browser. Downloading a chunk group on Cockpit Lite only looked the file up and reported `Failed to find .ass telemetry file for the recording.`, while the Standalone chunk processing already knew how to regenerate the overlay — from the recording metadata, and failing that from the chunk timestamps — but reads its own telemetry storage, not the browser's, so exporting to Standalone does not recover a Lite recording either.

This moves that fallback into the candidate windows an overlay can be generated for (`src/libs/video-telemetry.ts`), and resolves the overlay the same way on both paths, generating it when the recording has none and storing it next to the recording so it also survives the download. The Standalone path keeps its behavior and loses its duplicate copy of the fallback, which is where the net deletion comes from.

| Before | After |
| --- | --- |
| <img src="https://github.com/bluerobotics/cockpit/blob/0886773364677099b181dc3f8c23d1c38757eb02/before.png?raw=true" width="420"> | <img src="https://github.com/bluerobotics/cockpit/blob/0886773364677099b181dc3f8c23d1c38757eb02/after.png?raw=true" width="420"> |

## Test plan

- [ ] On Cockpit Lite, record a stream, stop it, and delete the recording's `.ass` from the `cockpit-video-recovery-db` IndexedDB store, leaving the chunks in place.
- [ ] Open the Video Library, go to Videos -> Raw and download that chunk group: the ZIP should carry the chunks plus a regenerated `.ass`, and the subtitle should play over the video once processed.
- [ ] Download a chunk group whose `.ass` does exist and confirm it is the stored file that ships, not a fresh one.
- [ ] Download a chunk group whose recording window has no logged telemetry (e.g. delete the entries in Settings -> Logs first): the download should still succeed, with a warning that it carries no subtitle file.
- [ ] On Standalone, process a leftover chunk group with and without an existing `.ass`, and confirm the overlay lands next to the MP4 in both cases.

## Checks

- Recording with 3 chunks, `1280x720`, 10 s of logged telemetry, subtitle removed. Before: `cockpit-video-recovery-db` keys `[]` and the red "Failed to find .ass telemetry file" snackbar. After: key `Cockpit (...) #a1b2c3d4.ass`, 7854 bytes, `PlayResX: 1280 PlayResY: 720`, 90 dialogue lines carrying the logged values, and no error snackbar.
- `yarn lint:fix`, `yarn typecheck` and the new `src/tests/libs/video-telemetry.test.ts` (5 cases) are clean. `src/tests/libs/cosmos.test.ts` and `src/tests/libs/connection/connection.test.ts` fail on `master` too, unrelated to this change.

Closes #3000