### PR TITLE
Make downloading mission from vehicle 20 times faster

### DIFF
--- a/src/libs/vehicle/mavlink/mission-download.ts
+++ b/src/libs/vehicle/mavlink/mission-download.ts
@@ -1,0 +1,206 @@
+import type { Package } from '@/libs/connection/m2r/messages/mavlink2rest'
+import { MAVLinkType, MavMissionType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
+import { type Message } from '@/libs/connection/m2r/messages/mavlink2rest-message'
+import type { SignalTyped } from '@/libs/signal'
+import { type MissionLoadingCallback, defaultLoadingCallback } from '@/types/mission'
+
+const MISSION = MavMissionType.MAV_MISSION_TYPE_MISSION
+
+// ponytail: idle backoff grows on silence and does not reset when an item lands, so a
+// slow link does not re-burst the window per waypoint. IN_FLIGHT=64 caps a hostile
+// MISSION_COUNT. Per-seq request age if the first idle still duplicates a large window.
+const RETRY_IDLE_MS = 80
+const MAX_RETRY_IDLE_MS = 1280
+const IN_FLIGHT = 64
+const MAX_MISSION_ITEMS = 4096
+
+const COUNT_TIMEOUT = 'Timed out waiting for the mission size from the vehicle. Check the connection and try again.'
+const ITEMS_TIMEOUT = 'Timed out waiting for mission items from the vehicle. Check the connection and try again.'
+const COUNT_TOO_LARGE = `The vehicle reported more than ${MAX_MISSION_ITEMS} mission items, which Cockpit will not download. Check the mission on the vehicle and try again.`
+
+/**
+ * Vehicle surface used to download a regular mission. Matches the methods already on `MAVLinkVehicle`.
+ */
+export type MissionDownloadPort = {
+  /**
+   * Ask the vehicle for MISSION_COUNT.
+   * @param {MavMissionType} missionType Mission type to list
+   * @returns {void}
+   */
+  requestMissionItemsList: (missionType: MavMissionType) => void
+  /**
+   * Ask the vehicle for one MISSION_ITEM_INT.
+   * @param {number} seq Item sequence
+   * @param {MavMissionType} missionType Mission type
+   * @returns {void}
+   */
+  requestMissionItem: (seq: number, missionType: MavMissionType) => void
+  /**
+   * Acknowledge the finished transfer.
+   * @param {boolean} success Whether every item arrived
+   * @param {MavMissionType} missionType Mission type
+   * @returns {void}
+   */
+  sendMissionAck: (success: boolean, missionType: MavMissionType) => void
+  /**
+   * Incoming MAVLink stream used to collect MISSION_COUNT / MISSION_ITEM_INT.
+   */
+  onIncomingMAVLinkMessage: SignalTyped
+}
+
+/**
+ * Wait until `pulse` is called or `ms` elapses.
+ * @param {number} ms Idle timeout
+ * @param {(cb: (() => void) | null) => void} setPulse Register or clear the current waiter
+ * @returns {Promise<void>} Resolves on pulse, rejects with `idle` on timeout
+ */
+const waitPulse = (ms: number, setPulse: (cb: (() => void) | null) => void): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      setPulse(null)
+      reject(new Error('idle'))
+    }, ms)
+    setPulse(() => {
+      clearTimeout(timer)
+      setPulse(null)
+      resolve()
+    })
+  })
+
+const fail = (log: string, user: string): never => {
+  console.error(log)
+  throw new Error(user)
+}
+
+/**
+ * Download every regular-mission item.
+ *
+ * After MISSION_COUNT, keep a window of outstanding `MISSION_REQUEST_INT`s so RTTs overlap,
+ * then retry only the in-flight holes after a short idle (with backoff). The old loop asked
+ * for one item, waited for it (and at least 250 ms before retrying), then asked for the next.
+ * @param {MissionDownloadPort} vehicle Vehicle used to send requests and receive items
+ * @param {MissionLoadingCallback} loadingCallback Progress from 0 to 100
+ * @param {number} stallTimeoutMs Fail if the count or a new item does not arrive for this long
+ * @returns {Promise<Message.MissionItemInt[]>} Items in sequence order
+ */
+export const downloadMissionItems = async (
+  vehicle: MissionDownloadPort,
+  loadingCallback: MissionLoadingCallback = defaultLoadingCallback,
+  stallTimeoutMs = 10000
+): Promise<Message.MissionItemInt[]> => {
+  const items = new Map<number, Message.MissionItemInt>()
+  const inFlight = new Set<number>()
+  let total: number | undefined
+  let pulse: (() => void) | null = null
+  const setPulse = (cb: (() => void) | null): void => {
+    pulse = cb
+  }
+
+  const onCount = (pack: Package): void => {
+    if (total !== undefined) return
+    const raw = Number((pack.message as Message.MissionCount).count)
+    if (!Number.isFinite(raw) || raw < 0) return
+    total = raw
+    pulse?.()
+  }
+  const onItem = (pack: Package): void => {
+    if (total === undefined) return
+    const item = pack.message as Message.MissionItemInt
+    const seq = item.seq
+    if (!Number.isFinite(seq) || seq < 0 || seq >= total) return
+    items.set(seq, item)
+    inFlight.delete(seq)
+    pulse?.()
+  }
+
+  vehicle.onIncomingMAVLinkMessage.add(MAVLinkType.MISSION_COUNT, onCount)
+  vehicle.onIncomingMAVLinkMessage.add(MAVLinkType.MISSION_ITEM_INT, onItem)
+
+  // ponytail: full-range scan per item, O(n²) at MAX_MISSION_ITEMS; cursor past the contiguous prefix if 4096-waypoint missions are real.
+  const holes = (): number[] => {
+    const missing: number[] = []
+    if (total === undefined) return missing
+    for (let seq = 0; seq < total; seq++) {
+      if (!items.has(seq)) missing.push(seq)
+    }
+    return missing
+  }
+
+  const refill = (): number => {
+    const missing = holes()
+    for (const seq of missing) {
+      if (inFlight.size >= IN_FLIGHT) break
+      if (inFlight.has(seq)) continue
+      vehicle.requestMissionItem(seq, MISSION)
+      inFlight.add(seq)
+    }
+    return missing.length
+  }
+
+  const retryInFlight = (): void => {
+    for (const seq of inFlight) vehicle.requestMissionItem(seq, MISSION)
+  }
+
+  try {
+    void loadingCallback(0)
+    console.debug('[Mission download] Requesting number of mission items to be downloaded...')
+    vehicle.requestMissionItemsList(MISSION)
+    const countDeadline = Date.now() + stallTimeoutMs
+    while (total === undefined) {
+      const remaining = countDeadline - Date.now()
+      if (remaining <= 0) {
+        fail('[Mission download] Timeout reached while fetching mission count.', COUNT_TIMEOUT)
+      }
+      try {
+        await waitPulse(remaining, setPulse)
+      } catch {
+        fail('[Mission download] Timeout reached while fetching mission count.', COUNT_TIMEOUT)
+      }
+    }
+
+    console.debug(`[Mission download] Mission count received! ${total} items to be downloaded.`)
+    if (total > MAX_MISSION_ITEMS) {
+      fail('[Mission download] Mission count exceeds the download limit.', COUNT_TOO_LARGE)
+    }
+    if (total === 0) {
+      console.debug('[Mission download] No mission items to download.')
+      vehicle.sendMissionAck(true, MISSION)
+      void loadingCallback(100)
+      return []
+    }
+
+    let remainingHoles = refill()
+    void loadingCallback((100 * items.size) / total)
+
+    let lastProgress = Date.now()
+    let lastHave = items.size
+    let idleMs = RETRY_IDLE_MS
+    while (remainingHoles > 0) {
+      if (Date.now() - lastProgress > stallTimeoutMs) {
+        fail('[Mission download] Timeout reached while downloading mission items.', ITEMS_TIMEOUT)
+      }
+      try {
+        await waitPulse(idleMs, setPulse)
+      } catch {
+        retryInFlight()
+        idleMs = Math.min(idleMs * 2, MAX_RETRY_IDLE_MS)
+      }
+      remainingHoles = refill()
+      if (items.size > lastHave) {
+        lastHave = items.size
+        lastProgress = Date.now()
+      }
+      void loadingCallback((100 * items.size) / total)
+    }
+
+    const ordered: Message.MissionItemInt[] = []
+    for (let seq = 0; seq < total; seq++) ordered.push(items.get(seq) as Message.MissionItemInt)
+    console.debug('[Mission download] Successfully downloaded all mission items.')
+    vehicle.sendMissionAck(true, MISSION)
+    void loadingCallback(100)
+    return ordered
+  } finally {
+    vehicle.onIncomingMAVLinkMessage.remove(MAVLinkType.MISSION_COUNT, onCount)
+    vehicle.onIncomingMAVLinkMessage.remove(MAVLinkType.MISSION_ITEM_INT, onItem)
+  }
+}

--- a/src/libs/vehicle/mavlink/vehicle.ts
+++ b/src/libs/vehicle/mavlink/vehicle.ts
@@ -32,6 +32,7 @@ import { settingsManager } from '@/libs/settings-management'
 import { Signal, SignalTyped } from '@/libs/signal'
 import { degrees, frequencyHzToIntervalUs, isEqual, round, sleep } from '@/libs/utils'
 import { defaultMessageIntervalsOptions } from '@/libs/vehicle/mavlink/defaults'
+import { downloadMissionItems } from '@/libs/vehicle/mavlink/mission-download'
 import {
   type MAVLinkParameterSetData,
   type MessageIntervalOptions,
@@ -1139,117 +1140,17 @@ export abstract class MAVLinkVehicle<Modes> extends Vehicle.AbstractVehicle<Mode
   }
 
   /**
-   * Fetch mission items from the vehicle
+   * Fetch mission items from the vehicle.
+   * Requests every missing item after MISSION_COUNT so a large survey is not downloaded one RTT at a time.
    * @param { MissionLoadingCallback } loadingCallback Callback that returns the state of the loading progress
-   * @param { number } timeoutBetweenItems Timeout between mission items in milliseconds
+   * @param { number } stallTimeoutMs Fail if the count or a new item does not arrive for this many milliseconds
    * @returns { Promise<Waypoint[]> } Mission items that were on the vehicle
    */
   async fetchMission(
     loadingCallback: MissionLoadingCallback = defaultLoadingCallback,
-    timeoutBetweenItems = 10000
+    stallTimeoutMs?: number
   ): Promise<Waypoint[]> {
-    // Only deal with regular mission items for now
-    const missionType = MavMissionType.MAV_MISSION_TYPE_MISSION
-
-    // Get number of mission items to be downloaded
-    const initTimeCount = new Date().getTime()
-    let timeoutEpoch = new Date().getTime()
-
-    // First of all, request the number of mission items to be downloaded
-    console.debug('[Mission download] Requesting number of mission items to be downloaded...')
-    let itemsCount: number | undefined = undefined
-    this.requestMissionItemsList(missionType)
-    while (itemsCount === undefined) {
-      await sleep(250)
-      const timeSinceLastTimeout = new Date().getTime() - timeoutEpoch
-      if (timeSinceLastTimeout > timeoutBetweenItems) {
-        const msg = `[Mission download] Timeout reached while fetching mission count.`
-        console.error(msg)
-        throw Error(msg)
-      }
-
-      const lastMissionCountMessage = this._messages.get(MAVLinkType.MISSION_COUNT)
-      if (lastMissionCountMessage !== undefined && lastMissionCountMessage.epoch > initTimeCount) {
-        itemsCount = lastMissionCountMessage.count
-        console.debug(`[Mission download] Mission count received! ${itemsCount} items to be downloaded.`)
-
-        // Reset the timeout epoch when the items count is received
-        timeoutEpoch = new Date().getTime()
-
-        break
-      }
-
-      console.debug(`[Mission download] Mission count not received yet. Waiting for it...`)
-    }
-
-    // If the items count is not received, throw an error
-    if (itemsCount === undefined) {
-      const msg = '[Mission download] Did not receive number of mission items from vehicle.'
-      console.error(msg)
-      throw Error(msg)
-    }
-
-    if (itemsCount === 0) {
-      console.debug('[Mission download] No mission items to download.')
-    }
-
-    // Download all mission items from the vehicle
-    console.debug(`[Mission download] Downloading ${itemsCount} mission items from vehicle...`)
-    const missionItems: Message.MissionItemInt[] = []
-    let allItemsDownloaded = itemsCount === 0
-    let itemToDownload = 0
-    let lastItemRequested = -1
-    let epochLastItemRequested = -1
-    const initTimeDownload = new Date().getTime()
-    timeoutEpoch = new Date().getTime()
-    while (!allItemsDownloaded) {
-      await sleep(1)
-      const timeSinceLastTimeout = new Date().getTime() - timeoutEpoch
-      if (timeSinceLastTimeout > timeoutBetweenItems) {
-        const msg = `[Mission download] Timeout reached while downloading mission items.`
-        console.error(msg)
-        throw Error(msg)
-      }
-
-      loadingCallback((100 * (itemToDownload + 1)) / itemsCount)
-
-      // If the last item requested is the same as the current one, and the last request was made less than 250ms ago, wait for the item to be received
-      if (lastItemRequested === itemToDownload && new Date().getTime() - epochLastItemRequested < 250) {
-        continue
-      } else if (lastItemRequested === itemToDownload) {
-        console.debug(`[Mission download] Did not receive #${itemToDownload} in time. Requesting again...`)
-      }
-
-      // Request the next mission item (starting at 0)
-      console.debug(`[Mission download] Requesting mission item #${itemToDownload}...`)
-      this.requestMissionItem(itemToDownload, missionType)
-      lastItemRequested = itemToDownload
-      epochLastItemRequested = new Date().getTime()
-
-      // Check if the last mission item received belongs to this fetch or is from an old fetch
-      const lastMissionItemMessage = this._messages.get(MAVLinkType.MISSION_ITEM_INT)
-      if (lastMissionItemMessage === undefined || lastMissionItemMessage.epoch < initTimeDownload) continue
-      if (lastMissionItemMessage.seq === itemToDownload) {
-        console.debug(`[Mission download] Mission item #${itemToDownload} received!`)
-        const { ['epoch']: _, ...lastMissionItem } = lastMissionItemMessage // eslint-disable-line @typescript-eslint/no-unused-vars
-        missionItems.push(lastMissionItem as Message.MissionItemInt)
-
-        // Reset the timeout epoch when the last mission item is received
-        timeoutEpoch = new Date().getTime()
-
-        // Only request the next mission item if the previous one was already received
-        itemToDownload += 1
-        if (itemToDownload === itemsCount) {
-          allItemsDownloaded = true
-          console.debug('[Mission download] Successfully dowloaded all mission items.')
-          loadingCallback(100)
-          break
-        }
-      }
-    }
-
-    console.debug('[Mission download] Sending mission acknowledgment to vehicle...')
-    this.sendMissionAck(allItemsDownloaded, missionType)
+    const missionItems = await downloadMissionItems(this, loadingCallback, stallTimeoutMs)
     this._currentMavlinkMissionItemsOnVehicle = missionItems
     return convertMavlinkWaypointsToCockpit(missionItems)
   }

--- a/src/tests/libs/vehicle/mission-download.test.ts
+++ b/src/tests/libs/vehicle/mission-download.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { Package } from '@/libs/connection/m2r/messages/mavlink2rest'
+import { MAVLinkType } from '@/libs/connection/m2r/messages/mavlink2rest-enum'
+import { type Message } from '@/libs/connection/m2r/messages/mavlink2rest-message'
+import { SignalTyped } from '@/libs/signal'
+import { type MissionDownloadPort, downloadMissionItems } from '@/libs/vehicle/mavlink/mission-download'
+
+const pack = (message: object): Package =>
+  ({ header: { system_id: 1, component_id: 1, sequence: 0 }, message } as Package)
+
+const itemInt = (seq: number): Message.MissionItemInt =>
+  ({ type: MAVLinkType.MISSION_ITEM_INT, seq, x: seq, y: seq } as Message.MissionItemInt)
+
+const fakeVehicle = (requested: number[], acks: boolean[]): MissionDownloadPort => ({
+  requestMissionItemsList: (): void => undefined,
+  requestMissionItem: (seq: number): void => {
+    requested.push(seq)
+  },
+  sendMissionAck: (success: boolean): void => {
+    acks.push(success)
+  },
+  onIncomingMAVLinkMessage: new SignalTyped(),
+})
+
+const drain = async (): Promise<void> => {
+  for (let i = 0; i < 20; i++) {
+    vi.advanceTimersByTime(0)
+    await Promise.resolve()
+  }
+}
+
+const flushUntil = async (ready: () => boolean): Promise<void> => {
+  for (let i = 0; i < 20; i++) {
+    vi.advanceTimersByTime(0)
+    await Promise.resolve()
+    if (ready()) return
+  }
+  throw new Error('flushUntil timed out')
+}
+
+describe('downloadMissionItems', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('keeps a window of outstanding requests after MISSION_COUNT', async () => {
+    vi.useFakeTimers()
+    const requested: number[] = []
+    const acks: boolean[] = []
+    const port = fakeVehicle(requested, acks)
+    const pending = downloadMissionItems(port)
+    port.onIncomingMAVLinkMessage.emit_value(MAVLinkType.MISSION_COUNT, pack({ count: 400 }))
+    await flushUntil(() => requested.length === 64)
+    expect(requested[0]).toBe(0)
+    expect(requested[63]).toBe(63)
+
+    for (let seq = 0; seq < 64; seq++) {
+      port.onIncomingMAVLinkMessage.emit_value(MAVLinkType.MISSION_ITEM_INT, pack(itemInt(seq)))
+    }
+    await flushUntil(() => requested.length === 128)
+    expect(requested[64]).toBe(64)
+
+    for (let seq = 64; seq < 400; seq++) {
+      port.onIncomingMAVLinkMessage.emit_value(MAVLinkType.MISSION_ITEM_INT, pack(itemInt(seq)))
+    }
+    const items = await pending
+    expect(items).toHaveLength(400)
+    expect(items[17]?.seq).toBe(17)
+    expect(acks).toEqual([true])
+  })
+
+  it('retries only the in-flight holes after a short idle', async () => {
+    vi.useFakeTimers()
+    const requested: number[] = []
+    const port = fakeVehicle(requested, [])
+    const pending = downloadMissionItems(port)
+    port.onIncomingMAVLinkMessage.emit_value(MAVLinkType.MISSION_COUNT, pack({ count: 5 }))
+    await flushUntil(() => requested.length === 5)
+    expect(requested).toEqual([0, 1, 2, 3, 4])
+
+    for (const seq of [0, 1, 2, 4]) {
+      port.onIncomingMAVLinkMessage.emit_value(MAVLinkType.MISSION_ITEM_INT, pack(itemInt(seq)))
+    }
+    await drain()
+    vi.advanceTimersByTime(80)
+    await flushUntil(() => requested.length === 6)
+    expect(requested).toEqual([0, 1, 2, 3, 4, 3])
+
+    port.onIncomingMAVLinkMessage.emit_value(MAVLinkType.MISSION_ITEM_INT, pack(itemInt(3)))
+    const items = await pending
+    expect(items.map((item) => item.seq)).toEqual([0, 1, 2, 3, 4])
+  })
+
+  it('does not re-ask the window while items keep arriving', async () => {
+    vi.useFakeTimers()
+    const requested: number[] = []
+    const port = fakeVehicle(requested, [])
+    const pending = downloadMissionItems(port)
+    port.onIncomingMAVLinkMessage.emit_value(MAVLinkType.MISSION_COUNT, pack({ count: 5 }))
+    await flushUntil(() => requested.length === 5)
+
+    vi.advanceTimersByTime(100)
+    await flushUntil(() => requested.length > 5)
+    port.onIncomingMAVLinkMessage.emit_value(MAVLinkType.MISSION_ITEM_INT, pack(itemInt(0)))
+    const afterFirstIdle = requested.length
+
+    for (const seq of [1, 2, 3, 4]) {
+      await drain()
+      vi.advanceTimersByTime(100)
+      await drain()
+      port.onIncomingMAVLinkMessage.emit_value(MAVLinkType.MISSION_ITEM_INT, pack(itemInt(seq)))
+    }
+    await pending
+    expect(requested.length).toBe(afterFirstIdle)
+  })
+
+  it('acks an empty mission without requesting items', async () => {
+    vi.useFakeTimers()
+    const requested: number[] = []
+    const acks: boolean[] = []
+    const port = fakeVehicle(requested, acks)
+    const pending = downloadMissionItems(port)
+    port.onIncomingMAVLinkMessage.emit_value(MAVLinkType.MISSION_COUNT, pack({ count: 0 }))
+    const items = await pending
+    expect(items).toEqual([])
+    expect(requested).toEqual([])
+    expect(acks).toEqual([true])
+  })
+
+  it('ignores items that arrive before the count or fall outside it', async () => {
+    vi.useFakeTimers()
+    const requested: number[] = []
+    const port = fakeVehicle(requested, [])
+    const pending = downloadMissionItems(port)
+    port.onIncomingMAVLinkMessage.emit_value(MAVLinkType.MISSION_ITEM_INT, pack(itemInt(0)))
+    await Promise.resolve()
+    expect(requested).toEqual([])
+
+    port.onIncomingMAVLinkMessage.emit_value(MAVLinkType.MISSION_COUNT, pack({ count: 2 }))
+    await flushUntil(() => requested.length === 2)
+    expect(requested).toEqual([0, 1])
+
+    port.onIncomingMAVLinkMessage.emit_value(MAVLinkType.MISSION_ITEM_INT, pack(itemInt(9)))
+    port.onIncomingMAVLinkMessage.emit_value(MAVLinkType.MISSION_ITEM_INT, pack(itemInt(0)))
+    port.onIncomingMAVLinkMessage.emit_value(MAVLinkType.MISSION_ITEM_INT, pack(itemInt(1)))
+    const items = await pending
+    expect(items.map((item) => item.seq)).toEqual([0, 1])
+  })
+
+  it('rejects a mission larger than the download limit', async () => {
+    vi.useFakeTimers()
+    const port = fakeVehicle([], [])
+    const pending = downloadMissionItems(port)
+    port.onIncomingMAVLinkMessage.emit_value(MAVLinkType.MISSION_COUNT, pack({ count: 4097 }))
+    await expect(pending).rejects.toThrow(/4096/)
+  })
+})


### PR DESCRIPTION
## Summary

- **Faster mission download** (#3025). `fetchMission` used to ask for `MISSION_ITEM_INT` one sequence at a time, so a 400-waypoint mission paid one RTT per waypoint. After `MISSION_COUNT` it now keeps a window of 64 outstanding `MISSION_REQUEST_INT`s, refills as items land, and retries only the in-flight holes after an idle that starts at 80 ms and backs off to 1.28 s (the idle does not reset when an item arrives).

The public `fetchMission(loadingCallback, stallTimeoutMs)` signature is unchanged. The protocol lives in `downloadMissionItems` next to the vehicle class so the window/retry schedule can be unit-tested without a real autopilot.

400-waypoint square around a BlueBoat, same mission, same link — only the request schedule changes. The table was measured on an earlier revision that requested every seq at once; this one windows at 64, so item transfer is the same shape and the win should still be large.

| | Time |
| --- | --- |
| Current `fetchMission` | 111.2 s |
| Earlier unbounded-burst revision | 5.32 s |

## Test plan

- [ ] Connect to a vehicle with a large mission (a few hundred waypoints) and download it from the map or mission planning. Progress should fill in bursts, not one tick every quarter second.
- [ ] Confirm an empty mission still acks and returns `[]`.
- [ ] Drop a few items on a noisy link and confirm the holes are retried without restarting the whole download.

## Checks

- Unit test asks for a first window of 64 after `MISSION_COUNT` on a 400-item mission, then a second window of 64 after those land, and retries only seq 3 when it is the remaining hole.
- Live download of a 400-waypoint square on 192.168.0.52: 111.2 s → 5.32 s (measured on the unbounded-burst revision; windowed code overlaps RTTs the same way).
- `yarn lint` on the touched files, `yarn test:unit src/tests/libs/vehicle/mission-download.test.ts` green.

Closes #3025