### PR TITLE
Map: Add brightness and contrast to custom map providers

### DIFF
--- a/src/components/map/CustomTileProvidersManager.vue
+++ b/src/components/map/CustomTileProvidersManager.vue
@@ -110,7 +110,7 @@
         <span class="flex-1">Name</span>
         <span class="w-[30%] text-center">Type</span>
         <span class="w-[24%] text-center">Max zoom</span>
-        <span class="w-[56px]" />
+        <span class="w-[84px]" />
       </div>
       <div
         v-for="provider in missionStore.customTileProviders"
@@ -149,7 +149,75 @@
         <span class="w-[24%] truncate text-xs opacity-80 text-center">{{
           provider.maxZoom != null ? provider.maxZoom : '—'
         }}</span>
-        <div class="flex items-center w-[56px] justify-end">
+        <div class="flex items-center w-[84px] justify-end">
+          <v-menu
+            :close-on-content-click="false"
+            location="bottom end"
+            theme="dark"
+            @update:model-value="logDisplayMenuToggle"
+          >
+            <template #activator="{ props: displayProps }">
+              <v-tooltip location="top" open-delay="300" text="Brightness and contrast">
+                <template #activator="{ props: displayTooltipProps }">
+                  <v-btn
+                    v-bind="{ ...displayProps, ...displayTooltipProps }"
+                    icon="mdi-brightness-6"
+                    variant="text"
+                    size="x-small"
+                    aria-label="Brightness and contrast"
+                  />
+                </template>
+              </v-tooltip>
+            </template>
+            <div
+              class="flex flex-col p-3 rounded-lg w-[290px] text-white"
+              :style="interfaceStore.globalGlassMenuStyles"
+            >
+              <v-slider
+                :model-value="provider.brightness ?? 1"
+                label="Brightness"
+                :min="tileDisplayAdjustmentRange.min"
+                :max="tileDisplayAdjustmentRange.max"
+                :step="0.05"
+                color="white"
+                density="compact"
+                hide-details
+                @update:model-value="missionStore.updateCustomTileProvider(provider.id, { brightness: $event })"
+                @end="logAdjustment('brightness', provider)"
+                @keyup="logAdjustment('brightness', provider)"
+              >
+                <template #append>
+                  <span class="text-xs w-10 text-right">{{ adjustmentLabel(provider.brightness) }}</span>
+                </template>
+              </v-slider>
+              <v-slider
+                :model-value="provider.contrast ?? 1"
+                label="Contrast"
+                :min="tileDisplayAdjustmentRange.min"
+                :max="tileDisplayAdjustmentRange.max"
+                :step="0.05"
+                color="white"
+                density="compact"
+                hide-details
+                @update:model-value="missionStore.updateCustomTileProvider(provider.id, { contrast: $event })"
+                @end="logAdjustment('contrast', provider)"
+                @keyup="logAdjustment('contrast', provider)"
+              >
+                <template #append>
+                  <span class="text-xs w-10 text-right">{{ adjustmentLabel(provider.contrast) }}</span>
+                </template>
+              </v-slider>
+              <v-btn
+                variant="text"
+                size="x-small"
+                class="self-end mt-1"
+                :disabled="!isDisplayAdjusted(provider)"
+                @click="resetDisplayAdjustments(provider)"
+              >
+                Reset
+              </v-btn>
+            </div>
+          </v-menu>
           <v-tooltip location="top" open-delay="300" text="Edit">
             <template #activator="{ props: editProps }">
               <v-btn
@@ -184,6 +252,7 @@
 import { computed, reactive, ref, watch } from 'vue'
 
 import { useInteractionDialog } from '@/composables/interactionDialog'
+import { tileDisplayAdjustmentRange } from '@/composables/map/useCustomTileProviderLayer'
 import { openSnackbar } from '@/composables/snackbar'
 import {
   buildUrlTileProvider,
@@ -196,12 +265,14 @@ import {
 } from '@/libs/map/tile-provider-import'
 import { cachedTileArchiveIds } from '@/libs/map/tile-provider-storage'
 import { messageFromError } from '@/libs/utils'
+import { useAppInterfaceStore } from '@/stores/appInterface'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
 import { useMissionStore } from '@/stores/mission'
 import type { CustomTileProviderMeta } from '@/types/mission'
 
 const missionStore = useMissionStore()
 const vehicleStore = useMainVehicleStore()
+const interfaceStore = useAppInterfaceStore()
 const { showDialog, closeDialog } = useInteractionDialog()
 
 const vehicleOnline = computed(() => vehicleStore.isVehicleOnline)
@@ -268,6 +339,35 @@ const pendingSyncHint = (provider: CustomTileProviderMeta): string =>
 const providerTypeLabel = (provider: CustomTileProviderMeta): string => {
   if (provider.type === 'url') return 'URL'
   return provider.format?.toUpperCase() ?? 'ARCHIVE'
+}
+
+const adjustmentLabel = (value = 1): string => `${Math.round(value * 100)}%`
+
+const isDisplayAdjusted = (provider: CustomTileProviderMeta): boolean =>
+  (provider.brightness ?? 1) !== 1 || (provider.contrast ?? 1) !== 1
+
+// Release covers a drag and key-up covers the arrow keys, so the last logged value is kept to stop an
+// adjustment that fires both from being logged twice.
+const lastLoggedAdjustments: Record<string, number> = {}
+
+const adjustmentLogKey = (id: string, property: 'brightness' | 'contrast'): string => `${id}:${property}`
+
+const logAdjustment = (property: 'brightness' | 'contrast', provider: CustomTileProviderMeta): void => {
+  const value = provider[property] ?? 1
+  const entryKey = adjustmentLogKey(provider.id, property)
+  if (lastLoggedAdjustments[entryKey] === value) return
+  lastLoggedAdjustments[entryKey] = value
+  logUserAction(`Set the ${property} of a custom map provider to ${adjustmentLabel(value)}`)
+}
+
+const logDisplayMenuToggle = (open: boolean): void =>
+  logUserAction(`${open ? 'Opened' : 'Closed'} the brightness and contrast controls of a custom map provider`)
+
+const resetDisplayAdjustments = (provider: CustomTileProviderMeta): void => {
+  missionStore.updateCustomTileProvider(provider.id, { brightness: 1, contrast: 1 })
+  lastLoggedAdjustments[adjustmentLogKey(provider.id, 'brightness')] = 1
+  lastLoggedAdjustments[adjustmentLogKey(provider.id, 'contrast')] = 1
+  logUserAction('Reset the brightness and contrast of a custom map provider')
 }
 
 const clearUrlForm = (): void => {

--- a/src/composables/map/useCustomTileProviderLayer.ts
+++ b/src/composables/map/useCustomTileProviderLayer.ts
@@ -1,4 +1,5 @@
 import L from 'leaflet'
+import { watchEffect } from 'vue'
 
 import { openSnackbar } from '@/composables/snackbar'
 import { downloadFileFromVehicle } from '@/libs/blueos-files'
@@ -8,10 +9,41 @@ import { archiveTransferTimeout, tileArchiveFileName, tileProviderSubfolder } fr
 import { getCachedTileArchive, setCachedTileArchive } from '@/libs/map/tile-provider-storage'
 import { messageFromError } from '@/libs/utils'
 import { useMainVehicleStore } from '@/stores/mainVehicle'
+import { useMissionStore } from '@/stores/mission'
 import type { CustomTileProviderMeta } from '@/types/mission'
 
 // Highest zoom a custom provider is shown at; tiles beyond the archive's native maximum are upscaled (overzoom).
 const CUSTOM_PROVIDER_MAX_ZOOM = 23
+
+/**
+ * Range the brightness and contrast multipliers of a custom provider are limited to, 1 being unadjusted.
+ */
+export const tileDisplayAdjustmentRange = { min: 0.2, max: 2 }
+
+const clampDisplayAdjustment = (value = 1): number =>
+  Number.isFinite(value) ? Math.min(Math.max(value, tileDisplayAdjustmentRange.min), tileDisplayAdjustmentRange.max) : 1
+
+// Leaflet has no tile-styling API, so brightness and contrast are a CSS filter on the layer's container, which
+// only exists while the layer is on a map. A neutral adjustment clears the filter rather than writing an
+// identity one, which would still make the tile pane a stacking context and containing block. The metadata is
+// resolved on each run because a settings sync replaces the whole provider array, so an entry captured once
+// would be an orphan the sliders no longer write to.
+const bindDisplayAdjustments = (layer: L.GridLayer, resolveMeta: () => CustomTileProviderMeta): (() => void) => {
+  const paint = (): void => {
+    const meta = resolveMeta()
+    const brightness = clampDisplayAdjustment(meta.brightness)
+    const contrast = clampDisplayAdjustment(meta.contrast)
+    const filter = brightness === 1 && contrast === 1 ? '' : `brightness(${brightness}) contrast(${contrast})`
+    const container = layer.getContainer()
+    if (container) container.style.filter = filter
+  }
+  layer.on('add', paint)
+  const stopWatch = watchEffect(paint)
+  return () => {
+    layer.off('add', paint)
+    stopWatch()
+  }
+}
 
 // Fields baked into the layer at build time (or into its control label); a change to any requires rebuilding.
 export const customTileProviderSignature = (meta: CustomTileProviderMeta): string =>
@@ -33,9 +65,9 @@ export interface CustomTileProviderLayer {
   /**
    * The live Leaflet layer drawing the provider's tiles.
    */
-  layer: L.Layer
+  layer: L.GridLayer
   /**
-   * Releases the backing tile source (file providers only), if it was ever opened.
+   * Releases the layer's display-adjustment binding and, for file providers, the backing tile source.
    */
   close?: () => void
 }
@@ -59,6 +91,7 @@ export interface UseCustomTileProviderLayerReturn {
  */
 export const useCustomTileProviderLayer = (): UseCustomTileProviderLayerReturn => {
   const vehicleStore = useMainVehicleStore()
+  const missionStore = useMissionStore()
 
   // Resolves a file provider's archive: local render cache first, else download from the vehicle (the durable
   // master copy) and cache it before use. Runs only when the provider is first selected (lazy layer).
@@ -123,8 +156,19 @@ export const useCustomTileProviderLayer = (): UseCustomTileProviderLayerReturn =
     return { layer, close }
   }
 
-  const createLayer = (meta: CustomTileProviderMeta): CustomTileProviderLayer =>
-    meta.type === 'url' ? buildUrlLayer(meta) : buildFileLayer(meta)
+  const createLayer = (meta: CustomTileProviderMeta): CustomTileProviderLayer => {
+    const built = meta.type === 'url' ? buildUrlLayer(meta) : buildFileLayer(meta)
+    const liveMeta = (): CustomTileProviderMeta =>
+      missionStore.customTileProviders.find((provider) => provider.id === meta.id) ?? meta
+    const unbindDisplayAdjustments = bindDisplayAdjustments(built.layer, liveMeta)
+    return {
+      layer: built.layer,
+      close: () => {
+        unbindDisplayAdjustments()
+        built.close?.()
+      },
+    }
+  }
 
   return { createLayer }
 }

--- a/src/composables/map/useMiniMap.ts
+++ b/src/composables/map/useMiniMap.ts
@@ -260,7 +260,8 @@ export const useMiniMap = (options: UseMiniMapOptions): UseMiniMapReturn => {
   watch(() => options.edgeFadeAmount(), applyFadeMask)
   watch(() => options.tileProvider(), applyTileProvider)
   // Editing or deleting the selected custom provider in Settings > Sources has to reach the layer too. The
-  // provider list is only written on commit (never per keystroke), and unchanged metadata is a no-op here.
+  // provider list is written on commit for text edits and live while a display slider is dragged, and
+  // unchanged metadata is a no-op here.
   watch(() => missionStore.customTileProviders, applyTileProvider, { deep: true })
   watch(
     () => options.vehicleOnline(),

--- a/src/types/mission.ts
+++ b/src/types/mission.ts
@@ -750,6 +750,14 @@ export interface CustomTileProviderMeta {
    */
   tms?: boolean
   /**
+   * Brightness multiplier applied to the provider's tiles. Defaults to 1 (unadjusted).
+   */
+  brightness?: number
+  /**
+   * Contrast multiplier applied to the provider's tiles. Defaults to 1 (unadjusted).
+   */
+  contrast?: number
+  /**
    * Archive container format (`file` providers only).
    */
   format?: CustomTileArchiveFormat


### PR DESCRIPTION
- Bright custom providers washed out the map, and nothing in Cockpit could tone them down.
- Per-provider `brightness` and `contrast` multipliers (0.2x to 2x, 1 being unadjusted), persisted in `CustomTileProviderMeta` alongside the rest of the provider metadata.
- `mdi-brightness-6` button in each Installed providers row, left of the pencil, opening a menu with a slider for each plus a Reset.
- Applied as a CSS filter on the Leaflet layer container from `useCustomTileProviderLayer`, since Leaflet exposes no tile-styling API.
- Binding lives in the layer factory, so the Map widget, Mission Planning and the MiniMap all honor it with no per-view wiring, and it is torn down by the `close` every consumer already calls.
- Kept out of `customTileProviderSignature`, so an adjustment restyles the live layer instead of rebuilding it and refetching every tile.
- New fields are optional and default to 1, so no migration is needed on `cockpit-custom-tile-providers-v1`.

https://github.com/user-attachments/assets/08a864cc-f78c-4aa1-8aa4-c3b7543a3de1

Closes #3047
