### PR TITLE
Widgets: Fix iframe content scaling defects

### DIFF
--- a/src/components/widgets/IFrame.vue
+++ b/src/components/widgets/IFrame.vue
@@ -199,6 +199,8 @@
                   :min="sliderMinPercent"
                   :max="sliderMaxPercent"
                   :step="5"
+                  :hint="contentZoomHint"
+                  persistent-hint
                   thumb-label
                   @end="logContentZoom"
                   @keyup="logContentZoom"
@@ -580,6 +582,14 @@ const logContentZoom = (): void => {
  */
 const effectiveZoom = computed<number>(() =>
   Math.min(maxContentZoom, Math.max(minContentZoom, contentZoom.value * effectiveAutoScale.value))
+)
+
+const effectiveZoomPercent = computed<number>(() => Math.round(effectiveZoom.value * 100))
+
+const contentZoomHint = computed<string>(() =>
+  widget.value.options.scaleContentWithWidget
+    ? `Rendering at ${effectiveZoomPercent.value}% at the current widget size`
+    : `Rendering at ${effectiveZoomPercent.value}%, independent of the widget size`
 )
 
 /**

--- a/src/components/widgets/IFrame.vue
+++ b/src/components/widgets/IFrame.vue
@@ -648,13 +648,17 @@ let vehicleAddressListenerId: string | undefined
 onBeforeMount((): void => {
   window.addEventListener('message', apiEventCallback, true)
 
+  // A widget persisted before content scaling existed has to keep rendering at the size its user
+  // last saw, so the seeded zoom cancels the width-derived auto scale.
+  const autoScaleFromWidth = widget.value.size.width > 0 ? widget.value.size.width / referenceWidth : 1
+
   const defaultOptions = {
     source: 'http://' + defaultBlueOsAddress,
     useVehicleAddressAsBase: false,
     startCollapsed: false,
     containerName: 'iframe',
     expandDirection: 'auto' as 'auto' | 'up' | 'down',
-    contentZoom: 1,
+    contentZoom: 1 / autoScaleFromWidth,
     scaleContentWithWidget: true,
   }
   widget.value.options = { ...defaultOptions, ...widget.value.options }

--- a/src/components/widgets/IFrame.vue
+++ b/src/components/widgets/IFrame.vue
@@ -196,8 +196,8 @@
                   v-model="contentZoomPercent"
                   label="Content zoom"
                   color="white"
-                  :min="minContentZoom * 100"
-                  :max="maxContentZoom * 100"
+                  :min="sliderMinPercent"
+                  :max="sliderMaxPercent"
                   :step="5"
                   thumb-label
                 >
@@ -524,11 +524,19 @@ const minContentZoom = 0.25
 const maxContentZoom = 3
 // Reference width used when scaling content with the widget.
 const referenceWidth = widgetDefaultSizes[WidgetType.IFrame]?.width ?? 0.4
+// WidgetHugger constrains a widget's width to [0.01, 1] window widths, which bounds the auto scale.
+const minAutoScale = 0.01 / referenceWidth
+const maxAutoScale = 1 / referenceWidth
+// The scaling toggle folds that auto scale into the stored base, so the base has to hold the
+// manual range divided by any auto scale a width can produce, or the toggle would clamp and drop
+// the zoom that was set.
+const minStoredZoom = minContentZoom / maxAutoScale
+const maxStoredZoom = maxContentZoom / minAutoScale
 
 const contentBox = ref<HTMLElement>()
 const { width: contentBoxWidth, height: contentBoxHeight } = useElementSize(contentBox)
 
-const clampZoom = (zoom: number): number => Math.min(maxContentZoom, Math.max(minContentZoom, zoom))
+const clampZoom = (zoom: number): number => Math.min(maxStoredZoom, Math.max(minStoredZoom, zoom))
 
 const contentZoom = computed<number>(() => clampZoom(widget.value.options.contentZoom ?? 1))
 
@@ -539,14 +547,28 @@ const contentZoomPercent = computed<number>({
   },
 })
 
+// The widget-derived scale as actually applied, which is 1 while the content does not scale with
+// the widget, and never zero so the box the iframe is laid out in stays finite.
+const effectiveAutoScale = computed<number>(() => {
+  const widthScale = widget.value.size.width / referenceWidth
+  return widget.value.options.scaleContentWithWidget && widthScale > 0 ? widthScale : 1
+})
+
+// The track spans the bases that render within the manual zoom range at the current width. Bounding
+// it by the widget rather than by the value it sets keeps it still under the pointer and keeps every
+// base the seed and the toggle produce reachable on it.
+const sliderMinPercent = computed<number>(() => (minContentZoom / effectiveAutoScale.value) * 100)
+const sliderMaxPercent = computed<number>(() => (maxContentZoom / effectiveAutoScale.value) * 100)
+
 /**
- * Effective scale applied to the iframe content. The manual content zoom is the base.
+ * Effective scale applied to the iframe content. The manual content zoom is the base, held to the
+ * manual range so the layout box below, which is the widget's area divided by this, stays a small
+ * multiple of the widget however the widget is resized after the zoom was set.
  * @returns {number} The scale factor applied to the iframe.
  */
-const effectiveZoom = computed<number>(() => {
-  const autoScale = widget.value.options.scaleContentWithWidget ? widget.value.size.width / referenceWidth : 1
-  return contentZoom.value * autoScale
-})
+const effectiveZoom = computed<number>(() =>
+  Math.min(maxContentZoom, Math.max(minContentZoom, contentZoom.value * effectiveAutoScale.value))
+)
 
 /**
  * Compensates the manual content zoom when toggling "scale content with widget" so the effective

--- a/src/components/widgets/IFrame.vue
+++ b/src/components/widgets/IFrame.vue
@@ -716,9 +716,12 @@ const widgetRectStyle = computed<string>(() => {
   newStyle = newStyle.concat(' ', `top: ${position.y * windowHeight.value}px;`)
   newStyle = newStyle.concat(' ', `width: ${size.width * windowWidth.value}px;`)
   newStyle = newStyle.concat(' ', `height: ${size.height * windowHeight.value}px;`)
+  // Click-through so the status overlay cannot block widgets underneath, which leaves the iframe
+  // to re-enable pointer events for itself.
+  newStyle = newStyle.concat(' ', 'pointer-events:none;')
 
   if (widgetStore.editingMode) {
-    newStyle = newStyle.concat(' ', 'pointer-events:none; border:0;')
+    newStyle = newStyle.concat(' ', 'border:0;')
   }
   if (!widgetStore.isWidgetVisible(widget.value)) {
     newStyle = newStyle.concat(' ', 'display: none;')
@@ -728,7 +731,8 @@ const widgetRectStyle = computed<string>(() => {
 
 const iframeStyle = computed<string>(() => {
   const size = liveSize?.value ?? widget.value.size
-  return buildContentStyle(size.width * windowWidth.value, size.height * windowHeight.value)
+  const contentStyle = buildContentStyle(size.width * windowWidth.value, size.height * windowHeight.value)
+  return widgetStore.editingMode ? contentStyle : `${contentStyle} pointer-events: auto;`
 })
 
 const iframeOpacity = computed<number>(() => {

--- a/src/components/widgets/IFrame.vue
+++ b/src/components/widgets/IFrame.vue
@@ -200,6 +200,8 @@
                   :max="sliderMaxPercent"
                   :step="5"
                   thumb-label
+                  @end="logContentZoom"
+                  @keyup="logContentZoom"
                 >
                   <template #append>
                     <span class="text-sm w-[48px] text-right">{{ contentZoomPercent }}%</span>
@@ -560,6 +562,16 @@ const effectiveAutoScale = computed<number>(() => {
 const sliderMinPercent = computed<number>(() => (minContentZoom / effectiveAutoScale.value) * 100)
 const sliderMaxPercent = computed<number>(() => (maxContentZoom / effectiveAutoScale.value) * 100)
 
+let lastLoggedZoomPercent: number | undefined
+
+// Bound to drag end and key release rather than the model so an adjustment logs once, with the
+// comparison dropping the key releases that leave the value alone.
+const logContentZoom = (): void => {
+  if (contentZoomPercent.value === lastLoggedZoomPercent) return
+  lastLoggedZoomPercent = contentZoomPercent.value
+  logUserAction(`Set the iframe content zoom to ${contentZoomPercent.value}%`)
+}
+
 /**
  * Effective scale applied to the iframe content. The manual content zoom is the base, held to the
  * manual range so the layout box below, which is the widget's area divided by this, stays a small
@@ -576,6 +588,7 @@ const effectiveZoom = computed<number>(() =>
  * @param {boolean | null} enabled The new toggle state.
  */
 const handleScaleContentToggle = (enabled: boolean | null): void => {
+  logUserAction(`${enabled ? 'Enabled' : 'Disabled'} scaling the iframe content with the widget size`)
   const autoScale = widget.value.size.width / referenceWidth
   if (autoScale <= 0) return
   widget.value.options.contentZoom = clampZoom(enabled ? contentZoom.value / autoScale : contentZoom.value * autoScale)


### PR DESCRIPTION
- Five defects that arrived with the iframe content-scaling feature in #3021, all still live on master, each found by the automated review of its 1.18 backport #3022.
- The content scaling toggle clamped the auto scale it folds into the stored zoom, discarding the zoom that was set at every width except exactly the reference one; a 25% zoom came back as 300%.
- The zoom is now stored over the manual range divided by any auto scale a width can produce, and the slider's end-stops come from the widget's own scale rather than from the value they bound, so the track holds still under the pointer and every base the seed and the toggle produce stays reachable on it.
- That also holds the zoom on screen inside the manual 25-300% range whatever the widget's width, which caps the box the embedded page is laid out in at four window widths.
- Seeds the content zoom from the widget's own width, so an iframe widget that was ever resized no longer comes back at up to 2.25x after an update; the seed lands 27% along the slider's track at every width.
- Makes the teleported wrapper click-through, so it stops intercepting clicks meant for whatever sits underneath while the URL-check status overlay is showing.
- Adds `logUserAction` to the content zoom slider, on drag end and on key release so keyboard adjustments are recorded too, and to the content scaling toggle.
- States the zoom the page is rendered at on the slider's hint line, in both toggle states, so the panel names it while the slider and its readout keep showing the base the handle sits on.
- #3022 carries the same five fixes; it additionally keeps the import and readout-width tidy-up that its own review round asked for, which is out of scope here.
