### PR TITLE
.github: ci.yml: move AWS auth to just before it's needed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,14 +308,6 @@ jobs:
           # Make keychain name available to electron-builder
           echo "CSC_KEYCHAIN_NAME=${KEYCHAIN_NAME}" >> $GITHUB_ENV
 
-      - name: Configure AWS Credentials (for Stable Release)
-        uses: aws-actions/configure-aws-credentials@v6
-        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') && success()
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-
       - name: Deploy (macOS - Release Build)
         if: (matrix.os == 'macos-15-intel' || matrix.os == 'macos-15') && github.event_name != 'pull_request'
         env:
@@ -391,6 +383,14 @@ jobs:
           tag: ${{ github.ref }}
           overwrite: true
           prerelease: true
+
+      - name: Configure AWS Credentials (for Stable Release)
+        uses: aws-actions/configure-aws-credentials@v6
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') && success()
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
 
       - name: Upload AWS Build (of Stable Release)
         if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') && success()


### PR DESCRIPTION
Applies an improvement spurred by the #3017 (backport) review.

Avoids an AWS auth failure stopping the rest of the deployment targets from receiving updated images, and avoids unrelated steps from having access to an authenticated AWS user.

This makes the electron deployment better match what was already being done for the flatpak deployment (defined just underneath it).