### PR TITLE
Widgets: Fix blurry iframe text when the widget grows

### DIFF
--- a/src/components/widgets/IFrame.vue
+++ b/src/components/widgets/IFrame.vue
@@ -561,6 +561,7 @@ const handleScaleContentToggle = (enabled: boolean | null): void => {
 
 /**
  * Builds the CSS that scales the iframe inside the given content-area box.
+ * Uses zoom so the iframe is rasterized at the target scale instead of upsampling a bitmap.
  * @param {number} areaWidth Content-area width in pixels.
  * @param {number} areaHeight Content-area height in pixels.
  * @returns {string} The CSS declarations positioning and scaling the iframe.
@@ -569,7 +570,7 @@ const buildContentStyle = (areaWidth: number, areaHeight: number): string => {
   const zoom = effectiveZoom.value
   const width = areaWidth / zoom
   const height = areaHeight / zoom
-  return `position: absolute; top: 0; left: 0; width: ${width}px; height: ${height}px; transform: scale(${zoom}); transform-origin: top left;`
+  return `position: absolute; top: 0; left: 0; width: ${width}px; height: ${height}px; zoom: ${zoom};`
 }
 
 const validateURL = (url: string): true | string => {
@@ -738,6 +739,13 @@ iframe {
   margin: 0;
   padding: 0;
   opacity: calc(v-bind('iframeOpacity'));
+}
+
+@supports not (zoom: 2) {
+  iframe {
+    transform: scale(v-bind('effectiveZoom'));
+    transform-origin: top left;
+  }
 }
 
 .iframe-status-overlay {


### PR DESCRIPTION
- Iframe widgets laid the document out at area/zoom and then applied `transform: scale`, so text was rasterized small and upsampled whenever the widget was wider than the 40% reference.
- `buildContentStyle` now uses CSS `zoom` so the iframe is painted at the target resolution. Child `window.innerWidth` is unchanged.
- Necessary for the 4K Cam launch, where that UI is shown in a large iframe and the blur is visible at typical sizes.

Closes #3020