### PR TITLE
Electron: Isolate userData written by a newer Chromium

### DIFF
--- a/src/electron/chromium-profile.ts
+++ b/src/electron/chromium-profile.ts
@@ -1,0 +1,46 @@
+// Chrome 124 moved the cookie DB into `Network/Cookies`. A real Electron 29 (Chrome 122)
+// profile still keeps Cookies at the userData root, so that file means a newer Electron wrote it.
+// Only consulted when Chromium's `Last Version` file is missing — Electron often does not write one.
+const NETWORK_COOKIES_SINCE_CHROME_MAJOR = 124
+
+/**
+ * Parse the major component of a Chromium version string (`150.0.7871.224` → 150).
+ * @param {string} version Chromium version string
+ * @returns {number | undefined} The major version, or undefined when it is not a number
+ */
+export const chromeMajor = (version: string): number | undefined => {
+  const major = Number.parseInt(version.trim().split('.')[0], 10)
+  return Number.isFinite(major) ? major : undefined
+}
+
+/**
+ * Whether this Chromium userData was written by a newer Chrome than the one we bundled.
+ * @param {string | undefined} lastVersionText Contents of Chromium's `Last Version` file, if present
+ * @param {string} ourChrome `process.versions.chrome` of this Electron binary
+ * @param {boolean} hasNetworkCookies Whether `Network/Cookies` exists on disk
+ * @returns {boolean} True when opening this profile would be a Chromium downgrade
+ */
+export const shouldIsolateChromiumProfile = (
+  lastVersionText: string | undefined,
+  ourChrome: string,
+  hasNetworkCookies: boolean
+): boolean => {
+  const ours = chromeMajor(ourChrome)
+  if (ours === undefined) return false
+
+  const last = lastVersionText === undefined ? undefined : chromeMajor(lastVersionText)
+  if (last !== undefined) return last > ours
+
+  return hasNetworkCookies && ours < NETWORK_COOKIES_SINCE_CHROME_MAJOR
+}
+
+/**
+ * Sibling userData path used when the default profile belongs to a newer Chrome.
+ * @param {string} userData Default Electron userData path
+ * @param {string} chromeVersion `process.versions.chrome` of this Electron binary
+ * @returns {string} Path that this Chrome major can own
+ */
+export const isolatedUserDataPath = (userData: string, chromeVersion: string): string => {
+  const major = chromeMajor(chromeVersion)
+  return major === undefined ? userData : `${userData}-chrome${major}`
+}

--- a/src/electron/isolate-chromium-profile.ts
+++ b/src/electron/isolate-chromium-profile.ts
@@ -1,0 +1,49 @@
+import { app } from 'electron'
+import { copyFileSync, existsSync, mkdirSync, readFileSync } from 'fs'
+import { join } from 'path'
+
+import { isolatedUserDataPath, shouldIsolateChromiumProfile } from './chromium-profile'
+
+let isolationLogMessage: string | undefined
+
+/**
+ * Emit the isolation decision after `setupElectronLogService` has hooked `console`.
+ * @returns {void}
+ */
+export const logChromiumProfileIsolation = (): void => {
+  if (isolationLogMessage === undefined) return
+  console.info(isolationLogMessage)
+}
+
+/**
+ * Point Electron at a sibling userData folder when the default profile was written by a newer
+ * Chrome. Must run before any other main-process code touches userData or `session`.
+ * @returns {void}
+ */
+const isolateNewerChromiumUserData = (): void => {
+  try {
+    const userData = app.getPath('userData')
+    const lastVersionFile = join(userData, 'Last Version')
+    const lastVersionText = existsSync(lastVersionFile) ? readFileSync(lastVersionFile, 'utf8') : undefined
+    const hasNetworkCookies = existsSync(join(userData, 'Network', 'Cookies'))
+    const ourChrome = process.versions.chrome ?? ''
+
+    if (!shouldIsolateChromiumProfile(lastVersionText, ourChrome, hasNetworkCookies)) return
+
+    const isolated = isolatedUserDataPath(userData, ourChrome)
+    mkdirSync(isolated, { recursive: true })
+
+    const configSrc = join(userData, 'config.json')
+    const configDst = join(isolated, 'config.json')
+    if (existsSync(configSrc) && !existsSync(configDst)) {
+      copyFileSync(configSrc, configDst)
+    }
+
+    app.setPath('userData', isolated)
+    isolationLogMessage = `Chromium profile at ${userData} was written by a newer Chrome. Using ${isolated}.`
+  } catch (error) {
+    isolationLogMessage = `Failed to isolate Chromium profile: ${error}`
+  }
+}
+
+isolateNewerChromiumUserData()

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -1,6 +1,8 @@
 import { app, BrowserWindow, powerSaveBlocker, protocol, screen } from 'electron'
 import { join } from 'path'
 
+// Must stay ahead of config-store/storage: both resolve userData at import time.
+import { logChromiumProfileIsolation } from './isolate-chromium-profile'
 import { setupAutoUpdater } from './services/auto-update'
 import store from './services/config-store'
 import { setupElectronLogService } from './services/electron-log'
@@ -19,6 +21,7 @@ import { setupWorkspaceService } from './services/workspace'
 
 // Setup the logger service as soon as possible to avoid different behaviors across runtime
 setupElectronLogService()
+logChromiumProfileIsolation()
 
 export const ROOT_PATH = {
   dist: join(__dirname, '..'),

--- a/src/tests/electron/chromium-profile.test.ts
+++ b/src/tests/electron/chromium-profile.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from 'vitest'
+
+import { isolatedUserDataPath, shouldIsolateChromiumProfile } from '@/electron/chromium-profile'
+
+test('isolates a Chrome 150 profile when this binary is Chrome 122', () => {
+  expect(shouldIsolateChromiumProfile('150.0.7871.224', '122.0.6261.156', false)).toBe(true)
+  expect(isolatedUserDataPath('/tmp/Cockpit', '122.0.6261.156')).toBe('/tmp/Cockpit-chrome122')
+})
+
+test('leaves a same-or-older Chrome profile on the default path', () => {
+  expect(shouldIsolateChromiumProfile('122.0.6261.156', '122.0.6261.156', false)).toBe(false)
+  expect(shouldIsolateChromiumProfile('122.0.6261.156', '122.0.6261.156', true)).toBe(false)
+  expect(shouldIsolateChromiumProfile(undefined, '122.0.6261.156', false)).toBe(false)
+})
+
+test('isolates a Chrome 124+ layout when Last Version is missing', () => {
+  expect(shouldIsolateChromiumProfile(undefined, '122.0.6261.156', true)).toBe(true)
+  expect(shouldIsolateChromiumProfile(undefined, '150.0.7871.224', true)).toBe(false)
+})


### PR DESCRIPTION
## Summary
- Electron 43 (1.19.0-beta.10) writes the Chromium profile at Chrome 150. Electron 29 (this line) is Chrome 122; opening that profile is a Chromium downgrade and can wipe or refuse localStorage/IndexedDB.
- On startup, before anything else touches `userData`, if `Last Version` is newer than our Chrome — or `Network/Cookies` exists (Chrome 124+ layout) while we are still on 122 — point Electron at a sibling `Cockpit-chrome122` folder and boot clean.
- The beta.10 profile is left intact. Lite is unaffected. Videos in `~/Cockpit` are unaffected. Vehicle-synced settings come back from BlueOS. No dialog.

To be cherry-picked onto #2997 so 1.18.3 ships this.

## Test plan
- [ ] Fresh 1.18 Standalone (never ran beta.10): boots as today, same `userData` path, settings still there.
- [ ] Run 1.19.0-beta.10 Standalone once, quit, install this build. App opens without a wipe/crash. Main-process log mentions the sibling folder. Window may reset; vehicle settings return after BlueOS sync.
- [ ] After that isolation, launch beta.10 again. Its original profile is still in the default `Cockpit` folder.
- [ ] `yarn vitest --run src/tests/electron/chromium-profile.test.ts`