### PR TITLE
refactor: drop Cockpit-side camera zoom and focus speed

### DIFF
--- a/src/libs/actions/data-lake-transformations.ts
+++ b/src/libs/actions/data-lake-transformations.ts
@@ -210,7 +210,10 @@ export const createTransformingFunction = (
 }
 
 /**
- * Returns all transforming functions
+ * Returns all transforming functions.
+ *
+ * The array and its entries are live. `migrateCameraSpeedFactorRemoval` mutates expressions at boot;
+ * do not copy the array or its objects here.
  * @returns {TransformingFunction[]} All transforming functions
  */
 export const getAllTransformingFunctions = (): TransformingFunction[] => {

--- a/src/libs/joystick/protocols/predefined-resources.ts
+++ b/src/libs/joystick/protocols/predefined-resources.ts
@@ -18,12 +18,10 @@ export const setupMavlinkCameraResources = (): void => {
   // Initialize camera zoom variables
   createDataLakeVariable({ id: 'camera-zoom-decrease', name: 'Camera Zoom Decrease', ...commonVariableConfig }, 0)
   createDataLakeVariable({ id: 'camera-zoom-increase', name: 'Camera Zoom Increase', ...commonVariableConfig }, 0)
-  createDataLakeVariable({ id: 'camera-zoom-speed', name: 'Camera Zoom Speed', ...commonVariableConfig }, 3)
 
   // Initialize camera focus variables
   createDataLakeVariable({ id: 'camera-focus-decrease', name: 'Camera Focus Decrease', ...commonVariableConfig }, 0)
   createDataLakeVariable({ id: 'camera-focus-increase', name: 'Camera Focus Increase', ...commonVariableConfig }, 0)
-  createDataLakeVariable({ id: 'camera-focus-speed', name: 'Camera Focus Speed', ...commonVariableConfig }, 3)
 
   // Initialize camera zoom transforming function
   try {
@@ -34,10 +32,10 @@ export const setupMavlinkCameraResources = (): void => {
         'Camera Zoom',
         'number',
         getUnindentedString(`
-          const zoom = ({{camera-zoom-increase}} - {{camera-zoom-decrease}}) * {{camera-zoom-speed}}
+          const zoom = {{camera-zoom-increase}} - {{camera-zoom-decrease}}
           return zoom < 0.05 && zoom > -0.05 ? 0 : Math.max(Math.min(1, zoom), -1)
         `),
-        'Used to control the camera zoom. The value is the difference between {{camera-zoom-increase}} and {{camera-zoom-decrease}}, multiplied by {{camera-zoom-speed}}.'
+        'Used to control the camera zoom. The value is the difference between {{camera-zoom-increase}} and {{camera-zoom-decrease}}.'
       )
     }
   } catch (error) {
@@ -53,10 +51,10 @@ export const setupMavlinkCameraResources = (): void => {
         'Camera Focus',
         'number',
         getUnindentedString(`
-          const focus = ({{camera-focus-increase}} - {{camera-focus-decrease}}) * {{camera-focus-speed}}
+          const focus = {{camera-focus-increase}} - {{camera-focus-decrease}}
           return focus < 0.05 && focus > -0.05 ? 0 : Math.max(Math.min(1, focus), -1)
         `),
-        'Used to control the camera focus. The value is the difference between {{camera-focus-increase}} and {{camera-focus-decrease}}, multiplied by {{camera-focus-speed}}.'
+        'Used to control the camera focus. The value is the difference between {{camera-focus-increase}} and {{camera-focus-decrease}}.'
       )
     }
   } catch (error) {

--- a/src/utils/migrations.ts
+++ b/src/utils/migrations.ts
@@ -1,5 +1,9 @@
+import { openSnackbar } from '@/composables/snackbar'
+import { getDataLakeVariableInfo, updateDataLakeVariableInfo } from '@/libs/actions/data-lake'
+import { getAllTransformingFunctions } from '@/libs/actions/data-lake-transformations'
 import { shareHardwareDetailsKey } from '@/libs/external-telemetry/event-tracking'
 import { settingsManager } from '@/libs/settings-management'
+import { getUnindentedString } from '@/libs/utils'
 
 /**
  * Migrate old localStorage keys to new ones
@@ -37,10 +41,83 @@ const migrateLegacyTelemetryOptOutToHardwareSharing = (): void => {
   localStorage.removeItem(legacyKey)
 }
 
+const cameraSpeedRemovedIds = ['camera-zoom-speed', 'camera-focus-speed'] as const
+const cameraSpeedNoticeKey = 'cockpit-camera-speed-notice-shown'
+
+const shippedCameraFunctions = [
+  {
+    id: 'camera-zoom',
+    oldExpression: getUnindentedString(`
+      const zoom = ({{camera-zoom-increase}} - {{camera-zoom-decrease}}) * {{camera-zoom-speed}}
+      return zoom < 0.05 && zoom > -0.05 ? 0 : Math.max(Math.min(1, zoom), -1)
+    `),
+    newExpression: getUnindentedString(`
+      const zoom = {{camera-zoom-increase}} - {{camera-zoom-decrease}}
+      return zoom < 0.05 && zoom > -0.05 ? 0 : Math.max(Math.min(1, zoom), -1)
+    `),
+    newDescription:
+      'Used to control the camera zoom. The value is the difference between {{camera-zoom-increase}} and {{camera-zoom-decrease}}.',
+  },
+  {
+    id: 'camera-focus',
+    oldExpression: getUnindentedString(`
+      const focus = ({{camera-focus-increase}} - {{camera-focus-decrease}}) * {{camera-focus-speed}}
+      return focus < 0.05 && focus > -0.05 ? 0 : Math.max(Math.min(1, focus), -1)
+    `),
+    newExpression: getUnindentedString(`
+      const focus = {{camera-focus-increase}} - {{camera-focus-decrease}}
+      return focus < 0.05 && focus > -0.05 ? 0 : Math.max(Math.min(1, focus), -1)
+    `),
+    newDescription:
+      'Used to control the camera focus. The value is the difference between {{camera-focus-increase}} and {{camera-focus-decrease}}.',
+  },
+]
+
+/**
+ * Drop Cockpit's camera zoom/focus speed factor from stored shipped formulas.
+ *
+ * Exact copies of the two originally shipped expressions are rewritten in memory whenever they are found;
+ * a user-tuned formula is left alone. The rewrite is not persisted: writing the whole function list
+ * at boot would stamp a new epoch and could overwrite a newer vehicle copy. Listeners already close
+ * over the same objects, so the in-memory edit is what this boot evaluates. The notice is shown at
+ * most once per browser profile.
+ * @returns {void}
+ */
+const migrateCameraSpeedFactorRemoval = (): void => {
+  let rewroteShippedFormula = false
+  for (const func of shippedCameraFunctions) {
+    const stored = getAllTransformingFunctions().find((candidate) => candidate.id === func.id)
+    if (stored === undefined || stored.expression.trim() !== func.oldExpression.trim()) continue
+    // ponytail: not persisted — a boot-time setKeyValue would newest-epoch-win the whole list.
+    // Ceiling: this patch must ship for as long as 1.18 installs keep the old stored formula.
+    // Upgrade: persist with the existing epoch (or 0) so the rewrite cannot outrank the vehicle.
+    stored.expression = func.newExpression
+    stored.description = func.newDescription
+    const info = getDataLakeVariableInfo(stored.id)
+    if (info !== undefined) updateDataLakeVariableInfo({ ...info, description: func.newDescription })
+    rewroteShippedFormula = true
+  }
+
+  const leftoverSpeedRef = getAllTransformingFunctions().some((func) =>
+    cameraSpeedRemovedIds.some((id) => func.expression.includes(id))
+  )
+  if ((rewroteShippedFormula || leftoverSpeedRef) && localStorage.getItem(cameraSpeedNoticeKey) !== 'true') {
+    openSnackbar({
+      message:
+        'Camera zoom and focus speed are now set on the vehicle. Cockpit no longer keeps those settings, so zoom and focus no longer use them. ' +
+        'If something you made still refers to them, edit it in Tools → Data-lake.',
+      variant: 'info',
+      duration: 12000,
+    })
+    localStorage.setItem(cameraSpeedNoticeKey, 'true')
+  }
+}
+
 /**
  * Run all migrations
  */
 export function runMigrations(): void {
   migrateRenameOfLocalStorageKeys()
   migrateLegacyTelemetryOptOutToHardwareSharing()
+  migrateCameraSpeedFactorRemoval()
 }


### PR DESCRIPTION
## Summary

Backport of #3014 onto `v1.18-dev` for 1.18.3.

Stops Cockpit from applying a camera zoom/focus speed factor, now that ArduPilot owns that scaling.

- Drop the `camera-zoom-speed` and `camera-focus-speed` data-lake variables. The compound variables become the increase/decrease difference plus the existing deadzone. The `[-1, 1]` clamp stays: analog joystick mappings scale to the configured min/max (shipped profiles use ±1000), and the increase/decrease variables are user-editable, so the difference is not already in range. Existing installs that still have the original shipped formula get an **in-memory** rewrite on every boot (exact match only); the stored copy is left alone so a boot-time save cannot overwrite a newer vehicle copy. User-edited expressions are left alone.

### 1.18 notes vs #3014

- Setup on this branch already creates the zoom/focus compounds only when they are missing, so changing the default expression is enough for new installs. This backport does not add `ensureCockpitTransformingFunction`.
- The speed variables were never `persistValue` on 1.18, and 1.18 rebuilds `cockpit-persistent-data-lake-values` from the current registry. The master create-then-delete prune is skipped so a boot-time save cannot wipe other persisted values.
- Unlike #3014, the rewrite is not persisted. Master writes through `updateTransformingFunction`; this backport mutates the live in-memory objects so it cannot newest-epoch-win the whole function list.

### Data lake variables

| Before | After |
| --- | --- |
| <img src="https://github.com/rafaellehmkuhl/cockpit-public/blob/5b7a29892c7570971e1052e09e0777e7106a1237/pr-assets/pr3014-camera-speed-before.png?raw=true" width="420"> | <img src="https://github.com/rafaellehmkuhl/cockpit-public/blob/5b7a29892c7570971e1052e09e0777e7106a1237/pr-assets/pr3014-camera-speed-after.png?raw=true" width="420"> |

### Camera Zoom expression

| Before | After |
| --- | --- |
| <img src="https://github.com/rafaellehmkuhl/cockpit-public/blob/5b7a29892c7570971e1052e09e0777e7106a1237/pr-assets/pr3014-camera-zoom-expr-before.png?raw=true" width="420"> | <img src="https://github.com/rafaellehmkuhl/cockpit-public/blob/5b7a29892c7570971e1052e09e0777e7106a1237/pr-assets/pr3014-camera-zoom-expr-after.png?raw=true" width="420"> |

### Camera Focus expression

| Before | After |
| --- | --- |
| <img src="https://github.com/rafaellehmkuhl/cockpit-public/blob/5b7a29892c7570971e1052e09e0777e7106a1237/pr-assets/pr3014-camera-focus-expr-before.png?raw=true" width="420"> | <img src="https://github.com/rafaellehmkuhl/cockpit-public/blob/5b7a29892c7570971e1052e09e0777e7106a1237/pr-assets/pr3014-camera-focus-expr-after.png?raw=true" width="420"> |

The expression screenshots were taken before the clamp was restored; the after formulas now also end with `Math.max(Math.min(1, …), -1)`.

## Test plan

- [ ] Open Tools → Data-lake and confirm Camera Zoom Speed and Camera Focus Speed are gone
- [ ] Edit the Camera Zoom compound variable: the expression is the increase/decrease difference plus deadzone and the `[-1, 1]` clamp, with no `* {{camera-zoom-speed}}`
- [ ] Same for Camera Focus
- [ ] Upgrade an install that still has the original shipped formula: zoom/focus still work. The edit dialog shows the patched formula; the stored expression is still the old one
- [ ] After that first boot, change the Camera Zoom expression, reload, and confirm the edit is still there
- [ ] Confirm a one-time snackbar about the speed settings moving to the vehicle

## Checks

- Fresh boot camera data-lake ids: 8 (including `camera-zoom-speed` / `camera-focus-speed`, default `3`) → 6 (those two gone)
- Compound descriptions no longer mention multiplication in the Data-lake list this session (an upgraded install’s stored copy stays old until something else saves the function)
- `yarn lint` clean on the touched files

