### PR TITLE
ci: let non-maintainers spend one leftover /review

### DIFF
--- a/.github/scripts/review-command.sh
+++ b/.github/scripts/review-command.sh
@@ -10,8 +10,8 @@
 # Reads COMMENT_BODY, COMMENT_AUTHOR and COMMENT_URL from the environment rather than taking the body
 # as an argument, so a comment can never reach a shell as code.
 #
-# Usage: review-command.sh --command          # prints `command=review|resolve|none` for GITHUB_OUTPUT
-#        review-command.sh <output-file>      # writes the /resolve payload, or `{}`
+# Usage: review-command.sh --command          # prints `command=review|resolve|allow-extra-reviews|none`
+#        review-command.sh <output-file>      # writes the /resolve or /allow-extra-reviews payload, or `{}`
 #        review-command.sh --self-check
 
 set -euo pipefail
@@ -38,10 +38,25 @@ parse() {
       }'
 }
 
+# Bare command → 3. A leading non-negative integer is taken even when it is 0 or less than 3.
+# A token that is not a non-negative integer is invalid, not a silent 3.
+parse_grant() {
+  jq -n --arg l "$1" --arg by "${2-}" --arg url "${3-}" '
+    (($l | capture("^/allow-extra-reviews(?:$|\\s+)(?<rest>.*)$") | .rest) // ""
+      | sub("^\\s+";"") | sub("\\s+$";"")) as $rest
+    | if $rest == "" then {valid:true, n:3, by:$by, url:$url}
+      elif ($rest | test("^[0-9]+(?:\\s|$)")) then
+        {valid:true, n:($rest | capture("^(?<n>[0-9]+)") | .n | tonumber), by:$by, url:$url}
+      else {valid:false, by:$by, url:$url}
+      end
+  '
+}
+
 command_of() {
   case $(first_line_of "${1-}") in
     '/review' | '/review '*) echo review ;;
     '/resolve' | '/resolve '*) echo resolve ;;
+    '/allow-extra-reviews' | '/allow-extra-reviews '*) echo allow-extra-reviews ;;
     *) echo none ;;
   esac
 }
@@ -78,6 +93,20 @@ self_check() {
     fi
   }
 
+  check_grant() {
+    local body=$1 expected=$2 got
+    COMMENT_BODY=$body COMMENT_AUTHOR=u COMMENT_URL=U "$0" "$tmp" > /dev/null
+    got=$(jq -c 'if has("valid") then (if .valid then {valid,n} else {valid} end) else . end' "$tmp")
+    if [ "$got" = "$expected" ]; then
+      echo "  ok    [grant]   ${body//$'\n'/\\n}"
+    else
+      echo "  FAIL  [grant]   ${body//$'\n'/\\n}"
+      echo "        expected $expected"
+      echo "        got      $got"
+      failures=$((failures + 1))
+    fi
+  }
+
   # A command is the first token of the first line. The bodies that broke when this lived in the
   # workflow `if:` — trailing newline, and command-then-context — are the first two here.
   check_command '/review' review
@@ -89,6 +118,11 @@ self_check() {
   check_command $'/resolve\n' resolve
   check_command '/reviewing this now' none
   check_command '/resolved 6.1 yesterday' none
+  check_command '/allow-extra-reviews' allow-extra-reviews
+  check_command $'/allow-extra-reviews\n' allow-extra-reviews
+  check_command '/allow-extra-reviews 5' allow-extra-reviews
+  check_command '/allow-extra-reviews 0' allow-extra-reviews
+  check_command '/allow-extra-reviews-please' none
   check_command 'just a normal comment' none
   check_command '' none
 
@@ -107,6 +141,14 @@ self_check() {
     '{"ids":["1.1"],"reason":"fine"}'
   check_resolve '/resolved 6.1 yesterday, see below' '{}'
   check_resolve '/review' '{}'
+  check_grant '/allow-extra-reviews' '{"valid":true,"n":3}'
+  check_grant $'/allow-extra-reviews\nfoo' '{"valid":true,"n":3}'
+  check_grant '/allow-extra-reviews 5' '{"valid":true,"n":5}'
+  check_grant '/allow-extra-reviews 0' '{"valid":true,"n":0}'
+  check_grant '/allow-extra-reviews 2 please' '{"valid":true,"n":2}'
+  check_grant '/allow-extra-reviews foo' '{"valid":false}'
+  check_grant '/allow-extra-reviews -1' '{"valid":false}'
+  check_grant '/review' '{}'
   # Shell metacharacters stay data: the body never reaches a shell, only jq --arg.
   check_resolve '/resolve 1.1 $(whoami) `id` && rm -rf /' \
     '{"ids":["1.1"],"reason":"$(whoami) `id` && rm -rf /"}'
@@ -132,11 +174,17 @@ case "${1:-}" in
   *)
     output=$1
     first_line=$(first_line_of "${COMMENT_BODY-}")
-    if [ "$(command_of "${COMMENT_BODY-}")" = resolve ]; then
-      parse "$first_line" "${COMMENT_AUTHOR-}" "${COMMENT_URL-}" > "$output"
-    else
-      echo '{}' > "$output"
-    fi
+    case "$(command_of "${COMMENT_BODY-}")" in
+      resolve)
+        parse "$first_line" "${COMMENT_AUTHOR-}" "${COMMENT_URL-}" > "$output"
+        ;;
+      allow-extra-reviews)
+        parse_grant "$first_line" "${COMMENT_AUTHOR-}" "${COMMENT_URL-}" > "$output"
+        ;;
+      *)
+        echo '{}' > "$output"
+        ;;
+    esac
     jq -c . "$output"
     ;;
 esac

--- a/.github/scripts/review-quota.sh
+++ b/.github/scripts/review-quota.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+#
+# Leftover `/review` count for a PR, shared by everyone who cannot push. Each PR starts with one.
+# A maintainer's `/allow-extra-reviews` banks more, and each leftover `/review` spends one.
+# The ledger is the bot comments this workflow already posts, same as a `/resolve`, so a run that
+# dies after banking still leaves the spend on the thread.
+#
+# Author-filtered: a marker is a label anyone can type. The record bodies are written here so the
+# workflow and the self-check post the same bytes.
+#
+# Usage: review-quota.sh remaining          # ndjson comments on stdin; prints a non-negative integer
+#        review-quota.sh record grant <n>   # prints a grant marker (jq -n, so stdin is unused)
+#        review-quota.sh record consume     # prints a consume marker
+#        review-quota.sh --self-check
+
+set -euo pipefail
+
+INITIAL=1
+
+print_record() {
+  printf '<!-- claude-pr-review-quota:v1\n'
+  case "${1-}" in
+    grant)
+      jq -nc --argjson n "${2:?}" '{op:"grant",n:$n}'
+      ;;
+    consume)
+      printf '{"op":"consume"}\n'
+      ;;
+    *)
+      echo 'usage: review-quota.sh record grant <n> | record consume' >&2
+      exit 1
+      ;;
+  esac
+  printf -- '-->\n'
+}
+
+remaining() {
+  jq -rs --argjson initial "$INITIAL" '
+    [.[] | select(.user.login == "github-actions[bot]" and .user.type == "Bot"
+                  and (.body | startswith("<!-- claude-pr-review-quota:v1")))
+     | (.body | capture("(?s)^<!-- claude-pr-review-quota:v1\n(?<j>.*?)\n-->") | .j | fromjson)? // empty]
+    | ($initial
+       + ([.[] | select(.op == "grant") | (.n | numbers)] | add // 0)
+       - ([.[] | select(.op == "consume")] | length))
+    | if . < 0 then 0 else . end
+  '
+}
+
+self_check() {
+  local failures=0
+
+  comment() {
+    jq -nc --arg login "$1" --arg type "$2" --arg body "$3" \
+      '{user:{login:$login,type:$type},body:$body}'
+  }
+
+  record() {
+    comment 'github-actions[bot]' Bot "$(print_record "$@")"
+  }
+
+  check() {
+    local name=$1 input=$2 expected=$3 got
+    got=$(printf '%s\n' "$input" | remaining) || {
+      echo "  FAIL  $name (remaining exited $?)"
+      failures=$((failures + 1))
+      return
+    }
+    if [ "$got" = "$expected" ]; then
+      echo "  ok    $name"
+    else
+      echo "  FAIL  $name"
+      echo "        expected $expected"
+      echo "        got      $got"
+      failures=$((failures + 1))
+    fi
+  }
+
+  check 'no comments is the initial leftover' '' 1
+  check 'one spend' "$(record consume)" 0
+  check 'spent then granted the default 3' \
+    "$(printf '%s\n%s\n' "$(record consume)" "$(record grant 3)")" \
+    3
+  check 'grant smaller than the default' \
+    "$(printf '%s\n%s\n' "$(record consume)" "$(record grant 1)")" \
+    1
+  check 'grant of 0 changes nothing' \
+    "$(printf '%s\n%s\n' "$(record consume)" "$(record grant 0)")" \
+    0
+  check 'unused leftover plus a grant' "$(record grant 3)" 4
+  check 'two spends without a grant floor at 0' \
+    "$(printf '%s\n%s\n' "$(record consume)" "$(record consume)")" \
+    0
+  check 'non-bot forgery is ignored' \
+    "$(printf '%s\n%s\n' \
+      "$(comment evil User '<!-- claude-pr-review-quota:v1
+{"op":"grant","n":99}
+-->')" \
+      "$(record consume)")" \
+    0
+
+  grant_body=$(print_record grant 3)
+  case $grant_body in
+    $'<!-- claude-pr-review-quota:v1\n{"op":"grant","n":3}\n-->')
+      echo '  ok    record grant uses jq -n'
+      ;;
+    *)
+      echo '  FAIL  record grant uses jq -n'
+      echo "        got $(printf '%q' "$grant_body")"
+      failures=$((failures + 1))
+      ;;
+  esac
+
+  if printf 'not json\n' | remaining >/dev/null 2>&1; then
+    echo '  FAIL  malformed input should exit non-zero'
+    failures=$((failures + 1))
+  else
+    echo '  ok    malformed input exits non-zero'
+  fi
+
+  if [ "$failures" -gt 0 ]; then
+    echo "$failures case(s) failed"
+    exit 1
+  fi
+  echo "all cases passed"
+}
+
+case "${1:-}" in
+  --self-check)
+    self_check
+    ;;
+  remaining)
+    remaining
+    ;;
+  record)
+    shift
+    print_record "$@"
+    ;;
+  *)
+    echo 'usage: review-quota.sh remaining | record grant <n> | record consume | --self-check' >&2
+    exit 1
+    ;;
+esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,9 @@ jobs:
       - name: Check the review command parser
         run: .github/scripts/review-command.sh --self-check
 
+      - name: Check the review leftover quota
+        run: .github/scripts/review-quota.sh --self-check
+
       - name: Check the review ledger reader
         run: .github/scripts/review-ledger.sh --self-check
 

--- a/.github/workflows/claude-pr-review-continue.yml
+++ b/.github/workflows/claude-pr-review-continue.yml
@@ -11,33 +11,46 @@ on:
 # superseded run now costs a duplicate run rather than a destroyed one.
 
 jobs:
-  # Only run when: the comment is on a PR, looks like one of our commands, is not from a bot, and the
-  # commenter can push here. The `if:` below is a cheap first pass that keeps the job from being
-  # scheduled for outsiders, and it stays deliberately loose: an expression cannot see past the first
-  # line of a body, so anchoring the command here rejected `/review` followed by a newline — silently,
-  # since an unscheduled job posts nothing at all. `command` below is the real answer, read off the
-  # first line by a script that is unit-checked, and `/reviewing this now` stops there having spent
-  # only this job. `author_association` is likewise only a first pass: an org member with read-only
-  # access to this repository still reports MEMBER, so the permission lookup is the real decision. It
-  # lives in its own job on purpose: the job that runs the model reads an untrusted diff and an
-  # untrusted comments file, and the gate that decides who may command this pipeline must not sit
-  # beside them. Only `.github/scripts` is checked out here, and without credentials. The endpoint
-  # asks an installation token for `metadata: read`, which every job here has; the wider scope below
-  # is kept because the older docs claimed push access and a gate that fails closed takes `/resolve`
-  # with it, and it costs nothing in a job that runs no untrusted input.
+  # Only run when: the comment is on an open PR, looks like one of our commands, and is not from a
+  # bot. Closed and merged PRs are ignored so the leftover cannot be spent on the archive.
+  # The `if:` below is a cheap first pass, and it stays deliberately loose: an expression cannot
+  # see past the first line of a body, so anchoring the command here rejected `/review` followed
+  # by a newline — silently, since an unscheduled job posts nothing at all. `command` below is the
+  # real answer, read off the first line by a script that is unit-checked, and `/reviewing this now`
+  # stops there having spent only this job. There is no `author_association` filter: a leftover
+  # `/review` is the same for every non-writer, org member or not. The permission lookup is the
+  # real decision for `/resolve` and `/allow-extra-reviews` (write only). A `/review` from someone
+  # without write spends a leftover on this PR (they start with one). The leftover is a comment
+  # this job posts, same as a resolution, so it outlives the run. The gate lives in its own job on
+  # purpose: the job that runs the model reads an untrusted diff and an untrusted comments file,
+  # and the gate that decides who may command this pipeline must not sit beside them. Only
+  # `.github/scripts` is checked out here, and without credentials. The endpoint asks an
+  # installation token for `metadata: read`, which every job here has; the wider scope below is
+  # kept because the older docs claimed push access and a gate that fails closed takes `/resolve`
+  # with it. The leftover path reads every comment body on the thread; those bodies reach `jq`
+  # as data and never a shell.
   #
-  # This job is also where a `/resolve` is made durable. It records the authorized resolution as a
-  # comment of its own and does not run the model: a `/review` later picks the resolution up. The
-  # acknowledging reaction lives here so a command waiting behind a 25-minute re-review still gets
-  # an immediate reply.
+  # This job is also where a `/resolve` is made durable, and where leftover `/review` spends and
+  # grants are banked. It records those as comments of its own and does not run the model: a
+  # `/review` later picks a resolution up. The acknowledging reaction lives here so a command
+  # waiting behind a 25-minute re-review still gets an immediate reply.
   authorize:
     name: Authorize
     runs-on: ubuntu-latest
     if: >
       github.event.issue.pull_request &&
-      (startsWith(github.event.comment.body, '/review') || startsWith(github.event.comment.body, '/resolve')) &&
-      github.event.comment.user.type != 'Bot' &&
-      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      github.event.issue.state == 'open' &&
+      (startsWith(github.event.comment.body, '/review') ||
+       startsWith(github.event.comment.body, '/resolve') ||
+       startsWith(github.event.comment.body, '/allow-extra-reviews')) &&
+      github.event.comment.user.type != 'Bot'
+    # Leftover spend is a read-then-write of the comment ledger. Two `/review`s in flight would both
+    # see one left and both spend it. Queueing makes the second read what the first posted.
+    # Grants and `/resolve` are append-only, so they must not sit in that one-pending slot. Anything
+    # that is not a leftover `/review` gets its own group keyed on the comment id.
+    concurrency:
+      group: ${{ startsWith(github.event.comment.body, '/review') && format('claude-pr-authorize-quota-{0}', github.event.issue.number) || format('claude-pr-authorize-once-{0}', github.event.comment.id) }}
+      cancel-in-progress: false
     permissions:
       contents: write
       issues: write
@@ -46,7 +59,7 @@ jobs:
       # the first `/resolve` a maintainer ever types is the worst place to be proved wrong.
       pull-requests: write
     outputs:
-      command: ${{ steps.command.outputs.command }}
+      command: ${{ steps.gate.outputs.command }}
     steps:
       - name: Checkout the command parser (trusted)
         uses: actions/checkout@v4
@@ -68,54 +81,131 @@ jobs:
           echo "$command" >> "$GITHUB_OUTPUT"
           echo "$command"
 
-      # Fails closed: anything other than a definite admin/write answer is a refusal.
-      # A failed Actions job does not show on the PR thread — this event is `issue_comment`,
-      # not a check on the head — so the refusal is also posted as a comment. Without that,
-      # an org member with read-only access (still `MEMBER` above) types `/review` and sees
-      # nothing happen.
-      - name: Require write access
+      # Fails closed for `/resolve` and `/allow-extra-reviews`: anything other than a definite
+      # admin/write answer is a refusal. `/review` is the exception — a leftover on this PR is
+      # enough. Write-required refusals get a `-1` on the command, not a comment: a comment
+      # there is how a stranger turns `/resolve` into unbounded watcher mail. Leftover spends,
+      # an exhausted leftover (once, as a notice so the consume's "0 left" does not hide it;
+      # later ones get a `-1`),
+      # and a failed permission lookup still comment, because those are the cases a real
+      # contributor would otherwise see as the bot ignoring them.
+      # An exhausted leftover is not a failure: the notice is the answer, and the job succeeds with
+      # `command=none` so the model does not run.
+      - name: Authorize the command
+        id: gate
         if: steps.command.outputs.command != 'none'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
           ACTOR: ${{ github.event.comment.user.login }}
-          COMMAND: /${{ steps.command.outputs.command }}
+          PARSED: ${{ steps.command.outputs.command }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          COMMENT_URL: ${{ github.event.comment.html_url }}
+          COMMENT_ID: ${{ github.event.comment.id }}
         run: |
           set -euo pipefail
+          command="/$PARSED"
           # Assign, then override on failure: `$(... || echo unknown)` would append to whatever
           # error body gh printed on stdout instead of replacing it.
           level=$(gh api "repos/$REPO/collaborators/$ACTOR/permission" --jq '.permission' 2>/dev/null) || level='unknown'
           echo "$ACTOR has '$level' permission on $REPO"
+
+          fetch_comments() {
+            gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate --jq '.[]' > all-comments.ndjson \
+              || {
+                printf 'Could not read the comments on this PR. Comment `%s` again.\n' "$command" \
+                  | post_notice
+                exit 1
+              }
+          }
+
+          leftover() {
+            .github/scripts/review-quota.sh remaining < all-comments.ndjson \
+              || {
+                printf 'Could not read how many `/review` requests are left. Comment `%s` again.\n' \
+                  "$command" | post_notice
+                exit 1
+              }
+          }
+
+          post_notice() {
+            {
+              printf '<!-- claude-pr-review-notice:v1 -->\n'
+              cat
+            } > notice.md
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file notice.md \
+              || echo "::warning::could not post the notice"
+          }
+
           case "$level" in
-            admin | write) ;;
+            admin | write)
+              if [ "$PARSED" = allow-extra-reviews ]; then
+                .github/scripts/review-command.sh grant.json
+                if [ "$(jq -r '.valid' grant.json)" != true ]; then
+                  printf 'Could not read a count from that `/allow-extra-reviews`. Use `/allow-extra-reviews` or `/allow-extra-reviews N`.\n' \
+                    | post_notice
+                  echo "command=none" >> "$GITHUB_OUTPUT"
+                  exit 0
+                fi
+                n=$(jq -r '.n' grant.json)
+                fetch_comments
+                after=$(( $(leftover) + n ))
+                {
+                  .github/scripts/review-quota.sh record grant "$n"
+                  printf 'Granted %s extra. This PR has %s left.\n' "$n" "$after"
+                } > grant.md
+                gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file grant.md \
+                  || { echo "::error::could not record the grant"; exit 1; }
+              fi
+              echo "command=$PARSED" >> "$GITHUB_OUTPUT"
+              ;;
             unknown)
-              echo "::error::$COMMAND: could not determine $ACTOR's permission on $REPO."
-              {
-                printf '<!-- claude-pr-review-notice:v1 -->\n'
-                printf 'Could not check whether @%s can run `%s`. Comment `%s` again.\n' \
-                  "$ACTOR" "$COMMAND" "$COMMAND"
-              } > refuse.md
-              gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file refuse.md \
-                || echo "::warning::could not post the refusal"
+              echo "::error::$command: could not determine $ACTOR's permission on $REPO."
+              printf 'Could not check whether @%s can run `%s`. Comment `%s` again.\n' \
+                "$ACTOR" "$command" "$command" | post_notice
               exit 1
               ;;
             *)
-              echo "::error::$COMMAND requires write access to $REPO. $ACTOR has '$level'."
+              if [ "$PARSED" != review ]; then
+                echo "::error::$command requires write access to $REPO. $ACTOR has '$level'."
+                gh api -X POST "repos/$REPO/issues/comments/$COMMENT_ID/reactions" -f content='-1' || true
+                exit 1
+              fi
+              fetch_comments
+              left=$(leftover)
+              if [ "$left" -le 0 ]; then
+                if ! jq -se '[.[] | select(.user.login == "github-actions[bot]" and .user.type == "Bot"
+                      and (.body | startswith("<!-- claude-pr-review-notice:v1"))
+                      and (.body | contains("This PR has 0 left")))] | length > 0' \
+                    all-comments.ndjson >/dev/null; then
+                  {
+                    printf 'This PR has 0 left. '
+                    printf 'A maintainer can comment `/allow-extra-reviews` to grant more (default 3).\n'
+                  } | post_notice
+                else
+                  gh api -X POST "repos/$REPO/issues/comments/$COMMENT_ID/reactions" -f content='-1' || true
+                fi
+                echo "command=none" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              after=$(( left - 1 ))
+              # ponytail: leftover is banked here before rereview; a queued rereview GitHub
+              # drops (one pending slot) burns it. Refund the consume if that starts happening.
               {
-                printf '<!-- claude-pr-review-notice:v1 -->\n'
-                printf '%s requires write access to this repository. @%s has `%s`.\n' \
-                  "$COMMAND" "$ACTOR" "$level"
-                printf 'A maintainer can comment `%s` to run it.\n' "$COMMAND"
-              } > refuse.md
-              gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file refuse.md \
-                || echo "::warning::could not post the refusal"
-              exit 1
+                .github/scripts/review-quota.sh record consume
+                printf 'This PR has %s left. ' "$after"
+                printf 'A maintainer can comment `/allow-extra-reviews` to grant more (default 3).\n'
+              } > consume.md
+              gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file consume.md \
+                || { echo "::error::could not record the leftover spend"; exit 1; }
+              echo "command=review" >> "$GITHUB_OUTPUT"
               ;;
           esac
 
       - name: Acknowledge the command
-        if: steps.command.outputs.command != 'none'
+        if: steps.gate.conclusion == 'success' && steps.gate.outputs.command != 'none'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -128,7 +218,7 @@ jobs:
       # record is a comment rather than a run artifact so it outlives this workflow: the next
       # `/review` reads every resolution posted since the last one.
       - name: Record the resolution
-        if: steps.command.outputs.command == 'resolve'
+        if: steps.gate.outputs.command == 'resolve'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -171,14 +261,16 @@ jobs:
     # second run read what the first published.
     #
     # A group holds one running entry and one pending entry, so a third command cancels whatever is
-    # queued. That is now only a lost run, not lost data: resolutions are banked by `authorize`
-    # before this job is ever scheduled, and the next review applies them.
+    # queued. Resolutions are banked by `authorize` before this job is scheduled, so a dropped
+    # rereview is only a lost run for those. A leftover `/review` is spent in `authorize`, so the
+    # same drop can burn the PR's leftover (see the spend-site ponytail).
     concurrency:
       group: claude-pr-rereview-serial-${{ github.event.issue.number }}
       cancel-in-progress: false
     # We intentionally do NOT allow the PR author by login alone, since an external fork author
     # could otherwise spend Anthropic credits by repeatedly commenting `/review` on their own PR.
-    # A maintainer can trigger a re-review on a contributor's behalf.
+    # A leftover `/review` is one spend, banked above; more needs `/allow-extra-reviews` from
+    # someone with write.
     permissions:
       contents: read
       pull-requests: write
@@ -291,8 +383,8 @@ jobs:
 
           # Human/reviewer discussion since the last review (general PR comments and
           # inline code-review comments), so the agent can factor it into the new
-          # review. The bot's own review, resolution, decision and notice comments
-          # (the markers) are excluded.
+          # review. The bot's own review, resolution, decision, leftover and notice
+          # comments (the markers) are excluded.
           jq -c '{kind:"comment", author:.user.login, created_at:.created_at, path:null, body:.body, url:.html_url}' \
             all-comments.ndjson > issue_comments.ndjson || : > issue_comments.ndjson
           gh api "repos/$REPO/pulls/$PR_NUMBER/comments" --paginate \
@@ -304,6 +396,7 @@ jobs:
                 | map(select(.body | startswith("<!-- claude-pr-review-resolution:v1") | not))
                 | map(select(.body | startswith("<!-- claude-pr-review-decision:v1") | not))
                 | map(select(.body | startswith("<!-- claude-pr-review-notice:v1") | not))
+                | map(select(.body | startswith("<!-- claude-pr-review-quota:v1") | not))
                 | map(select($since == "" or .created_at > $since))
                 | sort_by(.created_at)
               ' > new-comments.json


### PR DESCRIPTION
## Summary
- Anyone without write on this repo starts with one leftover `/review` per PR. After they spend it, the bot comments how many requests are left and that a maintainer must grant more.
- A maintainer comments `/allow-extra-reviews` to bank 3 more, or `/allow-extra-reviews N` to bank that number (including `N < 3` or `0`). `/resolve` and `/allow-extra-reviews` still require write. Maintainer `/review` is unlimited and does not spend a leftover.

## Test plan
- [ ] As a fork author who is not an org member, comment `/review`. Confirm the `+1`, a leftover comment, and a real re-review.
- [ ] Comment `/review` again as that same person. Confirm a "0 left" notice and no model run.
- [ ] As an org member without write, comment `/review` and confirm the same leftover rules.
- [ ] As a maintainer, comment `/allow-extra-reviews` (no number). Confirm it banks 3. Then `/allow-extra-reviews 1` and confirm it banks 1.
- [ ] After a grant, comment `/review` as a non-writer and confirm it runs and the leftover drops by one.
- [ ] As a non-writer, comment `/allow-extra-reviews` and `/resolve 1.1 test`. Confirm both are refused with a `-1` on the command and no comment.
- [ ] As a maintainer, comment `/review` and confirm it runs without spending a leftover.
