### PR TITLE
Map: Add mission control panel from the context menu

### DIFF
--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -303,6 +303,7 @@ import {
   TargetFollower,
   WhoToFollow,
 } from '@/libs/map/utils-map'
+import { missionControlPanelSetupInfo } from '@/libs/mission-control-panel'
 import { datalogger, DatalogVariable } from '@/libs/sensors-logging'
 import { copyToClipboard, degrees, messageFromError } from '@/libs/utils'
 import type { MAVLinkVehicle } from '@/libs/vehicle/mavlink/vehicle'
@@ -317,7 +318,7 @@ import type {
   Waypoint,
   WaypointCoordinates,
 } from '@/types/mission'
-import type { Widget } from '@/types/widgets'
+import { type Widget, WidgetType } from '@/types/widgets'
 
 import ContextMenu from '../ContextMenu.vue'
 
@@ -1541,12 +1542,39 @@ const baseStationMenuEntries = computed(() => {
   return entries
 })
 
-const menuItems = reactive([...staticTopMenuItems, ...baseStationMenuEntries.value, ...staticBottomMenuItems])
+const missionControlPanelSetup = missionControlPanelSetupInfo()
+
+const missionControlPanelMenuEntries = computed(() => {
+  if (!missionControlPanelSetup) return []
+  const hasPanel = widgetStore.currentView.widgets.some((w) => w.component === WidgetType.MissionControlPanel)
+  if (hasPanel) return []
+  return [
+    {
+      item: 'Add mission control panel',
+      action: () => onMenuOptionSelect('add-mission-control-panel'),
+      icon: 'mdi-plus-box',
+    },
+  ]
+})
+
+const menuItems = reactive([
+  ...staticTopMenuItems,
+  ...baseStationMenuEntries.value,
+  ...missionControlPanelMenuEntries.value,
+  ...staticBottomMenuItems,
+])
 
 // The base-station entries change label/visibility with the store; rebuild the fixed segments
 // around them so the reactive array handed to the context menu keeps its identity.
-watch(baseStationMenuEntries, (entries) => {
-  menuItems.splice(0, menuItems.length, ...staticTopMenuItems, ...entries, ...staticBottomMenuItems)
+watch([baseStationMenuEntries, missionControlPanelMenuEntries], ([baseStationEntries, mcpEntries]) => {
+  menuItems.splice(
+    0,
+    menuItems.length,
+    ...staticTopMenuItems,
+    ...baseStationEntries,
+    ...mcpEntries,
+    ...staticBottomMenuItems
+  )
   // The waypoint entry is appended after construction, so the rebuild has to put it back.
   updateSkipToWpMenu()
 })
@@ -1780,6 +1808,15 @@ const onMenuOptionSelect = async (option: string): Promise<void> => {
     case 'toggle-base-station-signal-visibility':
       baseStationStore.toggleSignalVisibility()
       break
+
+    case 'add-mission-control-panel': {
+      if (!missionControlPanelSetup) break
+      const added = widgetStore.addWidget(missionControlPanelSetup, widgetStore.currentView)
+      widgetStore.allowMovingAndResizing(added.hash, widgetStore.editingMode)
+      logUserAction('Added a mission control panel from the map context menu')
+      openSnackbar({ message: 'Mission control panel added to this view', variant: 'success' })
+      break
+    }
 
     default:
       console.warn('Unknown menu option selected:', option)

--- a/src/libs/mission-control-panel.ts
+++ b/src/libs/mission-control-panel.ts
@@ -1,0 +1,25 @@
+import { widgetProfiles } from '@/assets/defaults'
+import { type InternalWidgetSetupInfo, WidgetType } from '@/types/widgets'
+
+/**
+ * Derives the setup info for a mission control panel from the default profiles, so every producer
+ * places it where the stock map view keeps it. No size is returned, as the widget assigns its own
+ * on mount.
+ * @returns {InternalWidgetSetupInfo | undefined} The setup info, or undefined when no default profile carries the panel
+ */
+export const missionControlPanelSetupInfo = (): InternalWidgetSetupInfo | undefined => {
+  const template = widgetProfiles
+    .flatMap((profile) => profile.views)
+    .flatMap((view) => view.widgets)
+    .find((widget) => widget.component === WidgetType.MissionControlPanel)
+
+  if (!template) return undefined
+
+  return {
+    component: template.component,
+    name: template.name,
+    options: template.options,
+    icon: '',
+    defaultPosition: template.position,
+  }
+}

--- a/src/stores/widgetManager.ts
+++ b/src/stores/widgetManager.ts
@@ -513,8 +513,9 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
    * @param { WidgetType } widget - Type of the widget
    * @param { View } view - View
    * @param { Point2D } dropPosition - Optional position where the widget was dropped by the user
+   * @returns { Widget } The created widget
    */
-  function addWidget(widget: InternalWidgetSetupInfo, view: View, dropPosition?: Point2D): void {
+  function addWidget(widget: InternalWidgetSetupInfo, view: View, dropPosition?: Point2D): Widget {
     const widgetHash = uuid4()
 
     const newWidget: Widget = {
@@ -539,10 +540,13 @@ export const useWidgetManagerStore = defineStore('widget-manager', () => {
     }
 
     view.widgets.unshift(newWidget)
+    const addedWidget = view.widgets[0]
     Object.assign(widgetManagerVars(newWidget.hash), {
       ...defaultWidgetManagerVars,
       ...{ allowMoving: true },
     })
+
+    return addedWidget
   }
 
   /**

--- a/src/utils/widget-migrations.ts
+++ b/src/utils/widget-migrations.ts
@@ -1,7 +1,7 @@
 import { useStorage } from '@vueuse/core'
 import { watch } from 'vue'
 
-import { widgetProfiles } from '@/assets/defaults'
+import { missionControlPanelSetupInfo } from '@/libs/mission-control-panel'
 import { setupPostPiniaConnection } from '@/libs/post-pinia-connections'
 import { useMissionStore } from '@/stores/mission'
 import { useWidgetManagerStore } from '@/stores/widgetManager'
@@ -21,12 +21,9 @@ const performMapMissionControlPanelMigration = (username: string): void => {
 
   const widgetStore = useWidgetManagerStore()
 
-  const missionControlPanelTemplate = widgetProfiles
-    .flatMap((profile) => profile.views)
-    .flatMap((view) => view.widgets)
-    .find((widget) => widget.component === WidgetType.MissionControlPanel)
+  const missionControlPanelSetup = missionControlPanelSetupInfo()
 
-  if (!missionControlPanelTemplate) return
+  if (!missionControlPanelSetup) return
 
   let hasChanges = false
   const profile = widgetStore.currentProfile
@@ -35,20 +32,7 @@ const performMapMissionControlPanelMigration = (username: string): void => {
     const hasMissionCP = view.widgets.some((w) => w.component === WidgetType.MissionControlPanel)
 
     if (hasMap && !hasMissionCP) {
-      widgetStore.addWidget(
-        {
-          component: missionControlPanelTemplate.component,
-          name: missionControlPanelTemplate.name,
-          options: missionControlPanelTemplate.options,
-          icon: '',
-        },
-        view
-      )
-      const addedWidget = view.widgets[0]
-      if (addedWidget?.component === WidgetType.MissionControlPanel) {
-        addedWidget.position = missionControlPanelTemplate.position
-        addedWidget.size = missionControlPanelTemplate.size
-      }
+      widgetStore.addWidget(missionControlPanelSetup, view)
       hasChanges = true
     }
   })


### PR DESCRIPTION
**Problem:**

- The mission control panel only reaches a view through a one-shot startup migration (`src/utils/widget-migrations.ts:17`), which races the profile sync and leaves views without a panel.
- Recovering it means entering edit mode and placing the widget by hand.

**Fix:**

- New "Add mission control panel" entry in the map context menu, shown only while the view has no panel.
- The panel lands where the default map view keeps it, and stays locked outside edit mode.
- `missionControlPanelSetupInfo` derives that placement from the default profiles, so the menu entry and the migration share one source of truth instead of copying the coordinates.
- `addWidget` returns the widget it created, dropping the `widgets[0]` index assumption from both producers.
- The migration is deliberately not fixed, as suggested on the issue: its one-shot gate is untouched and it only sources its payload from the shared helper. The one difference is the size it stores before the panel's first mount, which `MissionControlPanel` overwrites on mount either way.

<img width="1640" height="984" alt="image" src="https://github.com/user-attachments/assets/439179f7-3e9a-46b9-af95-f978366fcbf7" />

Closes #2735
