### PR TITLE
refactor: drop Cockpit-side camera zoom and focus speed

### DIFF
--- a/src/libs/joystick/protocols/predefined-resources.ts
+++ b/src/libs/joystick/protocols/predefined-resources.ts
@@ -42,16 +42,13 @@ export const joystickInputAxes: Record<(typeof joystickAxisConfig)[number]['key'
 
 const setupMavlinkCameraResources = (): void => {
   const commonVariableConfig = { type: 'number' as DataLakeVariableType, allowUserToChangeValue: true }
-  const speedVariableConfig = { ...commonVariableConfig, persistValue: true }
   // Initialize camera zoom variables
   createDataLakeVariable({ id: 'camera-zoom-decrease', name: 'Camera Zoom Decrease', ...commonVariableConfig }, 0)
   createDataLakeVariable({ id: 'camera-zoom-increase', name: 'Camera Zoom Increase', ...commonVariableConfig }, 0)
-  createDataLakeVariable({ id: 'camera-zoom-speed', name: 'Camera Zoom Speed', ...speedVariableConfig }, 3)
 
   // Initialize camera focus variables
   createDataLakeVariable({ id: 'camera-focus-decrease', name: 'Camera Focus Decrease', ...commonVariableConfig }, 0)
   createDataLakeVariable({ id: 'camera-focus-increase', name: 'Camera Focus Increase', ...commonVariableConfig }, 0)
-  createDataLakeVariable({ id: 'camera-focus-speed', name: 'Camera Focus Speed', ...speedVariableConfig }, 3)
 
   // Initialize camera zoom transforming function
   try {
@@ -60,11 +57,11 @@ const setupMavlinkCameraResources = (): void => {
       name: 'Camera Zoom',
       type: 'number',
       expression: getUnindentedString(`
-        const zoom = ({{camera-zoom-increase}} - {{camera-zoom-decrease}}) * {{camera-zoom-speed}}
+        const zoom = {{camera-zoom-increase}} - {{camera-zoom-decrease}}
         return zoom < 0.05 && zoom > -0.05 ? 0 : Math.max(Math.min(1, zoom), -1)
       `),
       description:
-        'Used to control the camera zoom. The value is the difference between {{camera-zoom-increase}} and {{camera-zoom-decrease}}, multiplied by {{camera-zoom-speed}}.',
+        'Used to control the camera zoom. The value is the difference between {{camera-zoom-increase}} and {{camera-zoom-decrease}}.',
       allowUserToChangeValue: true,
     })
   } catch (error) {
@@ -78,11 +75,11 @@ const setupMavlinkCameraResources = (): void => {
       name: 'Camera Focus',
       type: 'number',
       expression: getUnindentedString(`
-        const focus = ({{camera-focus-increase}} - {{camera-focus-decrease}}) * {{camera-focus-speed}}
+        const focus = {{camera-focus-increase}} - {{camera-focus-decrease}}
         return focus < 0.05 && focus > -0.05 ? 0 : Math.max(Math.min(1, focus), -1)
       `),
       description:
-        'Used to control the camera focus. The value is the difference between {{camera-focus-increase}} and {{camera-focus-decrease}}, multiplied by {{camera-focus-speed}}.',
+        'Used to control the camera focus. The value is the difference between {{camera-focus-increase}} and {{camera-focus-decrease}}.',
       allowUserToChangeValue: true,
     })
   } catch (error) {

--- a/src/utils/migrations.ts
+++ b/src/utils/migrations.ts
@@ -1,6 +1,10 @@
+import { openSnackbar } from '@/composables/snackbar'
+import { createDataLakeVariable, deleteDataLakeVariable, getDataLakeVariableData } from '@/libs/actions/data-lake'
+import { getAllTransformingFunctions, updateTransformingFunction } from '@/libs/actions/data-lake-transformations'
 import { recordedDataLakeVariablesKey } from '@/libs/data-lake-logging'
 import { shareHardwareDetailsKey } from '@/libs/external-telemetry/event-tracking'
 import { settingsManager } from '@/libs/settings-management'
+import { getUnindentedString } from '@/libs/utils'
 import { collectOverlayRecordedVariableIds } from '@/utils/data-lake-recorded-variables-migration'
 
 // Tracks which one-off migrations have already run, keyed by migration name.
@@ -83,6 +87,82 @@ const migrateRecordedVariablesFromOverlay = (): void => {
   markMigrationAsRun(migrationName)
 }
 
+const cameraSpeedVariables = [
+  { id: 'camera-zoom-speed', name: 'Camera Zoom Speed' },
+  { id: 'camera-focus-speed', name: 'Camera Focus Speed' },
+] as const
+
+const shippedCameraFunctions = [
+  {
+    id: 'camera-zoom',
+    oldExpression: getUnindentedString(`
+      const zoom = ({{camera-zoom-increase}} - {{camera-zoom-decrease}}) * {{camera-zoom-speed}}
+      return zoom < 0.05 && zoom > -0.05 ? 0 : Math.max(Math.min(1, zoom), -1)
+    `),
+    newExpression: getUnindentedString(`
+      const zoom = {{camera-zoom-increase}} - {{camera-zoom-decrease}}
+      return zoom < 0.05 && zoom > -0.05 ? 0 : Math.max(Math.min(1, zoom), -1)
+    `),
+    newDescription:
+      'Used to control the camera zoom. The value is the difference between {{camera-zoom-increase}} and {{camera-zoom-decrease}}.',
+  },
+  {
+    id: 'camera-focus',
+    oldExpression: getUnindentedString(`
+      const focus = ({{camera-focus-increase}} - {{camera-focus-decrease}}) * {{camera-focus-speed}}
+      return focus < 0.05 && focus > -0.05 ? 0 : Math.max(Math.min(1, focus), -1)
+    `),
+    newExpression: getUnindentedString(`
+      const focus = {{camera-focus-increase}} - {{camera-focus-decrease}}
+      return focus < 0.05 && focus > -0.05 ? 0 : Math.max(Math.min(1, focus), -1)
+    `),
+    newDescription:
+      'Used to control the camera focus. The value is the difference between {{camera-focus-increase}} and {{camera-focus-decrease}}.',
+  },
+]
+
+/**
+ * Drop Cockpit's camera zoom/focus speed factor from stored formulas and persisted values, once.
+ *
+ * Only the two expressions Cockpit originally shipped are rewritten; a user-tuned formula is left alone.
+ * @returns {void}
+ */
+const migrateCameraSpeedFactorRemoval = (): void => {
+  const migrationName = 'camera-speed-factor-removed'
+  if (hasMigrationRun(migrationName)) return
+
+  let rewroteShippedFormula = false
+  for (const func of shippedCameraFunctions) {
+    const stored = getAllTransformingFunctions().find((candidate) => candidate.id === func.id)
+    if (stored === undefined || stored.expression.trim() !== func.oldExpression.trim()) continue
+    updateTransformingFunction({ ...stored, expression: func.newExpression, description: func.newDescription })
+    rewroteShippedFormula = true
+  }
+
+  let hadPersistedSpeed = false
+  for (const { id, name } of cameraSpeedVariables) {
+    // deleteDataLakeVariable only drops a stored persistValue when the id is registered.
+    createDataLakeVariable({ id, name, type: 'number', persistValue: true })
+    if (getDataLakeVariableData(id) !== undefined) hadPersistedSpeed = true
+    deleteDataLakeVariable(id)
+  }
+
+  const leftoverSpeedRef = getAllTransformingFunctions().some((func) =>
+    cameraSpeedVariables.some(({ id }) => func.expression.includes(id))
+  )
+  if (rewroteShippedFormula || hadPersistedSpeed || leftoverSpeedRef) {
+    openSnackbar({
+      message:
+        'Camera zoom and focus speed are now set on the vehicle. Cockpit no longer keeps those settings, so zoom and focus no longer use them. ' +
+        'If something you made still refers to them, edit it in Tools → Data-lake.',
+      variant: 'info',
+      duration: 12000,
+    })
+  }
+
+  markMigrationAsRun(migrationName)
+}
+
 /**
  * Run all migrations
  */
@@ -90,4 +170,5 @@ export function runMigrations(): void {
   migrateRenameOfLocalStorageKeys()
   migrateLegacyTelemetryOptOutToHardwareSharing()
   migrateRecordedVariablesFromOverlay()
+  migrateCameraSpeedFactorRemoval()
 }


### PR DESCRIPTION
## Summary

Stops Cockpit from applying a camera zoom/focus speed factor, now that ArduPilot owns that scaling.

- **Remove camera zoom/focus speed** (#3011). Drop the `camera-zoom-speed` and `camera-focus-speed` data-lake variables. The compound variables become the increase/decrease difference plus the existing deadzone. The `[-1, 1]` clamp stays: analog joystick mappings scale to the configured min/max (shipped profiles use ±1000), and the increase/decrease variables are user-editable, so the difference is not already in range. Existing installs that still have the original shipped formula are rewritten **once** (exact match only); later boots leave a user-edited expression alone.

A follow-up PR will land the same change on `v1.18-dev` for 1.18.3 after this merges.

### Data lake variables

| Before | After |
| --- | --- |
| <img src="https://github.com/rafaellehmkuhl/cockpit-public/blob/5b7a29892c7570971e1052e09e0777e7106a1237/pr-assets/pr3014-camera-speed-before.png?raw=true" width="420"> | <img src="https://github.com/rafaellehmkuhl/cockpit-public/blob/5b7a29892c7570971e1052e09e0777e7106a1237/pr-assets/pr3014-camera-speed-after.png?raw=true" width="420"> |

### Camera Zoom expression

| Before | After |
| --- | --- |
| <img src="https://github.com/rafaellehmkuhl/cockpit-public/blob/5b7a29892c7570971e1052e09e0777e7106a1237/pr-assets/pr3014-camera-zoom-expr-before.png?raw=true" width="420"> | <img src="https://github.com/rafaellehmkuhl/cockpit-public/blob/5b7a29892c7570971e1052e09e0777e7106a1237/pr-assets/pr3014-camera-zoom-expr-after.png?raw=true" width="420"> |

### Camera Focus expression

| Before | After |
| --- | --- |
| <img src="https://github.com/rafaellehmkuhl/cockpit-public/blob/5b7a29892c7570971e1052e09e0777e7106a1237/pr-assets/pr3014-camera-focus-expr-before.png?raw=true" width="420"> | <img src="https://github.com/rafaellehmkuhl/cockpit-public/blob/5b7a29892c7570971e1052e09e0777e7106a1237/pr-assets/pr3014-camera-focus-expr-after.png?raw=true" width="420"> |

The expression screenshots were taken before the clamp was restored; the after formulas now also end with `Math.max(Math.min(1, …), -1)`.

## Test plan

- [ ] Open Tools → Data-lake and confirm Camera Zoom Speed and Camera Focus Speed are gone
- [ ] Edit the Camera Zoom compound variable: the expression is the increase/decrease difference plus deadzone and the `[-1, 1]` clamp, with no `* {{camera-zoom-speed}}`
- [ ] Same for Camera Focus
- [ ] Upgrade an install that still has the original shipped formula and confirm zoom/focus still work (rewritten once)
- [ ] After that first boot, change the Camera Zoom expression, reload, and confirm the edit is still there
- [ ] Confirm a one-time snackbar about the speed settings moving to the vehicle

## Checks

- Fresh boot camera data-lake ids: 8 (including `camera-zoom-speed` / `camera-focus-speed`, default `3`) → 6 (those two gone)
- Data-lake table: 24 variables → 22, with the two speed rows removed
- Compound descriptions no longer mention multiplication
- `yarn lint`, `yarn typecheck` and `yarn test:unit` clean

Closes #3011