### PR TITLE
Map: Fix crash from points of interest saved by a newer version

### DIFF
--- a/src/stores/mission.ts
+++ b/src/stores/mission.ts
@@ -5,6 +5,7 @@ import { computed, reactive, ref, watch } from 'vue'
 
 import { useInteractionDialog } from '@/composables/interactionDialog'
 import { useBlueOsStorage } from '@/composables/settingsSyncer'
+import { openSnackbar } from '@/composables/snackbar'
 import { askForUsername } from '@/composables/usernamePrompDialog'
 import { eventCategoriesDefaultMapping } from '@/libs/slide-to-confirm'
 import {
@@ -65,7 +66,32 @@ export const useMissionStore = defineStore('mission', () => {
 
   const mainVehicleStore = useMainVehicleStore()
 
-  const pointsOfInterest = useBlueOsStorage<PointOfInterest[]>('cockpit-points-of-interest', [])
+  const storedPointsOfInterest = useBlueOsStorage<PointOfInterest[]>('cockpit-points-of-interest', [])
+
+  const hasReadableCoordinates = (poi: PointOfInterest): boolean =>
+    Array.isArray(poi?.coordinates) && Number.isFinite(poi.coordinates[0]) && Number.isFinite(poi.coordinates[1])
+
+  // A POI persisted by a version that stores coordinates differently is unplottable here, so it is hidden
+  // rather than deleted, keeping it intact for whichever version wrote it.
+  const pointsOfInterest = computed<readonly PointOfInterest[]>(() =>
+    Array.isArray(storedPointsOfInterest.value) ? storedPointsOfInterest.value.filter(hasReadableCoordinates) : []
+  )
+
+  let hiddenPointsOfInterestReported = false
+  watch(
+    storedPointsOfInterest,
+    (pois) => {
+      const storedCount = Array.isArray(pois) ? pois.length : 0
+      const hidden = storedCount - pointsOfInterest.value.length
+      if (hidden < 1 || hiddenPointsOfInterestReported) return
+      hiddenPointsOfInterestReported = true
+      const noun = hidden > 1 ? 'points' : 'point'
+      const verb = hidden > 1 ? 'were' : 'was'
+      const message = `${hidden} ${noun} of interest ${verb} saved by a newer version of Cockpit and cannot be shown here. Nothing was deleted.`
+      openSnackbar({ message, variant: 'warning', closeButton: true })
+    },
+    { immediate: true }
+  )
 
   watch(missionName, () => (lastMissionName.value = missionName.value))
 
@@ -210,25 +236,29 @@ export const useMissionStore = defineStore('mission', () => {
   }
 
   const addPointOfInterest = (poi: PointOfInterest): void => {
-    pointsOfInterest.value.push(poi)
+    storedPointsOfInterest.value.push(poi)
   }
 
   const updatePointOfInterest = (id: string, poiUpdate: Partial<PointOfInterest>): void => {
-    const index = pointsOfInterest.value.findIndex((p) => p.id === id)
+    const index = storedPointsOfInterest.value.findIndex((p) => p.id === id)
     if (index !== -1) {
-      pointsOfInterest.value[index] = { ...pointsOfInterest.value[index], ...poiUpdate, timestamp: Date.now() }
+      storedPointsOfInterest.value[index] = {
+        ...storedPointsOfInterest.value[index],
+        ...poiUpdate,
+        timestamp: Date.now(),
+      }
     }
   }
 
   const removePointOfInterest = (id: string): void => {
-    const index = pointsOfInterest.value.findIndex((p) => p.id === id)
+    const index = storedPointsOfInterest.value.findIndex((p) => p.id === id)
     if (index !== -1) {
-      pointsOfInterest.value.splice(index, 1)
+      storedPointsOfInterest.value.splice(index, 1)
     }
   }
 
   const movePointOfInterest = (id: string, newCoordinates: PointOfInterestCoordinates): void => {
-    const poi = pointsOfInterest.value.find((p) => p.id === id)
+    const poi = storedPointsOfInterest.value.find((p) => p.id === id)
     if (poi === undefined) {
       throw Error(`Could not move Point of Interest. No POI with id ${id} was found.`)
     }


### PR DESCRIPTION
**Problem:**

- Points of interest saved by a 1.19 beta record their position in a different shape, and every 1.18 surface that draws them reads a coordinate pair that is no longer there, so the map throws on each pan and zoom instead of drawing (`src/components/poi/PoiMapArrows.vue:414`, `src/components/widgets/Map.vue:1909`, `src/components/widgets/CompassHUD.vue:284`).
- Anyone who tried a 1.19 beta and moved back to the 1.18 line gets a broken map, mission planning view and compass HUD, with no way out short of clearing the saved points.

**Fix:**

- The mission store now hands out only the points of interest it can actually place, so an unplaceable one is skipped instead of taking the map down with it.
- Skipped points stay in storage untouched, so they come back intact on the version that wrote them, and the operator is told once through a snackbar that they are there and were not deleted.
- A non-list value at the key yields an empty list instead of throwing out of the store's setup.
- Those points are deliberately hidden rather than placed from the newer record's `fallbackCoordinates`: that field holds the last-known position of a live-tracked point, so it can be stale, and a point shown here is draggable, which writes `coordinates` that the newer line's migration then discards in favour of the `latitude`/`longitude` it already holds. Placing them would trade a crash for silent position loss.
- No equivalent change is needed on master, where points of interest already migrate older records as they are read.