### PR TITLE
Fix circular import on the joystick/data-lake integration

### DIFF
--- a/src/libs/joystick/protocols/data-lake.ts
+++ b/src/libs/joystick/protocols/data-lake.ts
@@ -1,8 +1,12 @@
 import { type DataLakeVariable, getAllDataLakeVariablesInfo, setDataLakeVariableData } from '@/libs/actions/data-lake'
-import { setupPostPiniaConnection } from '@/libs/post-pinia-connections'
 import { scale } from '@/libs/utils'
-import { useControllerStore } from '@/stores/controller'
-import { type ProtocolAction, CockpitModifierKeyOption, JoystickProtocol } from '@/types/joystick'
+import {
+  type JoystickProtocolActionsMapping,
+  type JoystickState,
+  type ProtocolAction,
+  CockpitModifierKeyOption,
+  JoystickProtocol,
+} from '@/types/joystick'
 
 import { modifierKeyActions } from './other'
 
@@ -43,49 +47,55 @@ export const availableDataLakeActions = (): Record<string, DataLakeVariableActio
   return actions
 }
 
-// Update data lake variables when joystick buttons or axes are used
-setupPostPiniaConnection(() => {
-  const controllerStore = useControllerStore()
-  controllerStore.registerControllerUpdateCallback((joystickState, actionsMapping, activeActions) => {
-    if (!joystickState || !actionsMapping) return
+/**
+ * Write mapped joystick button and axis values into their data-lake variables.
+ * @param {JoystickState} joystickState Current joystick buttons and axes
+ * @param {JoystickProtocolActionsMapping} actionsMapping Active protocol mapping
+ * @param {ProtocolAction[]} activeActions Actions currently held, including modifier keys
+ */
+export const updateDataLakeFromJoystick = (
+  joystickState: JoystickState,
+  actionsMapping: JoystickProtocolActionsMapping,
+  activeActions: ProtocolAction[]
+): void => {
+  if (!joystickState || !actionsMapping) return
 
-    const useShift = activeActions.map((a) => a.id).includes(modifierKeyActions.shift.id)
+  const useShift = activeActions.map((a) => a.id).includes(modifierKeyActions.shift.id)
 
-    // Handle button mappings
-    joystickState.buttons
-      .map((btnState, idx) => ({ id: idx, value: btnState }))
-      .forEach((btn) => {
-        // Check both regular and shift mappings
-        const regularMapping = actionsMapping.buttonsCorrespondencies[CockpitModifierKeyOption.regular][btn.id]
-        const shiftMapping = actionsMapping.buttonsCorrespondencies[CockpitModifierKeyOption.shift][btn.id]
+  // Handle button mappings
+  joystickState.buttons
+    .map((btnState, idx) => ({ id: idx, value: btnState }))
+    .forEach((btn) => {
+      // Check both regular and shift mappings
+      const regularMapping = actionsMapping.buttonsCorrespondencies[CockpitModifierKeyOption.regular][btn.id]
+      const shiftMapping = actionsMapping.buttonsCorrespondencies[CockpitModifierKeyOption.shift][btn.id]
 
-        // Handle regular button press
-        if (regularMapping?.action?.protocol === JoystickProtocol.DataLakeVariable) {
-          const shouldBeActive = btn.value && !useShift
-          setDataLakeVariableData(regularMapping.action.id, shouldBeActive ? Number(btn.value) : 0)
-        }
+      // Handle regular button press
+      if (regularMapping?.action?.protocol === JoystickProtocol.DataLakeVariable) {
+        const shouldBeActive = btn.value && !useShift
+        setDataLakeVariableData(regularMapping.action.id, shouldBeActive ? Number(btn.value) : 0)
+      }
 
-        // Handle shift+button press
-        if (shiftMapping?.action?.protocol === JoystickProtocol.DataLakeVariable) {
-          const shouldBeActive = btn.value && useShift
-          setDataLakeVariableData(shiftMapping.action.id, shouldBeActive ? Number(btn.value) : 0)
-        }
-      })
+      // Handle shift+button press
+      if (shiftMapping?.action?.protocol === JoystickProtocol.DataLakeVariable) {
+        const shouldBeActive = btn.value && useShift
+        setDataLakeVariableData(shiftMapping.action.id, shouldBeActive ? Number(btn.value) : 0)
+      }
+    })
 
-    // Handle axes mappings
-    joystickState.axes
-      .map((axisState, idx) => ({ id: idx, value: axisState }))
-      .forEach((axis) => {
-        if (axis.value === undefined) return
+  // Handle axes mappings
+  joystickState.axes
+    .map((axisState, idx) => ({ id: idx, value: axisState }))
+    .forEach((axis) => {
+      if (axis.value === undefined) return
 
-        const axisMapping = actionsMapping.axesCorrespondencies[axis.id]
+      const axisMapping = actionsMapping.axesCorrespondencies[axis.id]
 
-        // Handle axis mapped to data lake variable
-        if (axisMapping?.action?.protocol === JoystickProtocol.DataLakeVariable) {
-          // Scale the axis value from [-1, 1] to the configured [min, max] range
-          const scaledValue = scale(axis.value, -1, 1, axisMapping.min, axisMapping.max)
-          setDataLakeVariableData(axisMapping.action.id, scaledValue)
-        }
-      })
-  })
-})
+      // Handle axis mapped to data lake variable
+      if (axisMapping?.action?.protocol === JoystickProtocol.DataLakeVariable) {
+        // Scale the axis value from [-1, 1] to the configured [min, max] range
+        const scaledValue = scale(axis.value, -1, 1, axisMapping.min, axisMapping.max)
+        setDataLakeVariableData(axisMapping.action.id, scaledValue)
+      }
+    })
+}

--- a/src/stores/controller.ts
+++ b/src/stores/controller.ts
@@ -17,6 +17,7 @@ import {
 } from '@/libs/joystick/manager'
 import { allAvailableAxes, allAvailableButtons, performJoystickMappingMigrations } from '@/libs/joystick/protocols'
 import { CockpitActionsFunction, executeActionCallback } from '@/libs/joystick/protocols/cockpit-actions'
+import { updateDataLakeFromJoystick } from '@/libs/joystick/protocols/data-lake'
 import { modifierKeyActions, otherAvailableActions } from '@/libs/joystick/protocols/other'
 import { settingsManager } from '@/libs/settings-management'
 import { isElectron } from '@/libs/utils'
@@ -451,6 +452,8 @@ export const useControllerStore = defineStore('controller', () => {
   // Track previous button states to detect rising edges (button press transitions)
   // Format: Map<actionId, wasActive>
   const previousActionStates = ref<Map<string, boolean>>(new Map())
+
+  registerControllerUpdateCallback(updateDataLakeFromJoystick)
 
   registerControllerUpdateCallback(async (joystickState, actionsMapping, activeActions, actionsConfirmRequired) => {
     if (!joystickState || !actionsMapping || !activeActions || !actionsConfirmRequired) {

--- a/src/tests/libs/joystick/predefined-resources.test.ts
+++ b/src/tests/libs/joystick/predefined-resources.test.ts
@@ -1,0 +1,55 @@
+import { expect, test, vi } from 'vitest'
+
+import { getDataLakeVariableData } from '@/libs/actions/data-lake'
+import { updateDataLakeFromJoystick } from '@/libs/joystick/protocols/data-lake'
+import { joystickInputAxes } from '@/libs/joystick/protocols/predefined-resources'
+import {
+  type JoystickProtocolActionsMapping,
+  type ProtocolAction,
+  CockpitModifierKeyOption,
+  JoystickProtocol,
+} from '@/types/joystick'
+
+// The data lake reaches the settings manager at import time, and constructing the real one needs a working
+// localStorage that this environment does not provide.
+vi.mock('@/libs/settings-management', () => ({
+  settingsManager: { getKeyValue: () => undefined, setKeyValue: () => undefined, registerListener: () => undefined },
+}))
+
+// MAVLink message actions pull the wasm parser, which this environment cannot instantiate.
+vi.mock('@/libs/communication/mavlink', () => ({
+  sendMavlinkMessage: (): void => undefined,
+  sendManualControl: (): void => undefined,
+}))
+
+test('predefined joystick axis actions are initialized', () => {
+  expect(joystickInputAxes.axis_x.id).toBe('inputs/mavlink/axis-x')
+  expect(joystickInputAxes.axis_y.id).toBe('inputs/mavlink/axis-y')
+})
+
+const dataLakeAction = (id: string): ProtocolAction => ({
+  protocol: JoystickProtocol.DataLakeVariable,
+  id,
+  name: id,
+})
+
+test('mapped joystick inputs write into data-lake variables', () => {
+  const buttonAction = dataLakeAction('test/joystick/button')
+  const axisAction = dataLakeAction('test/joystick/axis')
+  const mapping: JoystickProtocolActionsMapping = {
+    name: 'test',
+    hash: 'test',
+    axesCorrespondencies: {
+      0: { action: axisAction, min: -1000, max: 1000 },
+    },
+    buttonsCorrespondencies: {
+      [CockpitModifierKeyOption.regular]: { 0: { action: buttonAction } },
+      [CockpitModifierKeyOption.shift]: {},
+    },
+  }
+
+  updateDataLakeFromJoystick({ buttons: [1], axes: [1] }, mapping, [])
+
+  expect(getDataLakeVariableData('test/joystick/button')).toBe(1)
+  expect(getDataLakeVariableData('test/joystick/axis')).toBe(1000)
+})


### PR DESCRIPTION
## Summary

This showed up after #3028 removed the side-effect import of `widget-migrations` from `main.ts`. That file used to load the widget store (and through it `joystick-profiles`) first, so the existing import cycle entered after `joystickInputAxes` was already initialized and boot survived. With that import gone, boot now reaches `predefined-resources` first; that pulls `data-lake`, which imported the controller store, which pulls `joystick-profiles` back into `predefined-resources` while `joystickInputAxes` is still in TDZ. The app died on that error and never left the config-broken splash.

The protocol now exports `updateDataLakeFromJoystick` and the controller store registers it — the same direction MAVLink already uses. No store import in the protocol module, static or dynamic.

## Test plan

- [ ] Hard-refresh Cockpit. It should leave the splash and reach the main UI; the console should not show `Cannot access 'joystickInputAxes' before initialization`.
- [ ] Confirm joystick mappings to data-lake variables still update when buttons and axes are used.

## Checks

- Boot: config-broken splash + TDZ at `joystick-profiles.ts` → app starts, `joystickInputAxes` initialized.
- Unit test imports `predefined-resources` and asserts a mapped button/axis write into the data lake.
- `yarn lint`, `yarn typecheck` and `yarn test:unit` clean.

Closes #3038
