### PR TITLE
ci: explain a refused /review and skip a repeat first review

### DIFF
--- a/.github/scripts/review-latest.sh
+++ b/.github/scripts/review-latest.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# Prints the sha the newest bot review recorded, from a stream of issue-comment JSON objects on
+# stdin — the same stream `gh api --paginate --jq '.[]'` produces. Empty stdout means no review
+# exists. `?` means a review comment exists but its marker has no readable sha — callers that
+# ask "has this been reviewed?" must treat that as yes, or a hand-edited marker would look like
+# a first review and overwrite seq=1. A non-zero exit means the input was unreadable.
+#
+# Author-filtered: a marker is a label anyone can type.
+#
+# Usage: review-latest.sh              # ndjson comments on stdin
+#        review-latest.sh --self-check
+
+set -euo pipefail
+
+extract() {
+  jq -rs '
+    [.[] | select(.user.login == "github-actions[bot]" and .user.type == "Bot"
+                  and (.body | startswith("<!-- claude-pr-review-bot:v1")))]
+    | sort_by((.body | capture("seq=(?<n>[0-9]+)").n | tonumber) // 0)
+    | if length == 0 then ""
+      else (last.body | try capture("sha=(?<s>[0-9a-fA-F]+)").s // "?")
+      end
+  '
+}
+
+self_check() {
+  local failures=0
+
+  comment() {
+    jq -nc --arg login "$1" --arg type "$2" --arg body "$3" \
+      '{user:{login:$login,type:$type},body:$body}'
+  }
+
+  check() {
+    local name=$1 input=$2 expected=$3 got
+    got=$(printf '%s\n' "$input" | extract) || {
+      echo "  FAIL  $name (extract exited $?)"
+      failures=$((failures + 1))
+      return
+    }
+    if [ "$got" = "$expected" ]; then
+      echo "  ok    $name"
+    else
+      echo "  FAIL  $name"
+      echo "        expected ${expected:-<empty>}"
+      echo "        got      ${got:-<empty>}"
+      failures=$((failures + 1))
+    fi
+  }
+
+  check 'no comments' '' ''
+  check 'marker without sha=' \
+    "$(comment 'github-actions[bot]' Bot '<!-- claude-pr-review-bot:v1 seq=1 -->')" \
+    '?'
+  check 'several seqs out of order' \
+    "$(printf '%s\n%s\n%s\n' \
+      "$(comment 'github-actions[bot]' Bot '<!-- claude-pr-review-bot:v1 seq=2 sha=bbbbbbb -->')" \
+      "$(comment 'github-actions[bot]' Bot '<!-- claude-pr-review-bot:v1 seq=1 sha=aaaaaaa -->')" \
+      "$(comment 'github-actions[bot]' Bot '<!-- claude-pr-review-bot:v1 seq=3 sha=ccccccc -->')" \
+    )" \
+    'ccccccc'
+  check 'non-bot forgery is ignored' \
+    "$(printf '%s\n%s\n' \
+      "$(comment evil User '<!-- claude-pr-review-bot:v1 seq=9 sha=deadbeef -->')" \
+      "$(comment 'github-actions[bot]' Bot '<!-- claude-pr-review-bot:v1 seq=1 sha=aaaaaaaa -->')" \
+    )" \
+    'aaaaaaaa'
+
+  if printf 'not json\n' | extract >/dev/null 2>&1; then
+    echo '  FAIL  malformed input should exit non-zero'
+    failures=$((failures + 1))
+  else
+    echo '  ok    malformed input exits non-zero'
+  fi
+
+  if [ "$failures" -gt 0 ]; then
+    echo "$failures case(s) failed"
+    exit 1
+  fi
+  echo "all cases passed"
+}
+
+case "${1:-}" in
+  --self-check) self_check ;;
+  '') extract ;;
+  *)
+    echo 'usage: review-latest.sh | review-latest.sh --self-check' >&2
+    exit 1
+    ;;
+esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,9 @@ jobs:
       - name: Check the review marker writer
         run: .github/scripts/review-marker.sh --self-check
 
+      - name: Check the newest-review lookup
+        run: .github/scripts/review-latest.sh --self-check
+
       - name: Check the review decision tally
         run: .github/scripts/review-decisions.sh --self-check
 

--- a/.github/workflows/claude-pr-review-continue.yml
+++ b/.github/workflows/claude-pr-review-continue.yml
@@ -69,11 +69,16 @@ jobs:
           echo "$command"
 
       # Fails closed: anything other than a definite admin/write answer is a refusal.
+      # A failed Actions job does not show on the PR thread — this event is `issue_comment`,
+      # not a check on the head — so the refusal is also posted as a comment. Without that,
+      # an org member with read-only access (still `MEMBER` above) types `/review` and sees
+      # nothing happen.
       - name: Require write access
         if: steps.command.outputs.command != 'none'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
           ACTOR: ${{ github.event.comment.user.login }}
           COMMAND: /${{ steps.command.outputs.command }}
         run: |
@@ -84,8 +89,27 @@ jobs:
           echo "$ACTOR has '$level' permission on $REPO"
           case "$level" in
             admin | write) ;;
+            unknown)
+              echo "::error::$COMMAND: could not determine $ACTOR's permission on $REPO."
+              {
+                printf '<!-- claude-pr-review-notice:v1 -->\n'
+                printf 'Could not check whether @%s can run `%s`. Comment `%s` again.\n' \
+                  "$ACTOR" "$COMMAND" "$COMMAND"
+              } > refuse.md
+              gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file refuse.md \
+                || echo "::warning::could not post the refusal"
+              exit 1
+              ;;
             *)
               echo "::error::$COMMAND requires write access to $REPO. $ACTOR has '$level'."
+              {
+                printf '<!-- claude-pr-review-notice:v1 -->\n'
+                printf '%s requires write access to this repository. @%s has `%s`.\n' \
+                  "$COMMAND" "$ACTOR" "$level"
+                printf 'A maintainer can comment `%s` to run it.\n' "$COMMAND"
+              } > refuse.md
+              gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file refuse.md \
+                || echo "::warning::could not post the refusal"
               exit 1
               ;;
           esac
@@ -267,7 +291,8 @@ jobs:
 
           # Human/reviewer discussion since the last review (general PR comments and
           # inline code-review comments), so the agent can factor it into the new
-          # review. The bot's own review comments (the marker) are excluded.
+          # review. The bot's own review, resolution, decision and notice comments
+          # (the markers) are excluded.
           jq -c '{kind:"comment", author:.user.login, created_at:.created_at, path:null, body:.body, url:.html_url}' \
             all-comments.ndjson > issue_comments.ndjson || : > issue_comments.ndjson
           gh api "repos/$REPO/pulls/$PR_NUMBER/comments" --paginate \
@@ -278,6 +303,7 @@ jobs:
                 map(select(.body | startswith("<!-- claude-pr-review-bot:v1") | not))
                 | map(select(.body | startswith("<!-- claude-pr-review-resolution:v1") | not))
                 | map(select(.body | startswith("<!-- claude-pr-review-decision:v1") | not))
+                | map(select(.body | startswith("<!-- claude-pr-review-notice:v1") | not))
                 | map(select($since == "" or .created_at > $since))
                 | sort_by(.created_at)
               ' > new-comments.json

--- a/.github/workflows/claude-pr-review-current.yml
+++ b/.github/workflows/claude-pr-review-current.yml
@@ -16,13 +16,22 @@ jobs:
     name: Review is current
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft }}
-    # SECURITY: this job checks out nothing, runs no model, and reads only the PR's own comments,
-    # so `pull_request_target` never brings PR code near anything. It needs the elevated token
-    # because the read-only one a fork PR gets cannot post a commit status.
+    # SECURITY: this job sparse-checkouts only `.github/scripts` from the base ref, runs
+    # no model, and reads only the PR's own comments, so `pull_request_target` never brings PR
+    # code near anything. It needs the elevated token because the read-only one a fork PR gets
+    # cannot post a commit status.
     permissions:
+      contents: read
       pull-requests: read
       statuses: write
     steps:
+      - name: Checkout the review lookup (trusted)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          sparse-checkout: .github/scripts
+          persist-credentials: false
+
       - name: Compare the latest review against the head commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -32,16 +41,9 @@ jobs:
         run: |
           set -euo pipefail
           # Newest review by seq, then the sha it recorded reviewing. Empty when the bot has not
-          # commented yet, which is the `pending` case rather than the stale one.
-          # Author-filtered: the marker is a label anyone can type, and this status is the only
-          # automated signal that a rebase shipped code no review has seen. Without the filter a
-          # commenter can post a high-seq marker naming the head sha and turn the gate green.
-          # Streamed and slurped because `--paginate` runs `--jq` per page.
+          # commented yet (`pending`). `?` when a review exists but its marker has no readable sha.
           reviewed=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate --jq '.[]' \
-            | jq -rs '[.[] | select(.user.login == "github-actions[bot]" and .user.type == "Bot"
-                                    and (.body | startswith("<!-- claude-pr-review-bot:v1")))]
-                      | sort_by((.body | capture("seq=(?<n>[0-9]+)").n | tonumber) // 0)
-                      | (last.body // "" | capture("sha=(?<s>[0-9a-fA-F]+)").s) // ""')
+            | .github/scripts/review-latest.sh)
 
           if [ "$reviewed" = "$HEAD_SHA" ]; then
             state=success
@@ -49,6 +51,9 @@ jobs:
           elif [ -z "$reviewed" ]; then
             state=pending
             description="No automated review yet."
+          elif [ "$reviewed" = '?' ]; then
+            state=failure
+            description="Last review marker has no commit. Comment /review."
           else
             state=failure
             description="Last review was ${reviewed:0:7}, head is ${HEAD_SHA:0:7}. Comment /review."

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -3,9 +3,11 @@ name: Claude PR Review
 on:
   pull_request_target:
     # `ready_for_review` as well as `opened`, because a PR opened as a draft is skipped by the
-    # guard below and would otherwise never get a full-PR review at all. `synchronize` stays off:
-    # the `review-is-current` status already asks for a `/review` when the head moves, without
-    # paying for a run on every push.
+    # guard below and would otherwise never get a full-PR review at all. A later `ready_for_review`
+    # on a PR that was already reviewed (ready → draft → ready) must not run again: the publish
+    # step overwrites the seq=1 comment in place and wipes the ledger a `/review` counts from.
+    # `synchronize` stays off: the `review-is-current` status already asks for a `/review` when
+    # the head moves, without paying for a run on every push.
     types: [opened, ready_for_review]
 
 concurrency:
@@ -13,10 +15,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  review:
-    name: Claude PR Review
+  # Cheap: no model. Sparse-checkouts the lookup script. Exists so a draft cycle cannot pay
+  # for a second "first" review that replaces the real one. `opened` always proceeds;
+  # `ready_for_review` proceeds only when this workflow has never posted. A stale head is
+  # already a red `review-is-current` check, so this job does not also comment.
+  needed:
+    name: First review needed
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft }}
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      run: ${{ steps.check.outputs.run }}
+    steps:
+      - name: Checkout the review lookup (trusted)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          sparse-checkout: .github/scripts
+          persist-credentials: false
+
+      - name: Skip ready_for_review when a review already exists
+        id: check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          ACTION: ${{ github.event.action }}
+        run: |
+          set -euo pipefail
+          if [ "$ACTION" != ready_for_review ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Lookup failure must fail the step: a green skip here is a draft-opened PR
+          # that never gets its only automated review, and nobody is told.
+          reviewed=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate --jq '.[]' \
+            | .github/scripts/review-latest.sh) \
+            || { echo "::error::could not list comments; not starting a first review that might overwrite"; exit 1; }
+          if [ -z "$reviewed" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "run=false" >> "$GITHUB_OUTPUT"
+          if [ "$reviewed" = '?' ]; then
+            echo "A review exists but its marker has no sha; not overwriting seq=1."
+          else
+            echo "Already reviewed at ${reviewed:0:7}; not overwriting seq=1."
+          fi
+
+  review:
+    name: Claude PR Review
+    needs: needed
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft && needs.needed.outputs.run == 'true' }}
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary
- `/review` from an org member without write access failed closed in Actions and posted nothing on the thread, so it looked like the bot ignored them. The refusal is now a PR comment pointing at a maintainer `/review`.
- Marking an already-reviewed PR ready again re-ran the initial review and overwrote the seq=1 comment (seen on #2998). That path now skips the model and asks for `/review` instead of wiping the ledger.

## Test plan
- [ ] On a PR you do not have write on (or a throwaway org-member account with read-only), comment `/review` and confirm a comment appears explaining the refusal. Confirm a maintainer `/review` still gets the `+1` and runs.
- [ ] Open a new (non-draft) PR and confirm the initial review still posts as seq=1.
- [ ] On a PR that already has a review, convert to draft and mark ready again. Confirm no new/overwritten seq=1 review. If the head moved, confirm the `review-is-current` check is red and says to comment `/review`.
- [ ] After that skip, comment `/review` as a maintainer and confirm a real re-review (seq=2) of the new head.