### PR TITLE
Widgets: Backport iframe content scaling with sharp text rendering

### DIFF
--- a/src/components/widgets/IFrame.vue
+++ b/src/components/widgets/IFrame.vue
@@ -31,7 +31,8 @@
         </div>
         <div
           v-show="!widget.options.startCollapsed"
-          class="relative flex-1 min-h-0 w-full"
+          ref="contentBox"
+          class="relative flex-1 min-h-0 w-full overflow-hidden"
           :class="expandsUpward ? 'order-1' : 'order-2'"
         >
           <iframe
@@ -73,43 +74,41 @@
     </div>
     <div v-else>
       <teleport to=".widgets-view">
-        <iframe
-          v-if="urlCheckStatus === 'ok'"
-          v-show="iframe_loaded"
-          ref="iframe"
-          :src="toBeUsedURL"
-          :style="[iframeStyle, { position: 'absolute' }]"
-          frameborder="0"
-          @load="loadFinished"
-        />
-        <div
-          v-else
-          class="iframe-status-overlay flex flex-col items-center justify-center text-center px-4 gap-2"
-          :style="[iframeStyle, { position: 'absolute' }]"
-        >
-          <template v-if="urlCheckStatus === 'waiting'">
-            <v-icon size="48" class="opacity-80">mdi-progress-clock</v-icon>
-            <p class="text-base font-semibold">{{ waitingTitle }}</p>
-            <p class="text-sm opacity-70">
-              Trying again in {{ retryCountdownSeconds }}
-              {{ retryCountdownSeconds === 1 ? 'second' : 'seconds' }}
-            </p>
-            <v-progress-linear
-              :model-value="retryRemainingPercent"
-              color="white"
-              height="4"
-              rounded
-              reverse
-              class="!max-w-[60%] mt-2"
-            />
-          </template>
-          <template v-else-if="urlCheckStatus === 'retrying'">
-            <v-progress-circular indeterminate color="white" size="48" width="3" />
-            <p class="text-base font-semibold">Retrying...</p>
-          </template>
-          <template v-else>
-            <v-progress-circular indeterminate color="white" size="32" width="3" />
-          </template>
+        <div class="absolute overflow-hidden" :style="widgetRectStyle">
+          <iframe
+            v-if="urlCheckStatus === 'ok'"
+            v-show="iframe_loaded"
+            ref="iframe"
+            :src="toBeUsedURL"
+            :style="iframeStyle"
+            frameborder="0"
+            @load="loadFinished"
+          />
+          <div v-else class="iframe-status-overlay flex flex-col items-center justify-center text-center px-4 gap-2">
+            <template v-if="urlCheckStatus === 'waiting'">
+              <v-icon size="48" class="opacity-80">mdi-progress-clock</v-icon>
+              <p class="text-base font-semibold">{{ waitingTitle }}</p>
+              <p class="text-sm opacity-70">
+                Trying again in {{ retryCountdownSeconds }}
+                {{ retryCountdownSeconds === 1 ? 'second' : 'seconds' }}
+              </p>
+              <v-progress-linear
+                :model-value="retryRemainingPercent"
+                color="white"
+                height="4"
+                rounded
+                reverse
+                class="!max-w-[60%] mt-2"
+              />
+            </template>
+            <template v-else-if="urlCheckStatus === 'retrying'">
+              <v-progress-circular indeterminate color="white" size="48" width="3" />
+              <p class="text-base font-semibold">Retrying...</p>
+            </template>
+            <template v-else>
+              <v-progress-circular indeterminate color="white" size="32" width="3" />
+            </template>
+          </div>
         </div>
       </teleport>
     </div>
@@ -190,6 +189,30 @@
                   class="ml-2"
                 />
               </div>
+              <div class="ml-3 mt-4 mr-2">
+                <v-slider
+                  v-model="contentZoomPercent"
+                  label="Content zoom"
+                  color="white"
+                  :min="minContentZoom * 100"
+                  :max="maxContentZoom * 100"
+                  :step="5"
+                  thumb-label
+                >
+                  <template #append>
+                    <span class="text-sm w-[48px] text-right">{{ contentZoomPercent }}%</span>
+                  </template>
+                </v-slider>
+              </div>
+              <v-switch
+                v-model="widget.options.scaleContentWithWidget"
+                label="Scale content when resizing widget"
+                color="white"
+                density="compact"
+                hide-details
+                class="ml-3 my-2"
+                @update:model-value="handleScaleContentToggle"
+              />
             </template>
           </ExpansiblePanel>
         </v-card-text>
@@ -205,7 +228,7 @@
 </template>
 
 <script setup lang="ts">
-import { useWindowSize } from '@vueuse/core'
+import { useElementSize, useWindowSize } from '@vueuse/core'
 import { computed, onBeforeMount, onBeforeUnmount, ref, toRefs, watch } from 'vue'
 
 import { defaultBlueOsAddress } from '@/assets/defaults'
@@ -215,6 +238,7 @@ import { isValidURL } from '@/libs/utils'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
 import type { Widget } from '@/types/widgets'
+import { widgetDefaultSizes, WidgetType } from '@/types/widgets'
 
 import ExpansiblePanel from '../ExpansiblePanel.vue'
 const interfaceStore = useAppInterfaceStore()
@@ -490,6 +514,58 @@ const canvasSize = computed(() => ({
   height: widget.value.size.height * windowWidth.value,
 }))
 
+const minContentZoom = 0.25
+const maxContentZoom = 3
+// Reference width used when scaling content with the widget.
+const referenceWidth = widgetDefaultSizes[WidgetType.IFrame]?.width ?? 0.4
+
+const contentBox = ref<HTMLElement>()
+const { width: contentBoxWidth, height: contentBoxHeight } = useElementSize(contentBox)
+
+const clampZoom = (zoom: number): number => Math.min(maxContentZoom, Math.max(minContentZoom, zoom))
+
+const contentZoom = computed<number>(() => clampZoom(widget.value.options.contentZoom ?? 1))
+
+const contentZoomPercent = computed<number>({
+  get: () => Math.round(contentZoom.value * 100),
+  set: (percent: number) => {
+    widget.value.options.contentZoom = clampZoom(percent / 100)
+  },
+})
+
+/**
+ * Effective scale applied to the iframe content. The manual content zoom is the base.
+ * @returns {number} The scale factor applied to the iframe.
+ */
+const effectiveZoom = computed<number>(() => {
+  const autoScale = widget.value.options.scaleContentWithWidget ? widget.value.size.width / referenceWidth : 1
+  return contentZoom.value * autoScale
+})
+
+/**
+ * Compensates the manual content zoom when toggling "scale content with widget" so the effective
+ * zoom stays continuous across the toggle.
+ * @param {boolean | null} enabled The new toggle state.
+ */
+const handleScaleContentToggle = (enabled: boolean | null): void => {
+  const autoScale = widget.value.size.width / referenceWidth
+  if (autoScale <= 0) return
+  widget.value.options.contentZoom = clampZoom(enabled ? contentZoom.value / autoScale : contentZoom.value * autoScale)
+}
+
+/**
+ * Builds the CSS that scales the iframe inside the given content-area box.
+ * @param {number} areaWidth Content-area width in pixels.
+ * @param {number} areaHeight Content-area height in pixels.
+ * @returns {string} The CSS declarations positioning and scaling the iframe.
+ */
+const buildContentStyle = (areaWidth: number, areaHeight: number): string => {
+  const zoom = effectiveZoom.value
+  const width = areaWidth / zoom
+  const height = areaHeight / zoom
+  return `position: absolute; top: 0; left: 0; width: ${width}px; height: ${height}px; transform: scale(${zoom}); transform-origin: top left;`
+}
+
 const validateURL = (url: string): true | string => {
   return isValidURL(url) ? true : 'URL is not valid.'
 }
@@ -547,6 +623,8 @@ onBeforeMount((): void => {
     startCollapsed: false,
     containerName: 'iframe',
     expandDirection: 'auto' as 'auto' | 'up' | 'down',
+    contentZoom: 1,
+    scaleContentWithWidget: true,
   }
   widget.value.options = { ...defaultOptions, ...widget.value.options }
 
@@ -584,7 +662,24 @@ onBeforeUnmount((): void => {
 })
 
 const collapsibleIframeStyle = computed<string>(() => {
+  let newStyle = buildContentStyle(contentBoxWidth.value, contentBoxHeight.value)
+  if (widgetStore.editingMode) {
+    newStyle = newStyle.concat(' ', 'pointer-events:none; border:0;')
+  }
+  if (!widgetStore.isWidgetVisible(widget.value)) {
+    newStyle = newStyle.concat(' ', 'display: none;')
+  }
+  return newStyle
+})
+
+// Full widget rect, used to position the teleported content box and its status overlay.
+const widgetRectStyle = computed<string>(() => {
   let newStyle = ''
+  newStyle = newStyle.concat(' ', `left: ${widget.value.position.x * windowWidth.value}px;`)
+  newStyle = newStyle.concat(' ', `top: ${widget.value.position.y * windowHeight.value}px;`)
+  newStyle = newStyle.concat(' ', `width: ${widget.value.size.width * windowWidth.value}px;`)
+  newStyle = newStyle.concat(' ', `height: ${widget.value.size.height * windowHeight.value}px;`)
+
   if (widgetStore.editingMode) {
     newStyle = newStyle.concat(' ', 'pointer-events:none; border:0;')
   }
@@ -595,22 +690,7 @@ const collapsibleIframeStyle = computed<string>(() => {
 })
 
 const iframeStyle = computed<string>(() => {
-  let newStyle = ''
-
-  newStyle = newStyle.concat(' ', `left: ${widget.value.position.x * windowWidth.value}px;`)
-  newStyle = newStyle.concat(' ', `top: ${widget.value.position.y * windowHeight.value}px;`)
-  newStyle = newStyle.concat(' ', `width: ${widget.value.size.width * windowWidth.value}px;`)
-  newStyle = newStyle.concat(' ', `height: ${widget.value.size.height * windowHeight.value}px;`)
-
-  if (widgetStore.editingMode) {
-    newStyle = newStyle.concat(' ', 'pointer-events:none; border:0;')
-  }
-
-  if (!widgetStore.isWidgetVisible(widget.value)) {
-    newStyle = newStyle.concat(' ', 'display: none;')
-  }
-
-  return newStyle
+  return buildContentStyle(widget.value.size.width * windowWidth.value, widget.value.size.height * windowHeight.value)
 })
 
 const iframeOpacity = computed<number>(() => {

--- a/src/components/widgets/IFrame.vue
+++ b/src/components/widgets/IFrame.vue
@@ -198,6 +198,8 @@
                   :max="sliderMaxPercent"
                   :step="5"
                   thumb-label
+                  @end="logContentZoom"
+                  @keyup="logContentZoom"
                 >
                   <template #append>
                     <span class="text-sm w-[48px] text-right">{{ contentZoomPercent }}%</span>
@@ -554,6 +556,16 @@ const effectiveAutoScale = computed<number>(() => {
 const sliderMinPercent = computed<number>(() => (minContentZoom / effectiveAutoScale.value) * 100)
 const sliderMaxPercent = computed<number>(() => (maxContentZoom / effectiveAutoScale.value) * 100)
 
+let lastLoggedZoomPercent: number | undefined
+
+// Bound to drag end and key release rather than the model so an adjustment logs once, with the
+// comparison dropping the key releases that leave the value alone.
+const logContentZoom = (): void => {
+  if (contentZoomPercent.value === lastLoggedZoomPercent) return
+  lastLoggedZoomPercent = contentZoomPercent.value
+  logUserAction(`Set the iframe content zoom to ${contentZoomPercent.value}%`)
+}
+
 /**
  * Effective scale applied to the iframe content. The manual content zoom is the base, held to the
  * manual range so the layout box below, which is the widget's area divided by this, stays a small
@@ -570,6 +582,7 @@ const effectiveZoom = computed<number>(() =>
  * @param {boolean | null} enabled The new toggle state.
  */
 const handleScaleContentToggle = (enabled: boolean | null): void => {
+  logUserAction(`${enabled ? 'Enabled' : 'Disabled'} scaling the iframe content with the widget size`)
   const autoScale = widget.value.size.width / referenceWidth
   if (autoScale <= 0) return
   widget.value.options.contentZoom = clampZoom(enabled ? contentZoom.value / autoScale : contentZoom.value * autoScale)

--- a/src/components/widgets/IFrame.vue
+++ b/src/components/widgets/IFrame.vue
@@ -555,6 +555,7 @@ const handleScaleContentToggle = (enabled: boolean | null): void => {
 
 /**
  * Builds the CSS that scales the iframe inside the given content-area box.
+ * Uses zoom so the iframe is rasterized at the target scale instead of upsampling a bitmap.
  * @param {number} areaWidth Content-area width in pixels.
  * @param {number} areaHeight Content-area height in pixels.
  * @returns {string} The CSS declarations positioning and scaling the iframe.
@@ -563,7 +564,7 @@ const buildContentStyle = (areaWidth: number, areaHeight: number): string => {
   const zoom = effectiveZoom.value
   const width = areaWidth / zoom
   const height = areaHeight / zoom
-  return `position: absolute; top: 0; left: 0; width: ${width}px; height: ${height}px; transform: scale(${zoom}); transform-origin: top left;`
+  return `position: absolute; top: 0; left: 0; width: ${width}px; height: ${height}px; zoom: ${zoom};`
 }
 
 const validateURL = (url: string): true | string => {
@@ -727,6 +728,13 @@ iframe {
   margin: 0;
   padding: 0;
   opacity: calc(v-bind('iframeOpacity'));
+}
+
+@supports not (zoom: 2) {
+  iframe {
+    transform: scale(v-bind('effectiveZoom'));
+    transform-origin: top left;
+  }
 }
 
 .iframe-status-overlay {

--- a/src/components/widgets/IFrame.vue
+++ b/src/components/widgets/IFrame.vue
@@ -706,9 +706,12 @@ const widgetRectStyle = computed<string>(() => {
   newStyle = newStyle.concat(' ', `top: ${widget.value.position.y * windowHeight.value}px;`)
   newStyle = newStyle.concat(' ', `width: ${widget.value.size.width * windowWidth.value}px;`)
   newStyle = newStyle.concat(' ', `height: ${widget.value.size.height * windowHeight.value}px;`)
+  // Click-through so the status overlay cannot block widgets underneath, which leaves the iframe
+  // to re-enable pointer events for itself.
+  newStyle = newStyle.concat(' ', 'pointer-events:none;')
 
   if (widgetStore.editingMode) {
-    newStyle = newStyle.concat(' ', 'pointer-events:none; border:0;')
+    newStyle = newStyle.concat(' ', 'border:0;')
   }
   if (!widgetStore.isWidgetVisible(widget.value)) {
     newStyle = newStyle.concat(' ', 'display: none;')
@@ -717,7 +720,11 @@ const widgetRectStyle = computed<string>(() => {
 })
 
 const iframeStyle = computed<string>(() => {
-  return buildContentStyle(widget.value.size.width * windowWidth.value, widget.value.size.height * windowHeight.value)
+  const contentStyle = buildContentStyle(
+    widget.value.size.width * windowWidth.value,
+    widget.value.size.height * windowHeight.value
+  )
+  return widgetStore.editingMode ? contentStyle : `${contentStyle} pointer-events: auto;`
 })
 
 const iframeOpacity = computed<number>(() => {

--- a/src/components/widgets/IFrame.vue
+++ b/src/components/widgets/IFrame.vue
@@ -640,13 +640,17 @@ let vehicleAddressListenerId: string | undefined
 onBeforeMount((): void => {
   window.addEventListener('message', apiEventCallback, true)
 
+  // A widget persisted before content scaling existed has to keep rendering at the size its user
+  // last saw, so the seeded zoom cancels the width-derived auto scale.
+  const autoScaleFromWidth = widget.value.size.width > 0 ? widget.value.size.width / referenceWidth : 1
+
   const defaultOptions = {
     source: 'http://' + defaultBlueOsAddress,
     useVehicleAddressAsBase: false,
     startCollapsed: false,
     containerName: 'iframe',
     expandDirection: 'auto' as 'auto' | 'up' | 'down',
-    contentZoom: 1,
+    contentZoom: 1 / autoScaleFromWidth,
     scaleContentWithWidget: true,
   }
   widget.value.options = { ...defaultOptions, ...widget.value.options }

--- a/src/components/widgets/IFrame.vue
+++ b/src/components/widgets/IFrame.vue
@@ -197,6 +197,8 @@
                   :min="sliderMinPercent"
                   :max="sliderMaxPercent"
                   :step="5"
+                  :hint="contentZoomHint"
+                  persistent-hint
                   thumb-label
                   @end="logContentZoom"
                   @keyup="logContentZoom"
@@ -574,6 +576,14 @@ const logContentZoom = (): void => {
  */
 const effectiveZoom = computed<number>(() =>
   Math.min(maxContentZoom, Math.max(minContentZoom, contentZoom.value * effectiveAutoScale.value))
+)
+
+const effectiveZoomPercent = computed<number>(() => Math.round(effectiveZoom.value * 100))
+
+const contentZoomHint = computed<string>(() =>
+  widget.value.options.scaleContentWithWidget
+    ? `Rendering at ${effectiveZoomPercent.value}% at the current widget size`
+    : `Rendering at ${effectiveZoomPercent.value}%, independent of the widget size`
 )
 
 /**

--- a/src/components/widgets/IFrame.vue
+++ b/src/components/widgets/IFrame.vue
@@ -204,7 +204,7 @@
                   @keyup="logContentZoom"
                 >
                   <template #append>
-                    <span class="text-sm w-[48px] text-right">{{ contentZoomPercent }}%</span>
+                    <span class="text-sm w-12 text-right">{{ contentZoomPercent }}%</span>
                   </template>
                 </v-slider>
               </div>
@@ -241,8 +241,7 @@ import { getDataLakeVariableData, listenDataLakeVariable, unlistenDataLakeVariab
 import { isValidURL } from '@/libs/utils'
 import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
-import type { Widget } from '@/types/widgets'
-import { widgetDefaultSizes, WidgetType } from '@/types/widgets'
+import { type Widget, widgetDefaultSizes, WidgetType } from '@/types/widgets'
 
 import ExpansiblePanel from '../ExpansiblePanel.vue'
 const interfaceStore = useAppInterfaceStore()

--- a/src/components/widgets/IFrame.vue
+++ b/src/components/widgets/IFrame.vue
@@ -194,8 +194,8 @@
                   v-model="contentZoomPercent"
                   label="Content zoom"
                   color="white"
-                  :min="minContentZoom * 100"
-                  :max="maxContentZoom * 100"
+                  :min="sliderMinPercent"
+                  :max="sliderMaxPercent"
                   :step="5"
                   thumb-label
                 >
@@ -518,11 +518,19 @@ const minContentZoom = 0.25
 const maxContentZoom = 3
 // Reference width used when scaling content with the widget.
 const referenceWidth = widgetDefaultSizes[WidgetType.IFrame]?.width ?? 0.4
+// WidgetHugger constrains a widget's width to [0.01, 1] window widths, which bounds the auto scale.
+const minAutoScale = 0.01 / referenceWidth
+const maxAutoScale = 1 / referenceWidth
+// The scaling toggle folds that auto scale into the stored base, so the base has to hold the
+// manual range divided by any auto scale a width can produce, or the toggle would clamp and drop
+// the zoom that was set.
+const minStoredZoom = minContentZoom / maxAutoScale
+const maxStoredZoom = maxContentZoom / minAutoScale
 
 const contentBox = ref<HTMLElement>()
 const { width: contentBoxWidth, height: contentBoxHeight } = useElementSize(contentBox)
 
-const clampZoom = (zoom: number): number => Math.min(maxContentZoom, Math.max(minContentZoom, zoom))
+const clampZoom = (zoom: number): number => Math.min(maxStoredZoom, Math.max(minStoredZoom, zoom))
 
 const contentZoom = computed<number>(() => clampZoom(widget.value.options.contentZoom ?? 1))
 
@@ -533,14 +541,28 @@ const contentZoomPercent = computed<number>({
   },
 })
 
+// The widget-derived scale as actually applied, which is 1 while the content does not scale with
+// the widget, and never zero so the box the iframe is laid out in stays finite.
+const effectiveAutoScale = computed<number>(() => {
+  const widthScale = widget.value.size.width / referenceWidth
+  return widget.value.options.scaleContentWithWidget && widthScale > 0 ? widthScale : 1
+})
+
+// The track spans the bases that render within the manual zoom range at the current width. Bounding
+// it by the widget rather than by the value it sets keeps it still under the pointer and keeps every
+// base the seed and the toggle produce reachable on it.
+const sliderMinPercent = computed<number>(() => (minContentZoom / effectiveAutoScale.value) * 100)
+const sliderMaxPercent = computed<number>(() => (maxContentZoom / effectiveAutoScale.value) * 100)
+
 /**
- * Effective scale applied to the iframe content. The manual content zoom is the base.
+ * Effective scale applied to the iframe content. The manual content zoom is the base, held to the
+ * manual range so the layout box below, which is the widget's area divided by this, stays a small
+ * multiple of the widget however the widget is resized after the zoom was set.
  * @returns {number} The scale factor applied to the iframe.
  */
-const effectiveZoom = computed<number>(() => {
-  const autoScale = widget.value.options.scaleContentWithWidget ? widget.value.size.width / referenceWidth : 1
-  return contentZoom.value * autoScale
-})
+const effectiveZoom = computed<number>(() =>
+  Math.min(maxContentZoom, Math.max(minContentZoom, contentZoom.value * effectiveAutoScale.value))
+)
 
 /**
  * Compensates the manual content zoom when toggling "scale content with widget" so the effective


### PR DESCRIPTION
- Backport of #3021 to `v1.18-dev`. The blur it fixes never reached 1.18, because the iframe content-scaling feature that causes it was never backported either, so both land here together.
- Adds the `Content zoom` slider and the `Scale content when resizing widget` option, so an embedded page grows with the widget instead of staying at native size.
- Paints the scaled iframe with CSS `zoom` rather than `transform: scale`, so text is rasterized at the final size and stays sharp as the widget grows, with an `@supports not (zoom: 2)` fallback to the transform for browsers without `zoom`.
- Necessary for the 4K Cam launch, where that UI is shown in a large iframe and the blur is visible at typical sizes.
- The bottom two commits are cherry-picks with patch-ids identical to master's `7df5c3ba47` and `a565a46edd`, so the feature itself is unchanged from what already merged.
- The six commits on top fix defects that arrived with that merged code and are still live on master. They are kept separate from the cherry-picks so those stay byte-identical:
  - The content scaling toggle clamped the auto scale it folds into the stored zoom, discarding the zoom that was set at every width except exactly the reference one; a 25% zoom came back as 300%. The zoom is now stored over the manual range divided by any auto scale a width can produce, and the slider's end-stops come from the widget's own scale rather than from the value they bound, so the track holds still under the pointer and every base the seed and the toggle produce stays reachable on it.
  - That also holds the zoom on screen inside the manual 25-300% range whatever the widget's width, which caps the box the embedded page is laid out in at four window widths.
  - Seeds the content zoom from the widget's own width, so a widget resized before this feature existed comes back at exactly the scale it had rather than up to 2.25x; the seed lands 27% along the slider's track at every width.
  - Makes the teleported wrapper click-through, so it stops intercepting clicks meant for whatever sits underneath while the status overlay is showing.
  - Adds `logUserAction` to the zoom slider, on drag end and on key release so keyboard adjustments are recorded too, and to the content scaling toggle.
  - States the zoom the page is rendered at on the slider's hint line, in both toggle states, so the panel names it while the slider and its readout keep showing the base the handle sits on.
  - Collapses the duplicated widgets-types import and swaps the `w-[48px]` readout for `w-12`.
- #3023 carries the same fixes to master, in the same commits, minus that last tidy-up (out of scope there) and adapted to master's live widget geometry in `widgetRectStyle` and `iframeStyle`.

**Deliberately out of scope:** master's `476317387e` also let a BlueOS extension declare `contentZoom` and `scaleContentWithWidget` in its `extras.json`, across `src/types/widgets.ts`, `src/libs/blueos/schemas.ts` and `src/components/EditMenu.vue`. That half is not backported: the 4K Cam manager, which this backport exists for, never emits either key (its `CockpitIframeWidget` struct has no such field, so the JSON it serializes cannot carry one), and `ExternalWidgetSetupInfoSchema` is a non-strict `z.object`, so an extension that did declare one has it dropped silently rather than erroring. So 1.18 and master differ here on purpose, and an extension relying on manifest-declared zoom needs master.

Ref #3020
