### PR TITLE
fix: video: keep recording when backup raw chunks are disabled

### DIFF
--- a/src/libs/cosmos.ts
+++ b/src/libs/cosmos.ts
@@ -551,12 +551,6 @@ declare global {
        */
       appendChunkToVideoRecording: (processId: string, chunk: Blob, chunkNumber: number) => Promise<void>
       /**
-       * Delete chunk
-       * @param hash - The hash of the video chunk to delete
-       * @param chunkNumber - The number of the video chunk to delete
-       */
-      deleteChunk: (hash: string, chunkNumber: number) => Promise<void>
-      /**
        * Finalize live video streaming by closing FFmpeg stdin
        * @param processId - The ID of the streaming process
        */

--- a/src/libs/live-video-processor.ts
+++ b/src/libs/live-video-processor.ts
@@ -1,6 +1,7 @@
 import { isElectron } from '@/libs/utils'
+import { tempVideoStorage } from '@/libs/videoStorage'
 import type { VideoChunkQueueItem, ZipExtractionResult } from '@/types/video'
-import { videoSubtitlesFilename } from '@/utils/video'
+import { videoChunkName, videoSubtitlesFilename } from '@/utils/video'
 
 /**
  * Error class for LiveVideoProcessor initialization errors
@@ -111,15 +112,14 @@ export class LiveVideoProcessor {
         this.chunkQueue.shift() // Remove from queue
         await this.processChunk(nextChunk.blob, nextChunk.chunkNumber)
         this.lastProcessedChunk = nextChunk.chunkNumber
-        if (!this.keepRawVideoChunksAsBackup) {
-          await this.deleteChunk(nextChunk.chunkNumber)
-        }
+        await this.deleteChunk(nextChunk.chunkNumber)
       } else {
         console.warn(`Expected chunk ${this.lastProcessedChunk + 1} but got ${nextChunk.chunkNumber}.`)
 
         if (this.chunkQueue.length > 5) {
           console.warn('Too many chunks in queue, skipping ahead to the next expected chunk.')
           this.lastProcessedChunk = this.lastProcessedChunk + 1
+          await this.deleteChunk(this.lastProcessedChunk)
         }
 
         break
@@ -156,7 +156,13 @@ export class LiveVideoProcessor {
    * @param {number} chunkNumber - The number of the video chunk to delete
    */
   private async deleteChunk(chunkNumber: number): Promise<void> {
-    await window.electronAPI?.deleteChunk(this.recordingHash, chunkNumber)
+    if (this.keepRawVideoChunksAsBackup) return
+    try {
+      await tempVideoStorage.removeItem(videoChunkName(this.recordingHash, chunkNumber))
+    } catch (error) {
+      // The processed file is already written; failing to drop the raw chunk must not abort recording.
+      console.warn(`Failed to delete raw chunk ${chunkNumber} after processing:`, error)
+    }
   }
 
   /**

--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -47,7 +47,7 @@ import {
   VideoExtensionContainer,
   VideoStreamCorrespondency,
 } from '@/types/video'
-import { videoFilename, videoSubtitlesFilename, videoThumbnailFilename } from '@/utils/video'
+import { videoChunkName, videoFilename, videoSubtitlesFilename, videoThumbnailFilename } from '@/utils/video'
 
 import { useAlertStore } from './alert'
 const { openSnackbar } = useSnackbar()
@@ -1109,39 +1109,17 @@ export const useVideoStore = defineStore('video', () => {
     let sequentialLostChunks = 0
     let totalChunks = 0
     let totalLostChunks = 0
+    let unexpectedProcessorErrorWarned = false
 
     let chunksCount = -1
     activeStreams.value[streamName]!.mediaRecorder!.ondataavailable = async (e) => {
       chunksCount++
       totalChunks++
-      const chunkName = `${recordingHash}_${chunksCount}`
+      const chunkName = videoChunkName(recordingHash, chunksCount)
 
       try {
         await tempVideoStorage.setItem(chunkName, e.data)
         sequentialLostChunks = 0
-
-        // Send chunk to live processor if active
-        const processor = liveProcessors.value[recordingHash]
-        if (processor && e.data.size > 0) {
-          try {
-            await processor.addChunk(e.data, chunksCount)
-          } catch (error) {
-            if (error instanceof LiveVideoProcessorChunkAppendingError) {
-              if (!isRecording(streamName)) {
-                // eslint-disable-next-line
-                console.warn(`Failed to add chunk ${chunksCount} to live video processor but stream ${streamName} was already not recording. This usually happens when stopping the recording, so it's expected and should not be a problem.`)
-                return
-              }
-              const msg = `Failed to add chunk ${chunksCount} to live processor: ${error.message}`
-              openSnackbar({ message: msg, variant: 'error' })
-            } else if (error instanceof LiveVideoProcessorInitializationError) {
-              const msg = `Failed to initialize live processor for stream ${streamName}: ${error.message}`
-              showDialog({ message: msg, variant: 'error' })
-              alertStore.pushAlert(new Alert(AlertLevel.Error, msg))
-              if (recorderIsStillAttached()) stopRecording(streamName)
-            } else throw error
-          }
-        }
       } catch {
         if (chunksCount === 0) {
           const msg = 'Failed to initiate recording. First chunk was lost. Try again.'
@@ -1155,6 +1133,39 @@ export const useVideoStore = defineStore('video', () => {
 
         warnAboutChunkLoss()
         return
+      }
+
+      // Send chunk to live processor if active
+      const processor = liveProcessors.value[recordingHash]
+      if (processor && e.data.size > 0) {
+        try {
+          await processor.addChunk(e.data, chunksCount)
+        } catch (error) {
+          if (error instanceof LiveVideoProcessorChunkAppendingError) {
+            if (!isRecording(streamName)) {
+              // eslint-disable-next-line
+              console.warn(`Failed to add chunk ${chunksCount} to live video processor but stream ${streamName} was already not recording. This usually happens when stopping the recording, so it's expected and should not be a problem.`)
+              return
+            }
+            const msg = `Failed to add chunk ${chunksCount} to live processor: ${error.message}`
+            openSnackbar({ message: msg, variant: 'error' })
+          } else if (error instanceof LiveVideoProcessorInitializationError) {
+            const msg = `Failed to initialize live processor for stream ${streamName}: ${error.message}`
+            showDialog({ message: msg, variant: 'error' })
+            alertStore.pushAlert(new Alert(AlertLevel.Error, msg))
+            if (recorderIsStillAttached()) stopRecording(streamName)
+          } else {
+            console.warn(`Unexpected live-processor error on chunk ${chunksCount} for stream ${streamName}:`, error)
+            if (!unexpectedProcessorErrorWarned) {
+              unexpectedProcessorErrorWarned = true
+              openSnackbar({
+                message:
+                  'Something went wrong while assembling the recorded video. Recording is still running; the saved file may be incomplete.',
+                variant: 'error',
+              })
+            }
+          }
+        }
       }
 
       const updatedInfo = unprocessedVideos.value[recordingHash]

--- a/src/tests/libs/live-video-processor.test.ts
+++ b/src/tests/libs/live-video-processor.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, expect, test, vi } from 'vitest'
+
+const removeItem = vi.fn(async () => undefined)
+
+vi.mock('@/libs/videoStorage', () => ({
+  tempVideoStorage: { removeItem },
+}))
+
+vi.mock('@/libs/utils', async () => ({
+  ...(await vi.importActual<typeof import('@/libs/utils')>('@/libs/utils')),
+  isElectron: () => true,
+}))
+
+import { LiveVideoProcessor } from '@/libs/live-video-processor'
+
+const chunk = new Blob([new Uint8Array([1, 2, 3])], { type: 'video/webm' })
+
+afterEach(() => {
+  removeItem.mockReset()
+  removeItem.mockResolvedValue(undefined)
+  delete window.electronAPI
+})
+
+const startProcessor = async (keepRawChunks: boolean): Promise<LiveVideoProcessor> => {
+  window.electronAPI = {
+    startVideoRecording: vi.fn(async () => ({ id: 'proc', outputPath: '/tmp/out.mp4' })),
+  } as unknown as typeof window.electronAPI
+
+  const processor = new LiveVideoProcessor('rec-hash', 'file.mp4', keepRawChunks)
+  await processor.startProcessing()
+  return processor
+}
+
+test('addChunk deletes the raw chunk from temp storage when backup is disabled', async () => {
+  const processor = await startProcessor(false)
+
+  // The regression this guards: delete used to call window.electronAPI.deleteChunk, which was never
+  // implemented, so the first chunk threw and recording aborted as "First chunk was lost".
+  await expect(processor.addChunk(chunk, 0)).resolves.toBeUndefined()
+  expect(removeItem).toHaveBeenCalledWith('rec-hash_0')
+})
+
+test('addChunk keeps the raw chunk when backup is enabled', async () => {
+  const processor = await startProcessor(true)
+
+  await expect(processor.addChunk(chunk, 0)).resolves.toBeUndefined()
+  expect(removeItem).not.toHaveBeenCalled()
+})
+
+test('addChunk still succeeds if deleting the raw chunk fails', async () => {
+  removeItem.mockRejectedValueOnce(new Error('ENOENT'))
+  const processor = await startProcessor(false)
+
+  await expect(processor.addChunk(chunk, 0)).resolves.toBeUndefined()
+})
+
+test('addChunk deletes a skipped chunk when backup is disabled', async () => {
+  const processor = await startProcessor(false)
+
+  // Six out-of-order chunks make the queue skip the missing first one.
+  for (let n = 2; n <= 7; n++) {
+    await processor.addChunk(chunk, n)
+  }
+  expect(removeItem).toHaveBeenCalledWith('rec-hash_0')
+})

--- a/src/utils/video.ts
+++ b/src/utils/video.ts
@@ -45,3 +45,13 @@ export const videoThumbnailFilename = (videoFileName: string): string => {
 export const videoSubtitlesFilename = (videoFileName: string): string => {
   return `${videoFilenameWithoutExtension(videoFileName)}.ass`
 }
+
+/**
+ * Storage key for one raw recording chunk in temp video storage.
+ * @param {string} hash - The recording session hash
+ * @param {number} chunkNumber - Sequential number of the chunk
+ * @returns {string} The temp-storage key
+ */
+export const videoChunkName = (hash: string, chunkNumber: number): string => {
+  return `${hash}_${chunkNumber}`
+}


### PR DESCRIPTION
## Summary

One commit. Unchecking **Save backup raw chunks** aborted recording on the first chunk because cleanup called a never-implemented Electron API.

- **Recording starts with backup chunks off** (#3034). After a chunk is processed — or skipped by the ordering queue — the live processor removes it from `tempVideoStorage` via a shared `videoChunkName` key. A cleanup failure is logged and ignored. The recorder's "First chunk was lost" dialog only fires when the chunk write itself fails; an unexpected processor error shows a one-shot snackbar that the recording is still running. The unused `electronAPI.deleteChunk` declaration is gone.

## Test plan

- [ ] In Cockpit standalone, uncheck **Save backup raw chunks** (Configuration → Video).
- [ ] Start a recording and confirm it stays running (no "First chunk was lost" dialog).
- [ ] Stop the recording and confirm the processed video is available.
- [ ] Repeat with the checkbox on and confirm raw chunks are still kept.

## Checks

- `addChunk` with backup disabled deletes `rec-hash_0` from temp storage, does not throw if that delete fails, and deletes a skipped first chunk when six out-of-order chunks arrive (`src/tests/libs/live-video-processor.test.ts`).
- `yarn lint`, `yarn typecheck` and `yarn test:unit` clean for the new tests.

Closes #3034