### PR TITLE
fix: mission-planning: keep the live plan when leaving Flight

### DIFF
--- a/src/composables/map/useMissionInsertion.ts
+++ b/src/composables/map/useMissionInsertion.ts
@@ -2,6 +2,7 @@ import { v4 as uuid } from 'uuid'
 import { type Ref, ref } from 'vue'
 
 import { openSnackbar } from '@/composables/snackbar'
+import { hasLivePlanningMission } from '@/libs/mission/planning-state'
 import { useMissionStore } from '@/stores/mission'
 import type { CockpitMission, MissionCommand, Survey, Waypoint, WaypointCoordinates } from '@/types/mission'
 
@@ -172,9 +173,7 @@ export const useMissionInsertion = (
       return
     }
 
-    const hasExistingPlanning =
-      missionStore.currentPlanningWaypoints.length > 0 || missionStore.currentPlanningSurveys.length > 0
-    if (hasExistingPlanning) {
+    if (hasLivePlanningMission(missionStore.currentPlanningWaypoints, missionStore.currentPlanningSurveys)) {
       appendMissionToPlanning(mission)
     } else {
       // A repositioned mission was just dropped on the visible map, so restoring the saved

--- a/src/libs/mission/planning-state.ts
+++ b/src/libs/mission/planning-state.ts
@@ -1,0 +1,10 @@
+import type { Survey, Waypoint } from '@/types/mission'
+
+/**
+ * Whether the planner already has a live mission in memory.
+ * @param {Waypoint[]} waypoints - Current planning waypoints.
+ * @param {Survey[]} surveys - Current planning surveys.
+ * @returns {boolean} True when either list still has items.
+ */
+export const hasLivePlanningMission = (waypoints: Waypoint[], surveys: Survey[]): boolean =>
+  waypoints.length > 0 || surveys.length > 0

--- a/src/stores/mission.ts
+++ b/src/stores/mission.ts
@@ -17,6 +17,7 @@ import {
   shouldRenewAutomaticMissionName,
 } from '@/libs/mission/automatic-name'
 import { generateMissionThumbnailSvg } from '@/libs/mission/library'
+import { hasLivePlanningMission } from '@/libs/mission/planning-state'
 import { eventCategoriesDefaultMapping } from '@/libs/slide-to-confirm'
 import { toPlain } from '@/libs/utils'
 import {
@@ -383,10 +384,17 @@ export const useMissionStore = defineStore('mission', () => {
     )
   }
 
-  const clearMission = (): void => {
+  const clearMission = (options?: {
+    /**
+     * Whether to assign a new automatic name and reset the mission start time. Defaults to true.
+     */
+    startNewMission?: boolean
+  }): void => {
     currentPlanningWaypoints.splice(0)
     currentPlanningSurveys.splice(0)
-    cycleAutomaticMissionName({ startNewMission: true })
+    if (options?.startNewMission !== false) {
+      cycleAutomaticMissionName({ startNewMission: true })
+    }
   }
 
   const changeUsername = async (): Promise<void> => {
@@ -447,7 +455,15 @@ export const useMissionStore = defineStore('mission', () => {
     return waypointIndex !== -1 ? waypointIndex + 1 : ''
   }
 
+  const clearDraft = (): void => {
+    draftMission.value = {}
+  }
+
   const persistDraft = (waypoints: Waypoint[]): void => {
+    if (!hasLivePlanningMission(waypoints, currentPlanningSurveys)) {
+      clearDraft()
+      return
+    }
     draftMission.value = {
       version: 0,
       settings: {
@@ -460,10 +476,6 @@ export const useMissionStore = defineStore('mission', () => {
       waypoints,
       surveys: [...currentPlanningSurveys],
     }
-  }
-
-  const clearDraft = (): void => {
-    draftMission.value = {}
   }
 
   const setLastUploadedMission = (mission: CockpitMission): void => {

--- a/src/tests/libs/mission/planning-state.test.ts
+++ b/src/tests/libs/mission/planning-state.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from 'vitest'
+
+import { hasLivePlanningMission } from '@/libs/mission/planning-state'
+import type { Survey, Waypoint } from '@/types/mission'
+
+test('hasLivePlanningMission', () => {
+  expect(hasLivePlanningMission([], [])).toBe(false)
+  expect(hasLivePlanningMission([{ id: 'wp' } as Waypoint], [])).toBe(true)
+  expect(hasLivePlanningMission([], [{ id: 'survey' } as Survey])).toBe(true)
+})

--- a/src/views/MissionPlanningView.vue
+++ b/src/views/MissionPlanningView.vue
@@ -952,6 +952,7 @@ import {
 } from '@/libs/mission/general-estimates'
 import { PLANNABLE_VEHICLE_TYPES, vehicleTypeLabel } from '@/libs/mission/library'
 import { endpointSplicePosition } from '@/libs/mission/planning-endpoints'
+import { hasLivePlanningMission } from '@/libs/mission/planning-state'
 import { degrees, messageFromError, toPlain } from '@/libs/utils'
 import router from '@/router'
 import { useAppInterfaceStore } from '@/stores/appInterface'
@@ -1736,8 +1737,13 @@ useMapPoiMarkers(planningMap, {
   onClick: (poi) => poiManagerRef.value?.openDialog(undefined, poi),
 })
 
-const clearCurrentMission = (): void => {
-  missionStore.clearMission()
+const clearCurrentMission = (options?: {
+  /**
+   * Whether to assign a new automatic name and reset the mission start time. Defaults to true.
+   */
+  startNewMission?: boolean
+}): void => {
+  missionStore.clearMission(options)
   missionStore.clearUndoStack()
   Object.values(waypointMarkers.value).forEach((marker) => {
     planningMap.value?.removeLayer(marker)
@@ -3187,8 +3193,8 @@ const drawMissionOnTheMap = (waypoints: Waypoint[]): void => {
 // When true, the next mount of `MissionLibraryModal` opens its "Save current mission" dialog.
 const missionLibraryOpenSaveOnMount = ref(false)
 
-const canSaveCurrentMissionToLibrary = computed(
-  () => missionStore.currentPlanningWaypoints.length > 0 || missionStore.currentPlanningSurveys.length > 0
+const canSaveCurrentMissionToLibrary = computed(() =>
+  hasLivePlanningMission(missionStore.currentPlanningWaypoints, missionStore.currentPlanningSurveys)
 )
 
 const openMissionLibraryWithSaveDialog = (): void => {
@@ -4264,9 +4270,13 @@ const loadDraftMission = async (
   options?: {
     /** Keep the host map's current center/zoom instead of restoring the saved-mission settings. */
     preserveMapView?: boolean
+    /**
+     * Whether to assign a new automatic name and reset the mission start time. Defaults to true.
+     */
+    startNewMission?: boolean
   }
 ): Promise<void> => {
-  clearCurrentMission()
+  clearCurrentMission({ startNewMission: options?.startNewMission })
 
   try {
     if (!options?.preserveMapView) {
@@ -4694,11 +4704,20 @@ onMounted(async () => {
 
   targetFollower.enableAutoUpdate()
   stopUnFollowOnUserDrag = targetFollower.unFollowOnUserDrag(planningMap.value)
-  missionStore.clearMission()
   clearAllSurveyAreas()
 
-  if (instanceOfCockpitMission(missionStore.draftMission)) {
-    loadDraftMission(missionStore.draftMission)
+  // Live Pinia arrays survive the route change; only an empty planner loads the BlueOS draft.
+  if (hasLivePlanningMission(missionStore.currentPlanningWaypoints, missionStore.currentPlanningSurveys)) {
+    const firstWaypoint = missionStore.currentPlanningWaypoints[0]
+    if (firstWaypoint) {
+      currentWaypointAltitude.value = firstWaypoint.altitude
+      currentWaypointAltitudeRefType.value = firstWaypoint.altitudeReferenceType
+    }
+    missionStore.currentPlanningWaypoints.forEach((wp) => addWaypointMarker(wp))
+    updateWaypointMarkers()
+    missionStore.currentPlanningSurveys.forEach((survey) => addSurveyPolygonToMap(survey))
+  } else if (instanceOfCockpitMission(missionStore.draftMission)) {
+    loadDraftMission(missionStore.draftMission, { startNewMission: false })
   }
 
   missionStore.clearUndoStack()


### PR DESCRIPTION
## Summary

- **Keep the live plan across Plan → Flight → Plan** (#3045). `MissionPlanningView` is not kept alive, but Pinia still holds the waypoints and surveys. Mount used to `clearMission()` and reload `cockpit-draft-mission`, a BlueOS-synced key that is often empty after a quick upload, so the survey came back only as a vehicle download of plain waypoints. Remount now redraws the live store (including the next-waypoint altitude), loads a draft only when the planner is empty, and `persistDraft` no longer writes a valid empty mission over a real one. Opening the planner no longer cycles the automatic mission name — that only happens on launch or when the user clears the mission.

## In-water

Uploaded a survey, started it, switched to Planning, edited the polygon mid-flight, re-uploaded, and went back to Flight. The vehicle followed the modified plan from the last waypoint.

<p align="center">
<img src="https://github.com/user-attachments/assets/42b1e622-2795-4833-88aa-819d9f2883ca" width="720" alt="Original survey underway — yellow track along a lawnmower row" />
</p>
<p align="center"><sub>Original survey underway.</sub></p>

<p align="center">
<img src="https://github.com/user-attachments/assets/ff387741-32c4-4f0f-8975-9e25f34fed75" width="720" alt="After the mid-flight edit, the vehicle follows the new dogleg from the last waypoint" />
</p>
<p align="center"><sub>After the edit: the vehicle follows the new dogleg from the last waypoint.</sub></p>

## Test plan

- [ ] Create a survey (or a simple path) in Mission Planning
- [ ] Switch to Flight, then back to Planning — the same waypoints and survey polygon are still there and still editable as a survey
- [ ] The altitude field still shows the plan's altitude, and a newly added waypoint uses it
- [ ] Upload, switch to Flight immediately, switch back — still the same editable survey (no download)
- [ ] Hard-refresh on an empty planner still restores a saved draft
- [ ] Clear current mission still empties the planner
- [ ] Mission name is unchanged by merely opening Planning
- [x] In-water: start a survey, edit the polygon in Planning mid-flight, re-upload, return to Flight — vehicle continues from the last waypoint on the modified plan

## Checks

- `hasLivePlanningMission` is true iff waypoints or surveys are present (`yarn test:unit --run src/tests/libs/mission/planning-state.test.ts`)
- In-water screenshots above: the live survey survives Plan → Flight → Plan, and a mid-flight re-upload is flown from the last waypoint. (Headless Chrome still cannot boot this tree — `Cannot access 'joystickInputAxes' before initialization`.)
- `yarn lint:fix` and `yarn typecheck` clean.

Closes #3045
