### PR TITLE
feat: zoom around the follow target instead of the cursor

### DIFF
--- a/src/components/widgets/Map.vue
+++ b/src/components/widgets/Map.vue
@@ -296,9 +296,11 @@ import { MavCmd, MavType } from '@/libs/connection/m2r/messages/mavlink2rest-enu
 import type { NoiseTileOptions } from '@/libs/map/map-tile-fallback'
 import { attachTileNoiseFallback, refreshNoiseFallbackTiles } from '@/libs/map/map-tile-fallback'
 import {
+  applyFollowZoomMode,
   createGridOverlay,
   fitMapToWaypoints,
   persistLiveMapView,
+  recenterMapOnFollowTarget,
   singleStepZoomMapOptions,
   TargetFollower,
   WhoToFollow,
@@ -915,6 +917,7 @@ onMounted(async () => {
   } else {
     targetFollower.unFollow()
   }
+  if (map.value) applyFollowZoomMode(map.value, !!followerTarget.value)
   await refreshMission()
 
   // Initialize vehicle history polyline if vehicle marker is on screen
@@ -1164,7 +1167,8 @@ watch(map, (newMap, oldMap) => {
 watch(zoom, (newZoom, oldZoom) => {
   if (newZoom === oldZoom) return
   contextMenuVisible.value = false
-  map.value?.setZoom(zoom.value)
+  if (!map.value) return
+  recenterMapOnFollowTarget(map.value, zoom.value, targetFollower.currentCoordinates())
 })
 
 // Watch for zoom level changes to update waypoint marker sizes
@@ -1282,6 +1286,7 @@ watch(followerTarget, (newTarget) => {
   } else {
     missionStore.followVehicleOnMap = false
   }
+  if (map.value) applyFollowZoomMode(map.value, !!newTarget)
 })
 
 // Dinamically update data of the vehicle tooltip

--- a/src/libs/map/utils-map.ts
+++ b/src/libs/map/utils-map.ts
@@ -264,6 +264,51 @@ export class TargetFollower {
   public getCurrentTarget(): string | undefined {
     return this.target
   }
+
+  /**
+   * Current follow-target coordinates, if a target is set and has a fix.
+   * @returns {WaypointCoordinates | undefined} Lat/lng of the followed target.
+   */
+  public currentCoordinates(): WaypointCoordinates | undefined {
+    if (!this.target) return undefined
+    return this.trackables[this.target]?.()
+  }
+}
+
+/**
+ * Whether a lat/lng tuple has two finite numbers.
+ * @param {WaypointCoordinates | undefined} pos Candidate coordinate
+ * @returns {pos is WaypointCoordinates} True when both components are finite
+ */
+export const isFiniteLatLng = (pos: WaypointCoordinates | undefined): pos is WaypointCoordinates =>
+  Array.isArray(pos) && Number.isFinite(pos[0]) && Number.isFinite(pos[1])
+
+/**
+ * Tell Leaflet's built-in handlers to zoom about the view center while following.
+ * Unfollowed maps keep zoom-around-cursor.
+ * @param {L.Map} map Leaflet map
+ * @param {boolean} following Whether a follow target is locked
+ * @returns {void}
+ */
+export const applyFollowZoomMode = (map: L.Map, following: boolean): void => {
+  map.options.scrollWheelZoom = following ? 'center' : true
+  map.options.doubleClickZoom = following ? 'center' : true
+  map.options.touchZoom = following ? 'center' : true
+}
+
+/**
+ * Keep the follow target under the view when zoom changes, otherwise apply a plain zoom.
+ * @param {L.Map} map Leaflet map
+ * @param {number} zoom Target zoom
+ * @param {WaypointCoordinates | undefined} pos Follow coordinate, if any
+ * @returns {void}
+ */
+export const recenterMapOnFollowTarget = (map: L.Map, zoom: number, pos: WaypointCoordinates | undefined): void => {
+  if (isFiniteLatLng(pos)) {
+    map.setView(pos, zoom, { animate: false })
+    return
+  }
+  map.setZoom(zoom)
 }
 
 /**
@@ -281,9 +326,7 @@ export const fitMapToWaypoints = (
   coordinates: WaypointCoordinates[],
   options?: L.FitBoundsOptions
 ): boolean => {
-  const validCoordinates = coordinates.filter(
-    (coord) => Array.isArray(coord) && Number.isFinite(coord[0]) && Number.isFinite(coord[1])
-  )
+  const validCoordinates = coordinates.filter(isFiniteLatLng)
   if (validCoordinates.length === 0) return false
 
   const bounds = L.latLngBounds(validCoordinates.map((coord) => L.latLng(coord[0], coord[1])))

--- a/src/tests/libs/map/utils-map.test.ts
+++ b/src/tests/libs/map/utils-map.test.ts
@@ -1,0 +1,37 @@
+import type * as L from 'leaflet'
+import { expect, test } from 'vitest'
+
+import { applyFollowZoomMode, isFiniteLatLng, TargetFollower } from '@/libs/map/utils-map'
+import type { WaypointCoordinates } from '@/types/mission'
+
+test('TargetFollower.currentCoordinates returns the followed trackable', () => {
+  const home: WaypointCoordinates = [-27.5, -48.4]
+  const follower = new TargetFollower(
+    () => undefined,
+    () => undefined
+  )
+  follower.setTrackableTarget('Home', () => home)
+  expect(follower.currentCoordinates()).toBeUndefined()
+  follower.follow('Home', false)
+  expect(follower.currentCoordinates()).toEqual(home)
+  follower.unFollow()
+  expect(follower.currentCoordinates()).toBeUndefined()
+})
+
+test('applyFollowZoomMode pins Leaflet zoom on the view center only while following', () => {
+  const map = { options: { scrollWheelZoom: true, doubleClickZoom: true, touchZoom: true } }
+  applyFollowZoomMode(map as unknown as L.Map, true)
+  expect(map.options.scrollWheelZoom).toBe('center')
+  expect(map.options.doubleClickZoom).toBe('center')
+  expect(map.options.touchZoom).toBe('center')
+  applyFollowZoomMode(map as unknown as L.Map, false)
+  expect(map.options.scrollWheelZoom).toBe(true)
+  expect(map.options.doubleClickZoom).toBe(true)
+  expect(map.options.touchZoom).toBe(true)
+})
+
+test('isFiniteLatLng requires both components', () => {
+  expect(isFiniteLatLng([-27.5, -48.4])).toBe(true)
+  expect(isFiniteLatLng([-27.5, undefined as unknown as number])).toBe(false)
+  expect(isFiniteLatLng(undefined)).toBe(false)
+})

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -933,10 +933,12 @@ import { positionPanelNearBounds, screenBounds } from '@/libs/map/screen-placeme
 import { applyLiveWaypointCoordinates } from '@/libs/map/survey-arrows'
 import { isOverSurveyHandle } from '@/libs/map/survey-polygon-edges'
 import {
+  applyFollowZoomMode,
   createGridOverlay,
   fitMapToWaypoints,
   mapPointerPositionFromClient,
   persistLiveMapView,
+  recenterMapOnFollowTarget,
   singleStepZoomMapOptions,
   TargetFollower,
   WhoToFollow,
@@ -3049,7 +3051,8 @@ watch(
 
 watch(zoom, (newZoom, oldZoom) => {
   if (newZoom === oldZoom) return
-  planningMap.value?.setZoom(zoom.value)
+  if (!planningMap.value) return
+  recenterMapOnFollowTarget(planningMap.value, zoom.value, targetFollower.currentCoordinates())
 })
 
 const addWaypoint = (
@@ -4715,6 +4718,7 @@ onMounted(async () => {
   } else {
     targetFollower.unFollow()
   }
+  if (planningMap.value) applyFollowZoomMode(planningMap.value, !!followerTarget.value)
   await nextTick()
   await tryFetchHome()
 })
@@ -4725,6 +4729,7 @@ watch(followerTarget, (newTarget) => {
   } else {
     missionStore.followVehicleOnMap = false
   }
+  if (planningMap.value) applyFollowZoomMode(planningMap.value, !!newTarget)
 })
 
 // Fetch home position when vehicle comes online


### PR DESCRIPTION
## Summary

- **Follow-aware zoom** (#3026). While the map is following the vehicle, home, or any other target, wheel and double-click zoom pinned on the cursor, so the followed coordinate slid off-center and the next follow tick had to chase it. Leaflet still owns the wheel math; we only redirect the zoom origin to the followed lat/lng. Unfollowed maps still zoom around the cursor.

Wired on both the live map widget and mission planning.

## Test plan

- [ ] Double-click the vehicle (or home) follow control so the map is locked on that coordinate.
- [ ] Park the cursor in a corner of the map and scroll. The target should stay put while the zoom changes.
- [ ] Stop following and confirm wheel zoom is back around the cursor.
- [ ] Repeat on the mission-planning map.

## Checks

- Headless: follow vehicle, wheel on the map — zoom 15 → 19 while still tracking.
- `TargetFollower.currentCoordinates()` returns the followed trackable; `applyFollowZoomMode` sets Leaflet to `'center'` only while following.
- `yarn lint` on the touched files, `yarn test:unit src/tests/libs/map/utils-map.test.ts` green.

Closes #3026
