### PR TITLE
electron: record the Chromium and Cockpit versions in the userData

### DIFF
--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -39,6 +39,27 @@ let appSuspensionPowerSaveBlockerId: number | undefined
 let displaySleepPowerSaveBlockerId: number | undefined
 
 /**
+ * Stamps this userData folder with the Chromium and Cockpit versions that opened it.
+ *
+ * Neither Chromium nor Electron leaves a version marker behind, so an older build has no way to tell that the profile
+ * it is about to open was written by a newer one - a downgrade Chromium answers by dropping the affected stores.
+ * config.json is plain JSON at the userData root, so a future build can read it before Chromium touches the profile.
+ *
+ * Runs once the renderer has loaded, so the stamp reflects a profile Chromium really opened rather than a launch that
+ * died on the way there, and so it stays below the module scope where a guard would have to read the previous value.
+ * @returns {void}
+ */
+const recordProfileOpenerVersions = (): void => {
+  try {
+    if (store.get('chromeVersion') !== process.versions.chrome) store.set('chromeVersion', process.versions.chrome)
+    if (store.get('cockpitVersion') !== app.getVersion()) store.set('cockpitVersion', app.getVersion())
+  } catch (error) {
+    // A marker nothing reads yet must never be the reason the app fails to start
+    console.error('Could not record the Chromium and Cockpit versions in the config file.', error)
+  }
+}
+
+/**
  * Create electron window
  */
 function createWindow(): void {
@@ -94,6 +115,7 @@ function createWindow(): void {
 
   mainWindow.webContents.on('did-finish-load', () => {
     mainWindow?.setTitle(`Cockpit (${app.getVersion()})`)
+    recordProfileOpenerVersions()
   })
 
   if (process.env.VITE_DEV_SERVER_URL) {

--- a/src/electron/services/config-store.ts
+++ b/src/electron/services/config-store.ts
@@ -1,7 +1,13 @@
 import Store from 'electron-store'
 
 const electronStoreSchema = {
+  chromeVersion: {
+    type: 'string',
+  },
   cockpitFolderPath: {
+    type: 'string',
+  },
+  cockpitVersion: {
     type: 'string',
   },
   windowBounds: {
@@ -29,9 +35,17 @@ const electronStoreSchema = {
  */
 export interface ElectronStoreSchema {
   /**
+   * Chromium version that last opened this userData folder, as `process.versions.chrome` (e.g. `122.0.6261.156`)
+   */
+  chromeVersion: string | undefined
+  /**
    * Custom Cockpit folder path, overriding the default ~/Cockpit
    */
   cockpitFolderPath: string | undefined
+  /**
+   * Cockpit version that last opened this userData folder, as `app.getVersion()` (e.g. `1.18.3`)
+   */
+  cockpitVersion: string | undefined
   /**
    * Window bounds
    */


### PR DESCRIPTION
## Summary

Records `process.versions.chrome` and `app.getVersion()` in `config.json` on every startup, so an older Cockpit build can tell which Chromium — and which Cockpit — last wrote the `userData` it is about to open.

Chromium refuses to open a profile written by a newer Chromium and drops the affected stores. Concretely, V8's `ValueSerializer` data format version differs between Chrome 122 (Electron 29) and Chrome 150 (Electron 43), so `IndexedDBBackingStore::SetUpMetadata()` on the older build takes the "`db_data_version` is in the future" branch, returns `leveldb::Status::Corruption`, and Chromium deletes that bucket's IndexedDB.

Chromium leaves no version marker of its own to detect this with. The `Last Version` file is written by the `chrome/` browser layer, which Electron does not compile in (no reference to it or to `kChromeVersionFilename` anywhere in the Electron tree, and real Electron profiles on disk do not have one). The alternative of inferring the writer's version from the profile's directory layout does not work either: the `Network/` subdirectory, for instance, is gated on `chrome::kTriggerNetworkDataMigration`, which is `FEATURE_ENABLED_BY_DEFAULT` on Windows and disabled elsewhere in both Chromium 122 and 150 — it tells you the platform, not the version.

`config.json` is the right place for both markers because it is plain JSON at the root of `userData`, so a future build can read it with `readFileSync` before Electron resolves its session and before Chromium touches the profile.

`chromeVersion` is the actionable half: it is what a downgrade guard would compare against. `cockpitVersion` is the human-readable half — it costs one line and makes a `config.json` pulled from a user's machine self-describing during support and bug triage.

This PR only writes the markers. It deliberately does not act on them: there is no consumer yet, and a guard that reads them can be added later without a migration. Absence of a marker means "unknown", which must keep meaning "do nothing" — that keeps false positives impossible by construction, which matters because a false positive here means a user boots into an empty profile.

Context: https://github.com/bluerobotics/cockpit/pull/3004

## Test plan

- [ ] Launch Standalone, quit, and check that `chromeVersion` and `cockpitVersion` appear in `config.json` in `userData`, matching the bundled Electron's Chromium and the app version in the window title.
- [ ] Launch again and confirm the existing `cockpitFolderPath` and `windowBounds` entries are untouched.
- [ ] Start from a `config.json` that predates this change (neither key present) and confirm the app boots normally and both keys get added.
